### PR TITLE
Fix: on iPad swapping apps resets the currently written text of the composer

### DIFF
--- a/ElementX/Sources/Screens/ComposerToolbar/View/ComposerToolbar.swift
+++ b/ElementX/Sources/Screens/ComposerToolbar/View/ComposerToolbar.swift
@@ -29,6 +29,7 @@ struct ComposerToolbar: View {
     @FocusState private var composerFocused: Bool
     @State private var frame: CGRect = .zero
     @Environment(\.verticalSizeClass) private var verticalSizeClass
+    @State private var hasAlreadyAppeared = false
     
     var body: some View {
         VStack(spacing: 8) {
@@ -174,7 +175,11 @@ struct ComposerToolbar: View {
         } editCancellationAction: {
             context.send(viewAction: .cancelEdit)
         } onAppearAction: {
+            guard !hasAlreadyAppeared else {
+                return
+            }
             context.send(viewAction: .composerAppeared)
+            hasAlreadyAppeared = true
         }
         .focused($composerFocused)
         .onChange(of: context.composerFocused) { newValue in

--- a/changelog.d/2275.bugfix
+++ b/changelog.d/2275.bugfix
@@ -1,0 +1,1 @@
+Composer won't reset its content the app is backgrounded on iPad.


### PR DESCRIPTION
Fixes #2275 

https://github.com/element-hq/element-x-ios/assets/34335419/af520464-4c53-440c-a81c-014b62d2a0e0

