### PR TITLE
Fix some preview snapshot tests.

### DIFF
--- a/ElementX/Sources/Screens/RoomRolesAndPermissionsScreen/RoomRolesAndPermissionsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomRolesAndPermissionsScreen/RoomRolesAndPermissionsScreenViewModel.swift
@@ -28,10 +28,10 @@ class RoomRolesAndPermissionsScreenViewModel: RoomRolesAndPermissionsScreenViewM
         actionsSubject.eraseToAnyPublisher()
     }
 
-    init(roomProxy: RoomProxyProtocol, userIndicatorController: UserIndicatorControllerProtocol) {
+    init(initialPermissions: RoomPermissions? = nil, roomProxy: RoomProxyProtocol, userIndicatorController: UserIndicatorControllerProtocol) {
         self.roomProxy = roomProxy
         self.userIndicatorController = userIndicatorController
-        super.init(initialViewState: RoomRolesAndPermissionsScreenViewState())
+        super.init(initialViewState: RoomRolesAndPermissionsScreenViewState(permissions: initialPermissions))
         
         // Automatically update the admin/moderator counts.
         roomProxy.membersPublisher

--- a/ElementX/Sources/Screens/RoomRolesAndPermissionsScreen/View/RoomRolesAndPermissionsScreen.swift
+++ b/ElementX/Sources/Screens/RoomRolesAndPermissionsScreen/View/RoomRolesAndPermissionsScreen.swift
@@ -126,12 +126,12 @@ struct RoomRolesAndPermissionsScreen: View {
 // MARK: - Previews
 
 struct RoomRolesAndPermissionsScreen_Previews: PreviewProvider, TestablePreview {
-    static let viewModel = RoomRolesAndPermissionsScreenViewModel(roomProxy: RoomProxyMock(with: .init(members: .allMembersAsAdmin)),
+    static let viewModel = RoomRolesAndPermissionsScreenViewModel(initialPermissions: RoomPermissions(powerLevels: .mock),
+                                                                  roomProxy: RoomProxyMock(with: .init(members: .allMembersAsAdmin)),
                                                                   userIndicatorController: UserIndicatorControllerMock())
     static var previews: some View {
         NavigationStack {
             RoomRolesAndPermissionsScreen(context: viewModel.context)
         }
-        .snapshot(delay: 0.2)
     }
 }

--- a/PreviewTests/__Snapshots__/PreviewTests/test_roomDetailsEditScreen-iPhone-15-pseudo.Normal.png
+++ b/PreviewTests/__Snapshots__/PreviewTests/test_roomDetailsEditScreen-iPhone-15-pseudo.Normal.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5cab7fba897f7aa2fea3b7ffe1b7af77d4ed65e5793de20f7dc6ec08bd5442df
-size 90800
+oid sha256:25ad8919a1ea2e61007ace8a390ded6473efcc89dd04814b2cd13d269839ab95
+size 92287


### PR DESCRIPTION
- Pass in the initial permissions for the roles and permissions screen - it's more reliable to pass in some mock permissions than waiting for them to load.
- Fix a reference snapshot for RoomDetailsEditScreen.