### PR TITLE
State events filtering + Bump sdk

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -6732,7 +6732,7 @@
 			repositoryURL = "https://github.com/matrix-org/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 1.1.35;
+				version = 1.1.36;
 			};
 		};
 		821C67C9A7F8CC3FD41B28B4 /* XCRemoteSwiftPackageReference "emojibase-bindings" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -130,8 +130,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-rust-components-swift",
       "state" : {
-        "revision" : "b7ed8b30a1b648ebdf87bb14a11f071df4999e03",
-        "version" : "1.1.35"
+        "revision" : "e6aecad747a12e399ee718b5fb2ece45b7b6e23a",
+        "version" : "1.1.36"
       }
     },
     {

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -586,23 +586,24 @@ class ClientProxy: ClientProxyProtocol {
         })
     }
     
-    private let eventFilters: TimelineEventTypeFilter = .exclude(eventTypes: [
-        .roomAliases,
-        .roomCanonicalAlias,
-        .roomGuestAccess,
-        .roomHistoryVisibility,
-        .roomJoinRules,
-        .roomPinnedEvents,
-        .roomPowerLevels,
-        .roomServerAcl,
-        .roomTombstone,
-        .spaceChild,
-        .spaceParent,
-        .policyRuleRoom,
-        .policyRuleServer,
-        .policyRuleServer
-    ].map { .state(eventType: $0) })
-    
+    private let eventFilters: TimelineEventTypeFilter = {
+        let stateEventFilters: [FilterStateEventType] = [.roomAliases,
+                                                         .roomCanonicalAlias,
+                                                         .roomGuestAccess,
+                                                         .roomHistoryVisibility,
+                                                         .roomJoinRules,
+                                                         .roomPinnedEvents,
+                                                         .roomPowerLevels,
+                                                         .roomServerAcl,
+                                                         .roomTombstone,
+                                                         .spaceChild,
+                                                         .spaceParent,
+                                                         .policyRuleRoom,
+                                                         .policyRuleServer]
+        
+        return .exclude(eventTypes: stateEventFilters.map { FilterTimelineEventType.state(eventType: $0) })
+    }()
+
     private func roomTupleForIdentifier(_ identifier: String) async -> (RoomListItem?, Room?) {
         do {
             let roomListItem = try roomListService?.room(roomId: identifier)

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -587,21 +587,21 @@ class ClientProxy: ClientProxyProtocol {
     }
     
     private let eventFilters: TimelineEventTypeFilter = .exclude(eventTypes: [
-        .state(eventType: .roomAliases),
-        .state(eventType: .roomCanonicalAlias),
-        .state(eventType: .roomGuestAccess),
-        .state(eventType: .roomHistoryVisibility),
-        .state(eventType: .roomJoinRules),
-        .state(eventType: .roomPinnedEvents),
-        .state(eventType: .roomPowerLevels),
-        .state(eventType: .roomServerAcl),
-        .state(eventType: .roomTombstone),
-        .state(eventType: .spaceChild),
-        .state(eventType: .spaceParent),
-        .state(eventType: .policyRuleRoom),
-        .state(eventType: .policyRuleServer),
-        .state(eventType: .policyRuleServer)
-    ])
+        .roomAliases,
+        .roomCanonicalAlias,
+        .roomGuestAccess,
+        .roomHistoryVisibility,
+        .roomJoinRules,
+        .roomPinnedEvents,
+        .roomPowerLevels,
+        .roomServerAcl,
+        .roomTombstone,
+        .spaceChild,
+        .spaceParent,
+        .policyRuleRoom,
+        .policyRuleServer,
+        .policyRuleServer
+    ].map { .state(eventType: $0) })
     
     private func roomTupleForIdentifier(_ identifier: String) async -> (RoomListItem?, Room?) {
         do {

--- a/changelog.d/2404.change
+++ b/changelog.d/2404.change
@@ -1,0 +1,1 @@
+The timeline will filter some unnecessary state events.

--- a/project.yml
+++ b/project.yml
@@ -47,7 +47,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/matrix-org/matrix-rust-components-swift
-    exactVersion: 1.1.35
+    exactVersion: 1.1.36
     # path: ../matrix-rust-sdk
   Compound:
     url: https://github.com/element-hq/compound-ios


### PR DESCRIPTION
Bumped SDK to 1.1.36, and introduced a way to check to filter specific state events from the timeline (however now this requires the roomListItem to be initialised first if not done yet)
