### PR TITLE
Use xcresultparser in all workflows.

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -36,14 +36,19 @@ jobs:
           INTEGRATION_TESTS_HOST: ${{ secrets.INTEGRATION_TESTS_HOST }}
           INTEGRATION_TESTS_USERNAME: ${{ secrets.INTEGRATION_TESTS_USERNAME }}
           INTEGRATION_TESTS_PASSWORD: ${{ secrets.INTEGRATION_TESTS_PASSWORD }}
+
+      - name: Zip results # for faster upload
+        if: failure()
+        working-directory: fastlane/test_output
+        run: zip -r IntegrationTests.xcresult.zip IntegrationTests.xcresult
       
       - name: Archive artifacts
         uses: actions/upload-artifact@v3
-        if: always()
+        if: failure()
         with:
-          name: test-output
-          path: fastlane/test_output
-          retention-days: 7
+          name: Results
+          path: fastlane/test_output/IntegrationTests.xcresult.zip
+          retention-days: 1
           if-no-files-found: ignore
 
       - name: Archive raw log file
@@ -71,6 +76,9 @@ jobs:
           git add .
           git commit -m "Results for $GITHUB_SHA"
           git push
+
+      - name: Collect coverage
+        run: xcresultparser -q -o cobertura -t ElementX -p $(pwd) fastlane/test_output/IntegrationTests.xcresult > fastlane/test_output/integration-cobertura.xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           name: Results
           path: fastlane/test_output/IntegrationTests.xcresult.zip
-          retention-days: 1
+          retention-days: 7
           if-no-files-found: ignore
 
       - name: Archive raw log file

--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           name: Results
           path: fastlane/test_output/UITests.xcresult.zip
-          retention-days: 1
+          retention-days: 7
           if-no-files-found: ignore
 
       - name: Collect coverage

--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -42,14 +42,22 @@ jobs:
             bundle exec fastlane ui_tests test_name:${{ github.event.inputs.test_name }}
           fi
 
+      - name: Zip results # for faster upload
+        if: failure()
+        working-directory: fastlane/test_output
+        run: zip -r UITests.xcresult.zip UITests.xcresult
+
       - name: Archive artifacts
         uses: actions/upload-artifact@v3
-        if: always()
+        if: failure()
         with:
-          name: test-output
-          path: fastlane/test_output
-          retention-days: 7
+          name: Results
+          path: fastlane/test_output/UITests.xcresult.zip
+          retention-days: 1
           if-no-files-found: ignore
+
+      - name: Collect coverage
+        run: xcresultparser -q -o cobertura -t ElementX -p $(pwd) fastlane/test_output/UITests.xcresult > fastlane/test_output/ui-cobertura.xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -61,8 +61,8 @@ jobs:
       
       - name: Collect coverage
         run: |
-          xcresultparser -q -o cobertura -t ElementX -p $(pwd) fastlane/test_output/UnitTests.xcresult > fastlane/test_output/unittests-cobertura.xml
-          xcresultparser -q -o cobertura -t ElementX -p $(pwd) fastlane/test_output/PreviewTests.xcresult > fastlane/test_output/previewtests-cobertura.xml
+          xcresultparser -q -o cobertura -t ElementX -p $(pwd) fastlane/test_output/UnitTests.xcresult > fastlane/test_output/unit-cobertura.xml
+          xcresultparser -q -o cobertura -t ElementX -p $(pwd) fastlane/test_output/PreviewTests.xcresult > fastlane/test_output/preview-cobertura.xml
       
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ source "https://rubygems.org"
 
 gem 'fastlane'
 gem "xcode-install"
-gem 'slather'
 gem 'semantic'
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,16 +9,6 @@ GEM
   specs:
     CFPropertyList (3.0.6)
       rexml
-    activesupport (7.1.3)
-      base64
-      bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      connection_pool (>= 2.2.5)
-      drb
-      i18n (>= 1.6, < 2)
-      minitest (>= 5.1)
-      mutex_m
-      tzinfo (~> 2.0)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     artifactory (3.0.15)
@@ -40,23 +30,16 @@ GEM
     aws-sigv4 (1.8.0)
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
-    base64 (0.2.0)
-    bigdecimal (3.1.6)
     claide (1.1.0)
-    clamp (1.3.2)
     colored (1.2)
     colored2 (3.1.2)
     commander (4.6.0)
       highline (~> 2.0.0)
-    concurrent-ruby (1.2.3)
-    connection_pool (2.4.1)
     declarative (0.0.20)
     digest-crc (0.6.5)
       rake (>= 12.0.0, < 14.0.0)
     domain_name (0.6.20240107)
     dotenv (2.8.1)
-    drb (2.2.0)
-      ruby2_keywords
     emoji_regex (3.2.3)
     excon (0.109.0)
     faraday (1.10.3)
