### PR TITLE
User ID is shown also in the room members list

### DIFF
--- a/ElementX/Sources/Screens/RoomMemberListScreen/View/RoomMembersListScreen.swift
+++ b/ElementX/Sources/Screens/RoomMemberListScreen/View/RoomMembersListScreen.swift
@@ -88,5 +88,6 @@ struct RoomMembersListScreen_Previews: PreviewProvider, TestablePreview {
         NavigationStack {
             RoomMembersListScreen(context: viewModel.context)
         }
+        .snapshot(delay: 1.0)
     }
 }

--- a/ElementX/Sources/Screens/RoomMemberListScreen/View/RoomMembersListScreenMemberCell.swift
+++ b/ElementX/Sources/Screens/RoomMemberListScreen/View/RoomMembersListScreenMemberCell.swift
@@ -31,11 +31,16 @@ struct RoomMembersListScreenMemberCell: View {
                                     avatarSize: .user(on: .roomDetails),
                                     imageProvider: context.imageProvider)
                     .accessibilityHidden(true)
-
-                Text(member.name ?? "")
-                    .font(.compound.bodyMDSemibold)
-                    .foregroundColor(.compound.textPrimary)
-                    .lineLimit(1)
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(member.name ?? "")
+                        .font(.compound.bodyMDSemibold)
+                        .foregroundColor(.compound.textPrimary)
+                        .lineLimit(1)
+                    Text(member.id)
+                        .font(.compound.bodySM)
+                        .foregroundColor(.compound.textSecondary)
+                        .lineLimit(1)
+                }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .accessibilityElement(children: .combine)

--- a/UnitTests/__Snapshots__/PreviewTests/test_roomMembersListMemberCell.1.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_roomMembersListMemberCell.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:61d335b7118fa8c3c46490768ae6cca2611faf24812b21061e9d13eb5fa7d65c
-size 71383
+oid sha256:55499e595ef08cf57db3e224d54f10ef2bc7c7b97ef03f653fdd53e7133af9c2
+size 87144

--- a/UnitTests/__Snapshots__/PreviewTests/test_roomMembersListScreen.1.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_roomMembersListScreen.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cd2bc1db544ad1ddfd4f7e8895c2335479993782305f309a0746abaf5909ca18
-size 67891
+oid sha256:23477e22db7bf4d5df68b9227f26d7ce306b729f0d29cc85c8abd481346696b5
+size 103846

--- a/changelog.d/pr-2332.change
+++ b/changelog.d/pr-2332.change
@@ -1,0 +1,1 @@
+Added the user id in the room members list cells, to avoid ambiguity.


### PR DESCRIPTION
This will avoid ambiguity when users share the same display name in the list