### PR TITLE
Add missing accessibility label to the add reaction button.

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/View/Supplementary/TimelineReactionsView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Supplementary/TimelineReactionsView.swift
@@ -196,6 +196,7 @@ struct TimelineReactionAddMoreButtonLabel: View {
                 .padding(.vertical, 8)
                 .padding(.horizontal, 12)
                 .foregroundColor(.compound.iconSecondary)
+                .accessibilityLabel(L10n.actionReact)
         }
     }
 }


### PR DESCRIPTION
It was previously reading out the file name "reaction-add".