### PR TITLE
Moar integration test tweaks

### DIFF
--- a/ElementX/Sources/Screens/InvitesScreen/InvitesScreenViewModel.swift
+++ b/ElementX/Sources/Screens/InvitesScreen/InvitesScreenViewModel.swift
@@ -80,6 +80,7 @@ class InvitesScreenViewModel: InvitesScreenViewModelType, InvitesScreenViewModel
         
         inviteSummaryProvider.roomListPublisher
             .removeDuplicates()
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] roomSummaries in
                 guard let self else { return }
                 

--- a/IntegrationTests/Sources/Common.swift
+++ b/IntegrationTests/Sources/Common.swift
@@ -23,8 +23,9 @@ extension XCUIApplication {
         XCTAssertTrue(getStartedButton.waitForExistence(timeout: 10.0))
         getStartedButton.tap()
         
+        // Get started is network bound, wait for the change homeserver button for longer
         let changeHomeserverButton = buttons[A11yIdentifiers.serverConfirmationScreen.changeServer]
-        XCTAssertTrue(changeHomeserverButton.waitForExistence(timeout: 10.0))
+        XCTAssertTrue(changeHomeserverButton.waitForExistence(timeout: 30.0))
         changeHomeserverButton.tap()
         
         let homeserverTextField = textFields[A11yIdentifiers.changeServerScreen.server]
@@ -36,7 +37,11 @@ extension XCUIApplication {
         XCTAssertTrue(confirmButton.waitForExistence(timeout: 10.0))
         confirmButton.tap()
         
-        // Server cofirmation is network bound and might take a while
+        // Wait for server confirmation to finish
+        let doesNotExistPredicate = NSPredicate(format: "exists == 0")
+        currentTestCase.expectation(for: doesNotExistPredicate, evaluatedWith: confirmButton)
+        currentTestCase.waitForExpectations(timeout: 300.0)
+        
         let continueButton = buttons[A11yIdentifiers.serverConfirmationScreen.continue]
         XCTAssertTrue(continueButton.waitForExistence(timeout: 30.0))
         continueButton.tap()
@@ -58,7 +63,6 @@ extension XCUIApplication {
         nextButton.tap()
         
         // Wait for login to finish
-        let doesNotExistPredicate = NSPredicate(format: "exists == 0")
         currentTestCase.expectation(for: doesNotExistPredicate, evaluatedWith: usernameTextField)
         currentTestCase.waitForExpectations(timeout: 300.0)
         
@@ -93,7 +97,6 @@ extension XCUIApplication {
         let message = staticTexts[A11yIdentifiers.migrationScreen.message]
         
         if message.waitForExistence(timeout: 10.0) {
-            let doesNotExistPredicate = NSPredicate(format: "exists == 0")
             currentTestCase.expectation(for: doesNotExistPredicate, evaluatedWith: message)
             currentTestCase.waitForExpectations(timeout: 300.0)
         }

--- a/IntegrationTests/Sources/UserFlowTests.swift
+++ b/IntegrationTests/Sources/UserFlowTests.swift
@@ -36,7 +36,11 @@ class UserFlowTests: XCTestCase {
         XCTAssertTrue(firstRoom.waitForExistence(timeout: 10.0))
         firstRoom.tap()
         
-        checkAttachmentsPicker()
+        checkPhotoSharing()
+        
+        checkDocumentSharing()
+        
+        checkLocationSharing()
         
         checkTimelineItemActionMenu()
         
@@ -55,15 +59,7 @@ class UserFlowTests: XCTestCase {
         tapOnBackButton("All Chats")
     }
     
-    private func checkAttachmentsPicker() {
-        for identifier in [A11yIdentifiers.roomScreen.attachmentPickerPhotoLibrary,
-                           A11yIdentifiers.roomScreen.attachmentPickerDocuments,
-                           A11yIdentifiers.roomScreen.attachmentPickerLocation] {
-            tapOnMenu(A11yIdentifiers.roomScreen.composerToolbar.openComposeOptions)
-            tapOnButton(identifier)
-            tapOnButton("Cancel")
-        }
-                
+    private func checkPhotoSharing() {
         // Open attachments picker
         tapOnMenu(A11yIdentifiers.roomScreen.composerToolbar.openComposeOptions)
 
@@ -77,6 +73,43 @@ class UserFlowTests: XCTestCase {
         tapOnButton("Cancel")
         
         sleep(2) // Wait for dismissal
+    }
+    
+    private func checkDocumentSharing() {
+        tapOnMenu(A11yIdentifiers.roomScreen.composerToolbar.openComposeOptions)
+        tapOnButton(A11yIdentifiers.roomScreen.attachmentPickerDocuments)
+        tapOnButton("Cancel")
+        
+        sleep(2) // Wait for dismissal
+    }
+    
+    private func checkLocationSharing() {
+        tapOnMenu(A11yIdentifiers.roomScreen.composerToolbar.openComposeOptions)
+        tapOnButton(A11yIdentifiers.roomScreen.attachmentPickerLocation)
+        
+        // The order of the alerts is a bit of a mistery so try twice
+        
+        allowLocationPermissionOnce()
+        
+        // Handle map loading errors (missing credentials)
+        let alertOkButton = app.alerts.firstMatch.buttons["OK"].firstMatch
+        if alertOkButton.waitForExistence(timeout: 10.0) {
+            alertOkButton.tap()
+        }
+        
+        allowLocationPermissionOnce()
+        
+        tapOnButton("Cancel")
+        
+        sleep(2) // Wait for dismissal
+    }
+    
+    private func allowLocationPermissionOnce() {
+        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        let notificationAlertAllowButton = springboard.buttons["Allow Once"].firstMatch
+        if notificationAlertAllowButton.waitForExistence(timeout: 10.0) {
+            notificationAlertAllowButton.tap()
+        }
     }
     
     private func checkRoomCreation() {

--- a/IntegrationTests/Sources/UserFlowTests.swift
+++ b/IntegrationTests/Sources/UserFlowTests.swift
@@ -67,7 +67,9 @@ class UserFlowTests: XCTestCase {
         tapOnButton(A11yIdentifiers.roomScreen.attachmentPickerPhotoLibrary)
         
         // Tap on the second image. First one is always broken on simulators.
-        app.scrollViews.images.element(boundBy: 1).tap()
+        let secondImage = app.scrollViews.images.element(boundBy: 1)
+        XCTAssertTrue(secondImage.waitForExistence(timeout: 10.0)) // Photo library takes a bit to load
+        secondImage.tap()
         
         // Cancel the upload flow
         tapOnButton("Cancel")


### PR DESCRIPTION
* wait for initial and secondary server confirmation
* handle location picker error and permission alerts
* wait for photo library to load
* fix missing main queue dispatching on the invites screen