### PR TITLE
Replace emoji detection implementation with a simpler one

### DIFF
--- a/UnitTests/Sources/EmojiDetectionTests.swift
+++ b/UnitTests/Sources/EmojiDetectionTests.swift
@@ -40,9 +40,10 @@ class EmojiDetectionTests: XCTestCase {
         
         XCTAssertTrue("👍".containsOnlyEmoji)
         XCTAssertTrue("🫱🏼‍🫲🏾".containsOnlyEmoji)
-        XCTAssertTrue("👁❤️🍝".containsOnlyEmoji)
         XCTAssertFalse("🙂 ".containsOnlyEmoji)
         XCTAssertFalse("Hello 👋".containsOnlyEmoji)
         XCTAssertFalse("Thanks".containsOnlyEmoji)
+        
+        XCTAssertFalse("0*".containsOnlyEmoji)
     }
 }


### PR DESCRIPTION
Went for a simpler implementation that correctly detects `0*` as non-emoji at the cost of having to remove one of the more complext test cases -> `XCTAssertTrue("👁❤️🍝".containsOnlyEmoji)`. I think it's a decent compromise.