### PR TITLE
Add a couple more error messages during authentication.

### DIFF
--- a/ElementX/Resources/Localizations/en.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Localizable.strings
@@ -351,6 +351,7 @@
 "screen_change_account_provider_subtitle" = "Use a different account provider, such as your own private server or a work account.";
 "screen_change_account_provider_title" = "Change account provider";
 "screen_change_server_error_invalid_homeserver" = "We couldn't reach this homeserver. Please check that you have entered the homeserver URL correctly. If the URL is correct, contact your homeserver administrator for further help.";
+"screen_change_server_error_invalid_well_known" = "Sliding sync isn't available due to an issue in the well-known file:\n%1$@";
 "screen_change_server_error_no_sliding_sync_message" = "This server currently doesn’t support sliding sync.";
 "screen_change_server_form_header" = "Homeserver URL";
 "screen_change_server_form_notice" = "You can only connect to an existing server that supports sliding sync. Your homeserver admin will need to configure it. %1$@";

--- a/ElementX/Resources/Localizations/en.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Localizable.strings
@@ -406,6 +406,7 @@
 "screen_login_error_deactivated_account" = "This account has been deactivated.";
 "screen_login_error_invalid_credentials" = "Incorrect username and/or password";
 "screen_login_error_invalid_user_id" = "This is not a valid user identifier. Expected format: ‘@user:homeserver.org’";
+"screen_login_error_refresh_tokens" = "This server is configured to use refresh tokens. These aren't supported when using password based login.";
 "screen_login_error_unsupported_authentication" = "The selected homeserver doesn't support password or OIDC login. Please contact your admin or choose another homeserver.";
 "screen_login_form_header" = "Enter your details";
 "screen_login_title" = "Welcome back!";

