### PR TITLE
Enable blank line rules for swiftformat.

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -3,8 +3,6 @@
 --exclude ElementX/Sources/Generated
 
 --disable wrapMultiLineStatementBraces
---disable blankLinesAtStartOfScope
---disable blankLinesAtEndOfScope
 --disable hoistPatternLet
 
 --commas inline

--- a/DesignKit/Sources/Fonts/ElementSharedFonts.swift
+++ b/DesignKit/Sources/Fonts/ElementSharedFonts.swift
@@ -19,7 +19,6 @@ import SwiftUI
 /// Fonts at  https://www.figma.com/file/X4XTH9iS2KGJ2wFKDqkyed/Compound?node-id=1362%3A0
 @objcMembers
 public class ElementSharedFonts {
-    
     // MARK: - Types
     
     /// A wrapper to provide both a `UIFont` and a SwiftUI `Font` in the same type.
@@ -43,7 +42,6 @@ public class ElementSharedFonts {
 // MARK: - Fonts protocol
 
 public extension ElementSharedFonts {
-    
     var largeTitle: SharedFont {
         let uiFont = font(forTextStyle: .largeTitle)
         return SharedFont(uiFont: uiFont, font: .largeTitle)

--- a/DesignKit/Sources/Fonts/Fonts.swift
+++ b/DesignKit/Sources/Fonts/Fonts.swift
@@ -20,7 +20,6 @@ import Foundation
 /// Font names are based on Element typography  https://www.figma.com/file/X4XTH9iS2KGJ2wFKDqkyed/Compound?node-id=1362%3A0 which is based on Apple font text styles (UIFont.TextStyle): https://developer.apple.com/documentation/uikit/uifonttextstyle
 /// Create a custom TextStyle enum (like DesignKit.Fonts.TextStyle) is also a possibility
 public protocol Fonts {
-    
     associatedtype FontType
     
     /// The font for large titles.

--- a/DesignKit/Sources/Fonts/UIFont.swift
+++ b/DesignKit/Sources/Fonts/UIFont.swift
@@ -17,7 +17,6 @@
 import UIKit
 
 public extension UIFont {
-    
     // MARK: - Convenient methods
     
     /// Update current font with a SymbolicTraits

--- a/ElementX/Sources/AppDelegate.swift
+++ b/ElementX/Sources/AppDelegate.swift
@@ -10,7 +10,6 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    
     private lazy var appCoordinator: Coordinator = isRunningUITests ? UITestsAppCoordinator() : AppCoordinator()
 
     func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {

--- a/ElementX/Sources/BuildSettings.swift
+++ b/ElementX/Sources/BuildSettings.swift
@@ -9,7 +9,6 @@
 import Foundation
 
 final class BuildSettings {
-    
     // MARK: - Servers
 
     static let defaultHomeserverURLString = "https://matrix.org"
@@ -32,5 +31,4 @@ final class BuildSettings {
     // MARK: - Room screen
 
     static let defaultRoomTimelineStyle: TimelineStyle = .bubbles
-
 }

--- a/ElementX/Sources/Other/Coordinator.swift
+++ b/ElementX/Sources/Other/Coordinator.swift
@@ -21,7 +21,6 @@ import UIKit
 /// It helps to isolate and reuse view controllers and pass dependencies down the navigation hierarchy.
 @MainActor
 protocol Coordinator: AnyObject {
-    
     /// Starts job of the coordinator.
     func start()
     
@@ -41,7 +40,6 @@ protocol Coordinator: AnyObject {
 
 // `Coordinator` default implementation
 extension Coordinator {
-    
     func add(childCoordinator coordinator: Coordinator) {
         childCoordinators.append(coordinator)
     }

--- a/ElementX/Sources/Other/ElementNavigationController.swift
+++ b/ElementX/Sources/Other/ElementNavigationController.swift
@@ -9,10 +9,8 @@
 import UIKit
 
 class ElementNavigationController: UINavigationController {
-
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
         navigationBar.topItem?.backButtonDisplayMode = .minimal
     }
-
 }

--- a/ElementX/Sources/Other/ElementSettings.swift
+++ b/ElementX/Sources/Other/ElementSettings.swift
@@ -11,7 +11,6 @@ import SwiftUI
 
 /// Store Element specific app settings.
 final class ElementSettings: ObservableObject {
-
     // MARK: - Constants
 
     public enum UserDefaultsKeys: String {

--- a/ElementX/Sources/Other/Extensions/Bundle.swift
+++ b/ElementX/Sources/Other/Extensions/Bundle.swift
@@ -9,7 +9,6 @@
 import Foundation
 
 public extension Bundle {
-
     /// Get an lproj language bundle from the receiver bundle.
     /// - Parameter language: The language to try to load.
     /// - Returns: The lproj bundle if found otherwise nil.
@@ -46,5 +45,4 @@ public extension Bundle {
             .compactMap { $0 }
             .filter { set.insert($0).inserted }
     }
-
 }

--- a/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilder.swift
+++ b/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilder.swift
@@ -10,7 +10,6 @@ import DTCoreText
 import Foundation
 
 struct AttributedStringBuilder: AttributedStringBuilderProtocol {
-    
     private let temporaryBlockquoteMarkingColor = UIColor.magenta
     private let temporaryCodeBlockMarkingColor = UIColor.cyan
     private let linkColor = UIColor.blue
@@ -159,7 +158,6 @@ struct AttributedStringBuilder: AttributedStringBuilderProtocol {
     }
     
     private func addLinks(_ attributedString: NSMutableAttributedString) {
-        
         let string = attributedString.string
         let range = NSRange(location: 0, length: attributedString.string.count)
         

--- a/ElementX/Sources/Other/HTMLParsing/DTHTMLElement+AttributedStringBuilder.swift
+++ b/ElementX/Sources/Other/HTMLParsing/DTHTMLElement+AttributedStringBuilder.swift
@@ -17,7 +17,6 @@ public extension DTHTMLElement {
     ///   - imageHandler: An optional image handler to be run on `img` tags (if allowed) to update the `src` attribute.
     @objc func sanitize(font: UIFont) {
         if let name = name, !Self.allowedHTMLTags.contains(name) {
-            
             // This is an unsupported tag.
             // Remove any attachments to fix rendering.
             textAttachment = nil

--- a/ElementX/Sources/Other/ImageAnonymizer.swift
+++ b/ElementX/Sources/Other/ImageAnonymizer.swift
@@ -15,7 +15,6 @@ enum ImageAnonymizerError: Error {
 }
 
 enum ImageAnonymizer {
-
     private static var allowedTextItems: [String] = [
         "#",
         "@",
@@ -113,5 +112,4 @@ enum ImageAnonymizer {
         }
         return result
     }
-
 }

--- a/ElementX/Sources/Other/Logging/MXLog.swift
+++ b/ElementX/Sources/Other/Logging/MXLog.swift
@@ -19,7 +19,6 @@ import SwiftyBeaver
 
 /// Various MXLog configuration options. Used in conjunction with `MXLog.configure()`
 @objc public class MXLogConfiguration: NSObject {
-    
     /// the desired log level. `.verbose` by default.
     @objc public var logLevel = MXLogLevel.verbose
     
@@ -58,7 +57,6 @@ private var logger: SwiftyBeaver.Type = {
  Please see `MXLog.h` for Objective-C options.
  */
 @objc public class MXLog: NSObject {
-    
     /// Method used to customize MXLog's behavior.
     /// Called automatically when first accessing the logger with the default values.
     /// Please see `MXLogConfiguration` for all available options.

--- a/ElementX/Sources/Other/Routers/NavigationModule.swift
+++ b/ElementX/Sources/Other/Routers/NavigationModule.swift
@@ -28,9 +28,7 @@ struct NavigationModule {
 // MARK: - CustomStringConvertible
 
 extension NavigationModule: CustomStringConvertible {
-    
     var description: String {
         "NavigationModule: \(presentable), pop completion: \(String(describing: popCompletion))"
     }
-    
 }

--- a/ElementX/Sources/Other/Routers/NavigationRouter.swift
+++ b/ElementX/Sources/Other/Routers/NavigationRouter.swift
@@ -18,7 +18,6 @@ import UIKit
 
 /// `NavigationRouter` is a concrete implementation of NavigationRouterType.
 final class NavigationRouter: NSObject, NavigationRouterType {
-    
     // MARK: - Properties
     
     // MARK: Private
@@ -117,7 +116,6 @@ final class NavigationRouter: NSObject, NavigationRouterType {
     }
         
     func setModules(_ modules: [NavigationModule], hideNavigationBar: Bool, animated: Bool) {
-        
         MXLog.debug("[NavigationRouter] Set modules \(modules)")
         
         let controllers = modules.map { module -> UIViewController in
@@ -279,7 +277,6 @@ final class NavigationRouter: NSObject, NavigationRouterType {
     }
     
     func contains(_ module: Presentable) -> Bool {
-        
         let controller = module.toPresentable()
         return navigationController.viewControllers.contains(controller)
     }
@@ -293,7 +290,6 @@ final class NavigationRouter: NSObject, NavigationRouterType {
     // MARK: - Private
     
     private func module(for viewController: UIViewController) -> Presentable {
-        
         guard let module = storedModules[viewController] as? Presentable else {
             return viewController
         }
@@ -339,7 +335,6 @@ final class NavigationRouter: NSObject, NavigationRouterType {
     }
     
     private func postNotification(withName name: Notification.Name, for viewController: UIViewController) {
-        
         let module = module(for: viewController)
         
         let userInfo: [String: Any] = [
@@ -354,14 +349,11 @@ final class NavigationRouter: NSObject, NavigationRouterType {
 // MARK: - UINavigationControllerDelegate
 
 extension NavigationRouter: UINavigationControllerDelegate {
-    
     func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
-        
         // Try to post `NavigationRouter.willPopModule` notification here
     }
     
     func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
-        
         // Ensure the view controller is popping
         guard let poppedViewController = navigationController.transitionCoordinator?.viewController(forKey: .from),
               !navigationController.viewControllers.contains(poppedViewController) else {
@@ -377,7 +369,6 @@ extension NavigationRouter: UINavigationControllerDelegate {
 // MARK: - NavigationRouter notification constants
 
 extension NavigationRouter {
-    
     // MARK: Notification names
     
     public static let willPushModule = Notification.Name("NavigationRouterWillPushModule")
@@ -391,7 +382,6 @@ extension NavigationRouter {
     // MARK: Notification keys
     
     public enum NotificationUserInfoKey {
-        
         /// The associated view controller (UIViewController).
         static let viewController = "viewController"
         

--- a/ElementX/Sources/Other/Routers/NavigationRouterStore.swift
+++ b/ElementX/Sources/Other/Routers/NavigationRouterStore.swift
@@ -18,7 +18,6 @@ import UIKit
 
 /// `NavigationRouterStore` enables to get a NavigationRouter from a UINavigationController instance.
 class NavigationRouterStore: NavigationRouterStoreProtocol {
-    
     // MARK: - Constants
     
     static let shared = NavigationRouterStore()
@@ -39,7 +38,6 @@ class NavigationRouterStore: NavigationRouterStoreProtocol {
     // MARK: - Public
     
     func navigationRouter(for navigationController: UINavigationController) -> NavigationRouterType {
-        
         if let existingNavigationRouter = findNavigationRouter(for: navigationController) {
             return existingNavigationRouter
         }
@@ -64,7 +62,6 @@ class NavigationRouterStore: NavigationRouterStoreProtocol {
     }
     
     @objc private func navigationRouterDidCreate(_ notification: Notification) {
-                
         guard let userInfo = notification.userInfo,
               let navigationRouter = userInfo[NavigationRouter.NotificationUserInfoKey.navigationRouter] as? NavigationRouterType,
               let navigationController = userInfo[NavigationRouter.NotificationUserInfoKey.navigationController] as? UINavigationController else {

--- a/ElementX/Sources/Other/Routers/NavigationRouterStoreProtocol.swift
+++ b/ElementX/Sources/Other/Routers/NavigationRouterStoreProtocol.swift
@@ -19,7 +19,6 @@ import UIKit
 /// `NavigationRouterStoreProtocol` describes a structure that enables to get a NavigationRouter from a UINavigationController instance.
 @MainActor
 protocol NavigationRouterStoreProtocol {
-    
     /// Gets the existing navigation router for the supplied controller, creating a new one if it doesn't yet exist.
     /// Note: The store only holds a weak reference to the returned router. It is the caller's responsibility to retain it.
     func navigationRouter(for navigationController: UINavigationController) -> NavigationRouterType

--- a/ElementX/Sources/Other/Routers/NavigationRouterType.swift
+++ b/ElementX/Sources/Other/Routers/NavigationRouterType.swift
@@ -20,7 +20,6 @@ import UIKit
 /// Routers are used to be passed between coordinators. They handles only `physical` navigation.
 @MainActor
 protocol NavigationRouterType: AnyObject, Presentable {
-
     /// Present modally a view controller on the navigation controller
     ///
     /// - Parameter module: The Presentable to present.
@@ -91,7 +90,6 @@ protocol NavigationRouterType: AnyObject, Presentable {
 
 // `NavigationRouterType` default implementation
 extension NavigationRouterType {
-    
     func setRootModule(_ module: Presentable) {
         setRootModule(module, hideNavigationBar: false, animated: false, popCompletion: nil)
     }
@@ -107,13 +105,11 @@ extension NavigationRouterType {
     func setModules(_ modules: [Presentable], animated: Bool) {
         setModules(modules, hideNavigationBar: false, animated: animated)
     }
-    
 }
 
 // MARK: - Presentable <--> NavigationModule Transitive Methods
 
 extension NavigationRouterType {
-    
     func setRootModule(_ module: NavigationModule) {
         setRootModule(module.presentable, popCompletion: module.popCompletion)
     }
@@ -132,5 +128,4 @@ extension NavigationRouterType {
         push(modules.map { $0.toModule() },
              animated: animated)
     }
-    
 }

--- a/ElementX/Sources/Other/Routers/Presentable.swift
+++ b/ElementX/Sources/Other/Routers/Presentable.swift
@@ -29,11 +29,9 @@ extension UIViewController: Presentable {
 }
 
 extension Presentable {
-    
     /// Returns a new module from the presentable without a pop completion block
     /// - Returns: Module
     func toModule() -> NavigationModule {
         NavigationModule(presentable: self, popCompletion: nil)
     }
-    
 }

--- a/ElementX/Sources/Other/Routers/RootRouter.swift
+++ b/ElementX/Sources/Other/Routers/RootRouter.swift
@@ -18,7 +18,6 @@ import UIKit
 
 /// `RootRouter` is a concrete implementation of RootRouterType.
 final class RootRouter: RootRouterType {
-    
     // MARK: - Constants
     
     // `rootViewController` animation constants
@@ -69,7 +68,6 @@ final class RootRouter: RootRouterType {
     // MARK: - Private methods
     
     private func updateRootViewController(rootViewController: UIViewController?, animated: Bool, completion: (() -> Void)?) {
-        
         if animated {
             UIView.transition(with: window, duration: RootViewControllerUpdateAnimation.duration, options: RootViewControllerUpdateAnimation.options, animations: {
                 let oldState: Bool = UIView.areAnimationsEnabled

--- a/ElementX/Sources/Other/Routers/RootRouterType.swift
+++ b/ElementX/Sources/Other/Routers/RootRouterType.swift
@@ -20,7 +20,6 @@ import UIKit
 /// Routers are used to be passed between coordinators. They handles only `physical` navigation.
 @MainActor
 protocol RootRouterType: AnyObject {
-    
     /// Update the root view controller
     ///
     /// - Parameter module: The new root view controller to set

--- a/ElementX/Sources/Other/SwiftUI/ViewModel/StateStoreViewModel.swift
+++ b/ElementX/Sources/Other/SwiftUI/ViewModel/StateStoreViewModel.swift
@@ -73,7 +73,6 @@ class ViewModelContext<ViewState: BindableState, ViewAction>: ObservableObject {
 /// we can do it in this centralised place.
 @MainActor
 class StateStoreViewModel<State: BindableState, ViewAction> {
-
     typealias Context = ViewModelContext<State, ViewAction>
 
     // MARK: - Properties

--- a/ElementX/Sources/Other/SwiftUI/Views/ElementToggleStyle.swift
+++ b/ElementX/Sources/Other/SwiftUI/Views/ElementToggleStyle.swift
@@ -10,7 +10,6 @@ import SwiftUI
 
 /// A toggle style that uses a button, with a checked/unchecked image like a checkbox.
 struct ElementToggleStyle: ToggleStyle {
-
     func makeBody(configuration: Configuration) -> some View {
         Button { configuration.isOn.toggle() } label: {
             Image(systemName: configuration.isOn ? "checkmark.square.fill" : "square")

--- a/ElementX/Sources/Other/UserIndicators/ActivityIndicatorPresenter.swift
+++ b/ElementX/Sources/Other/UserIndicators/ActivityIndicatorPresenter.swift
@@ -19,7 +19,6 @@ import UIKit
 
 /// Used to present activity indicator on a view
 final class ActivityIndicatorPresenter: ActivityIndicatorPresenterType {
-    
     // MARK: - Constants
     
     private enum Constants {
@@ -131,7 +130,6 @@ final class ActivityIndicatorPresenter: ActivityIndicatorPresenterType {
 }
 
 private extension UIView {
-    
     /// Add a subview matching parent view using autolayout
     @objc func vc_addSubViewMatchingParent(_ subView: UIView) {
         addSubview(subView)

--- a/ElementX/Sources/Other/UserIndicators/ActivityIndicatorView.swift
+++ b/ElementX/Sources/Other/UserIndicators/ActivityIndicatorView.swift
@@ -17,7 +17,6 @@
 import UIKit
 
 final class ActivityIndicatorView: UIView {
-    
     // MARK: - Constants
     
     private enum Constants {

--- a/ElementX/Sources/Other/UserIndicators/RectangleToastView.swift
+++ b/ElementX/Sources/Other/UserIndicators/RectangleToastView.swift
@@ -18,7 +18,6 @@ import Foundation
 import UIKit
 
 class RectangleToastView: UIView {
-    
     private enum Constants {
         static let padding = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
         static let cornerRadius: CGFloat = 8.0

--- a/ElementX/Sources/Other/UserIndicators/RoundedToastView.swift
+++ b/ElementX/Sources/Other/UserIndicators/RoundedToastView.swift
@@ -70,7 +70,6 @@ class RoundedToastView: UIView {
     }
 
     private func setup(viewState: ToastViewState) {
-        
         backgroundColor = .clear
         clipsToBounds = true
         

--- a/ElementX/Sources/Other/WeakDictionary/WeakDictionary.swift
+++ b/ElementX/Sources/Other/WeakDictionary/WeakDictionary.swift
@@ -9,7 +9,6 @@
 import Foundation
 
 public struct WeakDictionary<Key: Hashable, Value: AnyObject> {
-
     private var storage: [Key: WeakDictionaryReference<Value>]
 
     public init() {
@@ -48,7 +47,6 @@ public struct WeakDictionary<Key: Hashable, Value: AnyObject> {
 }
 
 extension WeakDictionary: Collection {
-
     public typealias Index = DictionaryIndex<Key, WeakDictionaryReference<Value>>
 
     public var startIndex: Index {

--- a/ElementX/Sources/Other/WeakDictionary/WeakDictionaryKeyReference.swift
+++ b/ElementX/Sources/Other/WeakDictionary/WeakDictionaryKeyReference.swift
@@ -9,7 +9,6 @@
 import Foundation
 
 public struct WeakDictionaryKey<Key: AnyObject & Hashable, Value: AnyObject>: Hashable {
-
     private weak var baseKey: Key?
     private let hash: Int
     private var retainedValue: Value?

--- a/ElementX/Sources/Other/WeakDictionary/WeakKeyDictionary.swift
+++ b/ElementX/Sources/Other/WeakDictionary/WeakKeyDictionary.swift
@@ -9,7 +9,6 @@
 import Foundation
 
 public struct WeakKeyDictionary<Key: AnyObject & Hashable, Value: AnyObject> {
-
     private var storage: WeakDictionary<WeakDictionaryKey<Key, Value>, Value>
     private let valuesRetainedByKey: Bool
 
@@ -69,7 +68,6 @@ public struct WeakKeyDictionary<Key: AnyObject & Hashable, Value: AnyObject> {
 }
 
 extension WeakKeyDictionary: Collection {
-
     public typealias Index = DictionaryIndex<WeakDictionaryKey<Key, Value>, WeakDictionaryReference<Value>>
 
     public var startIndex: Index {

--- a/ElementX/Sources/Screens/Authentication/AuthenticationCoordinator.swift
+++ b/ElementX/Sources/Screens/Authentication/AuthenticationCoordinator.swift
@@ -16,7 +16,6 @@ protocol AuthenticationCoordinatorDelegate: AnyObject {
 }
 
 class AuthenticationCoordinator: Coordinator, Presentable {
-    
     private let authenticationService: AuthenticationServiceProtocol
     private let navigationRouter: NavigationRouter
     

--- a/ElementX/Sources/Screens/Authentication/AuthenticationIconImage.swift
+++ b/ElementX/Sources/Screens/Authentication/AuthenticationIconImage.swift
@@ -18,7 +18,6 @@ import SwiftUI
 
 /// An image that is styled for use as the screen icon in the onboarding flow.
 struct AuthenticationIconImage: View {
-    
     let image: ImageAsset
     
     var body: some View {

--- a/ElementX/Sources/Screens/Authentication/LoginScreen/LoginCoordinator.swift
+++ b/ElementX/Sources/Screens/Authentication/LoginScreen/LoginCoordinator.swift
@@ -32,7 +32,6 @@ enum LoginCoordinatorAction {
 }
 
 final class LoginCoordinator: Coordinator, Presentable {
-    
     // MARK: - Properties
     
     // MARK: Private

--- a/ElementX/Sources/Screens/Authentication/LoginScreen/LoginHomeserver.swift
+++ b/ElementX/Sources/Screens/Authentication/LoginScreen/LoginHomeserver.swift
@@ -85,5 +85,4 @@ extension LoginHomeserver {
                         isMatrixDotOrg: false,
                         loginMode: .unsupported)
     }
-
 }

--- a/ElementX/Sources/Screens/Authentication/LoginScreen/LoginViewModel.swift
+++ b/ElementX/Sources/Screens/Authentication/LoginScreen/LoginViewModel.swift
@@ -19,7 +19,6 @@ import SwiftUI
 typealias LoginViewModelType = StateStoreViewModel<LoginViewState, LoginViewAction>
 
 class LoginViewModel: LoginViewModelType, LoginViewModelProtocol {
-
     // MARK: - Properties
 
     // MARK: Public

--- a/ElementX/Sources/Screens/Authentication/LoginScreen/LoginViewModelProtocol.swift
+++ b/ElementX/Sources/Screens/Authentication/LoginScreen/LoginViewModelProtocol.swift
@@ -18,7 +18,6 @@ import Foundation
 
 @MainActor
 protocol LoginViewModelProtocol {
-    
     var callback: (@MainActor(LoginViewModelAction) -> Void)? { get set }
     var context: LoginViewModelType.Context { get }
     

--- a/ElementX/Sources/Screens/Authentication/LoginScreen/View/LoginScreen.swift
+++ b/ElementX/Sources/Screens/Authentication/LoginScreen/View/LoginScreen.swift
@@ -17,7 +17,6 @@
 import SwiftUI
 
 struct LoginScreen: View {
-
     // MARK: - Properties
     
     // MARK: Private
@@ -54,7 +53,6 @@ struct LoginScreen: View {
                 default:
                     loginUnavailableText
                 }
-                
             }
             .readableFrame()
             .padding(.horizontal, 16)

--- a/ElementX/Sources/Screens/Authentication/LoginScreen/View/LoginServerInfoSection.swift
+++ b/ElementX/Sources/Screens/Authentication/LoginScreen/View/LoginServerInfoSection.swift
@@ -19,7 +19,6 @@ import SwiftUI
 /// A view that shows information about the chosen homeserver,
 /// along with an edit button to pick a different one.
 struct LoginServerInfoSection: View {
-    
     // MARK: - Public
     
     /// The address shown for the server.

--- a/ElementX/Sources/Screens/Authentication/ServerSelection/ServerSelectionCoordinator.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerSelection/ServerSelectionCoordinator.swift
@@ -29,7 +29,6 @@ enum ServerSelectionCoordinatorAction {
 }
 
 final class ServerSelectionCoordinator: Coordinator, Presentable {
-    
     // MARK: - Properties
     
     // MARK: Private

--- a/ElementX/Sources/Screens/Authentication/ServerSelection/ServerSelectionViewModel.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerSelection/ServerSelectionViewModel.swift
@@ -19,7 +19,6 @@ import SwiftUI
 typealias ServerSelectionViewModelType = StateStoreViewModel<ServerSelectionViewState, ServerSelectionViewAction>
 
 class ServerSelectionViewModel: ServerSelectionViewModelType, ServerSelectionViewModelProtocol {
-
     // MARK: - Properties
 
     // MARK: Private

--- a/ElementX/Sources/Screens/Authentication/ServerSelection/ServerSelectionViewModelProtocol.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerSelection/ServerSelectionViewModelProtocol.swift
@@ -18,7 +18,6 @@ import Foundation
 
 @MainActor
 protocol ServerSelectionViewModelProtocol {
-    
     var callback: (@MainActor(ServerSelectionViewModelAction) -> Void)? { get set }
     var context: ServerSelectionViewModelType.Context { get }
     

--- a/ElementX/Sources/Screens/Authentication/ServerSelection/View/ServerSelectionScreen.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerSelection/View/ServerSelectionScreen.swift
@@ -17,7 +17,6 @@
 import SwiftUI
 
 struct ServerSelectionScreen: View {
-
     // MARK: - Properties
     
     // MARK: Private

--- a/ElementX/Sources/Screens/BugReport/BugReportCoordinator.swift
+++ b/ElementX/Sources/Screens/BugReport/BugReportCoordinator.swift
@@ -22,7 +22,6 @@ struct BugReportCoordinatorParameters {
 }
 
 final class BugReportCoordinator: Coordinator, Presentable {
-    
     // MARK: - Properties
     
     // MARK: Private

--- a/ElementX/Sources/Screens/BugReport/BugReportViewModel.swift
+++ b/ElementX/Sources/Screens/BugReport/BugReportViewModel.swift
@@ -21,7 +21,6 @@ typealias BugReportViewModelType = StateStoreViewModel<BugReportViewState,
     BugReportViewAction>
 @available(iOS 14, *)
 class BugReportViewModel: BugReportViewModelType, BugReportViewModelProtocol {
-
     // MARK: - Properties
 
     let bugReportService: BugReportServiceProtocol

--- a/ElementX/Sources/Screens/BugReport/BugReportViewModelProtocol.swift
+++ b/ElementX/Sources/Screens/BugReport/BugReportViewModelProtocol.swift
@@ -18,7 +18,6 @@ import Foundation
 
 @MainActor
 protocol BugReportViewModelProtocol {
-    
     var callback: ((BugReportViewModelAction) -> Void)? { get set }
     @available(iOS 14, *)
     var context: BugReportViewModelType.Context { get }

--- a/ElementX/Sources/Screens/BugReport/View/BugReportScreen.swift
+++ b/ElementX/Sources/Screens/BugReport/View/BugReportScreen.swift
@@ -17,7 +17,6 @@
 import SwiftUI
 
 struct BugReportScreen: View {
-
     // MARK: Private
     
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenCoordinator.swift
@@ -30,7 +30,6 @@ enum HomeScreenCoordinatorAction {
 }
 
 final class HomeScreenCoordinator: Coordinator, Presentable {
-    
     // MARK: - Properties
     
     // MARK: Private

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -20,7 +20,6 @@ import SwiftUI
 typealias HomeScreenViewModelType = StateStoreViewModel<HomeScreenViewState, HomeScreenViewAction>
 
 class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol {
-    
     private let attributedStringBuilder: AttributedStringBuilderProtocol
     
     private var roomUpdateListeners = Set<AnyCancellable>()
@@ -82,7 +81,6 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
                 }
                 .store(in: &roomUpdateListeners)
         }
-        
     }
     
     func updateWithUserAvatar(_ avatar: UIImage) {

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
@@ -17,7 +17,6 @@
 import SwiftUI
 
 struct HomeScreen: View {
-    
     @ObservedObject var context: HomeScreenViewModel.Context
     
     // MARK: Views
@@ -30,7 +29,6 @@ struct HomeScreen: View {
                     ProgressView()
                 }
             } else {
-                
                 if context.viewState.showSessionVerificationBanner {
                     HStack {
                         Text(ElementL10n.verificationVerifyDevice)
@@ -115,7 +113,6 @@ struct HomeScreen: View {
 }
 
 struct RoomCell: View {
-    
     @ScaledMetric private var avatarSize = 32.0
     
     let room: HomeScreenRoom

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
@@ -24,7 +24,6 @@ struct RoomScreenCoordinatorParameters {
 }
 
 final class RoomScreenCoordinator: Coordinator, Presentable {
-    
     // MARK: - Properties
     
     // MARK: Private

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -19,7 +19,6 @@ import SwiftUI
 typealias RoomScreenViewModelType = StateStoreViewModel<RoomScreenViewState, RoomScreenViewAction>
 
 class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol {
-    
     private enum Constants {
         static let backPaginationPageSize: UInt = 30
     }

--- a/ElementX/Sources/Screens/RoomScreen/View/ListTableViewAdapter.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/ListTableViewAdapter.swift
@@ -10,7 +10,6 @@ import Combine
 import UIKit
 
 class ListTableViewAdapter: NSObject, UITableViewDelegate {
-    
     private enum ContentOffsetDetails {
         case topOffset(previousVisibleIndexPath: IndexPath, previousItemCount: Int)
         case bottomOffset

--- a/ElementX/Sources/Screens/RoomScreen/View/MessageComposer.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/MessageComposer.swift
@@ -9,7 +9,6 @@
 import SwiftUI
 
 struct MessageComposer: View {
-    
     @Binding var text: String
     var disabled: Bool
     let action: () -> Void

--- a/ElementX/Sources/Screens/RoomScreen/View/MessageComposerTextField.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/MessageComposerTextField.swift
@@ -9,7 +9,6 @@
 import SwiftUI
 
 struct MessageComposerTextField: View {
-    
     @Binding private var text: String
     @State private var dynamicHeight: CGFloat = 100
     @State private var isEditing = false

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomHeaderView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomHeaderView.swift
@@ -13,7 +13,6 @@ import SwiftUI
 import Introspect
 
 struct RoomHeaderView: View {
-
     @ObservedObject var context: RoomScreenViewModel.Context
 
     var body: some View {
@@ -49,7 +48,6 @@ struct RoomHeaderView: View {
                 .accessibilityIdentifier("roomAvatarPlaceholderImage")
         }
     }
-
 }
 
 struct RoomHeaderView_Previews: PreviewProvider {

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
@@ -17,7 +17,6 @@
 import SwiftUI
 
 struct RoomScreen: View {
-    
     @ObservedObject var context: RoomScreenViewModel.Context
     
     var body: some View {

--- a/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemBubbledStylerView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemBubbledStylerView.swift
@@ -10,7 +10,6 @@ import Foundation
 import SwiftUI
 
 struct TimelineItemBubbledStylerView<Content: View>: View {
-
     let timelineItem: EventBasedTimelineItemProtocol
     @ViewBuilder let content: () -> Content
 
@@ -96,7 +95,6 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
         let opacity = colorScheme == .light ? 0.06 : 0.15
         return timelineItem.isOutgoing ? .element.accent.opacity(opacity) : .element.system
     }
-
 }
 
 struct TimelineItemBubbledStylerView_Previews: PreviewProvider {

--- a/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemPlainStylerView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemPlainStylerView.swift
@@ -10,7 +10,6 @@ import Foundation
 import SwiftUI
 
 struct TimelineItemPlainStylerView<Content: View>: View {
-
     let timelineItem: EventBasedTimelineItemProtocol
     @ViewBuilder let content: () -> Content
 

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/FormattedBodyText.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/FormattedBodyText.swift
@@ -39,7 +39,6 @@ struct FormattedBodyText_Previews: PreviewProvider {
     static var previews: some View {
         body.preferredColorScheme(.light)
         body.preferredColorScheme(.dark)
-        
     }
     
     @ViewBuilder

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/PlaceholderAvatarImage.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/PlaceholderAvatarImage.swift
@@ -17,7 +17,6 @@
 import SwiftUI
 
 struct PlaceholderAvatarImage: View {
-    
     private let textForImage: String
     
     var body: some View {

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineItemContextMenu.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineItemContextMenu.swift
@@ -9,7 +9,6 @@
 import SwiftUI
 
 public struct TimelineItemContextMenu: View {
-    
     let contextMenuActions: [TimelineItemContextMenuAction]
     let callback: (TimelineItemContextMenuAction) -> Void
     

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineItemList.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineItemList.swift
@@ -11,7 +11,6 @@ import Introspect
 import SwiftUI
 
 struct TimelineItemList: View {
-    
     @State private var tableViewObserver = ListTableViewAdapter()
     @State private var timelineItems: [RoomTimelineViewProvider] = []
     @State private var hasPendingChanges = false

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineSenderAvatarView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineSenderAvatarView.swift
@@ -10,7 +10,6 @@ import Foundation
 import SwiftUI
 
 struct TimelineSenderAvatarView: View {
-
     let timelineItem: EventBasedTimelineItemProtocol
 
     @ScaledMetric private var avatarSize = 26
@@ -35,5 +34,4 @@ struct TimelineSenderAvatarView: View {
 
         .animation(.default, value: timelineItem.senderAvatar)
     }
-
 }

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineView.swift
@@ -13,7 +13,6 @@ import SwiftUI
 import Introspect
 
 struct TimelineView: View {
-    
     @State private var bottomVisiblePublisher = PassthroughSubject<Bool, Never>()
     @State private var scrollToBottomPublisher = PassthroughSubject<Void, Never>()
     @State private var scollToBottomButtonVisible = false

--- a/ElementX/Sources/Screens/SessionVerification/SessionVerificationCoordinator.swift
+++ b/ElementX/Sources/Screens/SessionVerification/SessionVerificationCoordinator.swift
@@ -21,7 +21,6 @@ struct SessionVerificationCoordinatorParameters {
 }
 
 final class SessionVerificationCoordinator: Coordinator, Presentable {
-    
     // MARK: - Properties
     
     // MARK: Private

--- a/ElementX/Sources/Screens/SessionVerification/SessionVerificationViewModel.swift
+++ b/ElementX/Sources/Screens/SessionVerification/SessionVerificationViewModel.swift
@@ -19,7 +19,6 @@ import SwiftUI
 typealias SessionVerificationViewModelType = StateStoreViewModel<SessionVerificationViewState, SessionVerificationViewAction>
 
 class SessionVerificationViewModel: SessionVerificationViewModelType, SessionVerificationViewModelProtocol {
-
     // MARK: - Properties
 
     // MARK: Private
@@ -36,7 +35,6 @@ class SessionVerificationViewModel: SessionVerificationViewModelType, SessionVer
 
     init(sessionVerificationControllerProxy: SessionVerificationControllerProxyProtocol,
          initialState: SessionVerificationViewState = SessionVerificationViewState()) {
-        
         self.sessionVerificationControllerProxy = sessionVerificationControllerProxy
         
         stateMachine = SessionVerificationStateMachine()

--- a/ElementX/Sources/Screens/SessionVerification/View/SessionVerificationScreen.swift
+++ b/ElementX/Sources/Screens/SessionVerification/View/SessionVerificationScreen.swift
@@ -18,7 +18,6 @@ import MatrixRustSDK
 import SwiftUI
 
 struct SessionVerificationScreen: View {
-    
     @ObservedObject var context: SessionVerificationViewModel.Context
     
     // MARK: Views

--- a/ElementX/Sources/Screens/Settings/SettingsCoordinator.swift
+++ b/ElementX/Sources/Screens/Settings/SettingsCoordinator.swift
@@ -26,7 +26,6 @@ enum SettingsCoordinatorAction {
 }
 
 final class SettingsCoordinator: Coordinator, Presentable {
-    
     // MARK: - Properties
     
     // MARK: Private

--- a/ElementX/Sources/Screens/Settings/SettingsViewModel.swift
+++ b/ElementX/Sources/Screens/Settings/SettingsViewModel.swift
@@ -21,7 +21,6 @@ typealias SettingsViewModelType = StateStoreViewModel<SettingsViewState,
     SettingsViewAction>
 @available(iOS 14, *)
 class SettingsViewModel: SettingsViewModelType, SettingsViewModelProtocol {
-
     // MARK: - Properties
 
     // MARK: Private

--- a/ElementX/Sources/Screens/Settings/SettingsViewModelProtocol.swift
+++ b/ElementX/Sources/Screens/Settings/SettingsViewModelProtocol.swift
@@ -18,7 +18,6 @@ import Foundation
 
 @MainActor
 protocol SettingsViewModelProtocol {
-    
     var callback: ((SettingsViewModelAction) -> Void)? { get set }
     @available(iOS 14, *)
     var context: SettingsViewModelType.Context { get }

--- a/ElementX/Sources/Screens/Settings/View/SettingsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/View/SettingsScreen.swift
@@ -17,7 +17,6 @@
 import SwiftUI
 
 struct SettingsScreen: View {
-
     // MARK: Private
 
     @State private var showingLogoutConfirmation = false

--- a/ElementX/Sources/Screens/SplashScreen/SplashScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/SplashScreen/SplashScreenCoordinator.swift
@@ -17,7 +17,6 @@
 import SwiftUI
 
 final class SplashScreenCoordinator: Coordinator, Presentable {
-    
     // MARK: - Properties
     
     // MARK: Private

--- a/ElementX/Sources/Screens/SplashScreen/SplashScreenModels.swift
+++ b/ElementX/Sources/Screens/SplashScreen/SplashScreenModels.swift
@@ -38,7 +38,6 @@ enum SplashScreenViewModelAction {
 // MARK: View
 
 struct SplashScreenViewState: BindableState {
-    
     /// The colours of the background gradient shown behind the 4 pages.
     private let gradientColors = [
         Color(red: 0.95, green: 0.98, blue: 0.96),

--- a/ElementX/Sources/Screens/SplashScreen/SplashScreenViewModel.swift
+++ b/ElementX/Sources/Screens/SplashScreen/SplashScreenViewModel.swift
@@ -20,7 +20,6 @@ import SwiftUI
 typealias SplashScreenViewModelType = StateStoreViewModel<SplashScreenViewState, SplashScreenViewAction>
 
 class SplashScreenViewModel: SplashScreenViewModelType, SplashScreenViewModelProtocol {
-
     // MARK: - Properties
 
     // MARK: Private

--- a/ElementX/Sources/Screens/SplashScreen/View/SplashScreen.swift
+++ b/ElementX/Sources/Screens/SplashScreen/View/SplashScreen.swift
@@ -19,7 +19,6 @@ import SwiftUI
 
 /// The splash screen shown at the beginning of the onboarding flow.
 struct SplashScreen: View {
-
     // MARK: - Properties
     
     // MARK: Private
@@ -47,7 +46,6 @@ struct SplashScreen: View {
                 
                 // The main content of the carousel
                 HStack(alignment: .top, spacing: 0) {
-                    
                     // Add a hidden page at the start of the carousel duplicating the content of the last page
                     SplashScreenPageView(content: context.viewState.content[pageCount - 1])
                         .frame(width: geometry.size.width)
@@ -57,7 +55,6 @@ struct SplashScreen: View {
                         SplashScreenPageView(content: context.viewState.content[index])
                             .frame(width: geometry.size.width)
                     }
-                    
                 }
                 .offset(x: pageOffset(in: geometry))
                 

--- a/ElementX/Sources/Screens/SplashScreen/View/SplashScreenPageIndicator.swift
+++ b/ElementX/Sources/Screens/SplashScreen/View/SplashScreenPageIndicator.swift
@@ -17,7 +17,6 @@
 import SwiftUI
 
 struct SplashScreenPageIndicator: View {
-    
     // MARK: - Properties
     
     // MARK: Public

--- a/ElementX/Sources/Screens/SplashScreen/View/SplashScreenPageView.swift
+++ b/ElementX/Sources/Screens/SplashScreen/View/SplashScreenPageView.swift
@@ -17,7 +17,6 @@
 import SwiftUI
 
 struct SplashScreenPageView: View {
-    
     // MARK: - Properties
     
     // MARK: Public

--- a/ElementX/Sources/Services/Authentication/AuthenticationService.swift
+++ b/ElementX/Sources/Services/Authentication/AuthenticationService.swift
@@ -10,7 +10,6 @@ import Foundation
 import MatrixRustSDK
 
 class AuthenticationService: AuthenticationServiceProtocol {
-    
     // MARK: - Properties
     
     // MARK: Private

--- a/ElementX/Sources/Services/Background/BackgroundTaskServiceProtocol.swift
+++ b/ElementX/Sources/Services/Background/BackgroundTaskServiceProtocol.swift
@@ -9,15 +9,12 @@
 import Foundation
 
 protocol BackgroundTaskServiceProtocol {
-
     func startBackgroundTask(withName name: String,
                              isReusable: Bool,
                              expirationHandler: (() -> Void)?) -> BackgroundTaskProtocol?
-
 }
 
 extension BackgroundTaskServiceProtocol {
-
     func startBackgroundTask(withName name: String) -> BackgroundTaskProtocol? {
         startBackgroundTask(withName: name,
                             expirationHandler: nil)
@@ -36,5 +33,4 @@ extension BackgroundTaskServiceProtocol {
                             isReusable: false,
                             expirationHandler: expirationHandler)
     }
-
 }

--- a/ElementX/Sources/Services/Background/UIKitBackgroundTaskService.swift
+++ b/ElementX/Sources/Services/Background/UIKitBackgroundTaskService.swift
@@ -11,7 +11,6 @@ import UIKit
 
 /// /// UIKitBackgroundTaskService is a concrete implementation of BackgroundTaskServiceProtocol using a given `ApplicationProtocol`  instance.
 class UIKitBackgroundTaskService: BackgroundTaskServiceProtocol {
-
     private let application: ApplicationProtocol?
     private var reusableTasks: WeakDictionary<String, UIKitBackgroundTask> = WeakDictionary()
 
@@ -91,7 +90,6 @@ class UIKitBackgroundTaskService: BackgroundTaskServiceProtocol {
         }
         return false
     }
-
 }
 
 private extension TimeInterval {

--- a/ElementX/Sources/Services/BugReport/BugReportService.swift
+++ b/ElementX/Sources/Services/BugReport/BugReportService.swift
@@ -213,7 +213,6 @@ class BugReportService: BugReportServiceProtocol {
 
         return zippedFiles
     }
-
 }
 
 private extension Data {

--- a/ElementX/Sources/Services/BugReport/BugReportServiceProtocol.swift
+++ b/ElementX/Sources/Services/BugReport/BugReportServiceProtocol.swift
@@ -14,7 +14,6 @@ struct SubmitBugReportResponse: Decodable {
 }
 
 protocol BugReportServiceProtocol {
-
     var crashedLastRun: Bool { get }
 
     func crash()

--- a/ElementX/Sources/Services/BugReport/MockBugReportService.swift
+++ b/ElementX/Sources/Services/BugReport/MockBugReportService.swift
@@ -10,7 +10,6 @@ import Foundation
 import UIKit
 
 class MockBugReportService: BugReportServiceProtocol {
-
     func submitBugReport(text: String,
                          includeLogs: Bool,
                          includeCrashLog: Bool,
@@ -24,5 +23,4 @@ class MockBugReportService: BugReportServiceProtocol {
     func crash() {
         // no-op
     }
-
 }

--- a/ElementX/Sources/Services/BugReport/ScreenshotDetector.swift
+++ b/ElementX/Sources/Services/BugReport/ScreenshotDetector.swift
@@ -17,7 +17,6 @@ enum ScreenshotDetectorError: String, Error {
 
 @MainActor
 class ScreenshotDetector {
-
     var callback: (@MainActor(UIImage?, Error?) -> Void)?
 
     /// Flag to whether ask for photos authorization by default if needed.
@@ -80,11 +79,9 @@ class ScreenshotDetector {
     func fail(withError error: Error) {
         callback?(nil, error)
     }
-
 }
 
 private extension PHAsset {
-
     static func fetchLastScreenshot() -> PHAsset? {
         let options = PHFetchOptions()
 
@@ -99,7 +96,6 @@ private extension PHAsset {
 }
 
 private extension PHImageRequestOptions {
-
     static var highQualitySyncLocal: PHImageRequestOptions {
         let options = PHImageRequestOptions()
         options.deliveryMode = .highQualityFormat

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -24,7 +24,6 @@ private class WeakClientProxyWrapper: ClientDelegate {
 }
 
 class ClientProxy: ClientProxyProtocol {
-    
     private let client: Client
     private let backgroundTaskService: BackgroundTaskServiceProtocol
     private var sessionVerificationControllerProxy: SessionVerificationControllerProxy?
@@ -71,7 +70,6 @@ class ClientProxy: ClientProxyProtocol {
             } catch {
                 return .failure(.failedRetrievingDisplayName)
             }
-            
         }
         .value
     }

--- a/ElementX/Sources/Services/Client/MockClientProxy.swift
+++ b/ElementX/Sources/Services/Client/MockClientProxy.swift
@@ -10,7 +10,6 @@ import Combine
 import MatrixRustSDK
 
 struct MockClientProxy: ClientProxyProtocol {
-    
     let callbacks = PassthroughSubject<ClientProxyCallback, Never>()
     
     let userIdentifier: String

--- a/ElementX/Sources/Services/Media/MockMediaProvider.swift
+++ b/ElementX/Sources/Services/Media/MockMediaProvider.swift
@@ -10,7 +10,6 @@ import Foundation
 import UIKit
 
 struct MockMediaProvider: MediaProviderProtocol {
-    
     func imageFromSource(_ source: MediaSource?) -> UIImage? {
         nil
     }

--- a/ElementX/Sources/Services/Room/Members/MemberDetailProviderManager.swift
+++ b/ElementX/Sources/Services/Room/Members/MemberDetailProviderManager.swift
@@ -10,7 +10,6 @@ import Foundation
 
 @MainActor
 class MemberDetailProviderManager {
-    
     private var memberDetailProviders: [String: MemberDetailProviderProtocol] = [:]
     
     func memberDetailProviderForRoomProxy(_ roomProxy: RoomProxyProtocol) -> MemberDetailProviderProtocol {

--- a/ElementX/Sources/Services/Room/RoomSummary/EventBriefFactory.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/EventBriefFactory.swift
@@ -9,7 +9,6 @@
 import Foundation
 
 struct EventBriefFactory: EventBriefFactoryProtocol {
-    
     private let memberDetailProvider: MemberDetailProviderProtocol
     
     init(memberDetailProvider: MemberDetailProviderProtocol) {

--- a/ElementX/Sources/Services/Timeline/MockRoomTimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/MockRoomTimelineController.swift
@@ -10,7 +10,6 @@ import Combine
 import Foundation
 
 class MockRoomTimelineController: RoomTimelineControllerProtocol {
-    
     let callbacks = PassthroughSubject<RoomTimelineControllerCallback, Never>()
     
     var timelineItems: [RoomTimelineItemProtocol] = [SeparatorRoomTimelineItem(id: UUID().uuidString,

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
@@ -67,7 +67,6 @@ struct RoomTimelineItemFactory: RoomTimelineItemFactoryProtocol {
                                                    _ showSenderDetails: Bool,
                                                    _ displayName: String?,
                                                    _ avatarImage: UIImage?) -> RoomTimelineItemProtocol {
-        
         var aspectRatio: CGFloat?
         if let width = message.width,
            let height = message.height {

--- a/ElementX/Sources/Services/UserSessionStore/UserSessionStore.swift
+++ b/ElementX/Sources/Services/UserSessionStore/UserSessionStore.swift
@@ -19,7 +19,6 @@ import Kingfisher
 import MatrixRustSDK
 
 class UserSessionStore: UserSessionStoreProtocol {
-    
     private let keychainController: KeychainControllerProtocol
     private let backgroundTaskService: BackgroundTaskServiceProtocol
     

--- a/ElementX/Sources/UITestsRootView.swift
+++ b/ElementX/Sources/UITestsRootView.swift
@@ -9,7 +9,6 @@
 import SwiftUI
 
 struct UITestsRootView: View {
-    
     let mockScreens: [MockScreen]
     var selectionCallback: ((UITestScreenIdentifier) -> Void)?
     

--- a/Tools/Scripts/Templates/SimpleScreenExample/ElementX/TemplateCoordinator.swift
+++ b/Tools/Scripts/Templates/SimpleScreenExample/ElementX/TemplateCoordinator.swift
@@ -26,7 +26,6 @@ enum TemplateCoordinatorAction {
 }
 
 final class TemplateCoordinator: Coordinator, Presentable {
-    
     // MARK: - Properties
     
     // MARK: Private

--- a/Tools/Scripts/Templates/SimpleScreenExample/ElementX/TemplateViewModel.swift
+++ b/Tools/Scripts/Templates/SimpleScreenExample/ElementX/TemplateViewModel.swift
@@ -19,7 +19,6 @@ import SwiftUI
 typealias TemplateViewModelType = StateStoreViewModel<TemplateViewState, TemplateViewAction>
 
 class TemplateViewModel: TemplateViewModelType, TemplateViewModelProtocol {
-
     // MARK: - Properties
 
     // MARK: Private

--- a/Tools/Scripts/Templates/SimpleScreenExample/ElementX/View/TemplateScreen.swift
+++ b/Tools/Scripts/Templates/SimpleScreenExample/ElementX/View/TemplateScreen.swift
@@ -17,7 +17,6 @@
 import SwiftUI
 
 struct TemplateScreen: View {
-
     // MARK: Private
     
     @Environment(\.colorScheme) private var colorScheme

--- a/UITests/Sources/BugReportUITests.swift
+++ b/UITests/Sources/BugReportUITests.swift
@@ -18,7 +18,6 @@ import ElementX
 import XCTest
 
 class BugReportUITests: XCTestCase {
-
     func testInitialStateComponents() {
         let app = Application.launch()
         app.goToScreenWithIdentifier(.bugReport)
@@ -85,7 +84,6 @@ class BugReportUITests: XCTestCase {
         XCTAssertEqual(sendButton.label, ElementL10n.actionSend)
         XCTAssertFalse(sendButton.isEnabled)
     }
-
 }
 
 extension XCUIElement {

--- a/UITests/Sources/RoomScreenUITests.swift
+++ b/UITests/Sources/RoomScreenUITests.swift
@@ -19,7 +19,6 @@ import XCTest
 
 @MainActor
 class RoomScreenUITests: XCTestCase {
-
     func testPlainNoAvatar() {
         let app = Application.launch()
         app.goToScreenWithIdentifier(.roomPlainNoAvatar)

--- a/UITests/Sources/ServerSelectionUITests.swift
+++ b/UITests/Sources/ServerSelectionUITests.swift
@@ -19,7 +19,6 @@ import XCTest
 
 @MainActor
 class ServerSelectionUITests: XCTestCase {
-    
     let textFieldIdentifier = "addressTextField"
     
     func testNormalState() async {

--- a/UITests/Sources/SessionVerificationUITests.swift
+++ b/UITests/Sources/SessionVerificationUITests.swift
@@ -18,7 +18,6 @@ import ElementX
 import XCTest
 
 class SessionVerificationUITests: XCTestCase {
-    
     func testChallengeMatches() {
         let app = Application.launch()
         app.goToScreenWithIdentifier(.sessionVerification)

--- a/UITests/Sources/SettingsUITests.swift
+++ b/UITests/Sources/SettingsUITests.swift
@@ -18,7 +18,6 @@ import ElementX
 import XCTest
 
 class SettingsUITests: XCTestCase {
-
     func testInitialStateComponents() {
         let app = Application.launch()
         app.goToScreenWithIdentifier(.settings)
@@ -37,5 +36,4 @@ class SettingsUITests: XCTestCase {
         XCTAssert(logoutButton.exists)
         XCTAssertEqual(logoutButton.label, ElementL10n.logout)
     }
-
 }

--- a/UnitTests/Sources/AttributedStringBuilderTests.swift
+++ b/UnitTests/Sources/AttributedStringBuilderTests.swift
@@ -10,7 +10,6 @@
 import XCTest
 
 class AttributedStringBuilderTests: XCTestCase {
-
     let attributedStringBuilder = AttributedStringBuilder()
     let maxHeaderPointSize = ceil(UIFont.preferredFont(forTextStyle: .body).pointSize * 1.2)
     
@@ -370,7 +369,6 @@ class AttributedStringBuilderTests: XCTestCase {
     // MARK: - Private
     
     private func checkMatrixEntityLinkIn(attributedString: AttributedString?, expected: String) {
-        
         guard let attributedString = attributedString else {
             XCTFail("Could not build the attributed string")
             return

--- a/UnitTests/Sources/BackgroundTaskTests.swift
+++ b/UnitTests/Sources/BackgroundTaskTests.swift
@@ -11,7 +11,6 @@ import XCTest
 @testable import ElementX
 
 class BackgroundTaskTests: XCTestCase {
-
     private enum Constants {
         static let bgTaskName = "test"
     }
@@ -155,11 +154,9 @@ class BackgroundTaskTests: XCTestCase {
 
         XCTAssertNil(task, "Task should not be created")
     }
-
 }
 
 private extension UIApplication {
-
     static var mockHealty: ApplicationProtocol {
         MockApplication()
     }
@@ -175,11 +172,9 @@ private extension UIApplication {
                         backgroundTimeRemaining: 2,
                         allowTasks: false)
     }
-
 }
 
 private class MockApplication: ApplicationProtocol {
-
     let applicationState: UIApplication.State
     let backgroundTimeRemaining: TimeInterval
     private let allowTasks: Bool
@@ -223,5 +218,4 @@ private class MockApplication: ApplicationProtocol {
         }
         bgTasks.removeValue(forKey: identifier)
     }
-
 }

--- a/UnitTests/Sources/BugReportServiceTests.swift
+++ b/UnitTests/Sources/BugReportServiceTests.swift
@@ -11,7 +11,6 @@ import Foundation
 import XCTest
 
 class BugReportServiceTests: XCTestCase {
-
     let bugReportService = MockBugReportService()
 
     func testInitialStateWithMockService() {
@@ -49,11 +48,9 @@ class BugReportServiceTests: XCTestCase {
         
         XCTAssertEqual(result.reportUrl, "https://example.com/123")
     }
-
 }
 
 private class MockURLProtocol: URLProtocol {
-
     override func startLoading() {
         let response = "{\"report_url\":\"https://example.com/123\"}"
         if let data = response.data(using: .utf8) {
@@ -75,16 +72,13 @@ private class MockURLProtocol: URLProtocol {
     override class func canInit(with request: URLRequest) -> Bool {
         true
     }
-
 }
 
 private extension URLSession {
-
     static var mock: URLSession {
         let configuration = URLSessionConfiguration.default
         configuration.protocolClasses = [MockURLProtocol.self] + (configuration.protocolClasses ?? [])
         let result = URLSession(configuration: configuration)
         return result
     }
-
 }

--- a/UnitTests/Sources/BugReportViewModelTests.swift
+++ b/UnitTests/Sources/BugReportViewModelTests.swift
@@ -20,7 +20,6 @@ import XCTest
 
 @MainActor
 class BugReportViewModelTests: XCTestCase {
-
     func testInitialState() {
         let viewModel = BugReportViewModel(bugReportService: MockBugReportService(), screenshot: nil)
         let context = viewModel.context

--- a/UnitTests/Sources/ElementXTests.swift
+++ b/UnitTests/Sources/ElementXTests.swift
@@ -10,7 +10,6 @@
 import XCTest
 
 class ElementXTests: XCTestCase {
-
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }

--- a/UnitTests/Sources/HomeScreenViewModelTests.swift
+++ b/UnitTests/Sources/HomeScreenViewModelTests.swift
@@ -19,7 +19,6 @@ import XCTest
 @testable import ElementX
 
 class HomeScreenViewModelTests: XCTestCase {
-
     var viewModel: HomeScreenViewModelProtocol!
     var context: HomeScreenViewModelType.Context!
 
@@ -63,5 +62,4 @@ class HomeScreenViewModelTests: XCTestCase {
         await Task.yield()
         XCTAssert(correctResult)
     }
-
 }

--- a/UnitTests/Sources/ImageAnonymizerTests.swift
+++ b/UnitTests/Sources/ImageAnonymizerTests.swift
@@ -14,7 +14,6 @@ enum ImageAnonymizerTestsError: String, Error {
 }
 
 class ImageAnonymizerTests: XCTestCase {
-
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
@@ -53,5 +52,4 @@ class ImageAnonymizerTests: XCTestCase {
         XCTAssertNotEqual(image, anonymizedRed)
         XCTAssertNotEqual(anonymizedBlue, anonymizedRed)
     }
-
 }

--- a/UnitTests/Sources/LocalizationTests.swift
+++ b/UnitTests/Sources/LocalizationTests.swift
@@ -10,7 +10,6 @@
 import XCTest
 
 class LocalizationTests: XCTestCase {
-
     /// Test ElementL10n considers app language changes
     func testAppLanguage() {
         //  set app language to English
@@ -101,5 +100,4 @@ class LocalizationTests: XCTestCase {
         XCTAssertEqual(ElementL10n.untranslatedPlural(1), "One untranslated item")
         XCTAssertEqual(ElementL10n.untranslatedPlural(5), "5 untranslated items")
     }
-
 }

--- a/UnitTests/Sources/LoggingTests.swift
+++ b/UnitTests/Sources/LoggingTests.swift
@@ -10,7 +10,6 @@
 import XCTest
 
 class LoggingTests: XCTestCase {
-
     private enum Constants {
         static let genericFailure = "Test failed"
     }
@@ -92,5 +91,4 @@ class LoggingTests: XCTestCase {
 
         XCTAssertTrue(logFile.contains(subLogName))
     }
-
 }

--- a/UnitTests/Sources/ScreenshotDetectorTests.swift
+++ b/UnitTests/Sources/ScreenshotDetectorTests.swift
@@ -12,7 +12,6 @@ import Photos
 import XCTest
 
 class ScreenshotDetectorTests: XCTestCase {
-
     @MainActor func testDetection() async {
         async { expectation in
             let detector = ScreenshotDetector()
@@ -59,5 +58,4 @@ class ScreenshotDetectorTests: XCTestCase {
         block(expectation)
         waiter.wait(for: [expectation], timeout: timeout)
     }
-
 }

--- a/UnitTests/Sources/SessionVerificationViewModelTests.swift
+++ b/UnitTests/Sources/SessionVerificationViewModelTests.swift
@@ -21,7 +21,6 @@ import XCTest
 
 @MainActor
 class SessionVerificationViewModelTests: XCTestCase {
-    
     var viewModel: SessionVerificationViewModelProtocol!
     var context: SessionVerificationViewModelType.Context!
     var sessionVerificationController: SessionVerificationControllerProxyProtocol!
@@ -70,7 +69,6 @@ class SessionVerificationViewModelTests: XCTestCase {
     }
     
     func testAcceptChallenge() {
-        
         setupChallengeReceived()
         
         let waitForAcceptance = XCTestExpectation(description: "Wait for acceptance")
@@ -98,7 +96,6 @@ class SessionVerificationViewModelTests: XCTestCase {
     }
     
     func testDeclineChallenge() {
-        
         setupChallengeReceived()
         
         let expectation = XCTestExpectation(description: "Wait for cancellation")

--- a/UnitTests/Sources/SettingsViewModelTests.swift
+++ b/UnitTests/Sources/SettingsViewModelTests.swift
@@ -20,7 +20,6 @@ import XCTest
 
 @MainActor
 class SettingsViewModelTests: XCTestCase {
-
     var viewModel: SettingsViewModelProtocol!
     var context: SettingsViewModelType.Context!
     
@@ -66,5 +65,4 @@ class SettingsViewModelTests: XCTestCase {
         await Task.yield()
         XCTAssert(correctResult)
     }
-
 }


### PR DESCRIPTION
@ismailgulek You were right, these are good too. TBH I thought they did something around `// MARK:` comments which was why I disabled them. Definitely makes sense to enable these 👍