### PR TITLE
Last session recovery

### DIFF
--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -361,7 +361,7 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
     private func runLogoutFlow() async {
         let secureBackupController = userSession.clientProxy.secureBackupController
         
-        guard case let .success(isLastDevice) = await userSession.clientProxy.isLastDevice() else {
+        guard case let .success(isLastDevice) = await userSession.clientProxy.isOnlyDeviceLeft() else {
             ServiceLocator.shared.userIndicatorController.alertInfo = .init(id: .init())
             return
         }

--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -376,7 +376,7 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
             return
         }
         
-        guard secureBackupController.recoveryKeyState.value == .enabled else {
+        guard secureBackupController.recoveryState.value == .enabled else {
             ServiceLocator.shared.userIndicatorController.alertInfo = .init(id: .init(),
                                                                             title: L10n.screenSignoutRecoveryDisabledTitle,
                                                                             message: L10n.screenSignoutRecoveryDisabledSubtitle,

--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -361,12 +361,12 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
     private func runLogoutFlow() async {
         let secureBackupController = userSession.clientProxy.secureBackupController
         
-        guard case let .success(isLastSession) = await secureBackupController.isLastSession() else {
+        guard case let .success(isLastDevice) = await userSession.clientProxy.isLastDevice() else {
             ServiceLocator.shared.userIndicatorController.alertInfo = .init(id: .init())
             return
         }
         
-        guard isLastSession else {
+        guard isLastDevice else {
             ServiceLocator.shared.userIndicatorController.alertInfo = .init(id: .init(),
                                                                             title: L10n.screenSignoutConfirmationDialogTitle,
                                                                             message: L10n.screenSignoutConfirmationDialogContent,

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -2446,23 +2446,6 @@ class SecureBackupControllerMock: SecureBackupControllerProtocol {
             return confirmRecoveryKeyReturnValue
         }
     }
-    //MARK: - isLastSession
-
-    var isLastSessionCallsCount = 0
-    var isLastSessionCalled: Bool {
-        return isLastSessionCallsCount > 0
-    }
-    var isLastSessionReturnValue: Result<Bool, SecureBackupControllerError>!
-    var isLastSessionClosure: (() async -> Result<Bool, SecureBackupControllerError>)?
-
-    func isLastSession() async -> Result<Bool, SecureBackupControllerError> {
-        isLastSessionCallsCount += 1
-        if let isLastSessionClosure = isLastSessionClosure {
-            return await isLastSessionClosure()
-        } else {
-            return isLastSessionReturnValue
-        }
-    }
     //MARK: - waitForKeyBackupUpload
 
     var waitForKeyBackupUploadCallsCount = 0

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -2363,11 +2363,11 @@ class RoomTimelineProviderMock: RoomTimelineProviderProtocol {
 
 }
 class SecureBackupControllerMock: SecureBackupControllerProtocol {
-    var recoveryKeyState: CurrentValuePublisher<SecureBackupRecoveryKeyState, Never> {
-        get { return underlyingRecoveryKeyState }
-        set(value) { underlyingRecoveryKeyState = value }
+    var recoveryState: CurrentValuePublisher<SecureBackupRecoveryState, Never> {
+        get { return underlyingRecoveryState }
+        set(value) { underlyingRecoveryState = value }
     }
-    var underlyingRecoveryKeyState: CurrentValuePublisher<SecureBackupRecoveryKeyState, Never>!
+    var underlyingRecoveryState: CurrentValuePublisher<SecureBackupRecoveryState, Never>!
     var keyBackupState: CurrentValuePublisher<SecureBackupKeyBackupState, Never> {
         get { return underlyingKeyBackupState }
         set(value) { underlyingKeyBackupState = value }

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
@@ -75,33 +75,21 @@ enum HomeScreenRoomListMode: CustomStringConvertible {
     }
 }
 
+enum SecurityBannerMode {
+    case none
+    case dismissed
+    case sessionVerification
+    case recoveryKeyConfirmation
+}
+
 struct HomeScreenViewState: BindableState {
     let userID: String
     var userDisplayName: String?
     var userAvatarURL: URL?
     
-    var isSessionVerified: Bool?
-    var hasSessionVerificationBannerBeenDismissed = false
-    var showSessionVerificationBanner: Bool {
-        guard let isSessionVerified else {
-            return false
-        }
+    var securityBannerMode = SecurityBannerMode.none
+    var requiresExtraAccountSetup = false
         
-        return !isSessionVerified && !hasSessionVerificationBannerBeenDismissed
-    }
-    
-    var requiresSecureBackupSetup = false
-
-    var needsRecoveryKeyConfirmation = false
-    var hasRecoveryKeyConfirmationBannerBeenDismissed = false
-    var showRecoveryKeyConfirmationBanner: Bool {
-        guard let isSessionVerified else {
-            return false
-        }
-        
-        return isSessionVerified && needsRecoveryKeyConfirmation && !hasRecoveryKeyConfirmationBannerBeenDismissed
-    }
-    
     var rooms: [HomeScreenRoom] = []
     var roomListMode: HomeScreenRoomListMode = .skeletons
     

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -61,7 +61,7 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
             .weakAssign(to: \.state.userDisplayName, on: self)
             .store(in: &cancellables)
         
-        userSession.sessionSecurityState
+        userSession.sessionSecurityStatePublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] securityState in
                 guard let self else { return }

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -61,20 +61,35 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
             .weakAssign(to: \.state.userDisplayName, on: self)
             .store(in: &cancellables)
         
-        userSession.sessionVerificationState
+        userSession.sessionSecurityState
             .receive(on: DispatchQueue.main)
-            .weakAssign(to: \.state.isSessionVerified, on: self)
-            .store(in: &cancellables)
-        
-        userSession.clientProxy.secureBackupController.recoveryKeyState
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] recoveryKeyState in
+            .sink { [weak self] securityState in
                 guard let self else { return }
                 
-                let requiresSecureBackupSetup = recoveryKeyState == .disabled || recoveryKeyState == .incomplete
-                state.requiresSecureBackupSetup = requiresSecureBackupSetup
-                
-                state.needsRecoveryKeyConfirmation = recoveryKeyState == .incomplete
+                switch (securityState.verificationState, securityState.recoveryState) {
+                case (.unverified, _):
+                    state.requiresExtraAccountSetup = true
+                    if state.securityBannerMode != .dismissed {
+                        state.securityBannerMode = .sessionVerification
+                    }
+                case (.unverifiedLastSession, .incomplete):
+                    state.requiresExtraAccountSetup = true
+                    if state.securityBannerMode != .dismissed {
+                        state.securityBannerMode = .recoveryKeyConfirmation
+                    }
+                case (.verified, .disabled):
+                    state.requiresExtraAccountSetup = true
+                    state.securityBannerMode = .none
+                case (.verified, .incomplete):
+                    state.requiresExtraAccountSetup = true
+                    
+                    if state.securityBannerMode != .dismissed {
+                        state.securityBannerMode = .recoveryKeyConfirmation
+                    }
+                default:
+                    state.securityBannerMode = .none
+                    state.requiresExtraAccountSetup = false
+                }
             }
             .store(in: &cancellables)
         
@@ -149,9 +164,9 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
         case .confirmRecoveryKey:
             actionsSubject.send(.presentSecureBackupSettings)
         case .skipSessionVerification:
-            state.hasSessionVerificationBannerBeenDismissed = true
+            state.securityBannerMode = .dismissed
         case .skipRecoveryKeyConfirmation:
-            state.hasRecoveryKeyConfirmationBannerBeenDismissed = true
+            state.securityBannerMode = .dismissed
         case .updateVisibleItemRange(let range, let isScrolling):
             visibleItemRangePublisher.send((range, isScrolling))
         case .startChat:

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreenContent.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreenContent.swift
@@ -116,10 +116,13 @@ struct HomeScreenContent: View {
                 filters
             }
             
-            if context.viewState.showSessionVerificationBanner {
+            switch context.viewState.securityBannerMode {
+            case .sessionVerification:
                 HomeScreenSessionVerificationBanner(context: context)
-            } else if context.viewState.showRecoveryKeyConfirmationBanner {
+            case .recoveryKeyConfirmation:
                 HomeScreenRecoveryKeyConfirmationBanner(context: context)
+            default:
+                EmptyView()
             }
             
             if context.viewState.hasPendingInvitations, !context.isSearchFieldFocused {

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreenUserMenuButton.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreenUserMenuButton.swift
@@ -29,7 +29,7 @@ struct HomeScreenUserMenuButton: View {
                     Label {
                         Text(L10n.commonSettings)
                     } icon: {
-                        if context.viewState.requiresSecureBackupSetup, context.viewState.isSessionVerified == true {
+                        if context.viewState.requiresExtraAccountSetup {
                             CompoundIcon(asset: Asset.Images.settingsIconWithBadge)
                         } else {
                             CompoundIcon(\.settings)
@@ -50,7 +50,7 @@ struct HomeScreenUserMenuButton: View {
                                 avatarSize: .user(on: .home),
                                 imageProvider: context.imageProvider)
                 .accessibilityIdentifier(A11yIdentifiers.homeScreen.userAvatar)
-                .overlayBadge(10, isBadged: context.viewState.requiresSecureBackupSetup && context.viewState.isSessionVerified == true)
+                .overlayBadge(10, isBadged: context.viewState.requiresExtraAccountSetup)
                 .compositingGroup()
         }
         .accessibilityLabel(L10n.a11yUserMenu)

--- a/ElementX/Sources/Screens/SecureBackup/SecureBackupRecoveryKeyScreen/SecureBackupRecoveryKeyScreenViewModel.swift
+++ b/ElementX/Sources/Screens/SecureBackup/SecureBackupRecoveryKeyScreen/SecureBackupRecoveryKeyScreenViewModel.swift
@@ -32,9 +32,9 @@ class SecureBackupRecoveryKeyScreenViewModel: SecureBackupRecoveryKeyScreenViewM
         self.secureBackupController = secureBackupController
         self.userIndicatorController = userIndicatorController
         
-        super.init(initialViewState: .init(mode: secureBackupController.recoveryKeyState.value.viewMode, bindings: .init()))
+        super.init(initialViewState: .init(mode: secureBackupController.recoveryState.value.viewMode, bindings: .init()))
         
-        secureBackupController.recoveryKeyState
+        secureBackupController.recoveryState
             .receive(on: DispatchQueue.main)
             .sink(receiveValue: { [weak userIndicatorController] state in
                 let loadingIndicatorIdentifier = "SecureBackupRecoveryKeyScreenLoading"
@@ -100,7 +100,7 @@ class SecureBackupRecoveryKeyScreenViewModel: SecureBackupRecoveryKeyScreenViewM
     }
 }
 
-extension SecureBackupRecoveryKeyState {
+extension SecureBackupRecoveryState {
     var viewMode: SecureBackupRecoveryKeyScreenViewMode {
         switch self {
         case .disabled:

--- a/ElementX/Sources/Screens/SecureBackup/SecureBackupRecoveryKeyScreen/View/SecureBackupRecoveryKeyScreen.swift
+++ b/ElementX/Sources/Screens/SecureBackup/SecureBackupRecoveryKeyScreen/View/SecureBackupRecoveryKeyScreen.swift
@@ -65,25 +65,7 @@ struct SecureBackupRecoveryKeyScreen: View {
     private var footer: some View {
         switch context.viewState.mode {
         case .setupRecovery, .changeRecovery:
-            VStack(spacing: 8.0) {
-                if let recoveryKey = context.viewState.recoveryKey {
-                    ShareLink(item: recoveryKey) {
-                        Label(L10n.screenRecoveryKeySaveAction, icon: \.download)
-                    }
-                    .buttonStyle(.compound(.primary))
-                    .simultaneousGesture(TapGesture().onEnded { _ in
-                        context.send(viewAction: .keySaved)
-                    })
-                }
-                
-                Button {
-                    context.send(viewAction: .done)
-                } label: {
-                    Text(L10n.actionDone)
-                }
-                .buttonStyle(.compound(.primary))
-                .disabled(context.viewState.recoveryKey == nil || context.viewState.doneButtonEnabled == false)
-            }
+            recoveryCreatedActionButtons
         case .fixRecovery:
             Button {
                 context.send(viewAction: .confirmKey)
@@ -92,6 +74,28 @@ struct SecureBackupRecoveryKeyScreen: View {
             }
             .buttonStyle(.compound(.primary))
             .disabled(context.confirmationRecoveryKey.isEmpty)
+        }
+    }
+    
+    private var recoveryCreatedActionButtons: some View {
+        VStack(spacing: 8.0) {
+            if let recoveryKey = context.viewState.recoveryKey {
+                ShareLink(item: recoveryKey) {
+                    Label(L10n.screenRecoveryKeySaveAction, icon: \.download)
+                }
+                .buttonStyle(.compound(.primary))
+                .simultaneousGesture(TapGesture().onEnded { _ in
+                    context.send(viewAction: .keySaved)
+                })
+            }
+            
+            Button {
+                context.send(viewAction: .done)
+            } label: {
+                Text(L10n.actionDone)
+            }
+            .buttonStyle(.compound(.primary))
+            .disabled(context.viewState.recoveryKey == nil || context.viewState.doneButtonEnabled == false)
         }
     }
     

--- a/ElementX/Sources/Screens/SecureBackup/SecureBackupRecoveryKeyScreen/View/SecureBackupRecoveryKeyScreen.swift
+++ b/ElementX/Sources/Screens/SecureBackup/SecureBackupRecoveryKeyScreen/View/SecureBackupRecoveryKeyScreen.swift
@@ -204,9 +204,9 @@ struct SecureBackupRecoveryKeyScreen: View {
 // MARK: - Previews
 
 struct SecureBackupRecoveryKeyScreen_Previews: PreviewProvider, TestablePreview {
-    static let setupViewModel = viewModel(recoveryKeyState: .enabled)
-    static let notSetUpViewModel = viewModel(recoveryKeyState: .disabled)
-    static let incompleteViewModel = viewModel(recoveryKeyState: .incomplete)
+    static let setupViewModel = viewModel(recoveryState: .enabled)
+    static let notSetUpViewModel = viewModel(recoveryState: .disabled)
+    static let incompleteViewModel = viewModel(recoveryState: .incomplete)
     
     static var previews: some View {
         NavigationStack {
@@ -225,9 +225,9 @@ struct SecureBackupRecoveryKeyScreen_Previews: PreviewProvider, TestablePreview 
         .previewDisplayName("Incomplete")
     }
     
-    static func viewModel(recoveryKeyState: SecureBackupRecoveryKeyState) -> SecureBackupRecoveryKeyScreenViewModelType {
+    static func viewModel(recoveryState: SecureBackupRecoveryState) -> SecureBackupRecoveryKeyScreenViewModelType {
         let backupController = SecureBackupControllerMock()
-        backupController.underlyingRecoveryKeyState = CurrentValueSubject<SecureBackupRecoveryKeyState, Never>(recoveryKeyState).asCurrentValuePublisher()
+        backupController.underlyingRecoveryState = CurrentValueSubject<SecureBackupRecoveryState, Never>(recoveryState).asCurrentValuePublisher()
         
         return SecureBackupRecoveryKeyScreenViewModel(secureBackupController: backupController, userIndicatorController: UserIndicatorControllerMock())
     }

--- a/ElementX/Sources/Screens/SecureBackup/SecureBackupRecoveryKeyScreen/View/SecureBackupRecoveryKeyScreen.swift
+++ b/ElementX/Sources/Screens/SecureBackup/SecureBackupRecoveryKeyScreen/View/SecureBackupRecoveryKeyScreen.swift
@@ -65,23 +65,25 @@ struct SecureBackupRecoveryKeyScreen: View {
     private var footer: some View {
         switch context.viewState.mode {
         case .setupRecovery, .changeRecovery:
-            if let recoveryKey = context.viewState.recoveryKey {
-                ShareLink(item: recoveryKey) {
-                    Label(L10n.screenRecoveryKeySaveAction, icon: \.download)
+            VStack(spacing: 8.0) {
+                if let recoveryKey = context.viewState.recoveryKey {
+                    ShareLink(item: recoveryKey) {
+                        Label(L10n.screenRecoveryKeySaveAction, icon: \.download)
+                    }
+                    .buttonStyle(.compound(.primary))
+                    .simultaneousGesture(TapGesture().onEnded { _ in
+                        context.send(viewAction: .keySaved)
+                    })
+                }
+                
+                Button {
+                    context.send(viewAction: .done)
+                } label: {
+                    Text(L10n.actionDone)
                 }
                 .buttonStyle(.compound(.primary))
-                .simultaneousGesture(TapGesture().onEnded { _ in
-                    context.send(viewAction: .keySaved)
-                })
+                .disabled(context.viewState.recoveryKey == nil || context.viewState.doneButtonEnabled == false)
             }
-            
-            Button {
-                context.send(viewAction: .done)
-            } label: {
-                Text(L10n.actionDone)
-            }
-            .buttonStyle(.compound(.primary))
-            .disabled(context.viewState.recoveryKey == nil || context.viewState.doneButtonEnabled == false)
         case .fixRecovery:
             Button {
                 context.send(viewAction: .confirmKey)

--- a/ElementX/Sources/Screens/SecureBackup/SecureBackupScreen/SecureBackupScreenModels.swift
+++ b/ElementX/Sources/Screens/SecureBackup/SecureBackupScreen/SecureBackupScreenModels.swift
@@ -23,7 +23,7 @@ enum SecureBackupScreenViewModelAction {
 
 struct SecureBackupScreenViewState: BindableState {
     let chatBackupDetailsURL: URL
-    var recoveryKeyState = SecureBackupRecoveryKeyState.unknown
+    var recoveryState = SecureBackupRecoveryState.unknown
     var keyBackupState = SecureBackupKeyBackupState.unknown
     var bindings = SecureBackupScreenViewStateBindings()
 }

--- a/ElementX/Sources/Screens/SecureBackup/SecureBackupScreen/SecureBackupScreenViewModel.swift
+++ b/ElementX/Sources/Screens/SecureBackup/SecureBackupScreen/SecureBackupScreenViewModel.swift
@@ -36,9 +36,9 @@ class SecureBackupScreenViewModel: SecureBackupScreenViewModelType, SecureBackup
         
         super.init(initialViewState: .init(chatBackupDetailsURL: chatBackupDetailsURL))
         
-        secureBackupController.recoveryKeyState
+        secureBackupController.recoveryState
             .receive(on: DispatchQueue.main)
-            .weakAssign(to: \.state.recoveryKeyState, on: self)
+            .weakAssign(to: \.state.recoveryState, on: self)
             .store(in: &cancellables)
         
         secureBackupController.keyBackupState

--- a/ElementX/Sources/Screens/SecureBackup/SecureBackupScreen/View/SecureBackupScreen.swift
+++ b/ElementX/Sources/Screens/SecureBackup/SecureBackupScreen/View/SecureBackupScreen.swift
@@ -25,7 +25,7 @@ struct SecureBackupScreen: View {
         Form {
             // Show recovery options for confirming the recovery key and
             // getting access to secrets and implicitly the key backup
-            if context.viewState.recoveryKeyState == .incomplete {
+            if context.viewState.recoveryState == .incomplete {
                 recoveryKeySection
             } else {
                 keyBackupSection
@@ -93,7 +93,7 @@ struct SecureBackupScreen: View {
     @ViewBuilder
     private var recoveryKeySection: some View {
         Section {
-            switch context.viewState.recoveryKeyState {
+            switch context.viewState.recoveryState {
             case .enabled:
                 ListRow(label: .plain(title: L10n.screenChatBackupRecoveryActionChange),
                         kind: .navigationLink { context.send(viewAction: .recoveryKey) })
@@ -116,7 +116,7 @@ struct SecureBackupScreen: View {
     
     @ViewBuilder
     private var recoveryKeySectionFooter: some View {
-        switch context.viewState.recoveryKeyState {
+        switch context.viewState.recoveryState {
         case .disabled:
             Text(L10n.screenChatBackupRecoveryActionSetupDescription(InfoPlistReader.main.bundleDisplayName))
         case .incomplete:
@@ -130,10 +130,10 @@ struct SecureBackupScreen: View {
 // MARK: - Previews
 
 struct SecureBackupScreen_Previews: PreviewProvider, TestablePreview {
-    static let bothSetupViewModel = viewModel(keyBackupState: .enabled, recoveryKeyState: .enabled)
-    static let onlyKeyBackupSetUpViewModel = viewModel(keyBackupState: .enabled, recoveryKeyState: .disabled)
-    static let keyBackupDisabledViewModel = viewModel(keyBackupState: .unknown, recoveryKeyState: .disabled)
-    static let recoveryIncompleteViewModel = viewModel(keyBackupState: .enabled, recoveryKeyState: .incomplete)
+    static let bothSetupViewModel = viewModel(keyBackupState: .enabled, recoveryState: .enabled)
+    static let onlyKeyBackupSetUpViewModel = viewModel(keyBackupState: .enabled, recoveryState: .disabled)
+    static let keyBackupDisabledViewModel = viewModel(keyBackupState: .unknown, recoveryState: .disabled)
+    static let recoveryIncompleteViewModel = viewModel(keyBackupState: .enabled, recoveryState: .incomplete)
     
     static var previews: some View {
         Group {
@@ -161,10 +161,10 @@ struct SecureBackupScreen_Previews: PreviewProvider, TestablePreview {
     }
     
     static func viewModel(keyBackupState: SecureBackupKeyBackupState,
-                          recoveryKeyState: SecureBackupRecoveryKeyState) -> SecureBackupScreenViewModelType {
+                          recoveryState: SecureBackupRecoveryState) -> SecureBackupScreenViewModelType {
         let backupController = SecureBackupControllerMock()
         backupController.underlyingKeyBackupState = CurrentValueSubject<SecureBackupKeyBackupState, Never>(keyBackupState).asCurrentValuePublisher()
-        backupController.underlyingRecoveryKeyState = CurrentValueSubject<SecureBackupRecoveryKeyState, Never>(recoveryKeyState).asCurrentValuePublisher()
+        backupController.underlyingRecoveryState = CurrentValueSubject<SecureBackupRecoveryState, Never>(recoveryState).asCurrentValuePublisher()
         
         return SecureBackupScreenViewModel(secureBackupController: backupController,
                                            userIndicatorController: UserIndicatorControllerMock(),

--- a/ElementX/Sources/Screens/Settings/SettingsScreen/SettingsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/SettingsScreen/SettingsScreenModels.swift
@@ -34,13 +34,13 @@ enum SettingsScreenViewModelAction {
     case logout
 }
 
+enum SettingsScreenSecuritySectionMode {
+    case none
+    case sessionVerification
+    case secureBackup
+}
+
 struct SettingsScreenViewState: BindableState {
-    enum SecuritySectionMode {
-        case none
-        case sessionVerification
-        case secureBackup
-    }
-    
     var deviceID: String?
     var userID: String
     var accountProfileURL: URL?
@@ -49,7 +49,7 @@ struct SettingsScreenViewState: BindableState {
     var userDisplayName: String?
     var showDeveloperOptions: Bool
     
-    var securitySectionMode = SecuritySectionMode.none
+    var securitySectionMode = SettingsScreenSecuritySectionMode.none
     var showSecuritySectionBadge = false
 }
 

--- a/ElementX/Sources/Screens/Settings/SettingsScreen/SettingsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/SettingsScreen/SettingsScreenModels.swift
@@ -35,15 +35,22 @@ enum SettingsScreenViewModelAction {
 }
 
 struct SettingsScreenViewState: BindableState {
+    enum SecuritySectionMode {
+        case none
+        case sessionVerification
+        case secureBackup
+    }
+    
     var deviceID: String?
     var userID: String
     var accountProfileURL: URL?
     var accountSessionsListURL: URL?
     var userAvatarURL: URL?
     var userDisplayName: String?
-    var isSessionVerified: Bool?
-    var showSecureBackupBadge = false
     var showDeveloperOptions: Bool
+    
+    var securitySectionMode = SecuritySectionMode.none
+    var showSecuritySectionBadge = false
 }
 
 enum SettingsScreenViewAction {

--- a/ElementX/Sources/Screens/Settings/SettingsScreen/SettingsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Settings/SettingsScreen/SettingsScreenViewModel.swift
@@ -44,7 +44,7 @@ class SettingsScreenViewModel: SettingsScreenViewModelType, SettingsScreenViewMo
             .weakAssign(to: \.state.userDisplayName, on: self)
             .store(in: &cancellables)
         
-        userSession.sessionSecurityState
+        userSession.sessionSecurityStatePublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] securityState in
                 guard let self else { return }

--- a/ElementX/Sources/Screens/Settings/SettingsScreen/View/SettingsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/SettingsScreen/View/SettingsScreen.swift
@@ -80,18 +80,20 @@ struct SettingsScreen: View {
     @ViewBuilder
     private var accountSecuritySection: some View {
         Section {
-            if let isSessionVerified = context.viewState.isSessionVerified {
-                if !isSessionVerified {
-                    ListRow(label: .default(title: L10n.actionCompleteVerification,
-                                            icon: \.checkCircle),
-                            kind: .button { context.send(viewAction: .sessionVerification) })
-                } else {
-                    ListRow(label: .default(title: L10n.commonChatBackup,
-                                            icon: \.key),
-                            details: context.viewState.showSecureBackupBadge ? .icon(secureBackupBadge) : nil,
-                            kind: .navigationLink { context.send(viewAction: .secureBackup) })
-                        .accessibilityIdentifier(A11yIdentifiers.settingsScreen.secureBackup)
-                }
+            switch context.viewState.securitySectionMode {
+            case .sessionVerification:
+                ListRow(label: .default(title: L10n.actionCompleteVerification,
+                                        icon: \.checkCircle),
+                        details: context.viewState.showSecuritySectionBadge ? .icon(securitySectionBadge) : nil,
+                        kind: .button { context.send(viewAction: .sessionVerification) })
+            case .secureBackup:
+                ListRow(label: .default(title: L10n.commonChatBackup,
+                                        icon: \.key),
+                        details: context.viewState.showSecuritySectionBadge ? .icon(securitySectionBadge) : nil,
+                        kind: .navigationLink { context.send(viewAction: .secureBackup) })
+                    .accessibilityIdentifier(A11yIdentifiers.settingsScreen.secureBackup)
+            default:
+                EmptyView()
             }
         }
     }
@@ -210,8 +212,8 @@ struct SettingsScreen: View {
     }
     
     @ViewBuilder
-    private var secureBackupBadge: some View {
-        if context.viewState.showSecureBackupBadge {
+    private var securitySectionBadge: some View {
+        if context.viewState.showSecuritySectionBadge {
             BadgeView(size: 10)
         }
     }

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -167,7 +167,7 @@ class ClientProxy: ClientProxyProtocol {
         return digest.compactMap { String(format: "%02x", $0) }.joined()
     }()
     
-    func isLastDevice() async -> Result<Bool, ClientProxyError> {
+    func isOnlyDeviceLeft() async -> Result<Bool, ClientProxyError> {
         do {
             let result = try await client.encryption().isLastDevice()
             return .success(result)

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -166,6 +166,16 @@ class ClientProxy: ClientProxyProtocol {
         let digest = SHA256.hash(data: data)
         return digest.compactMap { String(format: "%02x", $0) }.joined()
     }()
+    
+    func isLastDevice() async -> Result<Bool, ClientProxyError> {
+        do {
+            let result = try await client.encryption().isLastDevice()
+            return .success(result)
+        } catch {
+            MXLog.error("Failed checking isLastDevice with error: \(error)")
+            return .failure(.failedCheckingIsLastDevice(error))
+        }
+    }
 
     func startSync() {
         guard !hasEncounteredAuthError else {

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -97,7 +97,7 @@ protocol ClientProxyProtocol: AnyObject, MediaLoaderProtocol {
     
     var secureBackupController: SecureBackupControllerProtocol { get }
     
-    func isLastDevice() async -> Result<Bool, ClientProxyError>
+    func isOnlyDeviceLeft() async -> Result<Bool, ClientProxyError>
     
     func startSync()
 

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -49,6 +49,7 @@ enum ClientProxyError: Error {
     case failedSearchingUsers
     case failedGettingUserProfile
     case failedSettingUserAvatar
+    case failedCheckingIsLastDevice(Error?)
 }
 
 enum SlidingSyncConstants {
@@ -95,6 +96,8 @@ protocol ClientProxyProtocol: AnyObject, MediaLoaderProtocol {
     var notificationSettings: NotificationSettingsProxyProtocol { get }
     
     var secureBackupController: SecureBackupControllerProtocol { get }
+    
+    func isLastDevice() async -> Result<Bool, ClientProxyError>
     
     func startSync()
 

--- a/ElementX/Sources/Services/Client/MockClientProxy.swift
+++ b/ElementX/Sources/Services/Client/MockClientProxy.swift
@@ -54,7 +54,7 @@ class MockClientProxy: ClientProxyProtocol {
     }
     
     func isLastDevice() async -> Result<Bool, ClientProxyError> {
-        .failure(.failedCheckingIsLastDevice(nil))
+        .success(false)
     }
     
     func startSync() { }

--- a/ElementX/Sources/Services/Client/MockClientProxy.swift
+++ b/ElementX/Sources/Services/Client/MockClientProxy.swift
@@ -53,7 +53,7 @@ class MockClientProxy: ClientProxyProtocol {
         self.roomSummaryProvider = roomSummaryProvider
     }
     
-    func isLastDevice() async -> Result<Bool, ClientProxyError> {
+    func isOnlyDeviceLeft() async -> Result<Bool, ClientProxyError> {
         .success(false)
     }
     

--- a/ElementX/Sources/Services/Client/MockClientProxy.swift
+++ b/ElementX/Sources/Services/Client/MockClientProxy.swift
@@ -42,7 +42,7 @@ class MockClientProxy: ClientProxyProtocol {
     
     lazy var secureBackupController: SecureBackupControllerProtocol = {
         let secureBackupController = SecureBackupControllerMock()
-        secureBackupController.underlyingRecoveryKeyState = .init(CurrentValueSubject<SecureBackupRecoveryKeyState, Never>(.enabled))
+        secureBackupController.underlyingRecoveryState = .init(CurrentValueSubject<SecureBackupRecoveryState, Never>(.enabled))
         secureBackupController.underlyingKeyBackupState = .init(CurrentValueSubject<SecureBackupKeyBackupState, Never>(.enabled))
         return secureBackupController
     }()

--- a/ElementX/Sources/Services/Client/MockClientProxy.swift
+++ b/ElementX/Sources/Services/Client/MockClientProxy.swift
@@ -44,7 +44,6 @@ class MockClientProxy: ClientProxyProtocol {
         let secureBackupController = SecureBackupControllerMock()
         secureBackupController.underlyingRecoveryKeyState = .init(CurrentValueSubject<SecureBackupRecoveryKeyState, Never>(.enabled))
         secureBackupController.underlyingKeyBackupState = .init(CurrentValueSubject<SecureBackupKeyBackupState, Never>(.enabled))
-        secureBackupController.isLastSessionReturnValue = .success(false)
         return secureBackupController
     }()
 
@@ -52,6 +51,10 @@ class MockClientProxy: ClientProxyProtocol {
         self.userID = userID
         self.deviceID = deviceID
         self.roomSummaryProvider = roomSummaryProvider
+    }
+    
+    func isLastDevice() async -> Result<Bool, ClientProxyError> {
+        .failure(.failedCheckingIsLastDevice(nil))
     }
     
     func startSync() { }

--- a/ElementX/Sources/Services/SecureBackup/SecureBackupController.swift
+++ b/ElementX/Sources/Services/SecureBackup/SecureBackupController.swift
@@ -162,17 +162,7 @@ class SecureBackupController: SecureBackupControllerProtocol {
             return .failure(.failedConfirmingRecoveryKey)
         }
     }
-    
-    func isLastSession() async -> Result<Bool, SecureBackupControllerError> {
-        do {
-            MXLog.info("Checking if last session")
-            return try await .success(encryption.isLastDevice())
-        } catch {
-            MXLog.error("Failed checking if last session with error: \(error)")
-            return .failure(.failedFetchingSessionState)
-        }
-    }
-    
+        
     func waitForKeyBackupUpload() async -> Result<Void, SecureBackupControllerError> {
         do {
             MXLog.info("Waiting for backup upload steady state")

--- a/ElementX/Sources/Services/SecureBackup/SecureBackupControllerProtocol.swift
+++ b/ElementX/Sources/Services/SecureBackup/SecureBackupControllerProtocol.swift
@@ -17,7 +17,7 @@
 import Combine
 import Foundation
 
-enum SecureBackupRecoveryKeyState {
+enum SecureBackupRecoveryState {
     case unknown
     case disabled
     case enabled
@@ -50,7 +50,7 @@ enum SecureBackupControllerError: Error {
 
 // sourcery: AutoMockable
 protocol SecureBackupControllerProtocol {
-    var recoveryKeyState: CurrentValuePublisher<SecureBackupRecoveryKeyState, Never> { get }
+    var recoveryState: CurrentValuePublisher<SecureBackupRecoveryState, Never> { get }
     
     var keyBackupState: CurrentValuePublisher<SecureBackupKeyBackupState, Never> { get }
     

--- a/ElementX/Sources/Services/SecureBackup/SecureBackupControllerProtocol.swift
+++ b/ElementX/Sources/Services/SecureBackup/SecureBackupControllerProtocol.swift
@@ -60,7 +60,5 @@ protocol SecureBackupControllerProtocol {
     func generateRecoveryKey() async -> Result<String, SecureBackupControllerError>
     func confirmRecoveryKey(_ key: String) async -> Result<Void, SecureBackupControllerError>
     
-    func isLastSession() async -> Result<Bool, SecureBackupControllerError>
-    
     func waitForKeyBackupUpload() async -> Result<Void, SecureBackupControllerError>
 }

--- a/ElementX/Sources/Services/Session/MockUserSession.swift
+++ b/ElementX/Sources/Services/Session/MockUserSession.swift
@@ -25,5 +25,5 @@ struct MockUserSession: UserSessionProtocol {
     let clientProxy: ClientProxyProtocol
     let mediaProvider: MediaProviderProtocol
     let voiceMessageMediaManager: VoiceMessageMediaManagerProtocol
-    var sessionSecurityState: CurrentValuePublisher<SessionSecurityState, Never> = .init(.init(.init(verificationState: .verified, recoveryState: .enabled)))
+    var sessionSecurityStatePublisher: AnyPublisher<SessionSecurityState, Never> = CurrentValueSubject<SessionSecurityState, Never>(.init(verificationState: .verified, recoveryState: .enabled)).eraseToAnyPublisher()
 }

--- a/ElementX/Sources/Services/Session/MockUserSession.swift
+++ b/ElementX/Sources/Services/Session/MockUserSession.swift
@@ -25,5 +25,5 @@ struct MockUserSession: UserSessionProtocol {
     let clientProxy: ClientProxyProtocol
     let mediaProvider: MediaProviderProtocol
     let voiceMessageMediaManager: VoiceMessageMediaManagerProtocol
-    var sessionVerificationState: CurrentValuePublisher<Bool?, Never> = .init(.init(true))
+    var sessionSecurityState: CurrentValuePublisher<SessionSecurityState, Never> = .init(.init(.init(verificationState: .verified, recoveryState: .enabled)))
 }

--- a/ElementX/Sources/Services/Session/UserSession.swift
+++ b/ElementX/Sources/Services/Session/UserSession.swift
@@ -140,7 +140,7 @@ class UserSession: UserSessionProtocol {
         if isVerified {
             sessionVerificationStateSubject.send(.verified)
         } else {
-            guard case let .success(isLastDevice) = await clientProxy.isLastDevice() else {
+            guard case let .success(isLastDevice) = await clientProxy.isOnlyDeviceLeft() else {
                 MXLog.error("Failed checking isLastDevice. Will retry on the next sync update.")
                 return
             }

--- a/ElementX/Sources/Services/Session/UserSession.swift
+++ b/ElementX/Sources/Services/Session/UserSession.swift
@@ -84,6 +84,7 @@ class UserSession: UserSessionProtocol {
             }
         
         Publishers.CombineLatest(sessionVerificationStateSubject, clientProxy.secureBackupController.recoveryState)
+            .removeDuplicates { $0 == $1 }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] verificationState, recoveryState in
                 

--- a/ElementX/Sources/Services/Session/UserSession.swift
+++ b/ElementX/Sources/Services/Session/UserSession.swift
@@ -83,7 +83,7 @@ class UserSession: UserSessionProtocol {
                 }
             }
         
-        Publishers.CombineLatest(sessionVerificationStateSubject, clientProxy.secureBackupController.recoveryKeyState)
+        Publishers.CombineLatest(sessionVerificationStateSubject, clientProxy.secureBackupController.recoveryState)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] verificationState, recoveryState in
                 

--- a/ElementX/Sources/Services/Session/UserSessionProtocol.swift
+++ b/ElementX/Sources/Services/Session/UserSessionProtocol.swift
@@ -28,7 +28,7 @@ enum SessionVerificationState {
     case unverifiedLastSession
 }
 
-struct SessionSecurityState {
+struct SessionSecurityState: Equatable {
     let verificationState: SessionVerificationState
     let recoveryState: SecureBackupRecoveryState
 }
@@ -42,7 +42,7 @@ protocol UserSessionProtocol {
     var mediaProvider: MediaProviderProtocol { get }
     var voiceMessageMediaManager: VoiceMessageMediaManagerProtocol { get }
     
-    var sessionSecurityState: CurrentValuePublisher<SessionSecurityState, Never> { get }
+    var sessionSecurityStatePublisher: AnyPublisher<SessionSecurityState, Never> { get }
     var sessionVerificationController: SessionVerificationControllerProxyProtocol? { get }
     
     var callbacks: PassthroughSubject<UserSessionCallback, Never> { get }

--- a/ElementX/Sources/Services/Session/UserSessionProtocol.swift
+++ b/ElementX/Sources/Services/Session/UserSessionProtocol.swift
@@ -30,7 +30,7 @@ enum SessionVerificationState {
 
 struct SessionSecurityState {
     let verificationState: SessionVerificationState
-    let recoveryState: SecureBackupRecoveryKeyState
+    let recoveryState: SecureBackupRecoveryState
 }
 
 protocol UserSessionProtocol {

--- a/ElementX/Sources/Services/Session/UserSessionProtocol.swift
+++ b/ElementX/Sources/Services/Session/UserSessionProtocol.swift
@@ -21,6 +21,18 @@ enum UserSessionCallback {
     case didReceiveAuthError(isSoftLogout: Bool)
 }
 
+enum SessionVerificationState {
+    case unknown
+    case verified
+    case unverified
+    case unverifiedLastSession
+}
+
+struct SessionSecurityState {
+    let verificationState: SessionVerificationState
+    let recoveryState: SecureBackupRecoveryKeyState
+}
+
 protocol UserSessionProtocol {
     var homeserver: String { get }
     var userID: String { get }
@@ -30,7 +42,7 @@ protocol UserSessionProtocol {
     var mediaProvider: MediaProviderProtocol { get }
     var voiceMessageMediaManager: VoiceMessageMediaManagerProtocol { get }
     
-    var sessionVerificationState: CurrentValuePublisher<Bool?, Never> { get }
+    var sessionSecurityState: CurrentValuePublisher<SessionSecurityState, Never> { get }
     var sessionVerificationController: SessionVerificationControllerProxyProtocol? { get }
     
     var callbacks: PassthroughSubject<UserSessionCallback, Never> { get }

--- a/UnitTests/Sources/UserSession/UserSessionTests.swift
+++ b/UnitTests/Sources/UserSession/UserSessionTests.swift
@@ -32,8 +32,8 @@ final class UserSessionTests: XCTestCase {
 
     func test_whenUserSessionReceivesSyncUpdateAndSessionControllerRetrievedAndSessionNotVerified_sessionVerificationNeededEventReceived() throws {
         let expectation = expectation(description: "SessionVerificationNeeded expectation")
-        userSession.sessionVerificationState.sink { isVerified in
-            if let isVerified, isVerified == false {
+        userSession.sessionSecurityState.sink { securityState in
+            if securityState.verificationState == .unverified {
                 expectation.fulfill()
             }
         }

--- a/UnitTests/Sources/UserSession/UserSessionTests.swift
+++ b/UnitTests/Sources/UserSession/UserSessionTests.swift
@@ -32,7 +32,7 @@ final class UserSessionTests: XCTestCase {
 
     func test_whenUserSessionReceivesSyncUpdateAndSessionControllerRetrievedAndSessionNotVerified_sessionVerificationNeededEventReceived() throws {
         let expectation = expectation(description: "SessionVerificationNeeded expectation")
-        userSession.sessionSecurityState.sink { securityState in
+        userSession.sessionSecurityStatePublisher.sink { securityState in
             if securityState.verificationState == .unverified {
                 expectation.fulfill()
             }


### PR DESCRIPTION
Best reviewd commit by commit.

Allow the user to recover their last session through entering their recovery key. Fixes https://github.com/element-hq/element-x-ios/issues/2470 & https://github.com/element-hq/element-x-ios/issues/2424

This PR reworks how we handle session verification and session recovery. The userSession now publishes them combined after fetching the data internally from the session verification controller and secure backup controller.

On both the home and settings screens unverified/incompletely recovered sessions are now treated very similarly: listen to the `UserSession.sessionSecurity` callbacks, switch on session verification and recovery states, decide what UI to show. 

The UI is also very similar between them with both showing badges on the avatar and settings entry, and the view model being responsible for all the logic.