--- a/ElementX/Sources/Generated/Strings.swift
+++ b/ElementX/Sources/Generated/Strings.swift
@@ -1010,6 +1010,8 @@ internal enum L10n {
   internal static var screenLoginErrorInvalidCredentials: String { return L10n.tr("Localizable", "screen_login_error_invalid_credentials") }
   /// This is not a valid user identifier. Expected format: ‘@user:homeserver.org’
   internal static var screenLoginErrorInvalidUserId: String { return L10n.tr("Localizable", "screen_login_error_invalid_user_id") }
+  /// This server is configured to use refresh tokens. These aren't supported when using password based login.
+  internal static var screenLoginErrorRefreshTokens: String { return L10n.tr("Localizable", "screen_login_error_refresh_tokens") }
   /// The selected homeserver doesn't support password or OIDC login. Please contact your admin or choose another homeserver.
   internal static var screenLoginErrorUnsupportedAuthentication: String { return L10n.tr("Localizable", "screen_login_error_unsupported_authentication") }
   /// Enter your details

--- a/ElementX/Sources/Generated/Strings.swift
+++ b/ElementX/Sources/Generated/Strings.swift
@@ -864,6 +864,11 @@ internal enum L10n {
   internal static var screenChangeAccountProviderTitle: String { return L10n.tr("Localizable", "screen_change_account_provider_title") }
   /// We couldn't reach this homeserver. Please check that you have entered the homeserver URL correctly. If the URL is correct, contact your homeserver administrator for further help.
   internal static var screenChangeServerErrorInvalidHomeserver: String { return L10n.tr("Localizable", "screen_change_server_error_invalid_homeserver") }
+  /// Sliding sync isn't available due to an issue in the well-known file:
+  /// %1$@
+  internal static func screenChangeServerErrorInvalidWellKnown(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "screen_change_server_error_invalid_well_known", String(describing: p1))
+  }
   /// This server currently doesn’t support sliding sync.
   internal static var screenChangeServerErrorNoSlidingSyncMessage: String { return L10n.tr("Localizable", "screen_change_server_error_no_sliding_sync_message") }
   /// Homeserver URL

--- a/ElementX/Sources/Screens/Authentication/LoginScreen/LoginScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Authentication/LoginScreen/LoginScreenCoordinator.swift
@@ -114,6 +114,8 @@ final class LoginScreenCoordinator: CoordinatorProtocol {
             viewModel.displayError(.alert(L10n.screenLoginErrorDeactivatedAccount))
         case .slidingSyncNotAvailable:
             viewModel.displayError(.slidingSyncAlert)
+        case .sessionTokenRefreshNotSupported:
+            viewModel.displayError(.refreshTokenAlert)
         default:
             viewModel.displayError(.alert(L10n.errorUnknown))
         }

--- a/ElementX/Sources/Screens/Authentication/LoginScreen/LoginScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Authentication/LoginScreen/LoginScreenCoordinator.swift
@@ -112,6 +112,8 @@ final class LoginScreenCoordinator: CoordinatorProtocol {
             viewModel.displayError(.alert(L10n.screenLoginErrorInvalidCredentials))
         case .accountDeactivated:
             viewModel.displayError(.alert(L10n.screenLoginErrorDeactivatedAccount))
+        case .invalidWellKnown(let error):
+            viewModel.displayError(.invalidWellKnownAlert(error))
         case .slidingSyncNotAvailable:
             viewModel.displayError(.slidingSyncAlert)
         case .sessionTokenRefreshNotSupported:

--- a/ElementX/Sources/Screens/Authentication/LoginScreen/LoginScreenModels.swift
+++ b/ElementX/Sources/Screens/Authentication/LoginScreen/LoginScreenModels.swift
@@ -84,6 +84,8 @@ enum LoginScreenErrorType: Hashable {
     case invalidHomeserver
     /// An alert that allows the user to learn about sliding sync.
     case slidingSyncAlert
+    /// An alert that informs the user that login failed due to a refresh token being returned.
+    case refreshTokenAlert
     /// The response from the homeserver was unexpected.
     case unknown
 }

--- a/ElementX/Sources/Screens/Authentication/LoginScreen/LoginScreenModels.swift
+++ b/ElementX/Sources/Screens/Authentication/LoginScreen/LoginScreenModels.swift
@@ -82,6 +82,8 @@ enum LoginScreenErrorType: Hashable {
     case alert(String)
     /// Looking up the homeserver from the username failed.
     case invalidHomeserver
+    /// An alert that informs the user about a bad well-known file.
+    case invalidWellKnownAlert(String)
     /// An alert that allows the user to learn about sliding sync.
     case slidingSyncAlert
     /// An alert that informs the user that login failed due to a refresh token being returned.

--- a/ElementX/Sources/Screens/Authentication/LoginScreen/LoginScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Authentication/LoginScreen/LoginScreenViewModel.swift
@@ -76,6 +76,10 @@ class LoginScreenViewModel: LoginScreenViewModelType, LoginScreenViewModelProtoc
             
             // Clear out the invalid username to avoid an attempted login to matrix.org
             state.bindings.username = ""
+        case .refreshTokenAlert:
+            state.bindings.alertInfo = AlertInfo(id: type,
+                                                 title: L10n.commonServerNotSupported,
+                                                 message: L10n.screenLoginErrorRefreshTokens)
         case .unknown:
             state.bindings.alertInfo = AlertInfo(id: type)
         }

--- a/ElementX/Sources/Screens/Authentication/LoginScreen/LoginScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Authentication/LoginScreen/LoginScreenViewModel.swift
@@ -66,6 +66,10 @@ class LoginScreenViewModel: LoginScreenViewModelType, LoginScreenViewModelProtoc
             state.bindings.alertInfo = AlertInfo(id: type,
                                                  title: L10n.commonError,
                                                  message: L10n.screenLoginErrorInvalidUserId)
+        case .invalidWellKnownAlert(let error):
+            state.bindings.alertInfo = AlertInfo(id: .slidingSyncAlert,
+                                                 title: L10n.commonServerNotSupported,
+                                                 message: L10n.screenChangeServerErrorInvalidWellKnown(error))
         case .slidingSyncAlert:
             let openURL = { UIApplication.shared.open(self.slidingSyncLearnMoreURL) }
             state.bindings.alertInfo = AlertInfo(id: .slidingSyncAlert,

--- a/ElementX/Sources/Screens/Authentication/ServerSelectionScreen/ServerSelectionScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerSelectionScreen/ServerSelectionScreenCoordinator.swift
@@ -111,6 +111,8 @@ final class ServerSelectionScreenCoordinator: CoordinatorProtocol {
         switch error {
         case .invalidServer, .invalidHomeserverAddress:
             viewModel.displayError(.footerMessage(L10n.screenChangeServerErrorInvalidHomeserver))
+        case .invalidWellKnown(let error):
+            viewModel.displayError(.invalidWellKnownAlert(error))
         case .slidingSyncNotAvailable:
             viewModel.displayError(.slidingSyncAlert)
         default:

--- a/ElementX/Sources/Screens/Authentication/ServerSelectionScreen/ServerSelectionScreenModels.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerSelectionScreen/ServerSelectionScreenModels.swift
@@ -87,6 +87,8 @@ enum ServerSelectionScreenViewAction {
 enum ServerSelectionScreenErrorType: Hashable {
     /// An error message to be shown in the text field footer.
     case footerMessage(String)
+    /// An alert that informs the user about a bad well-known file.
+    case invalidWellKnownAlert(String)
     /// An alert that allows the user to learn about sliding sync.
     case slidingSyncAlert
 }

--- a/ElementX/Sources/Screens/Authentication/ServerSelectionScreen/ServerSelectionScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerSelectionScreen/ServerSelectionScreenViewModel.swift
@@ -54,6 +54,10 @@ class ServerSelectionScreenViewModel: ServerSelectionScreenViewModelType, Server
             withElementAnimation {
                 state.footerErrorMessage = message
             }
+        case .invalidWellKnownAlert(let error):
+            state.bindings.alertInfo = AlertInfo(id: .slidingSyncAlert,
+                                                 title: L10n.commonServerNotSupported,
+                                                 message: L10n.screenChangeServerErrorInvalidWellKnown(error))
         case .slidingSyncAlert:
             let openURL = { UIApplication.shared.open(self.slidingSyncLearnMoreURL) }
             state.bindings.alertInfo = AlertInfo(id: .slidingSyncAlert,

--- a/ElementX/Sources/Screens/Authentication/SoftLogoutScreen/SoftLogoutScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Authentication/SoftLogoutScreen/SoftLogoutScreenCoordinator.swift
@@ -187,8 +187,6 @@ final class SoftLogoutScreenCoordinator: CoordinatorProtocol {
             // No need to show an error, the user cancelled authentication.
             break
         case .sessionTokenRefreshNotSupported:
-            // We should display a specific error saying that we do not support this kind of login
-            // But the copy is TBD
             viewModel.displayError(.alert(L10n.errorUnknown))
         default:
             viewModel.displayError(.alert(L10n.errorUnknown))

--- a/ElementX/Sources/Screens/Authentication/SoftLogoutScreen/SoftLogoutScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Authentication/SoftLogoutScreen/SoftLogoutScreenCoordinator.swift
@@ -187,7 +187,7 @@ final class SoftLogoutScreenCoordinator: CoordinatorProtocol {
             // No need to show an error, the user cancelled authentication.
             break
         case .sessionTokenRefreshNotSupported:
-            viewModel.displayError(.alert(L10n.errorUnknown))
+            viewModel.displayError(.refreshTokenAlert)
         default:
             viewModel.displayError(.alert(L10n.errorUnknown))
         }

--- a/ElementX/Sources/Screens/Authentication/SoftLogoutScreen/SoftLogoutScreenModels.swift
+++ b/ElementX/Sources/Screens/Authentication/SoftLogoutScreen/SoftLogoutScreenModels.swift
@@ -101,6 +101,8 @@ enum SoftLogoutScreenViewAction {
 enum SoftLogoutScreenErrorType: Hashable {
     /// A specific error message shown in an alert.
     case alert(String)
+    /// An alert that informs the user that login failed due to a refresh token being returned.
+    case refreshTokenAlert
     /// An unknown error occurred.
     case unknown
 }

--- a/ElementX/Sources/Screens/Authentication/SoftLogoutScreen/SoftLogoutScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Authentication/SoftLogoutScreen/SoftLogoutScreenViewModel.swift
@@ -60,6 +60,10 @@ class SoftLogoutScreenViewModel: SoftLogoutScreenViewModelType, SoftLogoutScreen
             state.bindings.alertInfo = AlertInfo(id: type,
                                                  title: L10n.commonError,
                                                  message: message)
+        case .refreshTokenAlert:
+            state.bindings.alertInfo = AlertInfo(id: type,
+                                                 title: L10n.commonServerNotSupported,
+                                                 message: L10n.screenLoginErrorRefreshTokens)
         case .unknown:
             state.bindings.alertInfo = AlertInfo(id: type)
         }

--- a/ElementX/Sources/Services/Authentication/AuthenticationServiceProxy.swift
+++ b/ElementX/Sources/Services/Authentication/AuthenticationServiceProxy.swift
@@ -80,6 +80,9 @@ class AuthenticationServiceProxy: AuthenticationServiceProxyProtocol {
             
             homeserverSubject.send(homeserver)
             return .success(())
+        } catch AuthenticationError.WellKnownDeserializationError(let error) {
+            MXLog.error("The user entered a server with an invalid well-known file: \(error)")
+            return .failure(.invalidWellKnown(error))
         } catch AuthenticationError.SlidingSyncNotAvailable {
             MXLog.info("User entered a homeserver that isn't configured for sliding sync.")
             return .failure(.slidingSyncNotAvailable)

--- a/ElementX/Sources/Services/Authentication/AuthenticationServiceProxyProtocol.swift
+++ b/ElementX/Sources/Services/Authentication/AuthenticationServiceProxyProtocol.swift
@@ -31,6 +31,7 @@ enum AuthenticationServiceError: Error {
     case invalidServer
     case invalidCredentials
     case invalidHomeserverAddress
+    case invalidWellKnown(String)
     case slidingSyncNotAvailable
     case accountDeactivated
     case failedLoggingIn

--- a/changelog.d/pr-2497.change
+++ b/changelog.d/pr-2497.change
@@ -1,0 +1,1 @@
+Add error messages about refresh tokens and an invalid well-known file.


### PR DESCRIPTION
This PR adds 2 messages:

| Refresh tokens without OIDC | Invalid well-known file |
| - | - |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-02-23 at 14 37 34](https://github.com/element-hq/element-x-ios/assets/6060466/71391ba7-8df4-4686-b493-7e4da6085a40) | ![Simulator Screenshot - iPhone 15 Pro - 2024-02-23 at 14 29 44](https://github.com/element-hq/element-x-ios/assets/6060466/efcb17af-8bf4-4dca-b378-58a6aa023810) |
