### PR TITLE
Fix integration tests getting stuck in location error loop.

### DIFF
--- a/changelog.d/pr-2233.bugfix
+++ b/changelog.d/pr-2233.bugfix
@@ -1,0 +1,1 @@
+Don't keep throwing an error each time the user dismisses the error's alert when sharing a location.


### PR DESCRIPTION
Setting the map style URL every update breaks if an error is going to be thrown. It ended up going
```
update -> setURL -> error
   ^------------------|
```

Seems this wasn't a problem with Xcode 14, but it is with Xcode 15 and so Integration tests were blocked by it.

https://github.com/element-hq/element-x-ios/actions/runs/7185363878