### PR TITLE
Fix a crash that can occur when updating timeline items in a background thread

### DIFF
--- a/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineController.swift
@@ -238,7 +238,9 @@ class RoomTimelineController: RoomTimelineControllerProtocol {
     
     @objc private func contentSizeCategoryDidChange() {
         // Recompute all attributed strings on content size changes -> DynamicType support
-        updateTimelineItems()
+        serialDispatchQueue.async {
+            self.updateTimelineItems()
+        }
     }
     
     private func updateTimelineItems() {
@@ -303,7 +305,9 @@ class RoomTimelineController: RoomTimelineControllerProtocol {
             }
         }
         
-        timelineItems = newTimelineItems
+        DispatchQueue.main.sync {
+            timelineItems = newTimelineItems
+        }
         
         callbacks.send(.updatedTimelineItems)
         callbacks.send(.canBackPaginate(canBackPaginate))


### PR DESCRIPTION
This PR attempts to fix a crash when a timeline item ID is not found:
`Fatal error > TimelineItem TimelineItemIdentifier(....) not found`

The simplest reason for this is if the `RoomTimelineController.timelineItems` array is updated during use.

This PR also ensures that `updateTimelineItems()` is always executed using the same serialQueue (which was not the case with the `contentSizeCategoryChanged` notification).