### PR TITLE
Add RoomDetails for use (with RoomMemberDetails) in AvatarHeaderView.

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -524,6 +524,7 @@
 		858276B19C7C0AD4CA98EA78 /* portrait_test_image.jpg in Resources */ = {isa = PBXBuildFile; fileRef = AF042B0FB2EE88977C91E330 /* portrait_test_image.jpg */; };
 		858B0A45257174AAFD448EA0 /* MessageComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0A01AECFF54281CF35909A6 /* MessageComposer.swift */; };
 		858C04B62166B5BAFCD20F2D /* TimelineItemMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BF12A5E7C76777C4BF0F2B /* TimelineItemMenu.swift */; };
+		859E2CA2EDF343BD24DE52EB /* RoomDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6404166CBF5CC88673FF9E2 /* RoomDetails.swift */; };
 		85F89F3F320F4FADCFFFE68B /* ServerSelectionScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3059CFA00C67D8787273B20 /* ServerSelectionScreenViewModel.swift */; };
 		864C0D3A4077BF433DBC691F /* PollRoomTimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5281C5CDC4A712265A0B5FBF /* PollRoomTimelineItem.swift */; };
 		864C69CF951BF36D25BE0C03 /* DeveloperOptionsScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D0A27607AB09784C8501B5C /* DeveloperOptionsScreenViewModelTests.swift */; };
@@ -560,6 +561,7 @@
 		8CC12086CBF91A7E10CDC205 /* HomeScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D653265D006E708E4E51AD64 /* HomeScreenCoordinator.swift */; };
 		8D3E1FADD78E72504DE0E402 /* UserAgentBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB3B237387B8288A5A938F1B /* UserAgentBuilderTests.swift */; };
 		8D71E5E53F372202379BECCE /* BugReportScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 303FCADE77DF1F3670C086ED /* BugReportScreenViewModel.swift */; };
+		8DC176CC5ABA24138EB443DD /* RoomMemberDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = C55679AF67545EF8087E47BE /* RoomMemberDetails.swift */; };
 		8DCD9CC5361FF22A5B2C20F1 /* AppLockSetupSettingsScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D9FCE4D1E3A81AC1CC5CB91 /* AppLockSetupSettingsScreenCoordinator.swift */; };
 		8DDC6F28C797D8685F2F8E32 /* AnalyticsConsentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B6B383F1FD04CC0E7B60C6 /* AnalyticsConsentState.swift */; };
 		8E650379587C31D7912ED67B /* UNNotification+Creator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0AEA686E425F86F6BA0404 /* UNNotification+Creator.swift */; };
@@ -993,7 +995,6 @@
 		F99FB21EFC6D99D247FE7CBE /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = DE8DC9B3FBA402117DC4C49F /* Kingfisher */; };
 		F9EA79092C18A8CFE4922DD2 /* PollFormScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F64A8582F65567AC38C2976A /* PollFormScreenViewModel.swift */; };
 		FA2BBAE9FC5E2E9F960C0980 /* NavigationCoordinators.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F28602AC7AC881AED37EBA /* NavigationCoordinators.swift */; };
-		FA4296218444C48BC890F46B /* RoomMemberDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B35311C7FED04B0E1B80C2 /* RoomMemberDetails.swift */; };
 		FA5A7E32B1920FCB4EEDC1BA /* RoomDetailsScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6493AC9979CEB1410302BFE3 /* RoomDetailsScreenCoordinator.swift */; };
 		FA71CD334F2D2289BEF0D749 /* SecureBackupRecoveryKeyScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2FCA3D0F239B9E911B966B /* SecureBackupRecoveryKeyScreen.swift */; };
 		FA9C427FFB11B1AA2DCC5602 /* RoomProxyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47111410B6E659A697D472B5 /* RoomProxyProtocol.swift */; };
@@ -1255,7 +1256,6 @@
 		314F1C79850BE46E8ABEAFCB /* ReadReceipt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadReceipt.swift; sourceTree = "<group>"; };
 		317F41A4B5C4F457AF710666 /* PollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollView.swift; sourceTree = "<group>"; };
 		31A6314FDC51DA25712D9A81 /* PillContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PillContextTests.swift; sourceTree = "<group>"; };
-		31B35311C7FED04B0E1B80C2 /* RoomMemberDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomMemberDetails.swift; sourceTree = "<group>"; };
 		31D6764D6976D235926FE5FC /* HomeScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenViewModel.swift; sourceTree = "<group>"; };
 		3203C6566DC17B7AECC1B7FD /* RoomNotificationSettingsUserDefinedScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomNotificationSettingsUserDefinedScreen.swift; sourceTree = "<group>"; };
 		32B5E17028C02DFA7DDA3931 /* RoomMemberProxyProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomMemberProxyProtocol.swift; sourceTree = "<group>"; };
@@ -1726,6 +1726,7 @@
 		B61C339A2FDDBD067FF6635C /* ConfettiScene.scn */ = {isa = PBXFileReference; path = ConfettiScene.scn; sourceTree = "<group>"; };
 		B6311F21F911E23BE4DF51B4 /* ReadMarkerRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadMarkerRoomTimelineView.swift; sourceTree = "<group>"; };
 		B63B69F9A2BC74DD40DC75C8 /* AdvancedSettingsScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsScreenViewModel.swift; sourceTree = "<group>"; };
+		B6404166CBF5CC88673FF9E2 /* RoomDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomDetails.swift; sourceTree = "<group>"; };
 		B697816AF93DA06EC58C5D70 /* WaitlistScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitlistScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		B6E89E530A8E92EC44301CA1 /* Bundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bundle.swift; sourceTree = "<group>"; };
 		B70A50C41C5871B4DB905E7E /* VoiceMessageRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceMessageRoomTimelineView.swift; sourceTree = "<group>"; };
@@ -1785,6 +1786,7 @@
 		C4C89820BB2B88D4EA28131C /* BugReportScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugReportScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		C4CD503F5E0938FE53C7C6E7 /* UserDetailsEditScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDetailsEditScreenCoordinator.swift; sourceTree = "<group>"; };
 		C54464351F170D570110AFCA /* WelcomeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeScreen.swift; sourceTree = "<group>"; };
+		C55679AF67545EF8087E47BE /* RoomMemberDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomMemberDetails.swift; sourceTree = "<group>"; };
 		C55CC239AE12339C565F6C9A /* AudioRecorderStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderStateTests.swift; sourceTree = "<group>"; };
 		C55D7E514F9DE4E3D72FDCAD /* SessionVerificationControllerProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionVerificationControllerProxy.swift; sourceTree = "<group>"; };
 		C5B7A755E985FA14469E86B2 /* RoomMembersListScreenUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomMembersListScreenUITests.swift; sourceTree = "<group>"; };
@@ -2198,7 +2200,6 @@
 				114DC16B28140F885FD833E2 /* NotificationSettings */,
 				599DFFE0805B08454E40D64A /* Polls */,
 				40E6246F03D1FE377BC5D963 /* Room */,
-				07900E9BFFD109F91B35B4C5 /* RoomMember */,
 				BDCEF7C3BF6D09F5611CFC8B /* SecureBackup */,
 				82D5AD3EAE3A5C1068A44A88 /* Session */,
 				5329E48968EB951235E83DAE /* SessionVerification */,
@@ -2208,14 +2209,6 @@
 				0121014DD16467736455AF16 /* VoiceMessage */,
 			);
 			path = Services;
