### PR TITLE
Use the new RTE package repo.

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -7176,7 +7176,7 @@
 			repositoryURL = "https://github.com/matrix-org/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 1.1.54;
+				version = 1.1.55;
 			};
 		};
 		821C67C9A7F8CC3FD41B28B4 /* XCRemoteSwiftPackageReference "emojibase-bindings" */ = {

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -5307,7 +5307,7 @@
 				6582B5AF3F104B0F7E031E7D /* XCRemoteSwiftPackageReference "SwiftState" */,
 				9A472EE0218FE7DCF5283429 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */,
 				EC6D0C817B1C21D9D096505A /* XCRemoteSwiftPackageReference "Version" */,
-				945C99D66CE013061F6A3C71 /* XCRemoteSwiftPackageReference "matrix-wysiwyg-composer-swift" */,
+				44FA555384AD79668D886043 /* XCRemoteSwiftPackageReference "matrix-rich-text-editor-swift" */,
 			);
 			projectDirPath = "";
 			projectRoot = "";
@@ -7131,6 +7131,14 @@
 				kind = branch;
 			};
 		};
+		44FA555384AD79668D886043 /* XCRemoteSwiftPackageReference "matrix-rich-text-editor-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/matrix-org/matrix-rich-text-editor-swift";
+			requirement = {
+				kind = exactVersion;
+				version = 2.35.0;
+			};
+		};
 		4C34425923978C97409A3EF2 /* XCRemoteSwiftPackageReference "DSWaveformImage" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/dmrschmidt/DSWaveformImage";
@@ -7177,14 +7185,6 @@
 			requirement = {
 				kind = upToNextMinorVersion;
 				minimumVersion = 1.0.0;
-			};
-		};
-		945C99D66CE013061F6A3C71 /* XCRemoteSwiftPackageReference "matrix-wysiwyg-composer-swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/matrix-org/matrix-wysiwyg-composer-swift";
-			requirement = {
-				kind = exactVersion;
-				version = 2.35.0;
 			};
 		};
 		96495DD8554E2F39D3954354 /* XCRemoteSwiftPackageReference "posthog-ios" */ = {
@@ -7564,7 +7564,7 @@
 		};
 		CA07D57389DACE18AEB6A5E2 /* WysiwygComposer */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 945C99D66CE013061F6A3C71 /* XCRemoteSwiftPackageReference "matrix-wysiwyg-composer-swift" */;
+			package = 44FA555384AD79668D886043 /* XCRemoteSwiftPackageReference "matrix-rich-text-editor-swift" */;
 			productName = WysiwygComposer;
 		};
 		CCE5BF78B125320CBF3BB834 /* PostHog */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -139,8 +139,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-rust-components-swift",
       "state" : {
-        "revision" : "bfb73a441c6267449517869ea708e9201e7facb0",
-        "version" : "1.1.54"
+        "revision" : "407ad3da9444148ec71a775029c69c25e4a8bb2e",
+        "version" : "1.1.55"
       }
     },
     {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -126,21 +126,21 @@
       }
     },
     {
+      "identity" : "matrix-rich-text-editor-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/matrix-org/matrix-rich-text-editor-swift",
+      "state" : {
+        "revision" : "97400e639af30662e9325bc8f4cbc53b291ca6aa",
+        "version" : "2.35.0"
+      }
+    },
+    {
       "identity" : "matrix-rust-components-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-rust-components-swift",
       "state" : {
         "revision" : "bfb73a441c6267449517869ea708e9201e7facb0",
         "version" : "1.1.54"
-      }
-    },
-    {
-      "identity" : "matrix-wysiwyg-composer-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/matrix-org/matrix-wysiwyg-composer-swift",
-      "state" : {
-        "revision" : "7625628d5e6d46551a557d4812ea362b4af5cf89",
-        "version" : "2.35.0"
       }
     },
     {
@@ -263,7 +263,7 @@
     {
       "identity" : "swiftui-introspect",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/siteline/SwiftUI-Introspect.git",
+      "location" : "https://github.com/siteline/SwiftUI-Introspect",
       "state" : {
         "revision" : "b94da693e57eaf79d16464b8b7c90d09cba4e290",
         "version" : "0.9.2"

--- a/project.yml
+++ b/project.yml
@@ -48,7 +48,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/matrix-org/matrix-rust-components-swift
-    exactVersion: 1.1.54
+    exactVersion: 1.1.55
     # path: ../matrix-rust-sdk
   Compound:
     url: https://github.com/element-hq/compound-ios

--- a/project.yml
+++ b/project.yml
@@ -66,7 +66,7 @@ packages:
     minorVersion: 0.0.2
     # path: ../swift-ogg
   WysiwygComposer:
-    url: https://github.com/matrix-org/matrix-wysiwyg-composer-swift
+    url: https://github.com/matrix-org/matrix-rich-text-editor-swift
     exactVersion: 2.35.0
     # path: ../matrix-rich-text-editor/platforms/ios/lib/WysiwygComposer
   


### PR DESCRIPTION
Now that https://github.com/matrix-org/matrix-rich-text-editor/pull/954 is merged, this PR uses [matrix-org/matrix-rich-text-editor-swift](https://github.com/matrix-org/matrix-rich-text-editor-swift) removing the old dependency which was a rather large download at this point.