### PR TITLE
Enable database encryption for new logins on Nightly/PR builds.

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -277,6 +277,7 @@
 		46562110EE202E580A5FFD9C /* RoomScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CF7B19FFCF8EFBE0A8696A /* RoomScreenViewModelTests.swift */; };
 		4681820102DAC8BA586357D4 /* VoiceMessageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAB8D7926A5684E18196B538 /* VoiceMessageCache.swift */; };
 		46A261AA898344A1F3C406B1 /* ReportContentScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCE3636E3D01477C8B2E9D0 /* ReportContentScreenModels.swift */; };
+		46A6DB0F78FB399BD59E2D41 /* EncryptionKeyProviderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E78FC546F28E045A560F2963 /* EncryptionKeyProviderProtocol.swift */; };
 		46BA7F4B4D3A7164DED44B88 /* FullscreenDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565F1B2B300597C616B37888 /* FullscreenDialog.swift */; };
 		46C9F8FE3810A04A005FE16B /* AudioPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B19B2BCC779ED934E0BBC2A /* AudioPlayer.swift */; };
 		4714991754A08B58B4D7ED85 /* OnboardingScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F27BAB69EB568369F1F6B3 /* OnboardingScreenViewModelProtocol.swift */; };
@@ -987,6 +988,7 @@
 		FB595EC9C00AB32F39034055 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A37E2FACFD041CE466223CD /* SceneDelegate.swift */; };
 		FB9A1DD83EF641A75ABBCE69 /* WaitlistScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C796FC1DFDBCDD5573D0360F /* WaitlistScreenViewModelTests.swift */; };
 		FBCCF1EA25A071324FCD8544 /* TimelineItemDebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7023EB4F3B7C7D1FBA68638B /* TimelineItemDebugView.swift */; };
+		FBD402E3170EB1ED0D1AA672 /* EncryptionKeyProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2355398E4A55DA5A89128AD1 /* EncryptionKeyProvider.swift */; };
 		FBF09B6C900415800DDF2A21 /* EmojiProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C113E0CB7E15E9765B1817A /* EmojiProvider.swift */; };
 		FC10228E73323BDC09526F97 /* SwiftState in Frameworks */ = {isa = PBXBuildFile; productRef = 9573B94B1C86C6DF751AF3FD /* SwiftState */; };
 		FC4F6BA083A64840B38CE269 /* SecureBackupRecoveryKeyScreenUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDBA358C79F0DCBC4FA14A88 /* SecureBackupRecoveryKeyScreenUITests.swift */; };
