### PR TITLE
Fix crashes when blocking/unblocking users

### DIFF
--- a/ElementX/Sources/Screens/RoomMemberDetailsScreen/RoomMemberDetailsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomMemberDetailsScreen/RoomMemberDetailsScreenViewModel.swift
@@ -108,7 +108,10 @@ class RoomMemberDetailsScreenViewModel: RoomMemberDetailsScreenViewModelType, Ro
         state.isProcessingIgnoreRequest = false
         switch result {
         case .success:
-            state.memberDetails?.isIgnored = true
+            var details = state.memberDetails
+            details?.isIgnored = true
+            state.memberDetails = details
+            
             updateMembers()
         case .failure:
             state.bindings.alertInfo = .init(id: .unknown)
@@ -126,7 +129,10 @@ class RoomMemberDetailsScreenViewModel: RoomMemberDetailsScreenViewModelType, Ro
         state.isProcessingIgnoreRequest = false
         switch result {
         case .success:
-            state.memberDetails?.isIgnored = false
+            var details = state.memberDetails
+            details?.isIgnored = false
+            state.memberDetails = details
+            
             updateMembers()
         case .failure:
             state.bindings.alertInfo = .init(id: .unknown)

--- a/changelog.d/pr-2553.bugfix
+++ b/changelog.d/pr-2553.bugfix
@@ -1,0 +1,1 @@
+Fix crashes when blocking/unblocking users


### PR DESCRIPTION
- SwiftUI crashes when mutating optional state properties in place
- workaround it buy mutating a local reference first
