### PR TITLE
Always send formatted content

### DIFF
--- a/ElementX.xcodeproj/xcshareddata/xcschemes/ElementX.xcscheme
+++ b/ElementX.xcodeproj/xcshareddata/xcschemes/ElementX.xcscheme
@@ -4,8 +4,7 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES"
-      runPostActionsOnFailure = "NO">
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -30,12 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "YES">
-      <TestPlans>
-         <TestPlanReference
-            default = "YES"
-            reference = "container:UnitTests/SupportingFiles/UnitTests.xctestplan">
-         </TestPlanReference>
-      </TestPlans>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -45,10 +38,6 @@
             ReferencedContainer = "container:ElementX.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <Testables>
-      </Testables>
-      <CommandLineArguments>
-      </CommandLineArguments>
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -58,6 +47,12 @@
             ReferencedContainer = "container:ElementX.xcodeproj">
          </BuildableReference>
       </CodeCoverageTargets>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:UnitTests/SupportingFiles/UnitTests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -79,8 +74,6 @@
             ReferencedContainer = "container:ElementX.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-      </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "HTTPS_PROXY"
@@ -115,8 +108,6 @@
             ReferencedContainer = "container:ElementX.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/ElementX.xcodeproj/xcshareddata/xcschemes/ElementX.xcscheme
+++ b/ElementX.xcodeproj/xcshareddata/xcschemes/ElementX.xcscheme
@@ -4,7 +4,8 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -29,6 +30,12 @@
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <TestPlans>
+         <TestPlanReference
+            default = "YES"
+            reference = "container:UnitTests/SupportingFiles/UnitTests.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,6 +45,10 @@
             ReferencedContainer = "container:ElementX.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <Testables>
+      </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -47,12 +58,6 @@
             ReferencedContainer = "container:ElementX.xcodeproj">
          </BuildableReference>
       </CodeCoverageTargets>
-      <TestPlans>
-         <TestPlanReference
-            reference = "container:UnitTests/SupportingFiles/UnitTests.xctestplan"
-            default = "YES">
-         </TestPlanReference>
-      </TestPlans>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -74,6 +79,8 @@
             ReferencedContainer = "container:ElementX.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "HTTPS_PROXY"
@@ -108,6 +115,8 @@
             ReferencedContainer = "container:ElementX.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/ElementX/Sources/Screens/ComposerToolbar/ComposerToolbarModels.swift
+++ b/ElementX/Sources/Screens/ComposerToolbar/ComposerToolbarModels.swift
@@ -31,7 +31,7 @@ enum ComposerToolbarVoiceMessageAction {
 }
 
 enum ComposerToolbarViewModelAction {
-    case sendMessage(plain: String, html: String?, mode: RoomScreenComposerMode, intentionalMentions: IntentionalMentions)
+    case sendMessage(plain: String, html: String, mode: RoomScreenComposerMode, intentionalMentions: IntentionalMentions)
     case displayCameraPicker
     case displayMediaPicker
     case displayDocumentPicker

--- a/ElementX/Sources/Screens/ComposerToolbar/ComposerToolbarViewModel.swift
+++ b/ElementX/Sources/Screens/ComposerToolbar/ComposerToolbarViewModel.swift
@@ -109,7 +109,7 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
             default:
                 let sendHTML = ServiceLocator.shared.settings.richTextEditorEnabled
                 actionsSubject.send(.sendMessage(plain: wysiwygViewModel.content.markdown,
-                                                 html: sendHTML ? wysiwygViewModel.content.html : nil,
+                                                 html: wysiwygViewModel.content.html,
                                                  mode: state.composerMode,
                                                  intentionalMentions: wysiwygViewModel
                                                      .getMentionsState()

--- a/ElementX/Sources/Screens/ComposerToolbar/ComposerToolbarViewModel.swift
+++ b/ElementX/Sources/Screens/ComposerToolbar/ComposerToolbarViewModel.swift
@@ -107,7 +107,6 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
             case .previewVoiceMessage:
                 actionsSubject.send(.voiceMessage(.send))
             default:
-                let sendHTML = ServiceLocator.shared.settings.richTextEditorEnabled
                 actionsSubject.send(.sendMessage(plain: wysiwygViewModel.content.markdown,
                                                  html: wysiwygViewModel.content.html,
                                                  mode: state.composerMode,

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -439,7 +439,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
         state.showLoading = false
     }
 
-    private func sendCurrentMessage(_ message: String, html: String?, mode: RoomScreenComposerMode, intentionalMentions: IntentionalMentions) async {
+    private func sendCurrentMessage(_ message: String, html: String, mode: RoomScreenComposerMode, intentionalMentions: IntentionalMentions) async {
         guard !message.isEmpty else {
             fatalError("This message should never be empty")
         }

--- a/UnitTests/Sources/ComposerToolbarViewModelTests.swift
+++ b/UnitTests/Sources/ComposerToolbarViewModelTests.swift
@@ -180,4 +180,26 @@ class ComposerToolbarViewModelTests: XCTestCase {
         
         try await deferred.fulfill()
     }
+    
+    func testMentionsWorkInMarkdownMode() async throws {
+        appSettings.richTextEditorEnabled = false
+        
+        let userID = "@test:matrix.org"
+        let expectedFormattedBody = "<a href=\"https://matrix.to/#/@test:matrix.org\">Test</a> "
+        let suggestion = SuggestionItem.user(item: .init(id: userID, displayName: "Test", avatarURL: nil))
+        viewModel.context.send(viewAction: .selectedSuggestion(suggestion))
+        
+        let deferred = deferFulfillment(viewModel.actions) { action in
+            switch action {
+            case let .sendMessage(_, html, _, _):
+                XCTAssertEqual(html, expectedFormattedBody)
+                return html == expectedFormattedBody
+            default:
+                return false
+            }
+        }
+        viewModel.context.send(viewAction: .sendMessage)
+        
+        try await deferred.fulfill()
+    }
 }

--- a/changelog.d/1999.bugfix
+++ b/changelog.d/1999.bugfix
@@ -1,0 +1,1 @@
+Rich Text Editor: Formatted message content including mentions should be sent even when the RTE is disabled.


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-x-ios/issues/1999

I can understand the rational behind why the code that removes formatted_body for non-RTE mode might have been added but whether we send 'formatted_body' should not be tied to the RTE, we should always send it(e.g. the web client sends it even on the legacy client which is markdown based, as do legacy mobile markdown clients). 

It is the preferred field for clients that support displaying rich content, whereas `body` field is a plain text representation of what is in `formatted_body` and can be used for clients that don't support displaying rich content.

`formatted_body` is required for mentions to work and render correctly in the timeline, hence the bug.