@@ -1185,6 +1187,7 @@
 		225EFCA26877E75CDFE7F48D /* MapTilerStyleBuilderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapTilerStyleBuilderProtocol.swift; sourceTree = "<group>"; };
 		22730A30C50AC2E3D5BA8642 /* InviteUsersScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteUsersScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		227AC5D71A4CE43512062243 /* URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URL.swift; sourceTree = "<group>"; };
+		2355398E4A55DA5A89128AD1 /* EncryptionKeyProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptionKeyProvider.swift; sourceTree = "<group>"; };
 		2389732B0E115A999A069083 /* NotificationSettingsScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsScreenCoordinator.swift; sourceTree = "<group>"; };
 		23AA3F4B285570805CB0CCDD /* MapTiler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapTiler.swift; sourceTree = "<group>"; };
 		24227FF9A2797F6EA7F69CDD /* HomeScreenInvitesButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenInvitesButton.swift; sourceTree = "<group>"; };
@@ -1879,6 +1882,7 @@
 		E6F5D66F158A6662F953733E /* NotificationSettingsProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsProxy.swift; sourceTree = "<group>"; };
 		E6FCC416A3BFE73DF7B3E6BF /* RoomTimelineControllerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomTimelineControllerFactory.swift; sourceTree = "<group>"; };
 		E71C28CF29CD05B6D6AE8580 /* HomeScreenSessionVerificationBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenSessionVerificationBanner.swift; sourceTree = "<group>"; };
+		E78FC546F28E045A560F2963 /* EncryptionKeyProviderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptionKeyProviderProtocol.swift; sourceTree = "<group>"; };
 		E8294DB9E95C0C0630418466 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
 		E8774CF614849664B5B3C2A1 /* UserSessionFlowCoordinatorStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSessionFlowCoordinatorStateMachine.swift; sourceTree = "<group>"; };
 		E8A1BBEF7318CA6B6ACCF4AE /* AppLockSetupUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockSetupUITests.swift; sourceTree = "<group>"; };
@@ -4310,6 +4314,8 @@
 		CA555F7C7CA382ACACF0D82B /* Keychain */ = {
 			isa = PBXGroup;
 			children = (
+				2355398E4A55DA5A89128AD1 /* EncryptionKeyProvider.swift */,
+				E78FC546F28E045A560F2963 /* EncryptionKeyProviderProtocol.swift */,
 				E36CB905A2B9EC2C92A2DA7C /* KeychainController.swift */,
 				39C0D861FC397AC34BCF089E /* KeychainControllerMock.swift */,
 				E5E94DCFEE803E5ABAE8ACCE /* KeychainControllerProtocol.swift */,
@@ -5477,6 +5483,8 @@
 				9965CB800CE6BC74ACA969FC /* EncryptedHistoryRoomTimelineView.swift in Sources */,
 				4C5A638DAA8AF64565BA4866 /* EncryptedRoomTimelineItem.swift in Sources */,
 				B5903E48CF43259836BF2DBF /* EncryptedRoomTimelineView.swift in Sources */,
+				FBD402E3170EB1ED0D1AA672 /* EncryptionKeyProvider.swift in Sources */,
+				46A6DB0F78FB399BD59E2D41 /* EncryptionKeyProviderProtocol.swift in Sources */,
 				50539366B408780B232C1910 /* EstimatedWaveformView.swift in Sources */,
 				F78BAD28482A467287A9A5A3 /* EventBasedMessageTimelineItemProtocol.swift in Sources */,
 				02D8DF8EB7537EB4E9019DDB /* EventBasedTimelineItemProtocol.swift in Sources */,

--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -393,7 +393,9 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationCoordinatorDelegate,
     
     private func startAuthentication() {
         let authenticationNavigationStackCoordinator = NavigationStackCoordinator()
-        let authenticationService = AuthenticationServiceProxy(userSessionStore: userSessionStore, appSettings: appSettings)
+        let authenticationService = AuthenticationServiceProxy(userSessionStore: userSessionStore,
+                                                               encryptionKeyProvider: EncryptionKeyProvider(),
+                                                               appSettings: appSettings)
         authenticationCoordinator = AuthenticationCoordinator(authenticationService: authenticationService,
                                                               navigationStackCoordinator: authenticationNavigationStackCoordinator,
                                                               appSettings: appSettings,
@@ -418,7 +420,9 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationCoordinatorDelegate,
                                                           userDisplayName: userSession.clientProxy.userDisplayName.value ?? "",
                                                           deviceID: userSession.deviceID)
             
-            let authenticationService = AuthenticationServiceProxy(userSessionStore: userSessionStore, appSettings: appSettings)
+            let authenticationService = AuthenticationServiceProxy(userSessionStore: userSessionStore,
+                                                                   encryptionKeyProvider: EncryptionKeyProvider(),
+                                                                   appSettings: appSettings)
             _ = await authenticationService.configure(for: userSession.homeserver)
             
             let parameters = SoftLogoutScreenCoordinatorParameters(authenticationService: authenticationService,

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -72,7 +72,8 @@ final class AppSettings {
     
     // MARK: - Application
     
-    lazy var canShowDeveloperOptions: Bool = {
+    /// Whether or not the app is a development build that isn't in production.
+    lazy var isDevelopmentBuild: Bool = {
         #if DEBUG
         true
         #else

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.1.2 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.1.3 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable all

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenInteractionHandler.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenInteractionHandler.swift
@@ -112,7 +112,7 @@ class RoomScreenInteractionHandler {
         }
 
         var debugActions: [TimelineItemMenuAction] = []
-        if appSettings.canShowDeveloperOptions || appSettings.viewSourceEnabled {
+        if appSettings.isDevelopmentBuild || appSettings.viewSourceEnabled {
             debugActions.append(.viewSource)
         }
 

--- a/ElementX/Sources/Screens/Settings/SettingsScreen/SettingsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Settings/SettingsScreen/SettingsScreenViewModel.swift
@@ -31,7 +31,7 @@ class SettingsScreenViewModel: SettingsScreenViewModelType, SettingsScreenViewMo
                                            userID: userSession.userID,
                                            accountProfileURL: userSession.clientProxy.accountURL(action: .profile),
                                            accountSessionsListURL: userSession.clientProxy.accountURL(action: .sessionsList),
-                                           showDeveloperOptions: appSettings.canShowDeveloperOptions),
+                                           showDeveloperOptions: appSettings.isDevelopmentBuild),
                    imageProvider: userSession.mediaProvider)
         
         userSession.clientProxy.userAvatarURL

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -79,11 +79,13 @@ protocol ClientProxyProtocol: AnyObject, MediaLoaderProtocol {
 
     var homeserver: String { get }
     
+    var session: Session? { get }
+    
     var userDisplayName: CurrentValuePublisher<String?, Never> { get }
 
     var userAvatarURL: CurrentValuePublisher<URL?, Never> { get }
-
-    var restorationToken: RestorationToken? { get }
+    
+    var pusherNotificationClientIdentifier: String? { get }
     
     var roomSummaryProvider: RoomSummaryProviderProtocol? { get }
     

--- a/ElementX/Sources/Services/Client/MockClientProxy.swift
+++ b/ElementX/Sources/Services/Client/MockClientProxy.swift
@@ -26,7 +26,8 @@ class MockClientProxy: ClientProxyProtocol {
     let userID: String
     let deviceID: String?
     let homeserver = ""
-    let restorationToken: RestorationToken? = nil
+    let session: Session? = nil
+    let pusherNotificationClientIdentifier: String? = nil
     
     var roomSummaryProvider: RoomSummaryProviderProtocol? = MockRoomSummaryProvider()
     

--- a/ElementX/Sources/Services/Keychain/EncryptionKeyProvider.swift
+++ b/ElementX/Sources/Services/Keychain/EncryptionKeyProvider.swift
@@ -1,0 +1,26 @@
+//
+// Copyright 2023 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import CryptoKit
+import Foundation
+
+struct EncryptionKeyProvider: EncryptionKeyProviderProtocol {
+    func generateKey() -> Data {
+        SymmetricKey(size: .bits256).withUnsafeBytes { bytes in
+            Data(Array(bytes))
+        }
+    }
+}

--- a/ElementX/Sources/Services/Keychain/EncryptionKeyProviderProtocol.swift
+++ b/ElementX/Sources/Services/Keychain/EncryptionKeyProviderProtocol.swift
@@ -1,0 +1,21 @@
+//
+// Copyright 2023 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+protocol EncryptionKeyProviderProtocol {
+    func generateKey() -> Data
+}

--- a/ElementX/Sources/Services/Keychain/KeychainController.swift
+++ b/ElementX/Sources/Services/Keychain/KeychainController.swift
@@ -113,7 +113,14 @@ class KeychainController: KeychainControllerProtocol {
     
     func saveSessionInKeychain(session: Session) {
         MXLog.info("Saving session changes in the keychain.")
-        let restorationToken = RestorationToken(session: session)
+        
+        guard let oldToken = restorationTokenForUsername(session.userId) else {
+            MXLog.error("Failed retrieving the restoration token for \(session.userId)")
+            fatalError("Something has gone mega wrong, all bets are off.")
+        }
+        let restorationToken = RestorationToken(session: session,
+                                                passphrase: oldToken.passphrase,
+                                                pusherNotificationClientIdentifier: oldToken.pusherNotificationClientIdentifier)
         setRestorationToken(restorationToken, forUsername: session.userId)
     }
     

--- a/ElementX/Sources/Services/Notification/Manager/NotificationManager.swift
+++ b/ElementX/Sources/Services/Notification/Manager/NotificationManager.swift
@@ -127,7 +127,7 @@ final class NotificationManager: NSObject, NotificationManagerProtocol {
             let defaultPayload = APNSPayload(aps: APSInfo(mutableContent: 1,
                                                           alert: APSAlert(locKey: "Notification",
                                                                           locArgs: [])),
-                                             pusherNotificationClientIdentifier: clientProxy.restorationToken?.pusherNotificationClientIdentifier)
+                                             pusherNotificationClientIdentifier: clientProxy.pusherNotificationClientIdentifier)
 
             let configuration = try await PusherConfiguration(identifiers: .init(pushkey: deviceToken.base64EncodedString(),
                                                                                  appId: appSettings.pusherAppId),

--- a/ElementX/Sources/Services/UserSession/RestorationToken.swift
+++ b/ElementX/Sources/Services/UserSession/RestorationToken.swift
@@ -14,24 +14,13 @@
 // limitations under the License.
 //
 
-import CryptoKit
 import Foundation
-
 import MatrixRustSDK
 
 struct RestorationToken: Codable, Equatable {
     let session: MatrixRustSDK.Session
+    let passphrase: String?
     let pusherNotificationClientIdentifier: String?
-
-    init(session: MatrixRustSDK.Session) {
-        self.session = session
-        if let data = session.userId.data(using: .utf8) {
-            let digest = SHA256.hash(data: data)
-            pusherNotificationClientIdentifier = digest.compactMap { String(format: "%02x", $0) }.joined()
-        } else {
-            pusherNotificationClientIdentifier = nil
-        }
-    }
 }
 
 extension MatrixRustSDK.Session: Codable {

--- a/ElementX/Sources/Services/UserSession/UserSessionStore.swift
+++ b/ElementX/Sources/Services/UserSession/UserSessionStore.swift
@@ -112,6 +112,9 @@ class UserSessionStore: UserSessionStoreProtocol {
     }
     
     private func restorePreviousLogin(_ credentials: KeychainCredentials) async -> Result<ClientProxyProtocol, UserSessionStoreError> {
+        if credentials.restorationToken.passphrase != nil {
+            MXLog.info("Restoring client with encrypted store.")
+        }
         let builder = ClientBuilder()
             .basePath(path: baseDirectory.path)
             .username(username: credentials.userID)

--- a/ElementX/Sources/Services/UserSession/UserSessionStore.swift
+++ b/ElementX/Sources/Services/UserSession/UserSessionStore.swift
@@ -68,13 +68,21 @@ class UserSessionStore: UserSessionStoreProtocol {
         }
     }
     
-    func userSession(for client: Client) async -> Result<UserSessionProtocol, UserSessionStoreError> {
-        switch await setupProxyForClient(client) {
-        case .success(let clientProxy):
+    func userSession(for client: Client, passphrase: String?) async -> Result<UserSessionProtocol, UserSessionStoreError> {
+        do {
+            let session = try client.session()
+            let userID = try client.userId()
+            let clientProxy = await setupProxyForClient(client)
+            
+            keychainController.setRestorationToken(RestorationToken(session: session,
+                                                                    passphrase: passphrase,
+                                                                    pusherNotificationClientIdentifier: clientProxy.pusherNotificationClientIdentifier),
+                                                   forUsername: userID)
+            
             return .success(buildUserSessionWithClient(clientProxy))
-        case .failure(let error):
+        } catch {
             MXLog.error("Failed creating user session with error: \(error)")
-            return .failure(error)
+            return .failure(.failedSettingUpSession)
         }
     }
     
@@ -108,6 +116,7 @@ class UserSessionStore: UserSessionStoreProtocol {
             .basePath(path: baseDirectory.path)
             .username(username: credentials.userID)
             .homeserverUrl(url: credentials.restorationToken.session.homeserverUrl)
+            .passphrase(passphrase: credentials.restorationToken.passphrase)
             .userAgent(userAgent: UserAgentBuilder.makeASCIIUserAgent())
             .enableCrossProcessRefreshLock(processId: InfoPlistReader.main.bundleIdentifier,
                                            sessionDelegate: keychainController)
@@ -119,30 +128,18 @@ class UserSessionStore: UserSessionStoreProtocol {
                 try client.restoreSession(session: credentials.restorationToken.session)
                 return client
             }
-            return await setupProxyForClient(client)
+            return await .success(setupProxyForClient(client))
         } catch {
             MXLog.error("Failed restoring login with error: \(error)")
             return .failure(.failedRestoringLogin)
         }
     }
     
-    private func setupProxyForClient(_ client: Client) async -> Result<ClientProxyProtocol, UserSessionStoreError> {
-        do {
-            let session = try client.session()
-            let userID = try client.userId()
-            
-            keychainController.setRestorationToken(RestorationToken(session: session), forUsername: userID)
-        } catch {
-            MXLog.error("Failed setting up user session with error: \(error)")
-            return .failure(.failedSettingUpSession)
-        }
-        
-        let clientProxy = await ClientProxy(client: client,
-                                            backgroundTaskService: backgroundTaskService,
-                                            appSettings: ServiceLocator.shared.settings,
-                                            networkMonitor: ServiceLocator.shared.networkMonitor)
-        
-        return .success(clientProxy)
+    private func setupProxyForClient(_ client: Client) async -> ClientProxyProtocol {
+        await ClientProxy(client: client,
+                          backgroundTaskService: backgroundTaskService,
+                          appSettings: ServiceLocator.shared.settings,
+                          networkMonitor: ServiceLocator.shared.networkMonitor)
     }
     
     private func deleteSessionDirectory(for userID: String) {

--- a/ElementX/Sources/Services/UserSession/UserSessionStoreProtocol.swift
+++ b/ElementX/Sources/Services/UserSession/UserSessionStoreProtocol.swift
@@ -42,8 +42,8 @@ protocol UserSessionStoreProtocol {
     /// Restores an existing user session.
     func restoreUserSession() async -> Result<UserSessionProtocol, UserSessionStoreError>
     
-    /// Creates a user session for a new client from the SDK.
-    func userSession(for client: Client) async -> Result<UserSessionProtocol, UserSessionStoreError>
+    /// Creates a user session for a new client from the SDK along with the passphrase used for the data stores.
+    func userSession(for client: Client, passphrase: String?) async -> Result<UserSessionProtocol, UserSessionStoreError>
     
     /// Logs out of the specified session.
     func logout(userSession: UserSessionProtocol)

--- a/NSE/Sources/Other/NSEUserSession.swift
+++ b/NSE/Sources/Other/NSEUserSession.swift
@@ -28,6 +28,9 @@ final class NSEUserSession {
 
     init(credentials: KeychainCredentials, clientSessionDelegate: ClientSessionDelegate) throws {
         userID = credentials.userID
+        if credentials.restorationToken.passphrase != nil {
+            MXLog.info("Restoring client with encrypted store.")
+        }
         baseClient = try ClientBuilder()
             .basePath(path: URL.sessionsBaseDirectory.path)
             .username(username: credentials.userID)

--- a/NSE/Sources/Other/NSEUserSession.swift
+++ b/NSE/Sources/Other/NSEUserSession.swift
@@ -31,6 +31,7 @@ final class NSEUserSession {
         baseClient = try ClientBuilder()
             .basePath(path: URL.sessionsBaseDirectory.path)
             .username(username: credentials.userID)
+            .passphrase(passphrase: credentials.restorationToken.passphrase)
             .userAgent(userAgent: UserAgentBuilder.makeASCIIUserAgent())
             .enableCrossProcessRefreshLock(processId: InfoPlistReader.main.bundleIdentifier,
                                            sessionDelegate: clientSessionDelegate)

--- a/UnitTests/Sources/KeychainControllerTests.swift
+++ b/UnitTests/Sources/KeychainControllerTests.swift
@@ -39,7 +39,9 @@ class KeychainControllerTests: XCTestCase {
                                                                deviceId: "deviceId",
                                                                homeserverUrl: "homeserverUrl",
                                                                oidcData: "oidcData",
-                                                               slidingSyncProxy: "https://my.sync.proxy"))
+                                                               slidingSyncProxy: "https://my.sync.proxy"),
+                                                passphrase: "passphrase",
+                                                pusherNotificationClientIdentifier: "pusherClientID")
         keychain.setRestorationToken(restorationToken, forUsername: username)
         
         // Then the restoration token should be stored in the keychain.
@@ -55,7 +57,9 @@ class KeychainControllerTests: XCTestCase {
                                                                deviceId: "deviceId",
                                                                homeserverUrl: "homeserverUrl",
                                                                oidcData: "oidcData",
-                                                               slidingSyncProxy: "https://my.sync.proxy"))
+                                                               slidingSyncProxy: "https://my.sync.proxy"),
+                                                passphrase: "passphrase",
+                                                pusherNotificationClientIdentifier: "pusherClientID")
         keychain.setRestorationToken(restorationToken, forUsername: username)
         XCTAssertEqual(keychain.restorationTokens().count, 1, "The keychain should have 1 restoration token.")
         XCTAssertEqual(keychain.restorationTokenForUsername(username), restorationToken, "The initial restoration token should match the value that was stored.")
@@ -77,7 +81,9 @@ class KeychainControllerTests: XCTestCase {
                                                                    deviceId: "deviceId",
                                                                    homeserverUrl: "homeserverUrl",
                                                                    oidcData: "oidcData",
-                                                                   slidingSyncProxy: "https://my.sync.proxy"))
+                                                                   slidingSyncProxy: "https://my.sync.proxy"),
+                                                    passphrase: "passphrase",
+                                                    pusherNotificationClientIdentifier: "pusherClientID")
             keychain.setRestorationToken(restorationToken, forUsername: "@test\(index):example.com")
         }
         XCTAssertEqual(keychain.restorationTokens().count, 5, "The keychain should have 5 restoration tokens.")
@@ -98,7 +104,9 @@ class KeychainControllerTests: XCTestCase {
                                                                    deviceId: "deviceId",
                                                                    homeserverUrl: "homeserverUrl",
                                                                    oidcData: "oidcData",
-                                                                   slidingSyncProxy: "https://my.sync.proxy"))
+                                                                   slidingSyncProxy: "https://my.sync.proxy"),
+                                                    passphrase: "passphrase",
+                                                    pusherNotificationClientIdentifier: "pusherClientID")
             keychain.setRestorationToken(restorationToken, forUsername: "@test\(index):example.com")
         }
         XCTAssertEqual(keychain.restorationTokens().count, 5, "The keychain should have 5 restoration tokens.")

--- a/changelog.d/441.wip
+++ b/changelog.d/441.wip
@@ -1,0 +1,1 @@
+Enable database encryption for new logins on Nightly/PR builds.


### PR DESCRIPTION
This PR essentially closes #441, although we're going to test on Nightly first to measure any potential performance impact. The following approach has been taken:
- The `RestorationToken` now contains an optional `passphrase` string which is given to the SDK when restoring a session. Existing users won't have one set, so their accounts will continue to operate without encryption on the db.
- When running a dev build (inc Nightly and PRs) the `AuthenticationServiceProxy` will generate a passphrase in the init (which we do for each login so a fresh key will be generated for each login). This passphrase is handed to the SDK which will create the stores, and when a sucessfull login is made, it is handed to the session store to add to the `RestorationToken`
- OIDC sessions update the `RestorationToken` each time the restoration token is refreshed. We now need to fetch the token to preserve the passphrase and if it is missing the app will crash (which will likely result in the user being signed out on next launch but if this happened there wouldn't be much we could do app-side to fix it anyway).
- I've tweaked the location where the `pusherNotificationClientIdentifier` is generated, as getting it from the `ClientProxy` through the restoration token is no longer possible, due to the proxy not knowing what the passphrase is.