### PR TITLE
Fixes #2378 - Allow partial text selection in the timeline item view …

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineItemDebugView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineItemDebugView.swift
@@ -81,9 +81,10 @@ struct TimelineItemDebugView: View {
                 Divider()
                     .padding(.vertical, 8)
                 
-                Text(text)
+                TextField("", text: .constant(text), axis: .vertical)
                     .font(.compound.bodyXS.monospaced())
                     .foregroundColor(.compound.textPrimary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
             .frame(maxWidth: .infinity)
         }

--- a/UnitTests/__Snapshots__/PreviewTests/test_timelineItemDebugView.1.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_timelineItemDebugView.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3a809edfdea583bd03200ba58537a45633e6bd473477fb1689f064e64d66ed77
-size 120613
+oid sha256:d9fe2cee3fd40c7df9ccab21b558034012a881f74b3ef8e5aff64c1d19a8303c
+size 120629

--- a/changelog.d/2378.feature
+++ b/changelog.d/2378.feature
@@ -1,0 +1,1 @@
+Allow partial text selection in the timeline item view source menu


### PR DESCRIPTION
…source menu

Unfortunately I couldn't find a way to disable editing but keep partial selection so this will have to do.