### PR TITLE
RTE Bump

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -7136,7 +7136,7 @@
 			repositoryURL = "https://github.com/matrix-org/matrix-wysiwyg-composer-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 2.31.0;
+				version = 2.33.0;
 			};
 		};
 		96495DD8554E2F39D3954354 /* XCRemoteSwiftPackageReference "posthog-ios" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -139,8 +139,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-wysiwyg-composer-swift",
       "state" : {
-        "revision" : "e1cb970b144508a13108762651d141f3488e69ae",
-        "version" : "2.31.0"
+        "revision" : "35119f128237dd76a60f34d1508b1341ec652e53",
+        "version" : "2.33.0"
       }
     },
     {
@@ -263,7 +263,7 @@
     {
       "identity" : "swiftui-introspect",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/siteline/SwiftUI-Introspect.git",
+      "location" : "https://github.com/siteline/SwiftUI-Introspect",
       "state" : {
         "revision" : "b94da693e57eaf79d16464b8b7c90d09cba4e290",
         "version" : "0.9.2"

--- a/changelog.d/pr-2547.change
+++ b/changelog.d/pr-2547.change
@@ -1,1 +1,0 @@
-Auto-completion has temporarily been disabled.

--- a/changelog.d/pr-2558.change
+++ b/changelog.d/pr-2558.change
@@ -1,0 +1,1 @@
+Inline predictions have been disabled on iOS 17 temporarily to avoid issues with the text editor.

--- a/project.yml
+++ b/project.yml
@@ -66,7 +66,7 @@ packages:
     # path: ../swift-ogg
   WysiwygComposer:
     url: https://github.com/matrix-org/matrix-wysiwyg-composer-swift
-    exactVersion: 2.31.0
+    exactVersion: 2.33.0
     # path: ../matrix-wysiwyg/platforms/ios/lib/WysiwygComposer
   
   # External dependencies


### PR DESCRIPTION
auto correction is back but without inline predictive text