@@ -179,8 +162,6 @@ GEM
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    i18n (1.14.1)
-      concurrent-ruby (~> 1.0)
     jmespath (1.6.2)
     json (2.7.1)
     jwt (2.7.1)
@@ -189,20 +170,15 @@ GEM
     mime-types-data (3.2023.1205)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
-    minitest (5.22.0)
     multi_json (1.15.0)
     multipart-post (2.3.0)
-    mutex_m (0.2.0)
     nanaimo (0.3.0)
     naturally (2.2.1)
     netrc (0.11.0)
-    nokogiri (1.15.5-arm64-darwin)
-      racc (~> 1.4)
     optparse (0.4.0)
     os (1.1.4)
     plist (3.7.1)
     public_suffix (5.0.4)
-    racc (1.7.3)
     rake (13.1.0)
     representable (3.2.0)
       declarative (< 0.1.0)
@@ -228,12 +204,6 @@ GEM
     simctl (1.6.10)
       CFPropertyList
       naturally
-    slather (2.8.0)
-      CFPropertyList (>= 2.2, < 4)
-      activesupport
-      clamp (~> 1.3)
-      nokogiri (>= 1.14.3)
-      xcodeproj (~> 1.21)
     terminal-notifier (2.0.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -242,8 +212,6 @@ GEM
     tty-screen (0.8.2)
     tty-spinner (0.9.3)
       tty-cursor (~> 0.7)
-    tzinfo (2.0.6)
-      concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unicode-display_width (2.5.0)
     word_wrap (1.0.0)
@@ -273,7 +241,6 @@ DEPENDENCIES
   fastlane-plugin-xcconfig
   fastlane-plugin-xcodegen
   semantic
-  slather
   xcode-install
 
 BUNDLED WITH

--- a/IntegrationTests/Sources/PerformanceTests.swift
+++ b/IntegrationTests/Sources/PerformanceTests.swift
@@ -46,7 +46,7 @@ class PerformanceTests: XCTestCase {
         firstRoom.tap()
                 
         // Go back to the room list
-        let backButton = app.navigationBars.firstMatch.buttons["All Chats"]
+        let backButton = app.navigationBars.firstMatch.buttons["Chats"]
         XCTAssertTrue(backButton.waitForExistence(timeout: 10.0))
         backButton.tap()
         

--- a/IntegrationTests/Sources/UserFlowTests.swift
+++ b/IntegrationTests/Sources/UserFlowTests.swift
@@ -56,7 +56,7 @@ class UserFlowTests: XCTestCase {
         invitesButton.tap()
         
         // Go back to the room list
-        tapOnBackButton("All Chats")
+        tapOnBackButton("Chats")
     }
     
     private func checkPhotoSharing() {
@@ -162,7 +162,7 @@ class UserFlowTests: XCTestCase {
         tapOnBackButton()
         
         // Go back to the room list
-        tapOnBackButton("All Chats")
+        tapOnBackButton("Chats")
     }
     
     private func checkSettings() {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -132,22 +132,6 @@ lane :ui_tests do |options|
     only_testing: test_to_run,
     number_of_retries: 3,
   )
-
-  slather(
-    cobertura_xml: true,
-    output_directory: "./fastlane/test_output",
-    proj: "ElementX.xcodeproj",
-    scheme: "UITests",
-    binary_basename: "ElementX.app"
-  )
-  
-  # Zip the result bundle for faster upload.
-  zip(
-    path: "./fastlane/test_output/UITests.xcresult",
-    output_path: "./fastlane/test_output/UITests.xcresult.zip"
-  )
-  # Shell working directory is already inside the fastlane dir.
-  sh("rm -rf ./test_output/UITests.xcresult")
 end
 
 
@@ -167,14 +151,6 @@ lane :integration_tests do
     result_bundle: true,
     reset_simulator: true,
     include_simulator_logs: true
-  )
-
-  slather(
-    cobertura_xml: true,
-    output_directory: "./fastlane/test_output",
-    proj: "ElementX.xcodeproj",
-    scheme: "IntegrationTests",
-    binary_basename: "ElementX.app"
   )
 end
 


### PR DESCRIPTION
After using it in #2492 we saw it provided more reliable coverage reports so let's use it everywhere! Additionally this PR:
- Removes slather as a dependency.
- Fixes a bug where the UI test results would never be zipped after a failure by moving the zipping into the workflow.
- Also zips the results from integration tests.
- Sets both UI and Integration tests to only upload the results on failure.

[UI Tests run](https://github.com/element-hq/element-x-ios/actions/runs/8083588048)
[Integration Tests run](https://github.com/element-hq/element-x-ios/actions/runs/8084522027)