### PR TITLE
Remove `include_simulator_logs` from the integration tests.

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -143,8 +143,7 @@ lane :integration_tests do
     devices: ["iPhone 15 Pro"],
     ensure_devices_found: true,
     result_bundle: true,
-    reset_simulator: true,
-    include_simulator_logs: true
+    reset_simulator: true
   )
 end
 


### PR DESCRIPTION
The integration tests have failed on the recently updated performance runner with something that seems related to the fastlane `include_simulator_logs` flag. 

In practice, we don't seem to need that flag: successful run [here](https://github.com/element-hq/element-x-ios/actions/runs/8463134100) and correctly updated performance data [here](https://github.com/element-hq/element-x-ios/commit/ac18396ccdafaf5ce594e9c55f87b9dd45f7046b)