### PR TITLE
Zip results from Unit Test failures

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -49,13 +49,18 @@ jobs:
       - name: Run tests
         run: bundle exec fastlane unit_tests
         
+      - name: Zip results # for faster upload
+        if: failure()
+        working-directory: fastlane/test_output
+        run: zip -r UnitTests.xcresult.zip UnitTests.xcresult PreviewTests.xcresult
+      
       - name: Archive artifacts
         uses: actions/upload-artifact@v3
-        # We only care about artifcats if the tests fail
+        # We only care about artefacts if the tests fail
         if: failure()
         with:
-            name: test-output
-            path: fastlane/test_output
+            name: Results
+            path: fastlane/test_output/UnitTests.xcresult.zip
             retention-days: 1
             if-no-files-found: ignore
       

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Zip results # for faster upload
         if: failure()
         working-directory: fastlane/test_output
-        run: zip -r UnitTests.xcresult.zip UnitTests.xcresult PreviewTests.xcresult
+        run: zip -r UnitTests.zip UnitTests.xcresult PreviewTests.xcresult
       
       - name: Archive artifacts
         uses: actions/upload-artifact@v3
@@ -60,7 +60,7 @@ jobs:
         if: failure()
         with:
             name: Results
-            path: fastlane/test_output/UnitTests.xcresult.zip
+            path: fastlane/test_output/UnitTests.zip
             retention-days: 1
             if-no-files-found: ignore
       


### PR DESCRIPTION
Uploading the unit test results can be slow. E.g. for what ends up as a 41MB download:

<img width="499" alt="Screenshot 2024-03-07 at 3 32 59 pm" src="https://github.com/element-hq/element-x-ios/assets/6060466/9f87d149-04b4-4cbc-a7f5-fe7de74d9c7d">

So let's try zip them like we do for UI and Integration tests.

Test result, this looks more reasonable to me:
<img width="639" alt="Screenshot 2024-03-07 at 4 02 25 pm" src="https://github.com/element-hq/element-x-ios/assets/6060466/d27e9181-a1a6-435a-887c-2f1225916538">
