### PR TITLE
Disable trace logs for read receipts

### DIFF
--- a/ElementX/Sources/Other/Logging/TracingConfiguration.swift
+++ b/ElementX/Sources/Other/Logging/TracingConfiguration.swift
@@ -73,7 +73,6 @@ struct TracingConfiguration {
         case matrix_sdk_sliding_sync = "matrix_sdk::sliding_sync"
         case matrix_sdk_base_sliding_sync = "matrix_sdk_base::sliding_sync"
         case matrix_sdk_ui_timeline = "matrix_sdk_ui::timeline"
-        case matrix_sdk_base_read_receipts = "matrix_sdk_base::read_receipts"
     }
     
     static let targets: OrderedDictionary<Target, LogLevel> = [
@@ -88,8 +87,7 @@ struct TracingConfiguration {
         .matrix_sdk_http_client: .debug,
         .matrix_sdk_sliding_sync: .info,
         .matrix_sdk_base_sliding_sync: .info,
-        .matrix_sdk_ui_timeline: .info,
-        .matrix_sdk_base_read_receipts: .trace
+        .matrix_sdk_ui_timeline: .info
     ]
     
     let filter: String
@@ -124,8 +122,7 @@ struct TracingConfiguration {
                                             .matrix_sdk_client,
                                             .matrix_sdk_crypto,
                                             .matrix_sdk_crypto_account,
-                                            .matrix_sdk_http_client,
-                                            .matrix_sdk_base_read_receipts]
+                                            .matrix_sdk_http_client]
             if ignoredTargets.contains(target) {
                 return
             }

--- a/changelog.d/2544.misc
+++ b/changelog.d/2544.misc
@@ -1,0 +1,1 @@
+Remove the special log level for the Rust SDK read receipts.


### PR DESCRIPTION
Read receipts have been considered quite stable over the last few weeks, so there's no need to keep the trace level for the associated logs for the time being.

Signed-off-by: Benjamin Bouvier [public@benj.me](mailto:public@benj.me)