### PR TITLE
Timeline item flickering

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -615,8 +615,6 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationCoordinatorDelegate,
                 switch callback {
                 case .didReceiveAuthError(let isSoftLogout):
                     stateMachine.processEvent(.signOut(isSoft: isSoftLogout, disableAppLock: false))
-                default:
-                    break
                 }
             }
     }

--- a/ElementX/Sources/Mocks/AggregatedReactionMock.swift
+++ b/ElementX/Sources/Mocks/AggregatedReactionMock.swift
@@ -26,7 +26,7 @@ extension AggregatedReaction {
     private static func mockReaction(key: String, senderIDs: [String]) -> AggregatedReaction {
         let senders = senderIDs
             .map { id in
-                ReactionSender(senderID: id, timestamp: Date(timeIntervalSinceReferenceDate: 0))
+                ReactionSender(id: id, timestamp: Date(timeIntervalSinceReferenceDate: 0))
             }
         return AggregatedReaction(accountOwnerID: alice, key: key, senders: senders)
     }

--- a/ElementX/Sources/Other/Extensions/AttributedString.swift
+++ b/ElementX/Sources/Other/Extensions/AttributedString.swift
@@ -18,7 +18,12 @@ import Foundation
 
 extension AttributedString {
     var formattedComponents: [AttributedStringBuilderComponent] {
-        runs[\.blockquote].map { value, range in
+        var components = [AttributedStringBuilderComponent]()
+        
+        for (index, run) in runs[\.blockquote].enumerated() {
+            let value = run.0
+            let range = run.1
+            
             var attributedString = AttributedString(self[range])
             
             // Remove trailing new lines if any
@@ -29,8 +34,10 @@ extension AttributedString {
             
             let isBlockquote = value != nil
             
-            return AttributedStringBuilderComponent(attributedString: attributedString, isBlockquote: isBlockquote)
+            components.append(AttributedStringBuilderComponent(id: index, attributedString: attributedString, isBlockquote: isBlockquote))
         }
+        
+        return components
     }
     
     /// Replaces the specified placeholder with a string that links to the specified URL.

--- a/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilderProtocol.swift
+++ b/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilderProtocol.swift
@@ -16,7 +16,8 @@
 
 import Foundation
 
-struct AttributedStringBuilderComponent: Hashable {
+struct AttributedStringBuilderComponent: Hashable, Identifiable {
+    let id: Int
     let attributedString: AttributedString
     let isBlockquote: Bool
 }

--- a/ElementX/Sources/Screens/RoomScreen/View/Supplementary/ReactionsSummaryView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Supplementary/ReactionsSummaryView.swift
@@ -37,11 +37,10 @@ struct ReactionsSummaryView: View {
         ScrollView(.horizontal, showsIndicators: false) {
             ScrollViewReader { scrollView in
                 HStack(spacing: 8) {
-                    ForEach(reactions, id: \.self) { reaction in
+                    ForEach(reactions) { reaction in
                         ReactionSummaryButton(reaction: reaction, highlighted: selectedReactionKey == reaction.key) { key in
                             selectedReactionKey = key
                         }
-                        .id(reaction.key)
                     }
                 }
                 .padding(.horizontal, 20)
@@ -61,11 +60,11 @@ struct ReactionsSummaryView: View {
     
     private var sendersList: some View {
         TabView(selection: $selectedReactionKey) {
-            ForEach(reactions, id: \.self) { reaction in
+            ForEach(reactions) { reaction in
                 ScrollView {
                     VStack(alignment: .leading, spacing: 8) {
-                        ForEach(reaction.senders, id: \.self) { sender in
-                            ReactionSummarySenderView(sender: sender, member: members[sender.senderID], imageProvider: imageProvider)
+                        ForEach(reaction.senders) { sender in
+                            ReactionSummarySenderView(sender: sender, member: members[sender.id], imageProvider: imageProvider)
                                 .padding(.horizontal, 16)
                         }
                     }
@@ -114,14 +113,14 @@ private struct ReactionSummarySenderView: View {
     let imageProvider: ImageProviderProtocol?
     
     var displayName: String {
-        member?.displayName ?? sender.senderID
+        member?.displayName ?? sender.id
     }
     
     var body: some View {
         HStack(spacing: 8) {
             LoadableAvatarImage(url: member?.avatarURL,
                                 name: displayName,
-                                contentID: sender.senderID,
+                                contentID: sender.id,
                                 avatarSize: .user(on: .timeline),
                                 imageProvider: imageProvider)
             
@@ -134,7 +133,7 @@ private struct ReactionSummarySenderView: View {
                         .font(.compound.bodyXS)
                         .foregroundColor(.compound.textSecondary)
                 }
-                Text(sender.senderID)
+                Text(sender.id)
                     .font(.compound.bodySM)
                     .foregroundColor(.compound.textSecondary)
             }

--- a/ElementX/Sources/Screens/RoomScreen/View/Supplementary/TimelineReactionsView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Supplementary/TimelineReactionsView.swift
@@ -51,7 +51,7 @@ struct TimelineReactionsView: View {
     
     var body: some View {
         layout {
-            ForEach(reactions, id: \.self) { reaction in
+            ForEach(reactions) { reaction in
                 TimelineReactionButton(reaction: reaction) { key in
                     feedbackGenerator.impactOccurred()
                     context.send(viewAction: .toggleReaction(key: key, itemID: itemID))

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/FormattedBodyText.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/FormattedBodyText.swift
@@ -93,7 +93,7 @@ struct FormattedBodyText: View {
     /// The attributed components laid out for the bubbles timeline style.
     var bubbleLayout: some View {
         TimelineBubbleLayout(spacing: 8) {
-            ForEach(attributedComponents, id: \.self) { component in
+            ForEach(attributedComponents) { component in
                 // Ignore if the string contains only the layout correction
                 if String(component.attributedString.characters) == layoutDirection.isolateLayoutUnicodeString {
                     EmptyView()
@@ -123,7 +123,7 @@ struct FormattedBodyText: View {
             
             // Make a second iteration through the components adding fixed width blockquotes
             // which are used for layout calculations but won't be rendered.
-            ForEach(attributedComponents, id: \.self) { component in
+            ForEach(attributedComponents) { component in
                 if component.isBlockquote {
                     MessageText(attributedString: component.attributedString.mergingAttributes(blockquoteAttributes))
                         .fixedSize(horizontal: false, vertical: true)
@@ -138,7 +138,7 @@ struct FormattedBodyText: View {
     /// The attributed components laid out for the plain timeline style.
     var plainLayout: some View {
         VStack(alignment: .leading, spacing: 8.0) {
-            ForEach(attributedComponents, id: \.self) { component in
+            ForEach(attributedComponents) { component in
                 if component.isBlockquote {
                     HStack(spacing: 4.0) {
                         Rectangle()

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/FormattedBodyText.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/FormattedBodyText.swift
@@ -157,12 +157,13 @@ struct FormattedBodyText: View {
     }
     
     private var blockquoteAttributes: AttributeContainer {
-        var container = AttributeContainer()
+        // The paragraph style removes the block style paragraph that the parser adds by default
+        // Set directly in the constructor to avoid `Conformance to 'Sendable'` warnings
+        var container = AttributeContainer([.paragraphStyle: NSParagraphStyle.default])
         // Sadly setting SwiftUI fonts do not work so we would need UIFont equivalents for compound, this one is bodyMD
         container.font = UIFont.preferredFont(forTextStyle: .subheadline)
         container.foregroundColor = UIColor.compound.textSecondary
-        // To remove the block style paragraph that the parser adds by default
-        container.paragraphStyle = .default
+        
         return container
     }
 }

--- a/ElementX/Sources/Services/Timeline/Fixtures/RoomTimelineItemFixtures.swift
+++ b/ElementX/Sources/Services/Timeline/Fixtures/RoomTimelineItemFixtures.swift
@@ -38,7 +38,7 @@ enum RoomTimelineItemFixtures {
                              sender: .init(id: "", displayName: "Helena"),
                              content: .init(body: "Let’s get lunch soon! New salad place opened up 🥗. When are y’all free? 🤗"),
                              properties: RoomTimelineItemProperties(reactions: [
-                                 AggregatedReaction(accountOwnerID: "me", key: "🙌", senders: [ReactionSender(senderID: "me", timestamp: Date())])
+                                 AggregatedReaction(accountOwnerID: "me", key: "🙌", senders: [ReactionSender(id: "me", timestamp: Date())])
                              ])),
         TextRoomTimelineItem(id: .random,
                              timestamp: "10:11 AM",
@@ -49,13 +49,13 @@ enum RoomTimelineItemFixtures {
                              sender: .init(id: "", displayName: "Helena"),
                              content: .init(body: "I can be around on Wednesday. How about some 🌮 instead? Like https://www.tortilla.co.uk/"),
                              properties: RoomTimelineItemProperties(reactions: [
-                                 AggregatedReaction(accountOwnerID: "me", key: "🙏", senders: [ReactionSender(senderID: "helena", timestamp: Date())]),
+                                 AggregatedReaction(accountOwnerID: "me", key: "🙏", senders: [ReactionSender(id: "helena", timestamp: Date())]),
                                  AggregatedReaction(accountOwnerID: "me",
                                                     key: "🙌",
                                                     senders: [
-                                                        ReactionSender(senderID: "me", timestamp: Date()),
-                                                        ReactionSender(senderID: "helena", timestamp: Date()),
-                                                        ReactionSender(senderID: "jacob", timestamp: Date())
+                                                        ReactionSender(id: "me", timestamp: Date()),
+                                                        ReactionSender(id: "helena", timestamp: Date()),
+                                                        ReactionSender(id: "jacob", timestamp: Date())
                                                     ])
                              ])),
         SeparatorRoomTimelineItem(id: .init(timelineID: "Today"), text: "Today"),

--- a/ElementX/Sources/Services/Timeline/TimelineItemContent/AggregratedReaction.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItemContent/AggregratedReaction.swift
@@ -17,11 +17,15 @@
 import Foundation
 
 /// Represents all reactions of the same type for a single event.
-struct AggregatedReaction: Hashable {
+struct AggregatedReaction: Hashable, Identifiable {
     /// Length at which we ellipsize a reaction key for display
     /// Reactions can be free text, so we need to limit the length
     /// displayed on screen.
     private static let maxDisplayChars = 16
+    
+    var id: String {
+        key
+    }
     
     /// The id of the account owner
     let accountOwnerID: String
@@ -32,9 +36,9 @@ struct AggregatedReaction: Hashable {
 }
 
 /// Details of who sent the reaction
-struct ReactionSender: Hashable {
+struct ReactionSender: Hashable, Identifiable {
     /// The id of the user who sent the reaction
-    let senderID: String
+    let id: String
     /// The time that the reaction was received on the original homeserver
     let timestamp: Date
 }
@@ -47,7 +51,7 @@ extension AggregatedReaction {
     
     /// Whether to highlight the reaction, indicating that the current user sent this reaction.
     var isHighlighted: Bool {
-        senders.contains(where: { $0.senderID == accountOwnerID })
+        senders.contains(where: { $0.id == accountOwnerID })
     }
     
     /// The key to be displayed on screen. See `maxDisplayChars`.

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
@@ -418,7 +418,7 @@ struct RoomTimelineItemFactory: RoomTimelineItemFactoryProtocol {
         reactions.map { reaction in
             let senders = reaction.senders
                 .map { senderData in
-                    ReactionSender(senderID: senderData.senderId, timestamp: Date(timeIntervalSince1970: TimeInterval(senderData.timestamp / 1000)))
+                    ReactionSender(id: senderData.senderId, timestamp: Date(timeIntervalSince1970: TimeInterval(senderData.timestamp / 1000)))
                 }
                 .sorted { a, b in
                     // Sort reactions within an aggregation by timestamp descending.

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
@@ -54,7 +54,7 @@ struct RoomTimelineItemFactory: RoomTimelineItemFactoryProtocol {
             return buildUnsupportedTimelineItem(eventItemProxy, eventType, error, isOutgoing)
         case .message:
             return buildMessageTimelineItem(eventItemProxy, isOutgoing)
-        case .state(let stateKey, let content):
+        case .state(_, let content):
             return buildStateTimelineItem(for: eventItemProxy, state: content, isOutgoing: isOutgoing)
         case .roomMembership(userId: let userID, change: let change):
             return buildStateMembershipChangeTimelineItem(for: eventItemProxy, member: userID, membershipChange: change, isOutgoing: isOutgoing)

--- a/UnitTests/Sources/RoomScreenViewModelTests.swift
+++ b/UnitTests/Sources/RoomScreenViewModelTests.swift
@@ -619,7 +619,7 @@ class RoomScreenViewModelTests: XCTestCase {
 
 private extension TextRoomTimelineItem {
     init(text: String, sender: String, addReactions: Bool = false, addReadReceipts: [ReadReceipt] = []) {
-        let reactions = addReactions ? [AggregatedReaction(accountOwnerID: "bob", key: "🦄", senders: [ReactionSender(senderID: sender, timestamp: Date())])] : []
+        let reactions = addReactions ? [AggregatedReaction(accountOwnerID: "bob", key: "🦄", senders: [ReactionSender(id: sender, timestamp: Date())])] : []
         self.init(id: .random,
                   timestamp: "10:47 am",
                   isOutgoing: sender == "bob",

--- a/changelog.d/2286.bugfix
+++ b/changelog.d/2286.bugfix
@@ -1,0 +1,1 @@
+Fix timeline entries flickering when a lot of mention pills present


### PR DESCRIPTION
While I can't say I have a full grasp as to what's happening it seems that when pills are present the `NSTextAttachmentViewProvider` makes the views reload a lot more often than usual. 

There's nothing inherently wrong with this and (I believe) I tracked down the root cause to the FormattedBodyText not uniquely identifying its components and re-redenring them unnecessarily. 

I fixed it by making the AttributedStringComponents indentifiable based on their index and while there decided to do the same for the timeline reactions.