### PR TITLE
Update Compound.

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -7120,7 +7120,7 @@
 			repositoryURL = "https://github.com/element-hq/compound-ios";
 			requirement = {
 				kind = revision;
-				revision = d38528736c3abe9dc739d96391d1ffd372cd802d;
+				revision = 19c778b6ce0b82601ecdca23ff8d4a7aa41f990f;
 			};
 		};
 		F76A08D0EA29A07A54F4EB4D /* XCRemoteSwiftPackageReference "swift-collections" */ = {

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -7120,7 +7120,7 @@
 			repositoryURL = "https://github.com/element-hq/compound-ios";
 			requirement = {
 				kind = revision;
-				revision = 98bd0ed412c29bd5b3762b673ca5720b6fb9d713;
+				revision = d38528736c3abe9dc739d96391d1ffd372cd802d;
 			};
 		};
 		F76A08D0EA29A07A54F4EB4D /* XCRemoteSwiftPackageReference "swift-collections" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/compound-ios",
       "state" : {
-        "revision" : "d38528736c3abe9dc739d96391d1ffd372cd802d"
+        "revision" : "19c778b6ce0b82601ecdca23ff8d4a7aa41f990f"
       }
     },
     {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/compound-design-tokens.git",
       "state" : {
-        "revision" : "d7c3bba963d6b7ffab862c3293eb242a8932a0c1",
-        "version" : "1.0.0"
+        "revision" : "c3fff1f2b042295cd5f4bcf8d4fe68ec47ca4061",
+        "version" : "1.2.0"
       }
     },
     {
@@ -14,7 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/compound-ios",
       "state" : {
-        "revision" : "98bd0ed412c29bd5b3762b673ca5720b6fb9d713"
+        "revision" : "d38528736c3abe9dc739d96391d1ffd372cd802d"
       }
     },
     {

--- a/ElementX/Sources/Other/Extensions/UNNotificationContent.swift
+++ b/ElementX/Sources/Other/Extensions/UNNotificationContent.swift
@@ -180,7 +180,7 @@ extension UNMutableNotificationContent {
     private func getPlaceholderAvatarImageData(name: String, id: String) async -> Data? {
         // The version value is used in case the design of the placeholder is updated to force a replacement
         let shouldFlipAvatar = shouldFlipAvatar()
-        let prefix = "notification_placeholder\(shouldFlipAvatar ? "V7" : "V6")"
+        let prefix = "notification_placeholder\(shouldFlipAvatar ? "V8F" : "V8")"
         let fileName = "\(prefix)_\(name)_\(id).png"
         if let data = try? Data(contentsOf: URL.temporaryDirectory.appendingPathComponent(fileName)) {
             MXLog.info("Found existing notification icon placeholder")

--- a/changelog.d/pr-2514.bugfix
+++ b/changelog.d/pr-2514.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where some avatar backgrounds were hard to see in notifications.

--- a/project.yml
+++ b/project.yml
@@ -52,7 +52,7 @@ packages:
     # path: ../matrix-rust-sdk
   Compound:
     url: https://github.com/element-hq/compound-ios
-    revision: d38528736c3abe9dc739d96391d1ffd372cd802d
+    revision: 19c778b6ce0b82601ecdca23ff8d4a7aa41f990f
     # path: ../compound-ios
   AnalyticsEvents:
     url: https://github.com/matrix-org/matrix-analytics-events

--- a/project.yml
+++ b/project.yml
@@ -52,7 +52,7 @@ packages:
     # path: ../matrix-rust-sdk
   Compound:
     url: https://github.com/element-hq/compound-ios
-    revision: 98bd0ed412c29bd5b3762b673ca5720b6fb9d713
+    revision: d38528736c3abe9dc739d96391d1ffd372cd802d
     # path: ../compound-ios
   AnalyticsEvents:
     url: https://github.com/matrix-org/matrix-analytics-events


### PR DESCRIPTION
This fixes a bug introduced in #2438 where placeholder avatars in notifications looked a bit odd for new rooms due to using a colour with an alpha channel. Requires https://github.com/element-hq/compound-ios/pull/60

![notification@2x](https://github.com/element-hq/element-x-ios/assets/6060466/5a44a56f-ae6b-494f-8d1d-89fbd7b2ca7c)
