### PR TITLE
Update DSWaveformImage to 14.1.1

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -6395,8 +6395,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/dmrschmidt/DSWaveformImage";
 			requirement = {
-				kind = revision;
-				revision = 6a4c99a8ab2d2a03f42de21fb8777172ebbcccb1;
+				kind = exactVersion;
+				version = 14.1.1;
 			};
 		};
 		61916C63E3F5BD900F08DA0C /* XCRemoteSwiftPackageReference "KeychainAccess" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -30,7 +30,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/dmrschmidt/DSWaveformImage",
       "state" : {
-        "revision" : "6a4c99a8ab2d2a03f42de21fb8777172ebbcccb1"
+        "revision" : "6074c2334a5a34afaa8394df853c8ceb026ad137",
+        "version" : "14.1.1"
       }
     },
     {
@@ -261,7 +262,7 @@
     {
       "identity" : "swiftui-introspect",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/siteline/SwiftUI-Introspect.git",
+      "location" : "https://github.com/siteline/SwiftUI-Introspect",
       "state" : {
         "revision" : "b94da693e57eaf79d16464b8b7c90d09cba4e290",
         "version" : "0.9.2"

--- a/project.yml
+++ b/project.yml
@@ -119,7 +119,7 @@ packages:
     branch: 0.0.1
   DSWaveformImage:
     url: https://github.com/dmrschmidt/DSWaveformImage
-    revision: 6a4c99a8ab2d2a03f42de21fb8777172ebbcccb1
+    exactVersion: 14.1.1
 
 
 


### PR DESCRIPTION
This PR updates DSWaveformImage to 14.1.1 which is not compatible with Xcode 14 (undoing this [fix](https://github.com/vector-im/element-x-ios/pull/1928)).