### PR TITLE
Follow up to #2325 - Prevent tighlooping between `makeUIView` and `up…

### DIFF
--- a/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
+++ b/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
@@ -23,7 +23,8 @@ struct CallScreen: View {
     
     var body: some View {
         WebView(url: context.viewState.url, viewModelContext: context)
-            .id(UUID())
+            // This URL is stable, forces view reloads if this representable is ever reused for another url
+            .id(context.viewState.url)
             .ignoresSafeArea(edges: .bottom)
             .presentationDragIndicator(.visible)
             .environment(\.colorScheme, .dark)

--- a/ElementX/Sources/Screens/Other/GenericCallLinkCoordinator.swift
+++ b/ElementX/Sources/Screens/Other/GenericCallLinkCoordinator.swift
@@ -34,12 +34,11 @@ class GenericCallLinkCoordinator: CoordinatorProtocol {
     }
     
     func toPresentable() -> AnyView {
-        AnyView(
-            WebView(url: parameters.url)
-                .id(UUID())
-                .ignoresSafeArea(edges: .bottom)
-                .presentationDragIndicator(.visible)
-        )
+        AnyView(WebView(url: parameters.url)
+            // This URL is stable, forces view reloads if this representable is ever reused for another url
+            .id(parameters.url)
+            .ignoresSafeArea(edges: .bottom)
+            .presentationDragIndicator(.visible))
     }
 }
 


### PR DESCRIPTION
…dateUIView` when creating room calls.