### PR TITLE
chore: Setup HTTP request logging for the release as well

### DIFF
--- a/ElementX/Sources/Other/Logging/RustTracing.swift
+++ b/ElementX/Sources/Other/Logging/RustTracing.swift
@@ -50,7 +50,8 @@ struct TracingConfiguration {
         .hyper: .warn,
         .sled: .warn,
         .matrix_sdk_sled: .warn,
-        .matrix_sdk_crypto: .debug
+        .matrix_sdk_crypto: .debug,
+        .matrix_sdk_http_client: .debug
     ]
     
     var filter: String {


### PR DESCRIPTION
This should wait for https://github.com/matrix-org/matrix-rust-sdk/pull/1358

Available in https://github.com/matrix-org/matrix-rust-components-swift/releases/tag/v1.0.32-alpha, needs https://github.com/vector-im/element-x-ios/pull/463/