### PR TITLE
Prevent crashes when mentioning users on macOS

### DIFF
--- a/ElementX/Sources/Other/Pills/PillAttachmentViewProvider.swift
+++ b/ElementX/Sources/Other/Pills/PillAttachmentViewProvider.swift
@@ -27,7 +27,7 @@ protocol PillAttachmentViewProviderDelegate: AnyObject {
     func invalidateTextAttachmentsDisplay()
 }
 
-final class PillAttachmentViewProvider: NSTextAttachmentViewProvider {
+final class PillAttachmentViewProvider: NSTextAttachmentViewProvider, NSSecureCoding {
     private weak var delegate: PillAttachmentViewProviderDelegate?
     
     // MARK: - Override

--- a/changelog.d/2627.bugfix
+++ b/changelog.d/2627.bugfix
@@ -1,0 +1,1 @@
+Prevent crashes when mentioning users when running on the Mac


### PR DESCRIPTION
fixes #2627