### PR TITLE
Prevent the sync service from looping so tightly on failure.

### DIFF
--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -211,12 +211,38 @@ class ClientProxy: ClientProxyProtocol {
         }
     }
     
+    /// A stored task for restarting the sync after a failure. This is stored so that we can cancel
+    /// it when `stopSync` is called (e.g. when signing out) to prevent an otherwise infinite
+    /// loop that was triggered by trying to sync a signed out session.
+    @CancellableTask private var restartTask: Task<Void, Never>?
+    
+    func restartSync() {
+        guard restartTask == nil else { return }
+        
+        restartTask = Task { [weak self] in
+            do {
+                // Until the SDK can tell us the failure, we add a small
+                // delay to avoid generating multi-gigabyte log files.
+                try await Task.sleep(for: .milliseconds(250))
+                self?.startSync()
+            } catch {
+                MXLog.error("Restart cancelled.")
+            }
+            self?.restartTask = nil
+        }
+    }
+    
     func stopSync() {
         stopSync(completion: nil)
     }
     
     private func stopSync(completion: (() -> Void)?) {
         MXLog.info("Stopping sync")
+        
+        if restartTask != nil {
+            MXLog.warning("Removing the sync service restart task.")
+            restartTask = nil
+        }
         
         Task {
             do {
@@ -592,7 +618,7 @@ class ClientProxy: ClientProxyProtocol {
             case .running, .terminated, .idle:
                 break
             case .error:
-                startSync()
+                restartSync()
             }
         })
     }


### PR DESCRIPTION
When the sliding sync proxy is misconfigured in the well-known, EX will tightloop trying to restart the service easily generating log files that are multi-gigabytes in size. Once the user is bored of the migration screen, signing out doesn't help either as the client continues trying to restart (but this time fails due to the db not being readable).

This PR adds a 250ms delay when restarting the sync service so we generate less logs in this situation and additionally adds a task that can be cancelled to prevent the service from being restarting if `stopSync` has been called.

Note: This is just a workaround until we have https://github.com/matrix-org/matrix-rust-sdk/issues/2822