-			sourceTree = "<group>";
-		};
-		07900E9BFFD109F91B35B4C5 /* RoomMember */ = {
-			isa = PBXGroup;
-			children = (
-				31B35311C7FED04B0E1B80C2 /* RoomMemberDetails.swift */,
-			);
-			path = RoomMember;
 			sourceTree = "<group>";
 		};
 		09C599CB430ABF160C1EE55C /* AnalyticsSettingsScreen */ = {
@@ -2446,6 +2439,7 @@
 		2C0F49BD446849654C0D24E0 /* RoomMember */ = {
 			isa = PBXGroup;
 			children = (
+				C55679AF67545EF8087E47BE /* RoomMemberDetails.swift */,
 				2F36C5D9B37E50915ECBD3EE /* RoomMemberProxy.swift */,
 				32B5E17028C02DFA7DDA3931 /* RoomMemberProxyProtocol.swift */,
 			);
@@ -2772,6 +2766,7 @@
 		40E6246F03D1FE377BC5D963 /* Room */ = {
 			isa = PBXGroup;
 			children = (
+				B6404166CBF5CC88673FF9E2 /* RoomDetails.swift */,
 				A65F140F9FE5E8D4DAEFF354 /* RoomProxy.swift */,
 				47111410B6E659A697D472B5 /* RoomProxyProtocol.swift */,
 				2C0F49BD446849654C0D24E0 /* RoomMember */,
@@ -5798,6 +5793,7 @@
 				8285FF4B2C2331758C437FF7 /* ReportContentScreenViewModelProtocol.swift in Sources */,
 				A494741843F087881299ACF0 /* RestorationToken.swift in Sources */,
 				1772AFA97DDA51CF1B293A78 /* RoomAttachmentPicker.swift in Sources */,
+				859E2CA2EDF343BD24DE52EB /* RoomDetails.swift in Sources */,
 				0BDA19079FD6E17C5AC62E22 /* RoomDetailsEditScreen.swift in Sources */,
 				E78D429F18071545BF661A52 /* RoomDetailsEditScreenCoordinator.swift in Sources */,
 				A6D4C5EEA85A6A0ABA1559D6 /* RoomDetailsEditScreenModels.swift in Sources */,
@@ -5814,7 +5810,7 @@
 				F4996C82A4B3A5FF0C8EDD03 /* RoomListFilterModels.swift in Sources */,
 				4A9CEEE612D6D8B3DDBD28BA /* RoomListFilterView.swift in Sources */,
 				33F1FB19F222BA9930AB1A00 /* RoomListFiltersView.swift in Sources */,
-				FA4296218444C48BC890F46B /* RoomMemberDetails.swift in Sources */,
+				8DC176CC5ABA24138EB443DD /* RoomMemberDetails.swift in Sources */,
 				19FE025AE9BA2959B6589B0D /* RoomMemberDetailsScreen.swift in Sources */,
 				899793EFC63DF93C3E0141E7 /* RoomMemberDetailsScreenCoordinator.swift in Sources */,
 				A816F7087C495D85048AC50E /* RoomMemberDetailsScreenModels.swift in Sources */,

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -263,7 +263,7 @@
     {
       "identity" : "swiftui-introspect",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/siteline/SwiftUI-Introspect.git",
+      "location" : "https://github.com/siteline/SwiftUI-Introspect",
       "state" : {
         "revision" : "b94da693e57eaf79d16464b8b7c90d09cba4e290",
         "version" : "0.9.2"

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -1885,7 +1885,6 @@ class RoomProxyMock: RoomProxyProtocol {
     }
     var underlyingOwnUserID: String!
     var name: String?
-    var displayName: String?
     var topic: String?
     var avatarURL: URL?
     var members: CurrentValuePublisher<[RoomMemberProxyProtocol], Never> {

--- a/ElementX/Sources/Mocks/RoomProxyMock.swift
+++ b/ElementX/Sources/Mocks/RoomProxyMock.swift
@@ -20,7 +20,6 @@ import Foundation
 struct RoomProxyMockConfiguration {
     var id = UUID().uuidString
     var name: String?
-    let displayName: String?
     var topic: String?
     var avatarURL: URL?
     var isDirect = false
@@ -51,7 +50,6 @@ extension RoomProxyMock {
 
         id = configuration.id
         name = configuration.name
-        displayName = configuration.displayName
         topic = configuration.topic
         avatarURL = configuration.avatarURL
         isDirect = configuration.isDirect

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -441,12 +441,12 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
             }
             
             if room.isPublic {
-                state.bindings.leaveRoomAlertItem = LeaveRoomAlertItem(roomId: roomId, isDM: room.isEncryptedOneToOneRoom, state: .public)
+                state.bindings.leaveRoomAlertItem = LeaveRoomAlertItem(roomID: roomId, isDM: room.isEncryptedOneToOneRoom, state: .public)
             } else {
                 state.bindings.leaveRoomAlertItem = if room.joinedMembersCount > 1 {
-                    LeaveRoomAlertItem(roomId: roomId, isDM: room.isEncryptedOneToOneRoom, state: .private)
+                    LeaveRoomAlertItem(roomID: roomId, isDM: room.isEncryptedOneToOneRoom, state: .private)
                 } else {
-                    LeaveRoomAlertItem(roomId: roomId, isDM: room.isEncryptedOneToOneRoom, state: .empty)
+                    LeaveRoomAlertItem(roomID: roomId, isDM: room.isEncryptedOneToOneRoom, state: .empty)
                 }
             }
         }

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
@@ -172,7 +172,7 @@ struct HomeScreen: View {
     private func leaveRoomAlertActions(_ item: LeaveRoomAlertItem) -> some View {
         Button(item.cancelTitle, role: .cancel) { }
         Button(item.confirmationTitle, role: .destructive) {
-            context.send(viewAction: .confirmLeaveRoom(roomIdentifier: item.roomId))
+            context.send(viewAction: .confirmLeaveRoom(roomIdentifier: item.roomID))
         }
     }
     

--- a/ElementX/Sources/Screens/ReportContentScreen/View/ReportContentScreen.swift
+++ b/ElementX/Sources/Screens/ReportContentScreen/View/ReportContentScreen.swift
@@ -77,7 +77,7 @@ struct ReportContentScreen: View {
 struct ReportContentScreen_Previews: PreviewProvider, TestablePreview {
     static let viewModel = ReportContentScreenViewModel(eventID: "",
                                                         senderID: "",
-                                                        roomProxy: RoomProxyMock(with: .init(displayName: nil)))
+                                                        roomProxy: RoomProxyMock(with: .init()))
     
     static var previews: some View {
         NavigationStack {

--- a/ElementX/Sources/Screens/RoomDetailsEditScreen/View/RoomDetailsEditScreen.swift
+++ b/ElementX/Sources/Screens/RoomDetailsEditScreen/View/RoomDetailsEditScreen.swift
@@ -158,14 +158,14 @@ struct RoomDetailsEditScreen: View {
 struct RoomDetailsEditScreen_Previews: PreviewProvider, TestablePreview {
     static let viewModel = RoomDetailsEditScreenViewModel(accountOwner: RoomMemberProxyMock.mockAlice,
                                                           mediaProvider: MockMediaProvider(),
-                                                          roomProxy: RoomProxyMock(with: .init(id: "test_id", name: "Room", displayName: "Room")),
+                                                          roomProxy: RoomProxyMock(with: .init(id: "test_id", name: "Room")),
                                                           userIndicatorController: UserIndicatorControllerMock.default)
     
     static let readOnlyViewModel = {
         let accountOwner = RoomMemberProxyMock.mockOwner(allowedStateEvents: [])
         return RoomDetailsEditScreenViewModel(accountOwner: accountOwner,
                                               mediaProvider: MockMediaProvider(),
-                                              roomProxy: RoomProxyMock(with: .init(id: "test_id", name: "Room", displayName: "Room")),
+                                              roomProxy: RoomProxyMock(with: .init(id: "test_id", name: "Room")),
                                               userIndicatorController: UserIndicatorControllerMock.default)
     }()
     

--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenModels.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenModels.swift
@@ -33,7 +33,7 @@ enum RoomDetailsScreenViewModelAction {
 // MARK: View
 
 struct RoomDetailsScreenViewState: BindableState {
-    let roomId: String
+    let roomID: String
     let canonicalAlias: String?
     let isEncrypted: Bool
     let isDirect: Bool
@@ -148,7 +148,7 @@ struct LeaveRoomAlertItem: AlertProtocol {
         case `private`
     }
 
-    let roomId: String
+    let roomID: String
     let isDM: Bool
     let state: RoomState
     let confirmationTitle = L10n.actionLeave

--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenModels.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenModels.swift
@@ -33,16 +33,14 @@ enum RoomDetailsScreenViewModelAction {
 // MARK: View
 
 struct RoomDetailsScreenViewState: BindableState {
-    let roomID: String
-    let canonicalAlias: String?
+    var details: RoomDetails
+    
     let isEncrypted: Bool
     let isDirect: Bool
     let permalink: URL?
 
-    var title = ""
     var topic: AttributedString?
     var topicSummary: AttributedString?
-    var avatarURL: URL?
     var joinedMembersCount: Int
     var isProcessingIgnoreRequest = false
     var canInviteUsers = false

--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
@@ -57,7 +57,7 @@ class RoomDetailsScreenViewModel: RoomDetailsScreenViewModelType, RoomDetailsScr
         
         let topic = attributedStringBuilder.fromPlain(roomProxy.topic)
         
-        super.init(initialViewState: .init(roomId: roomProxy.id,
+        super.init(initialViewState: .init(roomID: roomProxy.id,
                                            canonicalAlias: roomProxy.canonicalAlias,
                                            isEncrypted: roomProxy.isEncrypted,
                                            isDirect: roomProxy.isDirect,
@@ -95,10 +95,10 @@ class RoomDetailsScreenViewModel: RoomDetailsScreenViewModelType, RoomDetailsScr
             actionsSubject.send(.requestInvitePeoplePresentation)
         case .processTapLeave:
             guard state.joinedMembersCount > 1 else {
-                state.bindings.leaveRoomAlertItem = LeaveRoomAlertItem(roomId: roomProxy.id, isDM: roomProxy.isEncryptedOneToOneRoom, state: .empty)
+                state.bindings.leaveRoomAlertItem = LeaveRoomAlertItem(roomID: roomProxy.id, isDM: roomProxy.isEncryptedOneToOneRoom, state: .empty)
                 return
             }
-            state.bindings.leaveRoomAlertItem = LeaveRoomAlertItem(roomId: roomProxy.id, isDM: roomProxy.isEncryptedOneToOneRoom, state: roomProxy.isPublic ? .public : .private)
+            state.bindings.leaveRoomAlertItem = LeaveRoomAlertItem(roomID: roomProxy.id, isDM: roomProxy.isEncryptedOneToOneRoom, state: roomProxy.isPublic ? .public : .private)
         case .confirmLeave:
             Task { await leaveRoom() }
         case .processTapIgnore:

--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
@@ -57,15 +57,12 @@ class RoomDetailsScreenViewModel: RoomDetailsScreenViewModelType, RoomDetailsScr
         
         let topic = attributedStringBuilder.fromPlain(roomProxy.topic)
         
-        super.init(initialViewState: .init(roomID: roomProxy.id,
-                                           canonicalAlias: roomProxy.canonicalAlias,
+        super.init(initialViewState: .init(details: roomProxy.details,
                                            isEncrypted: roomProxy.isEncrypted,
                                            isDirect: roomProxy.isDirect,
                                            permalink: roomProxy.permalink,
-                                           title: roomProxy.roomTitle,
                                            topic: topic,
                                            topicSummary: topic?.unattributedStringByReplacingNewlinesWithSpaces(),
-                                           avatarURL: roomProxy.avatarURL,
                                            joinedMembersCount: roomProxy.joinedMembersCount,
                                            notificationSettingsState: .loading,
                                            bindings: .init()),
@@ -145,12 +142,11 @@ class RoomDetailsScreenViewModel: RoomDetailsScreenViewModelType, RoomDetailsScr
     }
     
     private func updateRoomInfo() {
-        state.title = roomProxy.roomTitle
+        state.details = roomProxy.details
         
         let topic = attributedStringBuilder.fromPlain(roomProxy.topic)
         state.topic = topic
         state.topicSummary = topic?.unattributedStringByReplacingNewlinesWithSpaces()
-        state.avatarURL = roomProxy.avatarURL
         state.joinedMembersCount = roomProxy.joinedMembersCount
         
         Task {

--- a/ElementX/Sources/Screens/RoomDetailsScreen/View/RoomDetailsScreen.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/View/RoomDetailsScreen.swift
@@ -68,12 +68,9 @@ struct RoomDetailsScreen: View {
     // MARK: - Private
     
     private var normalRoomHeaderSection: some View {
-        AvatarHeaderView(avatarUrl: context.viewState.avatarURL,
-                         name: context.viewState.title,
-                         id: context.viewState.roomId,
+        AvatarHeaderView(room: context.viewState.details,
                          avatarSize: .room(on: .details),
-                         imageProvider: context.imageProvider,
-                         subtitle: context.viewState.canonicalAlias) {
+                         imageProvider: context.imageProvider) {
             context.send(viewAction: .displayAvatar)
         } footer: {
             if !context.viewState.shortcuts.isEmpty {
@@ -84,12 +81,9 @@ struct RoomDetailsScreen: View {
     }
     
     private func dmHeaderSection(recipient: RoomMemberDetails) -> some View {
-        AvatarHeaderView(avatarUrl: recipient.avatarURL,
-                         name: recipient.name,
-                         id: recipient.id,
+        AvatarHeaderView(member: recipient,
                          avatarSize: .user(on: .memberDetails),
-                         imageProvider: context.imageProvider,
-                         subtitle: recipient.id) {
+                         imageProvider: context.imageProvider) {
             context.send(viewAction: .displayAvatar)
         } footer: {
             if !context.viewState.shortcuts.isEmpty {
@@ -291,7 +285,7 @@ struct RoomDetailsScreen_Previews: PreviewProvider, TestablePreview {
             .mockCharlie
         ]
         let roomProxy = RoomProxyMock(with: .init(id: "room_a_id",
-                                                  displayName: "Room A",
+                                                  name: "Room A",
                                                   topic: """
                                                   Discussions about Element X iOS | https://github.com/vector-im/element-x-ios
                                                   
@@ -327,7 +321,7 @@ struct RoomDetailsScreen_Previews: PreviewProvider, TestablePreview {
         ]
         
         let roomProxy = RoomProxyMock(with: .init(id: "dm_room_id",
-                                                  displayName: "DM Room",
+                                                  name: "DM Room",
                                                   topic: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
                                                   isDirect: true,
                                                   isEncrypted: true,
@@ -354,7 +348,7 @@ struct RoomDetailsScreen_Previews: PreviewProvider, TestablePreview {
             .mockCharlie
         ]
         let roomProxy = RoomProxyMock(with: .init(id: "simple_room_id",
-                                                  displayName: "Room A",
+                                                  name: "Room A",
                                                   isDirect: false,
                                                   isEncrypted: false,
                                                   members: members))

--- a/ElementX/Sources/Screens/RoomMemberDetailsScreen/View/RoomMemberDetailsScreen.swift
+++ b/ElementX/Sources/Screens/RoomMemberDetailsScreen/View/RoomMemberDetailsScreen.swift
@@ -47,12 +47,9 @@ struct RoomMemberDetailsScreen: View {
     @ViewBuilder
     private var headerSection: some View {
         if let memberDetails = context.viewState.memberDetails {
-            AvatarHeaderView(avatarUrl: memberDetails.avatarURL,
-                             name: memberDetails.name,
-                             id: memberDetails.id,
+            AvatarHeaderView(member: memberDetails,
                              avatarSize: .user(on: .memberDetails),
-                             imageProvider: context.imageProvider,
-                             subtitle: memberDetails.id) {
+                             imageProvider: context.imageProvider) {
                 context.send(viewAction: .displayAvatar)
             } footer: {
                 if let permalink = memberDetails.permalink {
@@ -66,12 +63,9 @@ struct RoomMemberDetailsScreen: View {
                 }
             }
         } else {
-            AvatarHeaderView(avatarUrl: nil,
-                             name: nil,
-                             id: context.viewState.userID,
+            AvatarHeaderView(member: .init(loading: context.viewState.userID),
                              avatarSize: .user(on: .memberDetails),
                              imageProvider: context.imageProvider,
-                             subtitle: nil,
                              footer: { })
         }
     }

--- a/ElementX/Sources/Screens/RoomMemberDetailsScreen/View/RoomMemberDetailsScreen.swift
+++ b/ElementX/Sources/Screens/RoomMemberDetailsScreen/View/RoomMemberDetailsScreen.swift
@@ -121,7 +121,7 @@ struct RoomMemberDetailsScreen: View {
 struct RoomMemberDetailsScreen_Previews: PreviewProvider, TestablePreview {
     static let otherUserViewModel = {
         let member = RoomMemberProxyMock.mockDan
-        let roomProxyMock = RoomProxyMock(with: .init(displayName: ""))
+        let roomProxyMock = RoomProxyMock(with: .init(name: ""))
         roomProxyMock.getMemberUserIDReturnValue = .success(member)
         
         return RoomMemberDetailsScreenViewModel(roomProxy: roomProxyMock,
@@ -132,7 +132,7 @@ struct RoomMemberDetailsScreen_Previews: PreviewProvider, TestablePreview {
 
     static let accountOwnerViewModel = {
         let member = RoomMemberProxyMock.mockMe
-        let roomProxyMock = RoomProxyMock(with: .init(displayName: ""))
+        let roomProxyMock = RoomProxyMock(with: .init(name: ""))
         roomProxyMock.getMemberUserIDReturnValue = .success(member)
         
         return RoomMemberDetailsScreenViewModel(roomProxy: roomProxyMock,
@@ -143,7 +143,7 @@ struct RoomMemberDetailsScreen_Previews: PreviewProvider, TestablePreview {
 
     static let ignoredUserViewModel = {
         let member = RoomMemberProxyMock.mockIgnored
-        let roomProxyMock = RoomProxyMock(with: .init(displayName: ""))
+        let roomProxyMock = RoomProxyMock(with: .init(name: ""))
         roomProxyMock.getMemberUserIDReturnValue = .success(member)
         
         return RoomMemberDetailsScreenViewModel(roomProxy: roomProxyMock,

--- a/ElementX/Sources/Screens/RoomMemberListScreen/View/RoomMembersListScreen.swift
+++ b/ElementX/Sources/Screens/RoomMemberListScreen/View/RoomMembersListScreen.swift
@@ -160,7 +160,7 @@ struct RoomMembersListScreen_Previews: PreviewProvider, TestablePreview {
         }
         
         return RoomMembersListScreenViewModel(initialMode: initialMode,
-                                              roomProxy: RoomProxyMock(with: .init(displayName: "Some room", members: members)),
+                                              roomProxy: RoomProxyMock(with: .init(name: "Some room", members: members)),
                                               mediaProvider: MockMediaProvider(),
                                               userIndicatorController: ServiceLocator.shared.userIndicatorController)
     }

--- a/ElementX/Sources/Screens/RoomMemberListScreen/View/RoomMembersListScreenMemberCell.swift
+++ b/ElementX/Sources/Screens/RoomMemberListScreen/View/RoomMembersListScreenMemberCell.swift
@@ -106,7 +106,7 @@ struct RoomMembersListMemberCell_Previews: PreviewProvider, TestablePreview {
         .init(with: .init(userID: "@badavatar:matrix.org", avatarURL: .picturesDirectory, membership: .ban))
     ]
     
-    static let viewModel = RoomMembersListScreenViewModel(roomProxy: RoomProxyMock(with: .init(displayName: "Some room",
+    static let viewModel = RoomMembersListScreenViewModel(roomProxy: RoomProxyMock(with: .init(name: "Some room",
                                                                                                members: members)),
                                                           mediaProvider: MockMediaProvider(),
                                                           userIndicatorController: ServiceLocator.shared.userIndicatorController)

--- a/ElementX/Sources/Screens/RoomNotificationSettingsScreen/View/RoomNotificationSettingsCustomSectionView.swift
+++ b/ElementX/Sources/Screens/RoomNotificationSettingsScreen/View/RoomNotificationSettingsCustomSectionView.swift
@@ -42,7 +42,7 @@ struct RoomNotificationSettingsCustomSectionView_Previews: PreviewProvider, Test
     static let viewModel = {
         let notificationSettingsProxy = NotificationSettingsProxyMock(with: .init(defaultRoomMode: .allMessages, roomMode: .mentionsAndKeywordsOnly))
         
-        let roomProxy = RoomProxyMock(with: .init(displayName: "Room", isEncrypted: true))
+        let roomProxy = RoomProxyMock(with: .init(name: "Room", isEncrypted: true))
         
         return RoomNotificationSettingsScreenViewModel(notificationSettingsProxy: notificationSettingsProxy,
                                                        roomProxy: roomProxy,
@@ -52,7 +52,7 @@ struct RoomNotificationSettingsCustomSectionView_Previews: PreviewProvider, Test
     static let viewModelUnencrypted = {
         let notificationSettingsProxy = NotificationSettingsProxyMock(with: .init(defaultRoomMode: .allMessages, roomMode: .mentionsAndKeywordsOnly))
         
-        let roomProxy = RoomProxyMock(with: .init(displayName: "Room", isEncrypted: false))
+        let roomProxy = RoomProxyMock(with: .init(name: "Room", isEncrypted: false))
         
         return RoomNotificationSettingsScreenViewModel(notificationSettingsProxy: notificationSettingsProxy,
                                                        roomProxy: roomProxy,

--- a/ElementX/Sources/Screens/RoomNotificationSettingsScreen/View/RoomNotificationSettingsScreen.swift
+++ b/ElementX/Sources/Screens/RoomNotificationSettingsScreen/View/RoomNotificationSettingsScreen.swift
@@ -83,7 +83,7 @@ struct RoomNotificationSettingsScreen_Previews: PreviewProvider, TestablePreview
     static let viewModel = {
         let notificationSettingsProxy = NotificationSettingsProxyMock(with: .init(defaultRoomMode: .mentionsAndKeywordsOnly, roomMode: .mentionsAndKeywordsOnly))
 
-        let roomProxy = RoomProxyMock(with: .init(displayName: "Room", isEncrypted: true))
+        let roomProxy = RoomProxyMock(with: .init(name: "Room", isEncrypted: true))
         
         return RoomNotificationSettingsScreenViewModel(notificationSettingsProxy: notificationSettingsProxy,
                                                        roomProxy: roomProxy,
@@ -93,7 +93,7 @@ struct RoomNotificationSettingsScreen_Previews: PreviewProvider, TestablePreview
     static let viewModelCustom = {
         let notificationSettingsProxy = NotificationSettingsProxyMock(with: .init(defaultRoomMode: .allMessages, roomMode: .mentionsAndKeywordsOnly))
 
-        let roomProxy = RoomProxyMock(with: .init(displayName: "Room", isEncrypted: true))
+        let roomProxy = RoomProxyMock(with: .init(name: "Room", isEncrypted: true))
         
         return RoomNotificationSettingsScreenViewModel(notificationSettingsProxy: notificationSettingsProxy,
                                                        roomProxy: roomProxy,

--- a/ElementX/Sources/Screens/RoomNotificationSettingsScreen/View/RoomNotificationSettingsUserDefinedScreen.swift
+++ b/ElementX/Sources/Screens/RoomNotificationSettingsScreen/View/RoomNotificationSettingsUserDefinedScreen.swift
@@ -52,7 +52,7 @@ struct RoomNotificationSettingsUserDefinedScreen_Previews: PreviewProvider, Test
     static let viewModel = {
         let notificationSettingsProxy = NotificationSettingsProxyMock(with: .init(defaultRoomMode: .mentionsAndKeywordsOnly, roomMode: .mentionsAndKeywordsOnly))
 
-        let roomProxy = RoomProxyMock(with: .init(displayName: "Room", isEncrypted: true))
+        let roomProxy = RoomProxyMock(with: .init(name: "Room", isEncrypted: true))
         
         return RoomNotificationSettingsScreenViewModel(notificationSettingsProxy: notificationSettingsProxy,
                                                        roomProxy: roomProxy,
@@ -62,7 +62,7 @@ struct RoomNotificationSettingsUserDefinedScreen_Previews: PreviewProvider, Test
     static let viewModelUnencrypted = {
         let notificationSettingsProxy = NotificationSettingsProxyMock(with: .init(defaultRoomMode: .mentionsAndKeywordsOnly, roomMode: .mentionsAndKeywordsOnly))
 
-        let roomProxy = RoomProxyMock(with: .init(displayName: "Room", isEncrypted: false))
+        let roomProxy = RoomProxyMock(with: .init(name: "Room", isEncrypted: false))
         
         return RoomNotificationSettingsScreenViewModel(notificationSettingsProxy: notificationSettingsProxy,
                                                        roomProxy: roomProxy,

--- a/ElementX/Sources/Screens/RoomPollsHistoryScreen/View/RoomPollsHistoryScreen.swift
+++ b/ElementX/Sources/Screens/RoomPollsHistoryScreen/View/RoomPollsHistoryScreen.swift
@@ -124,7 +124,7 @@ struct RoomPollsHistoryScreen_Previews: PreviewProvider, TestablePreview {
     static let viewModelEmpty: RoomPollsHistoryScreenViewModel = {
         let roomTimelineController = MockRoomTimelineController()
         roomTimelineController.timelineItems = []
-        let roomProxyMockConfiguration = RoomProxyMockConfiguration(displayName: "Polls")
+        let roomProxyMockConfiguration = RoomProxyMockConfiguration(name: "Polls")
         roomProxyMockConfiguration.timeline.timelineStartReached = false
         let viewModel = RoomPollsHistoryScreenViewModel(pollInteractionHandler: PollInteractionHandlerMock(),
                                                         roomTimelineController: roomTimelineController,
@@ -147,7 +147,7 @@ struct RoomPollsHistoryScreen_Previews: PreviewProvider, TestablePreview {
             roomTimelineController.timelineItemsTimestamp[item.id] = date
         }
 
-        let roomProxyMockConfiguration = RoomProxyMockConfiguration(displayName: "Polls")
+        let roomProxyMockConfiguration = RoomProxyMockConfiguration(name: "Polls")
         roomProxyMockConfiguration.timeline.timelineStartReached = true
         let viewModel = RoomPollsHistoryScreenViewModel(pollInteractionHandler: PollInteractionHandlerMock(),
                                                         roomTimelineController: roomTimelineController,

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -652,7 +652,7 @@ private extension RoomProxyProtocol {
 // MARK: - Mocks
 
 extension RoomScreenViewModel {
-    static let mock = RoomScreenViewModel(roomProxy: RoomProxyMock(with: .init(displayName: "Preview room")),
+    static let mock = RoomScreenViewModel(roomProxy: RoomProxyMock(with: .init(name: "Preview room")),
                                           timelineController: MockRoomTimelineController(),
                                           mediaProvider: MockMediaProvider(),
                                           mediaPlayerProvider: MediaPlayerProviderMock(),

--- a/ElementX/Sources/Screens/RoomScreen/View/ReadReceipts/ReadReceiptsSummaryView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/ReadReceipts/ReadReceiptsSummaryView.swift
@@ -51,7 +51,7 @@ struct ReadReceiptsSummaryView_Previews: PreviewProvider, TestablePreview {
             .mockCharlie,
             .mockDan
         ]
-        let roomProxyMock = RoomProxyMock(with: .init(displayName: "Room", members: members))
+        let roomProxyMock = RoomProxyMock(with: .init(name: "Room", members: members))
         let mock = RoomScreenViewModel(roomProxy: roomProxyMock,
                                        timelineController: MockRoomTimelineController(),
                                        mediaProvider: MockMediaProvider(),

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomHeaderView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomHeaderView.swift
@@ -55,7 +55,7 @@ struct RoomHeaderView_Previews: PreviewProvider, TestablePreview {
 
     @ViewBuilder
     static var bodyPlain: some View {
-        let viewModel = RoomScreenViewModel(roomProxy: RoomProxyMock(with: .init(displayName: "Some Room name", avatarURL: URL.picturesDirectory)),
+        let viewModel = RoomScreenViewModel(roomProxy: RoomProxyMock(with: .init(name: "Some Room name", avatarURL: URL.picturesDirectory)),
                                             timelineController: MockRoomTimelineController(),
                                             mediaProvider: MockMediaProvider(),
                                             mediaPlayerProvider: MediaPlayerProviderMock(),
@@ -73,7 +73,7 @@ struct RoomHeaderView_Previews: PreviewProvider, TestablePreview {
     
     @ViewBuilder
     static var bodyEncrypted: some View {
-        let viewModel = RoomScreenViewModel(roomProxy: RoomProxyMock(with: .init(displayName: "Some Room name")),
+        let viewModel = RoomScreenViewModel(roomProxy: RoomProxyMock(with: .init(name: "Some Room name")),
                                             timelineController: MockRoomTimelineController(),
                                             mediaProvider: MockMediaProvider(),
                                             mediaPlayerProvider: MediaPlayerProviderMock(),

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
@@ -178,7 +178,7 @@ struct RoomScreen: View {
 // MARK: - Previews
 
 struct RoomScreen_Previews: PreviewProvider, TestablePreview {
-    static let viewModel = RoomScreenViewModel(roomProxy: RoomProxyMock(with: .init(displayName: "Preview room", hasOngoingCall: true)),
+    static let viewModel = RoomScreenViewModel(roomProxy: RoomProxyMock(with: .init(name: "Preview room", hasOngoingCall: true)),
                                                timelineController: MockRoomTimelineController(),
                                                mediaProvider: MockMediaProvider(),
                                                mediaPlayerProvider: MediaPlayerProviderMock(),

--- a/ElementX/Sources/Screens/RoomScreen/View/Supplementary/TimelineReadReceiptsView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Supplementary/TimelineReadReceiptsView.swift
@@ -90,7 +90,7 @@ struct TimelineReadReceiptsView_Previews: PreviewProvider, TestablePreview {
         .mockMe
     ]
 
-    static let viewModel = RoomScreenViewModel(roomProxy: RoomProxyMock(with: .init(displayName: "Test", members: members)),
+    static let viewModel = RoomScreenViewModel(roomProxy: RoomProxyMock(with: .init(name: "Test", members: members)),
                                                timelineController: MockRoomTimelineController(),
                                                mediaProvider: MockMediaProvider(),
                                                mediaPlayerProvider: MediaPlayerProviderMock(),

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/UITimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/UITimelineView.swift
@@ -77,7 +77,7 @@ struct UITimelineView: UIViewControllerRepresentable {
 // MARK: - Previews
 
 struct UITimelineView_Previews: PreviewProvider, TestablePreview {
-    static let viewModel = RoomScreenViewModel(roomProxy: RoomProxyMock(with: .init(displayName: "Preview room")),
+    static let viewModel = RoomScreenViewModel(roomProxy: RoomProxyMock(with: .init(name: "Preview room")),
                                                timelineController: MockRoomTimelineController(),
                                                mediaProvider: MockMediaProvider(),
                                                mediaPlayerProvider: MediaPlayerProviderMock(),

--- a/ElementX/Sources/Services/Client/MockClientProxy.swift
+++ b/ElementX/Sources/Services/Client/MockClientProxy.swift
@@ -94,9 +94,9 @@ class MockClientProxy: ClientProxyProtocol {
     
         switch room {
         case .empty:
-            return RoomProxyMock(with: .init(displayName: "Empty room"))
+            return RoomProxyMock(with: .init(name: "Empty room"))
         case .filled(let details), .invalidated(let details):
-            return RoomProxyMock(with: .init(displayName: details.name))
+            return RoomProxyMock(with: .init(name: details.name))
         }
     }
     

--- a/ElementX/Sources/Services/Room/RoomDetails.swift
+++ b/ElementX/Sources/Services/Room/RoomDetails.swift
@@ -1,0 +1,24 @@
+//
+// Copyright 2024 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+struct RoomDetails {
+    let id: String
+    let name: String?
+    let avatarURL: URL?
+    let canonicalAlias: String?
+}

--- a/ElementX/Sources/Services/Room/RoomMember/RoomMemberDetails.swift
+++ b/ElementX/Sources/Services/Room/RoomMember/RoomMemberDetails.swift
@@ -41,6 +41,17 @@ extension RoomMemberDetails {
         isBanned = proxy.membership == .ban
         role = .init(proxy.role)
     }
+    
+    init(loading id: String) {
+        self.id = id
+        name = nil
+        avatarURL = nil
+        permalink = nil
+        isAccountOwner = false
+        isIgnored = false
+        isBanned = false
+        role = .user
+    }
 }
 
 extension RoomMemberDetails.Role {

--- a/ElementX/Sources/Services/Room/RoomProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomProxy.swift
@@ -37,8 +37,6 @@ class RoomProxy: RoomProxyProtocol {
     private var typingNotificationObservationToken: TaskHandle?
     
     private var subscribedForUpdates = false
-    
-    private(set) var displayName: String?
 
     private let membersSubject = CurrentValueSubject<[RoomMemberProxyProtocol], Never>([])
     var members: CurrentValuePublisher<[RoomMemberProxyProtocol], Never> {

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -57,8 +57,6 @@ protocol RoomProxyProtocol {
     
     var name: String? { get }
     
-    var displayName: String? { get }
-    
     var topic: String? { get }
     
     var avatarURL: URL? { get }
@@ -130,6 +128,13 @@ protocol RoomProxyProtocol {
 }
 
 extension RoomProxyProtocol {
+    var details: RoomDetails {
+        RoomDetails(id: id,
+                    name: name,
+                    avatarURL: avatarURL,
+                    canonicalAlias: canonicalAlias)
+    }
+    
     var permalink: URL? {
         if let canonicalAlias, let link = try? PermalinkBuilder.permalinkTo(roomAlias: canonicalAlias,
                                                                             baseURL: ServiceLocator.shared.settings.permalinkBaseURL) {
@@ -146,7 +151,7 @@ extension RoomProxyProtocol {
     // Avoids to duplicate the same logic around in the app
     // Probably this should be done in rust.
     var roomTitle: String {
-        displayName ?? name ?? "Unknown room 💥"
+        name ?? "Unknown room 💥"
     }
     
     var isEncryptedOneToOneRoom: Bool {

--- a/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineController.swift
@@ -301,7 +301,7 @@ class RoomTimelineController: RoomTimelineControllerProtocol {
             switch timelineProvider.backPaginationState {
             case .timelineStartReached:
                 if !roomProxy.isEncryptedOneToOneRoom {
-                    let timelineStart = TimelineStartRoomTimelineItem(name: roomProxy.displayName ?? roomProxy.name)
+                    let timelineStart = TimelineStartRoomTimelineItem(name: roomProxy.name)
                     newTimelineItems.insert(timelineStart, at: 0)
                 }
                 canBackPaginate = false

--- a/ElementX/Sources/UITests/UITestsAppCoordinator.swift
+++ b/ElementX/Sources/UITests/UITestsAppCoordinator.swift
@@ -335,7 +335,7 @@ class MockScreen: Identifiable {
             return OnboardingScreenCoordinator()
         case .roomPlainNoAvatar:
             let navigationStackCoordinator = NavigationStackCoordinator()
-            let parameters = RoomScreenCoordinatorParameters(roomProxy: RoomProxyMock(with: .init(displayName: "Some room name", avatarURL: nil)),
+            let parameters = RoomScreenCoordinatorParameters(roomProxy: RoomProxyMock(with: .init(name: "Some room name", avatarURL: nil)),
                                                              timelineController: MockRoomTimelineController(),
                                                              mediaProvider: MockMediaProvider(),
                                                              mediaPlayerProvider: MediaPlayerProviderMock(),
@@ -348,7 +348,7 @@ class MockScreen: Identifiable {
             return navigationStackCoordinator
         case .roomEncryptedWithAvatar:
             let navigationStackCoordinator = NavigationStackCoordinator()
-            let parameters = RoomScreenCoordinatorParameters(roomProxy: RoomProxyMock(with: .init(displayName: "Some room name", avatarURL: URL.picturesDirectory)),
+            let parameters = RoomScreenCoordinatorParameters(roomProxy: RoomProxyMock(with: .init(name: "Some room name", avatarURL: URL.picturesDirectory)),
                                                              timelineController: MockRoomTimelineController(),
                                                              mediaProvider: MockMediaProvider(),
                                                              mediaPlayerProvider: MediaPlayerProviderMock(),
@@ -363,7 +363,7 @@ class MockScreen: Identifiable {
             let navigationStackCoordinator = NavigationStackCoordinator()
             let timelineController = MockRoomTimelineController()
             timelineController.timelineItems = RoomTimelineItemFixtures.smallChunk
-            let parameters = RoomScreenCoordinatorParameters(roomProxy: RoomProxyMock(with: .init(displayName: "New room", avatarURL: URL.picturesDirectory)),
+            let parameters = RoomScreenCoordinatorParameters(roomProxy: RoomProxyMock(with: .init(name: "New room", avatarURL: URL.picturesDirectory)),
                                                              timelineController: timelineController,
                                                              mediaProvider: MockMediaProvider(),
                                                              mediaPlayerProvider: MediaPlayerProviderMock(),
@@ -378,7 +378,7 @@ class MockScreen: Identifiable {
             let navigationStackCoordinator = NavigationStackCoordinator()
             let timelineController = MockRoomTimelineController()
             timelineController.timelineItems = RoomTimelineItemFixtures.default
-            let parameters = RoomScreenCoordinatorParameters(roomProxy: RoomProxyMock(with: .init(displayName: "New room", avatarURL: URL.picturesDirectory)),
+            let parameters = RoomScreenCoordinatorParameters(roomProxy: RoomProxyMock(with: .init(name: "New room", avatarURL: URL.picturesDirectory)),
                                                              timelineController: timelineController,
                                                              mediaProvider: MockMediaProvider(),
                                                              mediaPlayerProvider: MediaPlayerProviderMock(),
@@ -393,7 +393,7 @@ class MockScreen: Identifiable {
             let navigationStackCoordinator = NavigationStackCoordinator()
             let timelineController = MockRoomTimelineController()
             timelineController.timelineItems = RoomTimelineItemFixtures.smallChunkWithReadReceipts
-            let parameters = RoomScreenCoordinatorParameters(roomProxy: RoomProxyMock(with: .init(displayName: "New room", avatarURL: URL.picturesDirectory)),
+            let parameters = RoomScreenCoordinatorParameters(roomProxy: RoomProxyMock(with: .init(name: "New room", avatarURL: URL.picturesDirectory)),
                                                              timelineController: timelineController,
                                                              mediaProvider: MockMediaProvider(),
                                                              mediaPlayerProvider: MediaPlayerProviderMock(),
@@ -411,7 +411,7 @@ class MockScreen: Identifiable {
             timelineController.timelineItems = RoomTimelineItemFixtures.smallChunk
             timelineController.backPaginationResponses = [RoomTimelineItemFixtures.singleMessageChunk]
             timelineController.incomingItems = [RoomTimelineItemFixtures.incomingMessage]
-            let parameters = RoomScreenCoordinatorParameters(roomProxy: RoomProxyMock(with: .init(displayName: "Small timeline", avatarURL: URL.picturesDirectory)),
+            let parameters = RoomScreenCoordinatorParameters(roomProxy: RoomProxyMock(with: .init(name: "Small timeline", avatarURL: URL.picturesDirectory)),
                                                              timelineController: timelineController,
                                                              mediaProvider: MockMediaProvider(),
                                                              mediaPlayerProvider: MediaPlayerProviderMock(),
@@ -429,7 +429,7 @@ class MockScreen: Identifiable {
             let timelineController = MockRoomTimelineController(listenForSignals: true)
             timelineController.timelineItems = RoomTimelineItemFixtures.smallChunk
             timelineController.backPaginationResponses = [RoomTimelineItemFixtures.largeChunk]
-            let parameters = RoomScreenCoordinatorParameters(roomProxy: RoomProxyMock(with: .init(displayName: "Small timeline, paginating", avatarURL: URL.picturesDirectory)),
+            let parameters = RoomScreenCoordinatorParameters(roomProxy: RoomProxyMock(with: .init(name: "Small timeline, paginating", avatarURL: URL.picturesDirectory)),
                                                              timelineController: timelineController,
                                                              mediaProvider: MockMediaProvider(),
                                                              mediaPlayerProvider: MediaPlayerProviderMock(),
@@ -447,7 +447,7 @@ class MockScreen: Identifiable {
             let timelineController = MockRoomTimelineController(listenForSignals: true)
             timelineController.timelineItems = RoomTimelineItemFixtures.largeChunk
             timelineController.backPaginationResponses = [RoomTimelineItemFixtures.largeChunk]
-            let parameters = RoomScreenCoordinatorParameters(roomProxy: RoomProxyMock(with: .init(displayName: "Large timeline", avatarURL: URL.picturesDirectory)),
+            let parameters = RoomScreenCoordinatorParameters(roomProxy: RoomProxyMock(with: .init(name: "Large timeline", avatarURL: URL.picturesDirectory)),
                                                              timelineController: timelineController,
                                                              mediaProvider: MockMediaProvider(),
                                                              mediaPlayerProvider: MediaPlayerProviderMock(),
@@ -466,7 +466,7 @@ class MockScreen: Identifiable {
             timelineController.timelineItems = RoomTimelineItemFixtures.largeChunk
             timelineController.backPaginationResponses = [RoomTimelineItemFixtures.largeChunk]
             timelineController.incomingItems = [RoomTimelineItemFixtures.incomingMessage]
-            let parameters = RoomScreenCoordinatorParameters(roomProxy: RoomProxyMock(with: .init(displayName: "Large timeline", avatarURL: URL.picturesDirectory)),
+            let parameters = RoomScreenCoordinatorParameters(roomProxy: RoomProxyMock(with: .init(name: "Large timeline", avatarURL: URL.picturesDirectory)),
                                                              timelineController: timelineController,
                                                              mediaProvider: MockMediaProvider(),
                                                              mediaPlayerProvider: MediaPlayerProviderMock(),
@@ -484,7 +484,7 @@ class MockScreen: Identifiable {
             let timelineController = MockRoomTimelineController(listenForSignals: true)
             timelineController.timelineItems = RoomTimelineItemFixtures.largeChunk
             timelineController.incomingItems = [RoomTimelineItemFixtures.incomingMessage]
-            let parameters = RoomScreenCoordinatorParameters(roomProxy: RoomProxyMock(with: .init(displayName: "Large timeline", avatarURL: URL.picturesDirectory)),
+            let parameters = RoomScreenCoordinatorParameters(roomProxy: RoomProxyMock(with: .init(name: "Large timeline", avatarURL: URL.picturesDirectory)),
                                                              timelineController: timelineController,
                                                              mediaProvider: MockMediaProvider(),
                                                              mediaPlayerProvider: MediaPlayerProviderMock(),
@@ -502,7 +502,7 @@ class MockScreen: Identifiable {
             let timelineController = MockRoomTimelineController()
             timelineController.timelineItems = RoomTimelineItemFixtures.disclosedPolls
             timelineController.incomingItems = []
-            let parameters = RoomScreenCoordinatorParameters(roomProxy: RoomProxyMock(with: .init(displayName: "Polls timeline", avatarURL: URL.picturesDirectory)),
+            let parameters = RoomScreenCoordinatorParameters(roomProxy: RoomProxyMock(with: .init(name: "Polls timeline", avatarURL: URL.picturesDirectory)),
                                                              timelineController: timelineController,
                                                              mediaProvider: MockMediaProvider(),
                                                              mediaPlayerProvider: MediaPlayerProviderMock(),
@@ -520,7 +520,7 @@ class MockScreen: Identifiable {
             let timelineController = MockRoomTimelineController()
             timelineController.timelineItems = RoomTimelineItemFixtures.undisclosedPolls
             timelineController.incomingItems = []
-            let parameters = RoomScreenCoordinatorParameters(roomProxy: RoomProxyMock(with: .init(displayName: "Polls timeline", avatarURL: URL.picturesDirectory)),
+            let parameters = RoomScreenCoordinatorParameters(roomProxy: RoomProxyMock(with: .init(name: "Polls timeline", avatarURL: URL.picturesDirectory)),
                                                              timelineController: timelineController,
                                                              mediaProvider: MockMediaProvider(),
                                                              mediaPlayerProvider: MediaPlayerProviderMock(),
@@ -538,7 +538,7 @@ class MockScreen: Identifiable {
             let timelineController = MockRoomTimelineController()
             timelineController.timelineItems = RoomTimelineItemFixtures.outgoingPolls
             timelineController.incomingItems = []
-            let parameters = RoomScreenCoordinatorParameters(roomProxy: RoomProxyMock(with: .init(displayName: "Polls timeline", avatarURL: URL.picturesDirectory)),
+            let parameters = RoomScreenCoordinatorParameters(roomProxy: RoomProxyMock(with: .init(name: "Polls timeline", avatarURL: URL.picturesDirectory)),
                                                              timelineController: timelineController,
                                                              mediaProvider: MockMediaProvider(),
                                                              mediaPlayerProvider: MediaPlayerProviderMock(),
@@ -583,7 +583,7 @@ class MockScreen: Identifiable {
             let navigationStackCoordinator = NavigationStackCoordinator()
             let members: [RoomMemberProxyMock] = [.mockAlice, .mockBob, .mockCharlie]
             let roomProxy = RoomProxyMock(with: .init(id: "MockRoomIdentifier",
-                                                      displayName: "Room",
+                                                      name: "Room",
                                                       isEncrypted: true,
                                                       members: members,
                                                       memberForID: .mockOwner(allowedStateEvents: [], canInviteUsers: false)))
@@ -601,7 +601,7 @@ class MockScreen: Identifiable {
             let navigationStackCoordinator = NavigationStackCoordinator()
             let members: [RoomMemberProxyMock] = [.mockAlice, .mockBob, .mockCharlie]
             let roomProxy = RoomProxyMock(with: .init(id: "MockRoomIdentifier",
-                                                      displayName: "Room",
+                                                      name: "Room",
                                                       topic: "Bacon ipsum dolor amet commodo incididunt ribeye dolore cupidatat short ribs.",
                                                       avatarURL: URL.picturesDirectory,
                                                       isEncrypted: true,
@@ -623,7 +623,7 @@ class MockScreen: Identifiable {
             let owner: RoomMemberProxyMock = .mockOwner(allowedStateEvents: [.roomTopic], canInviteUsers: false)
             let members: [RoomMemberProxyMock] = [owner, .mockBob, .mockCharlie]
             let roomProxy = RoomProxyMock(with: .init(id: "MockRoomIdentifier",
-                                                      displayName: "Room",
+                                                      name: "Room",
                                                       topic: nil,
                                                       avatarURL: URL.picturesDirectory,
                                                       isDirect: false,
@@ -646,7 +646,7 @@ class MockScreen: Identifiable {
             let owner: RoomMemberProxyMock = .mockOwner(allowedStateEvents: [], canInviteUsers: true)
             let members: [RoomMemberProxyMock] = [owner, .mockBob, .mockCharlie]
             let roomProxy = RoomProxyMock(with: .init(id: "MockRoomIdentifier",
-                                                      displayName: "Room",
+                                                      name: "Room",
                                                       isEncrypted: true,
                                                       members: members,
                                                       memberForID: owner))
@@ -664,7 +664,7 @@ class MockScreen: Identifiable {
             let navigationStackCoordinator = NavigationStackCoordinator()
             let members: [RoomMemberProxyMock] = [.mockMe, .mockDan]
             let roomProxy = RoomProxyMock(with: .init(id: "MockRoomIdentifier",
-                                                      displayName: "Room",
+                                                      name: "Room",
                                                       topic: "test",
                                                       isDirect: true,
                                                       isEncrypted: true,
@@ -685,7 +685,6 @@ class MockScreen: Identifiable {
             let navigationStackCoordinator = NavigationStackCoordinator()
             let roomProxy = RoomProxyMock(with: .init(id: "MockRoomIdentifier",
                                                       name: "Room",
-                                                      displayName: "Room",
                                                       topic: "What a cool topic!",
                                                       avatarURL: .picturesDirectory))
             let coordinator = RoomDetailsEditScreenCoordinator(parameters: .init(accountOwner: RoomMemberProxyMock.mockOwner(allowedStateEvents: allowedStateEvents),
@@ -700,14 +699,14 @@ class MockScreen: Identifiable {
             let navigationStackCoordinator = NavigationStackCoordinator()
             let members: [RoomMemberProxyMock] = [.mockAlice, .mockBob, .mockCharlie]
             let coordinator = RoomMembersListScreenCoordinator(parameters: .init(mediaProvider: MockMediaProvider(),
-                                                                                 roomProxy: RoomProxyMock(with: .init(displayName: "test", members: members))))
+                                                                                 roomProxy: RoomProxyMock(with: .init(name: "test", members: members))))
             navigationStackCoordinator.setRootCoordinator(coordinator)
             return navigationStackCoordinator
         case .roomMembersListScreenPendingInvites:
             let navigationStackCoordinator = NavigationStackCoordinator()
             let members: [RoomMemberProxyMock] = [.mockInvitedAlice, .mockBob, .mockCharlie]
             let coordinator = RoomMembersListScreenCoordinator(parameters: .init(mediaProvider: MockMediaProvider(),
-                                                                                 roomProxy: RoomProxyMock(with: .init(displayName: "test", members: members))))
+                                                                                 roomProxy: RoomProxyMock(with: .init(name: "test", members: members))))
             navigationStackCoordinator.setRootCoordinator(coordinator)
             return navigationStackCoordinator
         case .roomNotificationSettingsDefaultSetting:
@@ -715,7 +714,7 @@ class MockScreen: Identifiable {
             let members: [RoomMemberProxyMock] = [.mockInvitedAlice, .mockBob, .mockCharlie]
             let coordinator = RoomNotificationSettingsScreenCoordinator(parameters: .init(navigationStackCoordinator: navigationStackCoordinator,
                                                                                           notificationSettingsProxy: NotificationSettingsProxyMock(with: .init(defaultRoomMode: .allMessages, roomMode: .allMessages)),
-                                                                                          roomProxy: RoomProxyMock(with: .init(displayName: "test", members: members)),
+                                                                                          roomProxy: RoomProxyMock(with: .init(name: "test", members: members)),
                                                                                           displayAsUserDefinedRoomSettings: false))
             navigationStackCoordinator.setRootCoordinator(coordinator)
             return navigationStackCoordinator
@@ -724,7 +723,7 @@ class MockScreen: Identifiable {
             let members: [RoomMemberProxyMock] = [.mockInvitedAlice, .mockBob, .mockCharlie]
             let coordinator = RoomNotificationSettingsScreenCoordinator(parameters: .init(navigationStackCoordinator: navigationStackCoordinator,
                                                                                           notificationSettingsProxy: NotificationSettingsProxyMock(with: .init(defaultRoomMode: .allMessages, roomMode: .mentionsAndKeywordsOnly)),
-                                                                                          roomProxy: RoomProxyMock(with: .init(displayName: "test", members: members)),
+                                                                                          roomProxy: RoomProxyMock(with: .init(name: "test", members: members)),
                                                                                           displayAsUserDefinedRoomSettings: false))
             navigationStackCoordinator.setRootCoordinator(coordinator)
             return navigationStackCoordinator
@@ -732,7 +731,7 @@ class MockScreen: Identifiable {
             let navigationStackCoordinator = NavigationStackCoordinator()
             let coordinator = ReportContentScreenCoordinator(parameters: .init(eventID: "test",
                                                                                senderID: RoomMemberProxyMock.mockAlice.userID,
-                                                                               roomProxy: RoomProxyMock(with: .init(displayName: "test")),
+                                                                               roomProxy: RoomProxyMock(with: .init(name: "test")),
                                                                                userIndicatorController: UserIndicatorControllerMock()))
             navigationStackCoordinator.setRootCoordinator(coordinator)
             return navigationStackCoordinator
@@ -767,7 +766,7 @@ class MockScreen: Identifiable {
             return navigationStackCoordinator
         case .roomMemberDetailsAccountOwner:
             let member = RoomMemberProxyMock.mockMe
-            let roomProxy = RoomProxyMock(with: .init(displayName: ""))
+            let roomProxy = RoomProxyMock(with: .init(name: ""))
             roomProxy.getMemberUserIDReturnValue = .success(member)
             
             let navigationStackCoordinator = NavigationStackCoordinator()
@@ -779,7 +778,7 @@ class MockScreen: Identifiable {
             return navigationStackCoordinator
         case .roomMemberDetails:
             let member = RoomMemberProxyMock.mockAlice
-            let roomProxy = RoomProxyMock(with: .init(displayName: ""))
+            let roomProxy = RoomProxyMock(with: .init(name: ""))
             roomProxy.getMemberUserIDReturnValue = .success(member)
             
             let navigationStackCoordinator = NavigationStackCoordinator()
@@ -791,7 +790,7 @@ class MockScreen: Identifiable {
             return navigationStackCoordinator
         case .roomMemberDetailsIgnoredUser:
             let member = RoomMemberProxyMock.mockIgnored
-            let roomProxy = RoomProxyMock(with: .init(displayName: ""))
+            let roomProxy = RoomProxyMock(with: .init(name: ""))
             roomProxy.getMemberUserIDReturnValue = .success(member)
             
             let navigationStackCoordinator = NavigationStackCoordinator()
@@ -805,8 +804,8 @@ class MockScreen: Identifiable {
             ServiceLocator.shared.settings.seenInvites = Set([RoomSummary].mockInvites.dropFirst(1).compactMap(\.id))
             let navigationStackCoordinator = NavigationStackCoordinator()
             let clientProxy = MockClientProxy(userID: "@mock:client.com")
-            clientProxy.roomForIdentifierMocks["someAwesomeRoomId1"] = .init(with: .init(displayName: "First room"))
-            clientProxy.roomForIdentifierMocks["someAwesomeRoomId2"] = .init(with: .init(displayName: "Second room"))
+            clientProxy.roomForIdentifierMocks["someAwesomeRoomId1"] = .init(with: .init(name: "First room"))
+            clientProxy.roomForIdentifierMocks["someAwesomeRoomId2"] = .init(with: .init(name: "Second room"))
             let summaryProvider = MockRoomSummaryProvider(state: .loaded(.mockInvites))
             clientProxy.inviteSummaryProvider = summaryProvider
             
@@ -817,8 +816,8 @@ class MockScreen: Identifiable {
             ServiceLocator.shared.settings.seenInvites = Set([RoomSummary].mockInvites.compactMap(\.id))
             let navigationStackCoordinator = NavigationStackCoordinator()
             let clientProxy = MockClientProxy(userID: "@mock:client.com")
-            clientProxy.roomForIdentifierMocks["someAwesomeRoomId1"] = .init(with: .init(displayName: "First room"))
-            clientProxy.roomForIdentifierMocks["someAwesomeRoomId2"] = .init(with: .init(displayName: "Second room"))
+            clientProxy.roomForIdentifierMocks["someAwesomeRoomId1"] = .init(with: .init(name: "First room"))
+            clientProxy.roomForIdentifierMocks["someAwesomeRoomId2"] = .init(with: .init(name: "Second room"))
             let summaryProvider = MockRoomSummaryProvider(state: .loaded(.mockInvites))
             clientProxy.inviteSummaryProvider = summaryProvider
             
@@ -840,7 +839,7 @@ class MockScreen: Identifiable {
             let mediaProvider = MockMediaProvider()
             let usersSubject = CurrentValueSubject<[UserProfileProxy], Never>([])
             let members: [RoomMemberProxyMock] = id == .inviteUsersInRoomExistingMembers ? [.mockInvitedAlice, .mockBob] : []
-            let roomProxy = RoomProxyMock(with: .init(displayName: "test", members: members))
+            let roomProxy = RoomProxyMock(with: .init(name: "test", members: members))
             let roomType: InviteUsersScreenRoomType = id == .inviteUsers ? .draft : .room(roomProxy: roomProxy)
             let coordinator = InviteUsersScreenCoordinator(parameters: .init(selectedUsers: usersSubject.asCurrentValuePublisher(),
                                                                              roomType: roomType,
@@ -904,7 +903,7 @@ class MockScreen: Identifiable {
                 [],
                 []
             ]
-            let roomProxyMockConfiguration = RoomProxyMockConfiguration(displayName: "Polls")
+            let roomProxyMockConfiguration = RoomProxyMockConfiguration(name: "Polls")
             roomProxyMockConfiguration.timeline.timelineStartReached = false
             let parameters = RoomPollsHistoryScreenCoordinatorParameters(roomProxy: RoomProxyMock(with: roomProxyMockConfiguration),
                                                                          pollInteractionHandler: interactionHandler,
@@ -922,7 +921,7 @@ class MockScreen: Identifiable {
             let date: Date! = DateComponents(calendar: .current, timeZone: .gmt, year: 2023, month: 12, day: 1, hour: 12).date
             roomTimelineController.timelineItemsTimestamp = [poll.id: date]
             
-            let roomProxyMockConfiguration = RoomProxyMockConfiguration(displayName: "Polls")
+            let roomProxyMockConfiguration = RoomProxyMockConfiguration(name: "Polls")
             roomProxyMockConfiguration.timeline.timelineStartReached = false
             let parameters = RoomPollsHistoryScreenCoordinatorParameters(roomProxy: RoomProxyMock(with: roomProxyMockConfiguration),
                                                                          pollInteractionHandler: interactionHandler,

--- a/UnitTests/Sources/CompletionSuggestionServiceTests.swift
+++ b/UnitTests/Sources/CompletionSuggestionServiceTests.swift
@@ -29,7 +29,7 @@ final class CompletionSuggestionServiceTests: XCTestCase {
     func testUserSuggestons() async throws {
         let alice: RoomMemberProxyMock = .mockAlice
         let members: [RoomMemberProxyMock] = [alice, .mockBob, .mockCharlie, .mockMe]
-        let roomProxyMock = RoomProxyMock(with: .init(displayName: "test", members: members))
+        let roomProxyMock = RoomProxyMock(with: .init(name: "test", members: members))
         let service = CompletionSuggestionService(roomProxy: roomProxyMock)
         
         var deferred = deferFulfillment(service.suggestionsPublisher) { suggestions in
@@ -66,7 +66,7 @@ final class CompletionSuggestionServiceTests: XCTestCase {
     func testUserSuggestonsIncludingAllUsers() async throws {
         let alice: RoomMemberProxyMock = .mockAlice
         let members: [RoomMemberProxyMock] = [alice, .mockBob, .mockCharlie, .mockMe]
-        let roomProxyMock = RoomProxyMock(with: .init(displayName: "test", members: members, canUserTriggerRoomNotification: true))
+        let roomProxyMock = RoomProxyMock(with: .init(name: "test", members: members, canUserTriggerRoomNotification: true))
         let service = CompletionSuggestionService(roomProxy: roomProxyMock)
                 
         var deferred = deferFulfillment(service.suggestionsPublisher) { suggestions in
@@ -92,7 +92,7 @@ final class CompletionSuggestionServiceTests: XCTestCase {
         let alice: RoomMemberProxyMock = .mockAlice
         let bob: RoomMemberProxyMock = .mockBob
         let members: [RoomMemberProxyMock] = [alice, bob, .mockMe]
-        let roomProxyMock = RoomProxyMock(with: .init(displayName: "test", members: members, canUserTriggerRoomNotification: true))
+        let roomProxyMock = RoomProxyMock(with: .init(name: "test", members: members, canUserTriggerRoomNotification: true))
         let service = CompletionSuggestionService(roomProxy: roomProxyMock)
                 
         var deferred = deferFulfillment(service.suggestionsPublisher) { suggestions in

--- a/UnitTests/Sources/HomeScreenViewModelTests.swift
+++ b/UnitTests/Sources/HomeScreenViewModelTests.swift
@@ -99,7 +99,7 @@ class HomeScreenViewModelTests: XCTestCase {
         
         try await deferred.fulfill()
         
-        XCTAssertEqual(context.leaveRoomAlertItem?.roomId, mockRoomId)
+        XCTAssertEqual(context.leaveRoomAlertItem?.roomID, mockRoomId)
     }
     
     func testLeaveRoomError() async throws {

--- a/UnitTests/Sources/HomeScreenViewModelTests.swift
+++ b/UnitTests/Sources/HomeScreenViewModelTests.swift
@@ -89,7 +89,7 @@ class HomeScreenViewModelTests: XCTestCase {
     
     func testLeaveRoomAlert() async throws {
         let mockRoomId = "1"
-        clientProxy.roomForIdentifierMocks[mockRoomId] = .init(with: .init(id: mockRoomId, displayName: "Some room"))
+        clientProxy.roomForIdentifierMocks[mockRoomId] = .init(with: .init(id: mockRoomId, name: "Some room"))
         
         let deferred = deferFulfillment(context.$viewState) { value in
             value.bindings.leaveRoomAlertItem != nil
@@ -104,7 +104,7 @@ class HomeScreenViewModelTests: XCTestCase {
     
     func testLeaveRoomError() async throws {
         let mockRoomId = "1"
-        let room: RoomProxyMock = .init(with: .init(id: mockRoomId, displayName: "Some room"))
+        let room: RoomProxyMock = .init(with: .init(id: mockRoomId, name: "Some room"))
         room.leaveRoomClosure = { .failure(.failedLeavingRoom) }
         clientProxy.roomForIdentifierMocks[mockRoomId] = room
 
@@ -134,7 +134,7 @@ class HomeScreenViewModelTests: XCTestCase {
                 expectation.fulfill()
             }
             .store(in: &cancellables)
-        let room: RoomProxyMock = .init(with: .init(id: mockRoomId, displayName: "Some room"))
+        let room: RoomProxyMock = .init(with: .init(id: mockRoomId, name: "Some room"))
         room.leaveRoomClosure = { .success(()) }
         clientProxy.roomForIdentifierMocks[mockRoomId] = room
         context.send(viewAction: .confirmLeaveRoom(roomIdentifier: mockRoomId))

--- a/UnitTests/Sources/InviteUsersViewModelTests.swift
+++ b/UnitTests/Sources/InviteUsersViewModelTests.swift
@@ -64,7 +64,7 @@ class InviteUsersScreenViewModelTests: XCTestCase {
      
     func testInviteButton() async throws {
         let mockedMembers: [RoomMemberProxyMock] = [.mockAlice, .mockBob]
-        setupWithRoomType(roomType: .room(roomProxy: RoomProxyMock(with: .init(displayName: "test", members: mockedMembers))))
+        setupWithRoomType(roomType: .room(roomProxy: RoomProxyMock(with: .init(name: "test", members: mockedMembers))))
         
         let deferredState = deferFulfillment(viewModel.context.$viewState) { state in
             state.isUserSelected(.mockAlice)

--- a/UnitTests/Sources/PillContextTests.swift
+++ b/UnitTests/Sources/PillContextTests.swift
@@ -23,7 +23,7 @@ import XCTest
 class PillContextTests: XCTestCase {
     func testUser() async throws {
         let id = "@test:matrix.org"
-        let proxyMock = RoomProxyMock(with: .init(displayName: "Test"))
+        let proxyMock = RoomProxyMock(with: .init(name: "Test"))
         let subject = CurrentValueSubject<[RoomMemberProxyProtocol], Never>([])
         proxyMock.members = subject.asCurrentValuePublisher()
         let mock = RoomScreenViewModel(roomProxy: proxyMock,
@@ -52,7 +52,7 @@ class PillContextTests: XCTestCase {
     
     func testOwnUser() async throws {
         let id = "@test:matrix.org"
-        let proxyMock = RoomProxyMock(with: .init(displayName: "Test", ownUserID: id))
+        let proxyMock = RoomProxyMock(with: .init(name: "Test", ownUserID: id))
         let subject = CurrentValueSubject<[RoomMemberProxyProtocol], Never>([])
         proxyMock.members = subject.asCurrentValuePublisher()
         let mock = RoomScreenViewModel(roomProxy: proxyMock,
@@ -74,7 +74,7 @@ class PillContextTests: XCTestCase {
         let avatarURL = URL(string: "https://matrix.jpg")
         let id = "test_room"
         let displayName = "Test"
-        let proxyMock = RoomProxyMock(with: .init(id: id, displayName: displayName, avatarURL: avatarURL))
+        let proxyMock = RoomProxyMock(with: .init(id: id, name: displayName, avatarURL: avatarURL))
         let mockController = MockRoomTimelineController()
         mockController.roomProxy = proxyMock
         let mock = RoomScreenViewModel(roomProxy: proxyMock,

--- a/UnitTests/Sources/ReportContentViewModelTests.swift
+++ b/UnitTests/Sources/ReportContentViewModelTests.swift
@@ -25,7 +25,7 @@ class ReportContentScreenViewModelTests: XCTestCase {
     
     func testReportContent() async throws {
         // Given the report content view for some content.
-        let roomProxy = RoomProxyMock(with: .init(displayName: "test"))
+        let roomProxy = RoomProxyMock(with: .init(name: "test"))
         roomProxy.reportContentReasonReturnValue = .success(())
         let viewModel = ReportContentScreenViewModel(eventID: eventID,
                                                      senderID: senderID,
@@ -52,7 +52,7 @@ class ReportContentScreenViewModelTests: XCTestCase {
     
     func testReportIgnoringSender() async throws {
         // Given the report content view for some content.
-        let roomProxy = RoomProxyMock(with: .init(displayName: "test"))
+        let roomProxy = RoomProxyMock(with: .init(name: "test"))
         roomProxy.reportContentReasonReturnValue = .success(())
         roomProxy.ignoreUserReturnValue = .success(())
         let viewModel = ReportContentScreenViewModel(eventID: eventID,

--- a/UnitTests/Sources/RoomDetailsEditScreenViewModelTests.swift
+++ b/UnitTests/Sources/RoomDetailsEditScreenViewModelTests.swift
@@ -31,13 +31,13 @@ class RoomDetailsEditScreenViewModelTests: XCTestCase {
     
     func testCannotSaveOnLanding() {
         setupViewModel(accountOwner: .mockOwner(allowedStateEvents: [.roomAvatar, .roomName, .roomTopic]),
-                       roomProxyConfiguration: .init(name: "Some room", displayName: "Some room"))
+                       roomProxyConfiguration: .init(name: "Some room"))
         XCTAssertFalse(context.viewState.canSave)
     }
     
     func testCanEdit() {
         setupViewModel(accountOwner: .mockOwner(allowedStateEvents: [.roomAvatar, .roomName, .roomTopic]),
-                       roomProxyConfiguration: .init(name: "Some room", displayName: "Some room"))
+                       roomProxyConfiguration: .init(name: "Some room"))
         XCTAssertTrue(context.viewState.canEditAvatar)
         XCTAssertTrue(context.viewState.canEditName)
         XCTAssertTrue(context.viewState.canEditTopic)
@@ -45,7 +45,7 @@ class RoomDetailsEditScreenViewModelTests: XCTestCase {
     
     func testCannotEdit() {
         setupViewModel(accountOwner: .mockOwner(allowedStateEvents: []),
-                       roomProxyConfiguration: .init(name: "Some room", displayName: "Some room"))
+                       roomProxyConfiguration: .init(name: "Some room"))
         XCTAssertFalse(context.viewState.canEditAvatar)
         XCTAssertFalse(context.viewState.canEditName)
         XCTAssertFalse(context.viewState.canEditTopic)
@@ -53,7 +53,7 @@ class RoomDetailsEditScreenViewModelTests: XCTestCase {
     
     func testNameDidChange() {
         setupViewModel(accountOwner: .mockOwner(allowedStateEvents: [.roomAvatar, .roomName, .roomTopic]),
-                       roomProxyConfiguration: .init(name: "Some room", displayName: "Some room"))
+                       roomProxyConfiguration: .init(name: "Some room"))
         context.name = "name"
         XCTAssertTrue(context.viewState.nameDidChange)
         XCTAssertTrue(context.viewState.canSave)
@@ -61,7 +61,7 @@ class RoomDetailsEditScreenViewModelTests: XCTestCase {
     
     func testTopicDidChange() {
         setupViewModel(accountOwner: .mockOwner(allowedStateEvents: [.roomAvatar, .roomName, .roomTopic]),
-                       roomProxyConfiguration: .init(name: "Some room", displayName: "Some room"))
+                       roomProxyConfiguration: .init(name: "Some room"))
         context.topic = "topic"
         XCTAssertTrue(context.viewState.topicDidChange)
         XCTAssertTrue(context.viewState.canSave)
@@ -69,7 +69,7 @@ class RoomDetailsEditScreenViewModelTests: XCTestCase {
     
     func testAvatarDidChange() {
         setupViewModel(accountOwner: .mockOwner(allowedStateEvents: [.roomAvatar, .roomName, .roomTopic]),
-                       roomProxyConfiguration: .init(name: "Some room", displayName: "Some room", avatarURL: .picturesDirectory))
+                       roomProxyConfiguration: .init(name: "Some room", avatarURL: .picturesDirectory))
         context.send(viewAction: .removeImage)
         XCTAssertTrue(context.viewState.avatarDidChange)
         XCTAssertTrue(context.viewState.canSave)
@@ -77,14 +77,14 @@ class RoomDetailsEditScreenViewModelTests: XCTestCase {
     
     func testEmptyNameCannotBeSaved() {
         setupViewModel(accountOwner: .mockOwner(allowedStateEvents: [.roomAvatar, .roomName, .roomTopic]),
-                       roomProxyConfiguration: .init(name: "Some room", displayName: "Some room"))
+                       roomProxyConfiguration: .init(name: "Some room"))
         context.name = ""
         XCTAssertFalse(context.viewState.canSave)
     }
     
     func testSaveShowsSheet() {
         setupViewModel(accountOwner: .mockOwner(allowedStateEvents: [.roomAvatar, .roomName, .roomTopic]),
-                       roomProxyConfiguration: .init(name: "Some room", displayName: "Some room"))
+                       roomProxyConfiguration: .init(name: "Some room"))
         context.name = "name"
         XCTAssertFalse(context.showMediaSheet)
         context.send(viewAction: .presentMediaSource)
@@ -93,7 +93,7 @@ class RoomDetailsEditScreenViewModelTests: XCTestCase {
     
     func testSaveTriggersViewModelAction() async throws {
         setupViewModel(accountOwner: .mockOwner(allowedStateEvents: [.roomAvatar, .roomName, .roomTopic]),
-                       roomProxyConfiguration: .init(name: "Some room", displayName: "Some room"))
+                       roomProxyConfiguration: .init(name: "Some room"))
         
         let deferred = deferFulfillment(viewModel.actions) { action in
             action == .saveFinished
@@ -108,7 +108,7 @@ class RoomDetailsEditScreenViewModelTests: XCTestCase {
     
     func testErrorShownOnFailedFetchOfMedia() async throws {
         setupViewModel(accountOwner: .mockOwner(allowedStateEvents: [.roomAvatar, .roomName, .roomTopic]),
-                       roomProxyConfiguration: .init(name: "Some room", displayName: "Some room"))
+                       roomProxyConfiguration: .init(name: "Some room"))
         viewModel.didSelectMediaUrl(url: .picturesDirectory)
         try? await Task.sleep(for: .milliseconds(100))
         XCTAssertNotNil(userIndicatorController.alertInfo)
@@ -116,7 +116,7 @@ class RoomDetailsEditScreenViewModelTests: XCTestCase {
     
     func testDeleteAvatar() {
         setupViewModel(accountOwner: .mockOwner(allowedStateEvents: [.roomAvatar, .roomName, .roomTopic]),
-                       roomProxyConfiguration: .init(name: "Some room", displayName: "Some room", avatarURL: .picturesDirectory))
+                       roomProxyConfiguration: .init(name: "Some room", avatarURL: .picturesDirectory))
         XCTAssertNotNil(context.viewState.avatarURL)
         context.send(viewAction: .removeImage)
         XCTAssertNil(context.viewState.avatarURL)

--- a/UnitTests/Sources/RoomDetailsViewModelTests.swift
+++ b/UnitTests/Sources/RoomDetailsViewModelTests.swift
@@ -31,7 +31,7 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
     
     override func setUp() {
         cancellables.removeAll()
-        roomProxyMock = RoomProxyMock(with: .init(displayName: "Test"))
+        roomProxyMock = RoomProxyMock(with: .init(name: "Test"))
         notificationSettingsProxyMock = NotificationSettingsProxyMock(with: NotificationSettingsProxyMockConfiguration())
         viewModel = RoomDetailsScreenViewModel(accountUserID: "@owner:somewhere.com",
                                                roomProxy: roomProxyMock,
@@ -47,7 +47,7 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
     
     func testLeaveRoomTappedWhenPublic() async throws {
         let mockedMembers: [RoomMemberProxyMock] = [.mockBob, .mockAlice]
-        roomProxyMock = RoomProxyMock(with: .init(displayName: "Test", isPublic: true, members: mockedMembers))
+        roomProxyMock = RoomProxyMock(with: .init(name: "Test", isPublic: true, members: mockedMembers))
         viewModel = RoomDetailsScreenViewModel(accountUserID: "@owner:somewhere.com",
                                                roomProxy: roomProxyMock,
                                                mediaProvider: MockMediaProvider(),
@@ -69,7 +69,7 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
     
     func testLeaveRoomTappedWhenRoomNotPublic() async throws {
         let mockedMembers: [RoomMemberProxyMock] = [.mockBob, .mockAlice]
-        roomProxyMock = RoomProxyMock(with: .init(displayName: "Test", isPublic: false, members: mockedMembers))
+        roomProxyMock = RoomProxyMock(with: .init(name: "Test", isPublic: false, members: mockedMembers))
         viewModel = RoomDetailsScreenViewModel(accountUserID: "@owner:somewhere.com",
                                                roomProxy: roomProxyMock,
                                                mediaProvider: MockMediaProvider(),
@@ -92,7 +92,7 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
     
     func testLeaveRoomTappedWithLessThanTwoMembers() async {
         let mockedMembers: [RoomMemberProxyMock] = [.mockAlice]
-        roomProxyMock = RoomProxyMock(with: .init(displayName: "Test", isPublic: false, members: mockedMembers))
+        roomProxyMock = RoomProxyMock(with: .init(name: "Test", isPublic: false, members: mockedMembers))
         viewModel = RoomDetailsScreenViewModel(accountUserID: "@owner:somewhere.com",
                                                roomProxy: roomProxyMock,
                                                mediaProvider: MockMediaProvider(),
@@ -145,7 +145,7 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
     func testInitialDMDetailsState() async throws {
         let recipient = RoomMemberProxyMock.mockDan
         let mockedMembers: [RoomMemberProxyMock] = [.mockMe, recipient]
-        roomProxyMock = RoomProxyMock(with: .init(displayName: "Test", isDirect: true, isEncrypted: true, members: mockedMembers))
+        roomProxyMock = RoomProxyMock(with: .init(name: "Test", isDirect: true, isEncrypted: true, members: mockedMembers))
         viewModel = RoomDetailsScreenViewModel(accountUserID: "@owner:somewhere.com",
                                                roomProxy: roomProxyMock,
                                                mediaProvider: MockMediaProvider(),
@@ -172,7 +172,7 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
         }
         
         let mockedMembers: [RoomMemberProxyMock] = [.mockMe, recipient]
-        roomProxyMock = RoomProxyMock(with: .init(displayName: "Test", isDirect: true, isEncrypted: true, members: mockedMembers))
+        roomProxyMock = RoomProxyMock(with: .init(name: "Test", isDirect: true, isEncrypted: true, members: mockedMembers))
         viewModel = RoomDetailsScreenViewModel(accountUserID: "@owner:somewhere.com",
                                                roomProxy: roomProxyMock,
                                                mediaProvider: MockMediaProvider(),
@@ -208,7 +208,7 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
             return .failure(.ignoreUserFailed)
         }
         let mockedMembers: [RoomMemberProxyMock] = [.mockMe, recipient]
-        roomProxyMock = RoomProxyMock(with: .init(displayName: "Test", isDirect: true, isEncrypted: true, members: mockedMembers))
+        roomProxyMock = RoomProxyMock(with: .init(name: "Test", isDirect: true, isEncrypted: true, members: mockedMembers))
         viewModel = RoomDetailsScreenViewModel(accountUserID: "@owner:somewhere.com",
                                                roomProxy: roomProxyMock,
                                                mediaProvider: MockMediaProvider(),
@@ -245,7 +245,7 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
             return .success(())
         }
         let mockedMembers: [RoomMemberProxyMock] = [.mockMe, recipient]
-        roomProxyMock = RoomProxyMock(with: .init(displayName: "Test", isDirect: true, isEncrypted: true, members: mockedMembers))
+        roomProxyMock = RoomProxyMock(with: .init(name: "Test", isDirect: true, isEncrypted: true, members: mockedMembers))
         viewModel = RoomDetailsScreenViewModel(accountUserID: "@owner:somewhere.com",
                                                roomProxy: roomProxyMock,
                                                mediaProvider: MockMediaProvider(),
@@ -281,7 +281,7 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
             return .failure(.unignoreUserFailed)
         }
         let mockedMembers: [RoomMemberProxyMock] = [.mockMe, recipient]
-        roomProxyMock = RoomProxyMock(with: .init(displayName: "Test", isDirect: true, isEncrypted: true, members: mockedMembers))
+        roomProxyMock = RoomProxyMock(with: .init(name: "Test", isDirect: true, isEncrypted: true, members: mockedMembers))
         viewModel = RoomDetailsScreenViewModel(accountUserID: "@owner:somewhere.com",
                                                roomProxy: roomProxyMock,
                                                mediaProvider: MockMediaProvider(),
@@ -313,7 +313,7 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
     
     func testCannotInvitePeople() async {
         let mockedMembers: [RoomMemberProxyMock] = [.mockBob, .mockAlice]
-        roomProxyMock = RoomProxyMock(with: .init(displayName: "Test",
+        roomProxyMock = RoomProxyMock(with: .init(name: "Test",
                                                   isPublic: true,
                                                   members: mockedMembers,
                                                   memberForID: .mockOwner(allowedStateEvents: [], canInviteUsers: false)))
@@ -333,7 +333,7 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
     
     func testInvitePeople() async {
         let mockedMembers: [RoomMemberProxyMock] = [.mockMe, .mockBob, .mockAlice]
-        roomProxyMock = RoomProxyMock(with: .init(displayName: "Test", isPublic: true, members: mockedMembers))
+        roomProxyMock = RoomProxyMock(with: .init(name: "Test", isPublic: true, members: mockedMembers))
         viewModel = RoomDetailsScreenViewModel(accountUserID: "@owner:somewhere.com",
                                                roomProxy: roomProxyMock,
                                                mediaProvider: MockMediaProvider(),
@@ -367,7 +367,7 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
     func testCanEditAvatar() async {
         let owner: RoomMemberProxyMock = .mockOwner(allowedStateEvents: [.roomAvatar])
         let mockedMembers: [RoomMemberProxyMock] = [owner, .mockBob, .mockAlice]
-        roomProxyMock = RoomProxyMock(with: .init(displayName: "Test", isDirect: false, isPublic: false, members: mockedMembers, memberForID: owner))
+        roomProxyMock = RoomProxyMock(with: .init(name: "Test", isDirect: false, isPublic: false, members: mockedMembers, memberForID: owner))
         viewModel = RoomDetailsScreenViewModel(accountUserID: "@owner:somewhere.com",
                                                roomProxy: roomProxyMock,
                                                mediaProvider: MockMediaProvider(),
@@ -388,7 +388,7 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
     func testCanEditName() async {
         let owner: RoomMemberProxyMock = .mockOwner(allowedStateEvents: [.roomName])
         let mockedMembers: [RoomMemberProxyMock] = [owner, .mockBob, .mockAlice]
-        roomProxyMock = RoomProxyMock(with: .init(displayName: "Test", isDirect: false, isPublic: false, members: mockedMembers, memberForID: owner))
+        roomProxyMock = RoomProxyMock(with: .init(name: "Test", isDirect: false, isPublic: false, members: mockedMembers, memberForID: owner))
         viewModel = RoomDetailsScreenViewModel(accountUserID: "@owner:somewhere.com",
                                                roomProxy: roomProxyMock,
                                                mediaProvider: MockMediaProvider(),
@@ -409,7 +409,7 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
     func testCanEditTopic() async {
         let owner: RoomMemberProxyMock = .mockOwner(allowedStateEvents: [.roomTopic])
         let mockedMembers: [RoomMemberProxyMock] = [owner, .mockBob, .mockAlice]
-        roomProxyMock = RoomProxyMock(with: .init(displayName: "Test", isDirect: false, isPublic: false, members: mockedMembers, memberForID: owner))
+        roomProxyMock = RoomProxyMock(with: .init(name: "Test", isDirect: false, isPublic: false, members: mockedMembers, memberForID: owner))
         viewModel = RoomDetailsScreenViewModel(accountUserID: "@owner:somewhere.com",
                                                roomProxy: roomProxyMock,
                                                mediaProvider: MockMediaProvider(),
@@ -430,7 +430,7 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
     func testCannotEditRoom() async {
         let owner: RoomMemberProxyMock = .mockOwner(allowedStateEvents: [])
         let mockedMembers: [RoomMemberProxyMock] = [owner, .mockBob, .mockAlice]
-        roomProxyMock = RoomProxyMock(with: .init(displayName: "Test", isDirect: false, isPublic: false, members: mockedMembers, memberForID: owner))
+        roomProxyMock = RoomProxyMock(with: .init(name: "Test", isDirect: false, isPublic: false, members: mockedMembers, memberForID: owner))
         viewModel = RoomDetailsScreenViewModel(accountUserID: "@owner:somewhere.com",
                                                roomProxy: roomProxyMock,
                                                mediaProvider: MockMediaProvider(),
@@ -450,7 +450,7 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
     
     func testCannotEditDirectRoom() async {
         let mockedMembers: [RoomMemberProxyMock] = [.mockOwner(allowedStateEvents: [.roomAvatar, .roomName, .roomTopic]), .mockBob, .mockAlice]
-        roomProxyMock = RoomProxyMock(with: .init(displayName: "Test", isDirect: true, isPublic: false, members: mockedMembers))
+        roomProxyMock = RoomProxyMock(with: .init(name: "Test", isDirect: true, isPublic: false, members: mockedMembers))
         viewModel = RoomDetailsScreenViewModel(accountUserID: "@owner:somewhere.com",
                                                roomProxy: roomProxyMock,
                                                mediaProvider: MockMediaProvider(),

--- a/UnitTests/Sources/RoomMemberDetailsViewModelTests.swift
+++ b/UnitTests/Sources/RoomMemberDetailsViewModelTests.swift
@@ -26,7 +26,7 @@ class RoomMemberDetailsViewModelTests: XCTestCase {
     var context: RoomMemberDetailsScreenViewModelType.Context { viewModel.context }
 
     override func setUp() async throws {
-        roomProxyMock = RoomProxyMock(with: .init(displayName: ""))
+        roomProxyMock = RoomProxyMock(with: .init(name: ""))
         
         roomProxyMock.getMemberUserIDClosure = { _ in
             .success(self.roomMemberProxyMock)

--- a/UnitTests/Sources/RoomMembersListViewModelTests.swift
+++ b/UnitTests/Sources/RoomMembersListViewModelTests.swift
@@ -126,7 +126,7 @@ class RoomMembersListScreenViewModelTests: XCTestCase {
     }
     
     private func setup(with members: [RoomMemberProxyMock]) {
-        viewModel = .init(roomProxy: RoomProxyMock(with: .init(displayName: "test", members: members)),
+        viewModel = .init(roomProxy: RoomProxyMock(with: .init(name: "test", members: members)),
                           mediaProvider: MockMediaProvider(),
                           userIndicatorController: ServiceLocator.shared.userIndicatorController)
     }

--- a/UnitTests/Sources/RoomNotificationSettingsScreenViewModelTests.swift
+++ b/UnitTests/Sources/RoomNotificationSettingsScreenViewModelTests.swift
@@ -28,12 +28,12 @@ class RoomNotificationSettingsScreenViewModelTests: XCTestCase {
 
     override func setUpWithError() throws {
         cancellables.removeAll()
-        roomProxyMock = RoomProxyMock(with: .init(displayName: "Test"))
+        roomProxyMock = RoomProxyMock(with: .init(name: "Test"))
         notificationSettingsProxyMock = NotificationSettingsProxyMock(with: NotificationSettingsProxyMockConfiguration())
     }
     
     func testInitialStateDefaultModeEncryptedRoom() async throws {
-        let roomProxyMock = RoomProxyMock(with: .init(displayName: "Test", isEncrypted: true))
+        let roomProxyMock = RoomProxyMock(with: .init(name: "Test", isEncrypted: true))
         let notificationSettingsProxyMock = NotificationSettingsProxyMock(with: NotificationSettingsProxyMockConfiguration())
         
         notificationSettingsProxyMock.getNotificationSettingsRoomIdIsEncryptedIsOneToOneReturnValue = RoomNotificationSettingsProxyMock(with: .init(mode: .mentionsAndKeywordsOnly, isDefault: true))
@@ -55,7 +55,7 @@ class RoomNotificationSettingsScreenViewModelTests: XCTestCase {
     }
     
     func testInitialStateDefaultModeEncryptedRoomWithCanPushEncrypted() async throws {
-        let roomProxyMock = RoomProxyMock(with: .init(displayName: "Test", isEncrypted: true))
+        let roomProxyMock = RoomProxyMock(with: .init(name: "Test", isEncrypted: true))
         let notificationSettingsProxyMock = NotificationSettingsProxyMock(with: .init(canPushEncryptedEvents: true))
         
         notificationSettingsProxyMock.getNotificationSettingsRoomIdIsEncryptedIsOneToOneReturnValue = RoomNotificationSettingsProxyMock(with: .init(mode: .mentionsAndKeywordsOnly, isDefault: true))
@@ -77,7 +77,7 @@ class RoomNotificationSettingsScreenViewModelTests: XCTestCase {
     }
     
     func testInitialStateDefaultModeUnencryptedRoom() async throws {
-        let roomProxyMock = RoomProxyMock(with: .init(displayName: "Test", isEncrypted: false))
+        let roomProxyMock = RoomProxyMock(with: .init(name: "Test", isEncrypted: false))
         let notificationSettingsProxyMock = NotificationSettingsProxyMock(with: NotificationSettingsProxyMockConfiguration())
         
         notificationSettingsProxyMock.getNotificationSettingsRoomIdIsEncryptedIsOneToOneReturnValue = RoomNotificationSettingsProxyMock(with: .init(mode: .mentionsAndKeywordsOnly, isDefault: true))

--- a/UnitTests/Sources/RoomPollsHistoryScreenViewModelTests.swift
+++ b/UnitTests/Sources/RoomPollsHistoryScreenViewModelTests.swift
@@ -27,7 +27,7 @@ class RoomPollsHistoryScreenViewModelTests: XCTestCase {
     override func setUpWithError() throws {
         interactionHandler = PollInteractionHandlerMock()
         timelineController = MockRoomTimelineController()
-        let roomProxyMockConfiguration = RoomProxyMockConfiguration(displayName: "Polls")
+        let roomProxyMockConfiguration = RoomProxyMockConfiguration(name: "Polls")
         roomProxyMockConfiguration.timeline.timelineStartReached = false
         viewModel = RoomPollsHistoryScreenViewModel(pollInteractionHandler: interactionHandler,
                                                     roomTimelineController: timelineController,

--- a/UnitTests/Sources/RoomScreenViewModelTests.swift
+++ b/UnitTests/Sources/RoomScreenViewModelTests.swift
@@ -50,7 +50,7 @@ class RoomScreenViewModelTests: XCTestCase {
         // When showing them in a timeline.
         let timelineController = MockRoomTimelineController()
         timelineController.timelineItems = items
-        let viewModel = RoomScreenViewModel(roomProxy: RoomProxyMock(with: .init(displayName: "")),
+        let viewModel = RoomScreenViewModel(roomProxy: RoomProxyMock(with: .init(name: "")),
                                             timelineController: timelineController,
                                             mediaProvider: MockMediaProvider(),
                                             mediaPlayerProvider: MediaPlayerProviderMock(),
@@ -87,7 +87,7 @@ class RoomScreenViewModelTests: XCTestCase {
         // When showing them in a timeline.
         let timelineController = MockRoomTimelineController()
         timelineController.timelineItems = items
-        let viewModel = RoomScreenViewModel(roomProxy: RoomProxyMock(with: .init(displayName: "")),
+        let viewModel = RoomScreenViewModel(roomProxy: RoomProxyMock(with: .init(name: "")),
                                             timelineController: timelineController,
                                             mediaProvider: MockMediaProvider(),
                                             mediaPlayerProvider: MediaPlayerProviderMock(),
@@ -122,7 +122,7 @@ class RoomScreenViewModelTests: XCTestCase {
         // When showing them in a timeline.
         let timelineController = MockRoomTimelineController()
         timelineController.timelineItems = items
-        let viewModel = RoomScreenViewModel(roomProxy: RoomProxyMock(with: .init(displayName: "")),
+        let viewModel = RoomScreenViewModel(roomProxy: RoomProxyMock(with: .init(name: "")),
                                             timelineController: timelineController,
                                             mediaProvider: MockMediaProvider(),
                                             mediaPlayerProvider: MediaPlayerProviderMock(),
@@ -154,7 +154,7 @@ class RoomScreenViewModelTests: XCTestCase {
         // When showing them in a timeline.
         let timelineController = MockRoomTimelineController()
         timelineController.timelineItems = items
-        let viewModel = RoomScreenViewModel(roomProxy: RoomProxyMock(with: .init(displayName: "")),
+        let viewModel = RoomScreenViewModel(roomProxy: RoomProxyMock(with: .init(name: "")),
                                             timelineController: timelineController,
                                             mediaProvider: MockMediaProvider(),
                                             mediaPlayerProvider: MediaPlayerProviderMock(),
@@ -186,7 +186,7 @@ class RoomScreenViewModelTests: XCTestCase {
         // When showing them in a timeline.
         let timelineController = MockRoomTimelineController()
         timelineController.timelineItems = items
-        let viewModel = RoomScreenViewModel(roomProxy: RoomProxyMock(with: .init(displayName: "")),
+        let viewModel = RoomScreenViewModel(roomProxy: RoomProxyMock(with: .init(name: "")),
                                             timelineController: timelineController,
                                             mediaProvider: MockMediaProvider(),
                                             mediaPlayerProvider: MediaPlayerProviderMock(),
@@ -207,7 +207,7 @@ class RoomScreenViewModelTests: XCTestCase {
 
     func testRetrySend() async throws {
         let timelineController = MockRoomTimelineController()
-        let roomProxyMock = RoomProxyMock(with: .init(displayName: ""))
+        let roomProxyMock = RoomProxyMock(with: .init(name: ""))
         
         let timelineProxy = TimelineProxyMock()
         timelineProxy.underlyingActions = Empty(completeImmediately: false).eraseToAnyPublisher()
@@ -236,7 +236,7 @@ class RoomScreenViewModelTests: XCTestCase {
 
     func testRetrySendNoTransactionID() async {
         let timelineController = MockRoomTimelineController()
-        let roomProxyMock = RoomProxyMock(with: .init(displayName: ""))
+        let roomProxyMock = RoomProxyMock(with: .init(name: ""))
         
         let timelineProxy = TimelineProxyMock()
         timelineProxy.underlyingActions = Empty(completeImmediately: false).eraseToAnyPublisher()
@@ -263,7 +263,7 @@ class RoomScreenViewModelTests: XCTestCase {
 
     func testCancelSend() async {
         let timelineController = MockRoomTimelineController()
-        let roomProxyMock = RoomProxyMock(with: .init(displayName: ""))
+        let roomProxyMock = RoomProxyMock(with: .init(name: ""))
         
         let timelineProxy = TimelineProxyMock()
         timelineProxy.underlyingActions = Empty(completeImmediately: false).eraseToAnyPublisher()
@@ -292,7 +292,7 @@ class RoomScreenViewModelTests: XCTestCase {
 
     func testCancelSendNoTransactionID() async {
         let timelineController = MockRoomTimelineController()
-        let roomProxyMock = RoomProxyMock(with: .init(displayName: ""))
+        let roomProxyMock = RoomProxyMock(with: .init(name: ""))
         
         let timelineProxy = TimelineProxyMock()
         timelineProxy.underlyingActions = Empty(completeImmediately: false).eraseToAnyPublisher()
@@ -411,7 +411,7 @@ class RoomScreenViewModelTests: XCTestCase {
                                                                                        MockRoomTimelineController,
                                                                                        NotificationCenterMock) {
         let notificationCenter = NotificationCenterMock()
-        let roomProxy = RoomProxyMock(with: .init(displayName: ""))
+        let roomProxy = RoomProxyMock(with: .init(name: ""))
         
         let timelineProxy = TimelineProxyMock()
         timelineProxy.underlyingActions = Empty(completeImmediately: false).eraseToAnyPublisher()
@@ -449,7 +449,7 @@ class RoomScreenViewModelTests: XCTestCase {
         // When showing them in a timeline.
         let timelineController = MockRoomTimelineController()
         timelineController.timelineItems = [message]
-        let viewModel = RoomScreenViewModel(roomProxy: RoomProxyMock(with: .init(displayName: "",
+        let viewModel = RoomScreenViewModel(roomProxy: RoomProxyMock(with: .init(name: "",
                                                                                  members: [RoomMemberProxyMock.mockAlice, RoomMemberProxyMock.mockCharlie])),
                                             timelineController: timelineController,
                                             mediaProvider: MockMediaProvider(),

--- a/UnitTests/__Snapshots__/PreviewTests/test_avatarHeaderView.Members.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_avatarHeaderView.Members.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7833be660342b496d8c652c0351ef87746844a57bff98b708e08405c37518a92
+size 64979

--- a/UnitTests/__Snapshots__/PreviewTests/test_avatarHeaderView.Room.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_avatarHeaderView.Room.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a2018e28af9bff5d97c3a49fc824ba47f648987e7ed7d7e4af56041db872219
+size 130410

--- a/UnitTests/__Snapshots__/PreviewTests/test_headerView.1.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_headerView.1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2e396f25c3a5f10594b9cd47fc3f20b00aa2719db55478a026afd3ee842b34ab
-size 130060

--- a/changelog.d/pr-2490.misc
+++ b/changelog.d/pr-2490.misc
@@ -1,0 +1,1 @@
+Refactor AvatarHeaderView.


### PR DESCRIPTION
As a precursor to implementing the sheet for banning users, this PR makes the following changes
- Add a `RoomDetails` struct as an analogue to `RoomMemberDetails`
    - This is used in `RoomDetailsScreen` but could potentially be used in more places in the future.
- Refactors `AvatarHeaderView` to only accept a room or member details in the init to share the logic for configuring the avatar, title and subtitle.
- Removes the unused `RoomProxy.displayName` property in favour of `.name` which we get from sliding sync.

Split into 2 commits for easier reviewing as the second commit contains a load of refactoring of mocks for `displayName` → `name`