### PR TITLE
Remove ”copy” action for location events

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -411,7 +411,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
             actions.append(.edit)
         }
 
-        if item.isMessage, !(item is LocationRoomTimelineItem) {
+        if item.isMessage, !item.isLocation {
             actions.append(.copy)
         }
         

--- a/ElementX/Sources/Services/Timeline/TimelineItems/EventBasedTimelineItemProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/EventBasedTimelineItemProtocol.swift
@@ -42,6 +42,10 @@ extension EventBasedTimelineItemProtocol {
         self is EventBasedMessageTimelineItemProtocol
     }
 
+    var isLocation: Bool {
+        self is LocationRoomTimelineItem
+    }
+
     var isRedacted: Bool {
         self is RedactedRoomTimelineItem
     }


### PR DESCRIPTION
Reason: copying the textual representation of a location isn't really useful for users. When people want to share a location, they should use the forward action or the share sheet instead.

| Before | After |
| --- | --- |
|![before](https://github.com/vector-im/element-x-ios/assets/19324622/7659b6df-a387-41c2-9ac0-98e499afc737)|![after](https://github.com/vector-im/element-x-ios/assets/19324622/04ee3899-598d-4817-86df-4b2013af53ff)|
