### PR TITLE
Update most references of vector-im to element-hq

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @vector-im/element-x-ios-reviewers 
+* @element-hq/element-x-ios-reviewers 

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,5 +1,5 @@
 name: Bug report for the Element X iOS app
-description: Report any issues that you have found with the Element X app. Please [check open issues](https://github.com/vector-im/element-x-ios/issues) first, in case it has already been reported.
+description: Report any issues that you have found with the Element X app. Please [check open issues](https://github.com/element-hq/element-x-ios/issues) first, in case it has already been reported.
 labels: [T-Defect]
 body:
   - type: markdown

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ### Pull Request Checklist
 
-- [ ] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
+- [ ] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md)
 - [ ] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
 - [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
 

--- a/.github/workflows/translations-pr.yml
+++ b/.github/workflows/translations-pr.yml
@@ -9,7 +9,7 @@ jobs:
   open-translations-pr:
     runs-on: macos-13
     # Skip in forks
-    if: github.repository == 'vector-im/element-x-ios'
+    if: github.repository == 'element-hq/element-x-ios'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/triage_incoming.yml
+++ b/.github/workflows/triage_incoming.yml
@@ -8,11 +8,11 @@ jobs:
   add_to_triage:
     runs-on: ubuntu-latest
     if: >
-      github.repository == 'vector-im/element-x-ios'
+      github.repository == 'element-hq/element-x-ios'
     steps:
         - uses: actions/add-to-project@main
           with:
-              project-url: https://github.com/orgs/vector-im/projects/81
+              project-url: https://github.com/orgs/element-hq/projects/81
               github-token: ${{ secrets.ELEMENT_BOT_TOKEN }}
 
   move_element_x_issues:
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     # Skip in forks
     if: >
-      github.repository == 'vector-im/element-x-ios'
+      github.repository == 'element-hq/element-x-ios'
     steps:
         - uses: actions/add-to-project@main
           with:
-              project-url: https://github.com/orgs/vector-im/projects/43
+              project-url: https://github.com/orgs/element-hq/projects/43
               github-token: ${{ secrets.ELEMENT_BOT_TOKEN }}

--- a/.github/workflows/triage_labelled.yml
+++ b/.github/workflows/triage_labelled.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/add-to-project@main
         with:
-          project-url: https://github.com/orgs/vector-im/projects/73
+          project-url: https://github.com/orgs/element-hq/projects/73
           github-token: ${{ secrets.ELEMENT_BOT_TOKEN }}
 
   verticals_feature:
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/add-to-project@main
         with:
-          project-url: https://github.com/orgs/vector-im/projects/57
+          project-url: https://github.com/orgs/element-hq/projects/57
           github-token: ${{ secrets.ELEMENT_BOT_TOKEN }}
 
   platform:
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/add-to-project@main
         with:
-          project-url: https://github.com/orgs/vector-im/projects/43
+          project-url: https://github.com/orgs/element-hq/projects/43
           github-token: ${{ secrets.ELEMENT_BOT_TOKEN }}
 
   qa:
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/add-to-project@main
         with:
-          project-url: https://github.com/orgs/vector-im/projects/69
+          project-url: https://github.com/orgs/element-hq/projects/69
           github-token: ${{ secrets.ELEMENT_BOT_TOKEN }}
 
   signoff:
@@ -58,5 +58,5 @@ jobs:
     steps:
       - uses: actions/add-to-project@main
         with:
-          project-url: https://github.com/orgs/vector-im/projects/89
+          project-url: https://github.com/orgs/element-hq/projects/89
           github-token: ${{ secrets.ELEMENT_BOT_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ git config core.hooksPath .githooks
 
 The project uses Localazy and is sharing its translations with the ElementX Android project: https://localazy.com/p/element 
 
-Please read the [Android docs](https://github.com/vector-im/element-x-android/blob/develop/tools/localazy/README.md) for more information about how this works. Note: On iOS we don't have the additional step of filtering strings per module.
+Please read the [Android docs](https://github.com/element-hq/element-x-android/blob/develop/tools/localazy/README.md) for more information about how this works. Note: On iOS we don't have the additional step of filtering strings per module.
 
 ### Continuous Integration
 
@@ -92,7 +92,7 @@ It's possible to debug the app's network traffic with a proxy server by setting 
 
 ## Pull requests
 
-Please see our [pull request guide](https://github.com/vector-im/element-android/blob/develop/docs/pull_request.md).
+Please see our [pull request guide](https://github.com/element-hq/element-android/blob/develop/docs/pull_request.md).
 
 ## Implementing a new screen
 

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -26,7 +26,7 @@ if editedFiles.count > 0, changelogFiles.isEmpty {
 // Check for a ticket number
 if let ticketNumberRegex = try? NSRegularExpression(pattern: "#\\d+") {
     let missingTicketNumber = !danger.git.commits.filter {
-        !$0.message.contains("vector-im/element-x-ios/issues/") &&
+        !$0.message.contains("element-hq/element-x-ios/issues/") &&
             ticketNumberRegex.firstMatch(in: $0.message, options: [], range: .init(location: 0, length: $0.message.utf16.count)) == nil
     }.isEmpty
     

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -1066,7 +1066,7 @@
 		033DB41C51865A2E83174E87 /* target.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = target.yml; sourceTree = "<group>"; };
 		035177BCD8E8308B098AC3C2 /* WindowManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowManager.swift; sourceTree = "<group>"; };
 		0376C429FAB1687C3D905F3E /* MockCoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCoder.swift; sourceTree = "<group>"; };
-		0392E3FDE372C9B56FEEED8B /* test_voice_message.m4a */ = {isa = PBXFileReference; lastKnownFileType = file; path = test_voice_message.m4a; sourceTree = "<group>"; };
+		0392E3FDE372C9B56FEEED8B /* test_voice_message.m4a */ = {isa = PBXFileReference; path = test_voice_message.m4a; sourceTree = "<group>"; };
 		03DD998E523D4EC93C7ED703 /* RoomNotificationSettingsScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomNotificationSettingsScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		03FABD73FD8086EFAB699F42 /* MediaUploadPreviewScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaUploadPreviewScreenViewModelTests.swift; sourceTree = "<group>"; };
 		044E501B8331B339874D1B96 /* CompoundIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompoundIcon.swift; sourceTree = "<group>"; };
@@ -1127,7 +1127,7 @@
 		127C8472672A5BA09EF1ACF8 /* CurrentValuePublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentValuePublisher.swift; sourceTree = "<group>"; };
 		12EDAFB64FA5F6812D54F39A /* MigrationScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationScreenViewModel.swift; sourceTree = "<group>"; };
 		12F1E7F9C2BE8BB751037826 /* WaitlistScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitlistScreenCoordinator.swift; sourceTree = "<group>"; };
-		1304D9191300873EADA52D6E /* IntegrationTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = IntegrationTests.xctestplan; sourceTree = "<group>"; };
+		1304D9191300873EADA52D6E /* IntegrationTests.xctestplan */ = {isa = PBXFileReference; path = IntegrationTests.xctestplan; sourceTree = "<group>"; };
 		130ED565A078F7E0B59D9D25 /* UNTextInputNotificationResponse+Creator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UNTextInputNotificationResponse+Creator.swift"; sourceTree = "<group>"; };
 		13802897C7AFA360EA74C0B0 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		1423AB065857FA546444DB15 /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
@@ -1548,7 +1548,7 @@
 		8D55702474F279D910D2D162 /* RoomStateEventStringBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomStateEventStringBuilder.swift; sourceTree = "<group>"; };
 		8D8169443E5AC5FF71BFB3DB /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/Localizable.strings; sourceTree = "<group>"; };
 		8DC2C9E0E15C79BBDA80F0A2 /* TimelineStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineStyle.swift; sourceTree = "<group>"; };
-		8E088F2A1B9EC529D3221931 /* UITests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UITests.xctestplan; sourceTree = "<group>"; };
+		8E088F2A1B9EC529D3221931 /* UITests.xctestplan */ = {isa = PBXFileReference; path = UITests.xctestplan; sourceTree = "<group>"; };
 		8E1BBA73B611EDEEA6E20E05 /* InvitesScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitesScreenModels.swift; sourceTree = "<group>"; };
 		8EC57A32ABC80D774CC663DB /* SettingsScreenUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScreenUITests.swift; sourceTree = "<group>"; };
 		8F21ED7205048668BEB44A38 /* AppActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppActivityView.swift; sourceTree = "<group>"; };
@@ -1683,7 +1683,7 @@
 		B50F03079F6B5EF9CA005F14 /* TimelineProxyProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineProxyProtocol.swift; sourceTree = "<group>"; };
 		B590BD4507D4F0A377FDE01A /* LoadableAvatarImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadableAvatarImage.swift; sourceTree = "<group>"; };
 		B5B243E7818E5E9F6A4EDC7A /* NoticeRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeRoomTimelineView.swift; sourceTree = "<group>"; };
-		B61C339A2FDDBD067FF6635C /* ConfettiScene.scn */ = {isa = PBXFileReference; lastKnownFileType = file.bplist; path = ConfettiScene.scn; sourceTree = "<group>"; };
+		B61C339A2FDDBD067FF6635C /* ConfettiScene.scn */ = {isa = PBXFileReference; path = ConfettiScene.scn; sourceTree = "<group>"; };
 		B6311F21F911E23BE4DF51B4 /* ReadMarkerRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadMarkerRoomTimelineView.swift; sourceTree = "<group>"; };
 		B63B69F9A2BC74DD40DC75C8 /* AdvancedSettingsScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsScreenViewModel.swift; sourceTree = "<group>"; };
 		B697816AF93DA06EC58C5D70 /* WaitlistScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitlistScreenViewModelProtocol.swift; sourceTree = "<group>"; };
@@ -1789,7 +1789,7 @@
 		CD95B3714F806AC9CF9A557B /* ComposerToolbarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerToolbarViewModel.swift; sourceTree = "<group>"; };
 		CDB3227C7A74B734924942E9 /* RoomSummaryProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomSummaryProvider.swift; sourceTree = "<group>"; };
 		CEE0E6043EFCF6FD2A341861 /* TimelineReplyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineReplyView.swift; sourceTree = "<group>"; };
-		CEE41494C837AA403A06A5D9 /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UnitTests.xctestplan; sourceTree = "<group>"; };
+		CEE41494C837AA403A06A5D9 /* UnitTests.xctestplan */ = {isa = PBXFileReference; path = UnitTests.xctestplan; sourceTree = "<group>"; };
 		CF48AF076424DBC1615C74AD /* AuthenticationServiceProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationServiceProxy.swift; sourceTree = "<group>"; };
 		D0140615D2232612C813FD6C /* EncryptedHistoryRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptedHistoryRoomTimelineItem.swift; sourceTree = "<group>"; };
 		D071F86CD47582B9196C9D16 /* UserDiscoverySection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDiscoverySection.swift; sourceTree = "<group>"; };
@@ -1894,7 +1894,7 @@
 		ECF79FB25E2D4BD6F50CE7C9 /* RoomMembersListScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomMembersListScreenViewModel.swift; sourceTree = "<group>"; };
 		ED044D00F2176681CC02CD54 /* HomeScreenRoomCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenRoomCell.swift; sourceTree = "<group>"; };
 		ED1D792EB82506A19A72C8DE /* RoomTimelineItemProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomTimelineItemProtocol.swift; sourceTree = "<group>"; };
-		ED482057AE39D5C6D9C5F3D8 /* message.caf */ = {isa = PBXFileReference; lastKnownFileType = file; path = message.caf; sourceTree = "<group>"; };
+		ED482057AE39D5C6D9C5F3D8 /* message.caf */ = {isa = PBXFileReference; path = message.caf; sourceTree = "<group>"; };
 		ED983D4DCA5AFA6E1ED96099 /* StateRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateRoomTimelineView.swift; sourceTree = "<group>"; };
 		EDAA4472821985BF868CC21C /* ServerSelectionViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSelectionViewModelTests.swift; sourceTree = "<group>"; };
 		EE378083653EF0C9B5E9D580 /* EmoteRoomTimelineItemContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmoteRoomTimelineItemContent.swift; sourceTree = "<group>"; };
@@ -1910,7 +1910,7 @@
 		F174A5627CDB3CAF280D1880 /* EmojiPickerScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiPickerScreenModels.swift; sourceTree = "<group>"; };
 		F17EFA1D3D09FC2F9C5E1CB2 /* MediaProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaProvider.swift; sourceTree = "<group>"; };
 		F1B8500C152BC59445647DA8 /* UnsupportedRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedRoomTimelineItem.swift; sourceTree = "<group>"; };
-		F2D513D2477B57F90E98EEC0 /* portrait_test_video.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = portrait_test_video.mp4; sourceTree = "<group>"; };
+		F2D513D2477B57F90E98EEC0 /* portrait_test_video.mp4 */ = {isa = PBXFileReference; path = portrait_test_video.mp4; sourceTree = "<group>"; };
 		F31F59030205A6F65B057E1A /* MatrixEntityRegexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatrixEntityRegexTests.swift; sourceTree = "<group>"; };
 		F348B5F2C12F9D4F4B4D3884 /* VideoRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoRoomTimelineItem.swift; sourceTree = "<group>"; };
 		F36C0A6D59717193F49EA986 /* UserSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSessionTests.swift; sourceTree = "<group>"; };
@@ -4889,9 +4889,6 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				KnownAssetTags = (
-					New,
-				);
 				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = Element;
 				TargetAttributes = {
@@ -4944,7 +4941,7 @@
 				E025F19D013D9BA6C58B37F4 /* XCRemoteSwiftPackageReference "swift-algorithms" */,
 				AC3475112CA40C2C6E78D1EB /* XCRemoteSwiftPackageReference "matrix-analytics-events" */,
 				F76A08D0EA29A07A54F4EB4D /* XCRemoteSwiftPackageReference "swift-collections" */,
-				9754C4B03F6255F67FC15E52 /* XCRemoteSwiftPackageReference "compound-ios" */,
+				F71C70A4404CC6D9C4AF35F2 /* XCRemoteSwiftPackageReference "compound-ios" */,
 				4C34425923978C97409A3EF2 /* XCRemoteSwiftPackageReference "DSWaveformImage" */,
 				C13F55E4518415CB4C278E73 /* XCRemoteSwiftPackageReference "DTCoreText" */,
 				D5F7D47BBAAE0CF1DDEB3034 /* XCRemoteSwiftPackageReference "DeviceKit" */,
@@ -4960,7 +4957,7 @@
 				22E7BA2ED466B74739AB8567 /* XCRemoteSwiftPackageReference "Prefire" */,
 				A08925A9D5E3770DEB9D8509 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 				E9C4F3A12AA1F65C13A8C8EB /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */,
-				FCB417752B308730C87E6BC8 /* XCRemoteSwiftPackageReference "swift-ogg" */,
+				E2F3DA35D462724CCC61DE2C /* XCRemoteSwiftPackageReference "swift-ogg" */,
 				6582B5AF3F104B0F7E031E7D /* XCRemoteSwiftPackageReference "SwiftState" */,
 				9A472EE0218FE7DCF5283429 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */,
 				EC6D0C817B1C21D9D096505A /* XCRemoteSwiftPackageReference "Version" */,
@@ -6217,7 +6214,9 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = "$(MARKETING_VERSION)";
-				OTHER_SWIFT_FLAGS = "-DIS_NSE";
+				OTHER_SWIFT_FLAGS = (
+					"-DIS_NSE",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "${BASE_BUNDLE_IDENTIFIER}.nse";
 				PRODUCT_DISPLAY_NAME = "$(APP_DISPLAY_NAME)";
 				PRODUCT_NAME = NSE;
@@ -6248,7 +6247,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = "$(MARKETING_VERSION)";
-				OTHER_SWIFT_FLAGS = "-DIS_MAIN_APP";
+				OTHER_SWIFT_FLAGS = (
+					"-DIS_MAIN_APP",
+				);
 				PILLS_UT_TYPE_IDENTIFIER = "$(BASE_BUNDLE_IDENTIFIER).pills";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(BASE_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(APP_NAME)";
@@ -6274,7 +6275,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = "$(MARKETING_VERSION)";
-				OTHER_SWIFT_FLAGS = "-DIS_MAIN_APP";
+				OTHER_SWIFT_FLAGS = (
+					"-DIS_MAIN_APP",
+				);
 				PILLS_UT_TYPE_IDENTIFIER = "$(BASE_BUNDLE_IDENTIFIER).pills";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(BASE_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(APP_NAME)";
@@ -6517,7 +6520,9 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = "$(MARKETING_VERSION)";
-				OTHER_SWIFT_FLAGS = "-DIS_NSE";
+				OTHER_SWIFT_FLAGS = (
+					"-DIS_NSE",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "${BASE_BUNDLE_IDENTIFIER}.nse";
 				PRODUCT_DISPLAY_NAME = "$(APP_DISPLAY_NAME)";
 				PRODUCT_NAME = NSE;
@@ -6755,14 +6760,6 @@
 				minimumVersion = 2.0.3;
 			};
 		};
-		9754C4B03F6255F67FC15E52 /* XCRemoteSwiftPackageReference "compound-ios" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/vector-im/compound-ios";
-			requirement = {
-				kind = revision;
-				revision = 56456508d27b7defef647da15d1bd854d6f88a2d;
-			};
-		};
 		9A472EE0218FE7DCF5283429 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/siteline/SwiftUI-Introspect";
@@ -6827,6 +6824,14 @@
 				minimumVersion = 1.0.0;
 			};
 		};
+		E2F3DA35D462724CCC61DE2C /* XCRemoteSwiftPackageReference "swift-ogg" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/element-hq/swift-ogg";
+			requirement = {
+				branch = 0.0.1;
+				kind = branch;
+			};
+		};
 		E9C4F3A12AA1F65C13A8C8EB /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pointfreeco/swift-snapshot-testing";
@@ -6843,20 +6848,20 @@
 				minimumVersion = 2.0.0;
 			};
 		};
+		F71C70A4404CC6D9C4AF35F2 /* XCRemoteSwiftPackageReference "compound-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/element-hq/compound-ios";
+			requirement = {
+				kind = revision;
+				revision = e9cfcebf02f7f5cd204159f6f6ab1d07840e656c;
+			};
+		};
 		F76A08D0EA29A07A54F4EB4D /* XCRemoteSwiftPackageReference "swift-collections" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-collections";
 			requirement = {
 				kind = upToNextMinorVersion;
 				minimumVersion = 1.0.0;
-			};
-		};
-		FCB417752B308730C87E6BC8 /* XCRemoteSwiftPackageReference "swift-ogg" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/vector-im/swift-ogg";
-			requirement = {
-				branch = 0.0.1;
-				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -6869,7 +6874,7 @@
 		};
 		07FEEEDB11543A7DED420F04 /* Compound */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 9754C4B03F6255F67FC15E52 /* XCRemoteSwiftPackageReference "compound-ios" */;
+			package = F71C70A4404CC6D9C4AF35F2 /* XCRemoteSwiftPackageReference "compound-ios" */;
 			productName = Compound;
 		};
 		0DD568A494247444A4B56031 /* Kingfisher */ = {
@@ -6959,12 +6964,12 @@
 		};
 		391D11F92DFC91666AA1503F /* SwiftOGG */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = FCB417752B308730C87E6BC8 /* XCRemoteSwiftPackageReference "swift-ogg" */;
+			package = E2F3DA35D462724CCC61DE2C /* XCRemoteSwiftPackageReference "swift-ogg" */;
 			productName = SwiftOGG;
 		};
 		3FE40E79C36E7903121E6E3B /* SwiftOGG */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = FCB417752B308730C87E6BC8 /* XCRemoteSwiftPackageReference "swift-ogg" */;
+			package = E2F3DA35D462724CCC61DE2C /* XCRemoteSwiftPackageReference "swift-ogg" */;
 			productName = SwiftOGG;
 		};
 		4003BC24B24C9E63D3304177 /* DeviceKit */ = {
@@ -7144,7 +7149,7 @@
 		};
 		DCA3C4A997AD28E6918D4CE5 /* Compound */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 9754C4B03F6255F67FC15E52 /* XCRemoteSwiftPackageReference "compound-ios" */;
+			package = F71C70A4404CC6D9C4AF35F2 /* XCRemoteSwiftPackageReference "compound-ios" */;
 			productName = Compound;
 		};
 		DE8DC9B3FBA402117DC4C49F /* Kingfisher */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -3,7 +3,7 @@
     {
       "identity" : "compound-design-tokens",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/vector-im/compound-design-tokens.git",
+      "location" : "https://github.com/element-hq/compound-design-tokens.git",
       "state" : {
         "revision" : "b603371c5e4ac798f4613a7388d2305100b31911",
         "version" : "0.0.7"
@@ -12,9 +12,9 @@
     {
       "identity" : "compound-ios",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/vector-im/compound-ios",
+      "location" : "https://github.com/element-hq/compound-ios",
       "state" : {
-        "revision" : "56456508d27b7defef647da15d1bd854d6f88a2d"
+        "revision" : "e9cfcebf02f7f5cd204159f6f6ab1d07840e656c"
       }
     },
     {
@@ -227,7 +227,7 @@
     {
       "identity" : "swift-ogg",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/vector-im/swift-ogg",
+      "location" : "https://github.com/element-hq/swift-ogg",
       "state" : {
         "branch" : "0.0.1",
         "revision" : "e9a9e7601da662fd8b97d93781ff5c60b4becf88"

--- a/ElementX/Sources/Application/Application.swift
+++ b/ElementX/Sources/Application/Application.swift
@@ -63,7 +63,7 @@ struct Application: App {
         ProcessInfo.isRunningUITests
     }
     
-    /// https://github.com/vector-im/element-x-ios/issues/1824
+    /// https://github.com/element-hq/element-x-ios/issues/1824
     /// Avoid opening universal links in other app variants and infinite loops between them
     private func openURLInSystemBrowser(_ originalURL: URL) {
         guard var urlComponents = URLComponents(url: originalURL, resolvingAgainstBaseURL: true) else {

--- a/ElementX/Sources/Application/Navigation/AppRoutes.swift
+++ b/ElementX/Sources/Application/Navigation/AppRoutes.swift
@@ -77,7 +77,7 @@ struct ElementCallURLParser: URLParser {
     
     func route(from url: URL) -> AppRoute? {
         // Element Call not supported, WebRTC not available
-        // https://github.com/vector-im/element-x-ios/issues/1794
+        // https://github.com/element-hq/element-x-ios/issues/1794
         if ProcessInfo.processInfo.isiOSAppOnMac {
             return nil
         }

--- a/ElementX/Sources/Application/Navigation/NavigationCoordinators.swift
+++ b/ElementX/Sources/Application/Navigation/NavigationCoordinators.swift
@@ -385,7 +385,7 @@ private struct NavigationSplitCoordinatorView: View {
             module.coordinator?.toPresentable()
         }
         // Handle `horizontalSizeClass` changes breaking the navigation bar
-        // https://github.com/vector-im/element-x-ios/issues/617
+        // https://github.com/element-hq/element-x-ios/issues/617
         .onChange(of: horizontalSizeClass) { value in
             guard scenePhase != .background else {
                 return

--- a/ElementX/Sources/Other/MapLibre/MapTilerStyle.swift
+++ b/ElementX/Sources/Other/MapLibre/MapTilerStyle.swift
@@ -16,7 +16,7 @@
 
 /// The style for a map.
 /// Values should be Map Libre style IDs generated with an account where the API key belongs to.
-/// For more information read [FORKING.md](https://github.com/vector-im/element-x-ios/blob/develop/docs/FORKING.md#setup-the-location-sharing).
+/// For more information read [FORKING.md](https://github.com/element-hq/element-x-ios/blob/develop/docs/FORKING.md#setup-the-location-sharing).
 enum MapTilerStyle: String {
     case light = "9bc819c8-e627-474a-a348-ec144fe3d810"
     case dark = "dea61faf-292b-4774-9660-58fcef89a7f3"

--- a/ElementX/Sources/Other/Pills/PillAttachmentViewProvider.swift
+++ b/ElementX/Sources/Other/Pills/PillAttachmentViewProvider.swift
@@ -78,7 +78,7 @@ final class PillAttachmentViewProvider: NSTextAttachmentViewProvider {
     // MARK: - NSSecureCoding
     
     // Fixes crashes when inserting mention pills in the composer on Mac
-    // https://github.com/vector-im/element-x-ios/issues/2070
+    // https://github.com/element-hq/element-x-ios/issues/2070
     
     static var supportsSecureCoding = false
     

--- a/ElementX/Sources/Screens/ComposerToolbar/View/RoomAttachmentPicker.swift
+++ b/ElementX/Sources/Screens/ComposerToolbar/View/RoomAttachmentPicker.swift
@@ -23,7 +23,7 @@ struct RoomAttachmentPicker: View {
     
     var body: some View {
         // Use a menu instead of the popover/sheet shown in Figma because overriding the colour scheme
-        // results in a rendering bug on 17.1: https://github.com/vector-im/element-x-ios/issues/2157
+        // results in a rendering bug on 17.1: https://github.com/element-hq/element-x-ios/issues/2157
         Menu {
             menuContent
         } label: {

--- a/ElementX/Sources/Services/SecureBackup/SecureBackupControllerProtocol.swift
+++ b/ElementX/Sources/Services/SecureBackup/SecureBackupControllerProtocol.swift
@@ -22,7 +22,7 @@ enum SecureBackupRecoveryKeyState {
     case disabled
     case enabled
     /// Recovery is not set up properly, the user will need to re-enter it so we can cleanup
-    /// https://github.com/vector-im/element-meta/issues/2107
+    /// https://github.com/element-hq/element-meta/issues/2107
     case incomplete
     case settingUp
 }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![Element iOS Matrix room #element-x-ios:matrix.org](https://img.shields.io/matrix/element-x-ios:matrix.org.svg?label=%23element-x-ios:matrix.org&logo=matrix&server_fqdn=matrix.org)](https://matrix.to/#/#element-x-ios:matrix.org)
-![GitHub](https://img.shields.io/github/license/vector-im/element-x-ios)
+![GitHub](https://img.shields.io/github/license/element-hq/element-x-ios)
 
-![Build Status](https://img.shields.io/github/actions/workflow/status/vector-im/element-x-ios/unit_tests.yml?style=flat-square)
-![GitHub release (latest by date)](https://img.shields.io/github/v/release/vector-im/element-x-ios)
+![Build Status](https://img.shields.io/github/actions/workflow/status/element-hq/element-x-ios/unit_tests.yml?style=flat-square)
+![GitHub release (latest by date)](https://img.shields.io/github/v/release/element-hq/element-x-ios)
 
 [![codecov](https://codecov.io/gh/vector-im/element-x-ios/branch/develop/graph/badge.svg?token=AVIJB2MJU2)](https://codecov.io/gh/vector-im/element-x-ios)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=vector-im_element-x-ios&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=vector-im_element-x-ios)
@@ -13,7 +13,7 @@
 
 ElementX iOS is a [Matrix](https://matrix.org/) iOS Client provided by [Element](https://element.io/).
 
-The application is a total rewrite of [Element-iOS](https://github.com/vector-im/element-ios) using the [Matrix Rust SDK](https://github.com/matrix-org/matrix-rust-sdk) underneath and targetting devices running iOS 16+.
+The application is a total rewrite of [Element-iOS](https://github.com/element-hq/element-ios) using the [Matrix Rust SDK](https://github.com/matrix-org/matrix-rust-sdk) underneath and targetting devices running iOS 16+.
 
 ## Rust SDK
 
@@ -37,7 +37,7 @@ Please refer to the [setting up a development environment](CONTRIBUTING.md#setti
 
 ## Support
 
-When you are experiencing an issue on ElementX iOS, please first search in [GitHub issues](https://github.com/vector-im/element-x-ios/issues)
+When you are experiencing an issue on ElementX iOS, please first search in [GitHub issues](https://github.com/element-hq/element-x-ios/issues)
 and then in [#element-x-ios:matrix.org](https://matrix.to/#/#element-x-ios:matrix.org).
 If after your research you still have a question, ask at [#element-x-ios:matrix.org](https://matrix.to/#/#element-x-ios:matrix.org). Otherwise feel free to create a GitHub issue if you encounter a bug or a crash, by explaining clearly in detail what happened. You can also perform bug reporting (Rageshake) from the Element application by shaking your phone or going to the application settings. This is especially recommended when you encounter a crash.
 

--- a/changelog.d/_template.md.jinja
+++ b/changelog.d/_template.md.jinja
@@ -1,6 +1,6 @@
 {# iOS Repositories #}
 {%- set gh_sdk = "https://github.com/matrix-org/matrix-rust-sdk" -%}
-{%- set gh_element = "https://github.com/vector-im/element-x-ios" -%}
+{%- set gh_element = "https://github.com/element-hq/element-x-ios" -%}
 
 ## {{ versiondata.name }} {{ versiondata.version }} ({{ versiondata.date }})
 {% for section, _ in sections.items() %}

--- a/changelog.d/pr-2231.build
+++ b/changelog.d/pr-2231.build
@@ -1,0 +1,1 @@
+Update most references of the old vector-im organisation to the new element-hq one.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -258,7 +258,7 @@ lane :release_to_github do
   end
 
   github_release = set_github_release(
-    repository_name: "vector-im/element-x-ios",
+    repository_name: "element-hq/element-x-ios",
     api_token: api_token,
     name: release_version,
     tag_name: release_version,

--- a/project.yml
+++ b/project.yml
@@ -49,8 +49,8 @@ packages:
     exactVersion: 1.1.28
     # path: ../matrix-rust-sdk
   Compound:
-    url: https://github.com/vector-im/compound-ios
-    revision: 56456508d27b7defef647da15d1bd854d6f88a2d
+    url: https://github.com/element-hq/compound-ios
+    revision: e9cfcebf02f7f5cd204159f6f6ab1d07840e656c
     # path: ../compound-ios
   AnalyticsEvents:
     url: https://github.com/matrix-org/matrix-analytics-events
@@ -58,6 +58,13 @@ packages:
   Emojibase:
     url: https://github.com/matrix-org/emojibase-bindings
     minorVersion: 1.0.0
+  SwiftOGG:
+    url: https://github.com/element-hq/swift-ogg
+    branch: 0.0.1
+  WysiwygComposer:
+    url: https://github.com/matrix-org/matrix-wysiwyg-composer-swift
+    exactVersion: 2.19.0
+    # path: ../matrix-wysiwyg/platforms/ios/lib/WysiwygComposer
   
   # External dependencies
   Algorithms:
@@ -69,6 +76,9 @@ packages:
   DeviceKit:
     url: https://github.com/devicekit/DeviceKit
     minorVersion: 5.0.0
+  DSWaveformImage:
+    url: https://github.com/dmrschmidt/DSWaveformImage
+    exactVersion: 14.1.1
   DTCoreText:
     url: https://github.com/Cocoanetics/DTCoreText
     exactVersion: 1.6.26
@@ -111,16 +121,6 @@ packages:
   Version:
     url: https://github.com/mxcl/Version
     minorVersion: 2.0.0
-  WysiwygComposer:
-    url: https://github.com/matrix-org/matrix-wysiwyg-composer-swift
-    exactVersion: 2.19.0
-#    path: ../matrix-wysiwyg/platforms/ios/lib/WysiwygComposer
-  SwiftOGG:
-    url: https://github.com/vector-im/swift-ogg
-    branch: 0.0.1
-  DSWaveformImage:
-    url: https://github.com/dmrschmidt/DSWaveformImage
-    exactVersion: 14.1.1
 
 aggregateTargets:
   Periphery:


### PR DESCRIPTION
Sonarcloud and codecov will follow in a later PR when confirmed working. Changelog ignored as it isn't particularly important with the redirect.