### PR TITLE
Cleanup proxy errors

### DIFF
--- a/ElementX/Sources/Mocks/ClientProxyMock.swift
+++ b/ElementX/Sources/Mocks/ClientProxyMock.swift
@@ -24,6 +24,10 @@ struct ClientProxyMockConfiguration {
     var roomDirectorySearchProxy: RoomDirectorySearchProxyProtocol?
 }
 
+enum ClientProxyMockError: Error {
+    case generic
+}
+
 extension ClientProxyMock {
     convenience init(_ configuration: ClientProxyMockConfiguration) {
         self.init()
@@ -53,25 +57,25 @@ extension ClientProxyMock {
         
         isOnlyDeviceLeftReturnValue = .success(false)
         accountURLActionReturnValue = "https://matrix.org/account"
-        directRoomForUserIDReturnValue = .failure(.failedRetrievingDirectRoom)
-        createDirectRoomWithExpectedRoomNameReturnValue = .failure(.failedCreatingRoom)
-        createRoomNameTopicIsRoomPrivateUserIDsAvatarURLReturnValue = .failure(.failedCreatingRoom)
-        uploadMediaReturnValue = .failure(.failedUploadingMedia(.unknown))
-        loadUserDisplayNameReturnValue = .failure(.failedRetrievingUserDisplayName)
-        setUserDisplayNameReturnValue = .failure(.failedSettingUserDisplayName)
-        loadUserAvatarURLReturnValue = .failure(.failedRetrievingUserAvatarURL)
-        setUserAvatarMediaReturnValue = .failure(.failedSettingUserAvatar)
-        removeUserAvatarReturnValue = .failure(.failedSettingUserAvatar)
+        directRoomForUserIDReturnValue = .failure(.sdkError(ClientProxyMockError.generic))
+        createDirectRoomWithExpectedRoomNameReturnValue = .failure(.sdkError(ClientProxyMockError.generic))
+        createRoomNameTopicIsRoomPrivateUserIDsAvatarURLReturnValue = .failure(.sdkError(ClientProxyMockError.generic))
+        uploadMediaReturnValue = .failure(.sdkError(ClientProxyMockError.generic))
+        loadUserDisplayNameReturnValue = .failure(.sdkError(ClientProxyMockError.generic))
+        setUserDisplayNameReturnValue = .failure(.sdkError(ClientProxyMockError.generic))
+        loadUserAvatarURLReturnValue = .failure(.sdkError(ClientProxyMockError.generic))
+        setUserAvatarMediaReturnValue = .failure(.sdkError(ClientProxyMockError.generic))
+        removeUserAvatarReturnValue = .failure(.sdkError(ClientProxyMockError.generic))
         logoutReturnValue = nil
         searchUsersSearchTermLimitReturnValue = .success(.init(results: [], limited: false))
         profileForReturnValue = .success(.init(userID: "@a:b.com", displayName: "Some user"))
-        sessionVerificationControllerProxyReturnValue = .failure(.failedRetrievingSessionVerificationController)
+        sessionVerificationControllerProxyReturnValue = .failure(.sdkError(ClientProxyMockError.generic))
         ignoreUserReturnValue = .success(())
         unignoreUserReturnValue = .success(())
         
-        loadMediaContentForSourceThrowableError = ClientProxyError.failedLoadingMedia
-        loadMediaThumbnailForSourceWidthHeightThrowableError = ClientProxyError.failedLoadingMedia
-        loadMediaFileForSourceBodyThrowableError = ClientProxyError.failedLoadingMedia
+        loadMediaContentForSourceThrowableError = ClientProxyError.sdkError(ClientProxyMockError.generic)
+        loadMediaThumbnailForSourceWidthHeightThrowableError = ClientProxyError.sdkError(ClientProxyMockError.generic)
+        loadMediaFileForSourceBodyThrowableError = ClientProxyError.sdkError(ClientProxyMockError.generic)
         
         secureBackupController = {
             let secureBackupController = SecureBackupControllerMock()

--- a/ElementX/Sources/Mocks/RoomProxyMock.swift
+++ b/ElementX/Sources/Mocks/RoomProxyMock.swift
@@ -49,6 +49,10 @@ struct RoomProxyMockConfiguration {
     var canUserJoinCall = true
 }
 
+enum RoomProxyMockError: Error {
+    case generic
+}
+
 extension RoomProxyMock {
     @MainActor
     convenience init(with configuration: RoomProxyMockConfiguration) {
@@ -83,7 +87,7 @@ extension RoomProxyMock {
         setTopicClosure = { _ in .success(()) }
         getMemberUserIDClosure = { [weak self] userID in
             guard let member = self?.membersPublisher.value.first(where: { $0.userID == userID }) else {
-                return .failure(.failedRetrievingMember)
+                return .failure(.sdkError(RoomProxyMockError.generic))
             }
             return .success(member)
         }
@@ -98,7 +102,7 @@ extension RoomProxyMock {
         resetPowerLevelsReturnValue = .success(.mock)
         suggestedRoleForClosure = { [weak self] userID in
             guard case .success(let member) = await self?.getMember(userID: userID) else {
-                return .failure(.failedCheckingPermission)
+                return .failure(.sdkError(RoomProxyMockError.generic))
             }
             return .success(member.role)
         }

--- a/ElementX/Sources/Screens/InvitesScreen/InvitesScreenViewModel.swift
+++ b/ElementX/Sources/Screens/InvitesScreen/InvitesScreenViewModel.swift
@@ -119,7 +119,7 @@ class InvitesScreenViewModel: InvitesScreenViewModelType, InvitesScreenViewModel
             userIndicatorController.submitIndicator(UserIndicator(id: roomID, type: .modal, title: L10n.commonLoading, persistent: true))
             
             guard let roomProxy = await clientProxy.roomForIdentifier(roomID) else {
-                displayError(.failedAcceptingInvite)
+                displayError()
                 return
             }
             
@@ -127,8 +127,8 @@ class InvitesScreenViewModel: InvitesScreenViewModelType, InvitesScreenViewModel
             case .success:
                 actionsSubject.send(.openRoom(withIdentifier: roomID))
                 analytics.trackJoinedRoom(isDM: roomProxy.isDirect, isSpace: roomProxy.isSpace, activeMemberCount: UInt(roomProxy.activeMembersCount))
-            case .failure(let error):
-                displayError(error)
+            case .failure:
+                displayError()
             }
         }
     }
@@ -143,20 +143,19 @@ class InvitesScreenViewModel: InvitesScreenViewModelType, InvitesScreenViewModel
             userIndicatorController.submitIndicator(UserIndicator(id: roomID, type: .modal, title: L10n.commonLoading, persistent: true))
             
             guard let roomProxy = await clientProxy.roomForIdentifier(roomID) else {
-                displayError(.failedRejectingInvite)
+                displayError()
                 return
             }
             
             let result = await roomProxy.rejectInvitation()
             
-            if case .failure(let error) = result {
-                displayError(error)
+            if case .failure = result {
+                displayError()
             }
         }
     }
     
-    private func displayError(_ error: RoomProxyError) {
-        MXLog.error("Failed to accept/decline invite: \(error)")
+    private func displayError() {
         state.bindings.alertInfo = .init(id: true,
                                          title: L10n.commonError,
                                          message: L10n.errorUnknown)

--- a/ElementX/Sources/Screens/RoomDetailsEditScreen/RoomDetailsEditScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomDetailsEditScreen/RoomDetailsEditScreenViewModel.swift
@@ -48,9 +48,9 @@ class RoomDetailsEditScreenViewModel: RoomDetailsEditScreenViewModelType, RoomDe
         
         Task {
             // Can't use async let because the mocks aren't thread safe when calling the same method 🤦‍♂️
-            state.canEditAvatar = await roomProxy.canUser(userID: roomProxy.ownUserID, sendStateEvent: .roomAvatar) == .success(true)
-            state.canEditName = await roomProxy.canUser(userID: roomProxy.ownUserID, sendStateEvent: .roomName) == .success(true)
-            state.canEditTopic = await roomProxy.canUser(userID: roomProxy.ownUserID, sendStateEvent: .roomTopic) == .success(true)
+            state.canEditAvatar = await (try? roomProxy.canUser(userID: roomProxy.ownUserID, sendStateEvent: .roomAvatar).get()) == .some(true)
+            state.canEditName = await (try? roomProxy.canUser(userID: roomProxy.ownUserID, sendStateEvent: .roomName).get()) == .some(true)
+            state.canEditTopic = await (try? roomProxy.canUser(userID: roomProxy.ownUserID, sendStateEvent: .roomTopic).get()) == .some(true)
         }
     }
     

--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
@@ -178,15 +178,15 @@ class RoomDetailsScreenViewModel: RoomDetailsScreenViewModelType, RoomDetailsScr
     }
     
     private func updatePowerLevelPermissions() async {
-        async let canInviteUsers = roomProxy.canUserInvite(userID: roomProxy.ownUserID) == .success(true)
-        // Can't use async let because the mocks aren't thread safe when calling the same method 🤦‍♂️
-        state.canEditRoomName = await roomProxy.canUser(userID: roomProxy.ownUserID, sendStateEvent: .roomName) == .success(true)
-        state.canEditRoomTopic = await roomProxy.canUser(userID: roomProxy.ownUserID, sendStateEvent: .roomTopic) == .success(true)
-        state.canEditRoomAvatar = await roomProxy.canUser(userID: roomProxy.ownUserID, sendStateEvent: .roomAvatar) == .success(true)
+        state.canEditRoomName = await (try? roomProxy.canUser(userID: roomProxy.ownUserID, sendStateEvent: .roomName).get()) == true
+        state.canEditRoomTopic = await (try? roomProxy.canUser(userID: roomProxy.ownUserID, sendStateEvent: .roomTopic).get()) == true
+        state.canEditRoomAvatar = await (try? roomProxy.canUser(userID: roomProxy.ownUserID, sendStateEvent: .roomAvatar).get()) == true
+        
         if appSettings.roomModerationEnabled {
-            state.canEditRolesOrPermissions = await roomProxy.suggestedRole(for: roomProxy.ownUserID) == .success(.administrator)
+            state.canEditRolesOrPermissions = await (try? roomProxy.suggestedRole(for: roomProxy.ownUserID).get()) == .administrator
         }
-        state.canInviteUsers = await canInviteUsers
+        
+        state.canInviteUsers = await (try? roomProxy.canUserInvite(userID: roomProxy.ownUserID).get()) == true
     }
     
     private func setupNotificationSettingsSubscription() {

--- a/ElementX/Sources/Screens/RoomMemberListScreen/RoomMembersListScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomMemberListScreen/RoomMembersListScreenViewModel.swift
@@ -110,12 +110,9 @@ class RoomMembersListScreenViewModel: RoomMembersListScreenViewModelType, RoomMe
                                bannedMembers: roomMembersDetails.bannedMembers,
                                bindings: state.bindings)
             
-            async let canInviteUsers = roomProxy.canUserInvite(userID: roomProxy.ownUserID)
-            async let canKickUsers = roomProxy.canUserKick(userID: roomProxy.ownUserID)
-            async let canBanUsers = roomProxy.canUserBan(userID: roomProxy.ownUserID)
-            self.state.canInviteUsers = await canInviteUsers == .success(true)
-            self.state.canKickUsers = await canKickUsers == .success(true)
-            self.state.canBanUsers = await canBanUsers == .success(true)
+            self.state.canInviteUsers = await (try? roomProxy.canUserInvite(userID: roomProxy.ownUserID).get()) == true
+            self.state.canKickUsers = await (try? roomProxy.canUserKick(userID: roomProxy.ownUserID).get()) == true
+            self.state.canBanUsers = await (try? roomProxy.canUserBan(userID: roomProxy.ownUserID).get()) == true
             
             hideLoader()
         }

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -38,22 +38,9 @@ enum ClientProxyLoadingState {
 }
 
 enum ClientProxyError: Error {
-    case failedCreatingRoom
-    case failedRetrievingDirectRoom
-    case failedRetrievingUserDisplayName
-    case failedRetrievingUserAvatarURL
-    case failedSettingUserDisplayName
-    case failedRetrievingSessionVerificationController
-    case failedLoadingMedia
-    case mediaFileError
-    case failedUploadingMedia(MatrixErrorCode)
-    case failedSearchingUsers
-    case failedGettingUserProfile
-    case failedSettingUserAvatar
-    case failedCheckingIsLastDevice(Error?)
-    case failedIgnoringUser
-    case failedUnignoringUser
-    case failedJoiningRoom
+    case sdkError(Error)
+    case invalidMedia
+    case failedUploadingMedia(Error, MatrixErrorCode)
 }
 
 enum SlidingSyncConstants {

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -18,26 +18,11 @@ import Combine
 import Foundation
 import MatrixRustSDK
 
-enum RoomProxyError: Error, Equatable {
-    case generic(String?)
-    case failedRedactingEvent
-    case failedReportingContent
-    case failedRetrievingMember
-    case failedLeavingRoom
-    case failedAcceptingInvite
-    case failedRejectingInvite
-    case failedInvitingUser
-    case failedSettingRoomName
-    case failedSettingRoomTopic
-    case failedRemovingAvatar
-    case failedUploadingAvatar
-    case failedCheckingPermission
-    case failedSettingPermission
-    case failedFlaggingAsUnread
-    case failedMarkingAsRead
-    case failedSendingTypingNotice
-    case failedFlaggingAsFavourite
-    case failedModeration
+enum RoomProxyError: Error {
+    case sdkError(Error)
+    
+    case invalidURL
+    case invalidMedia
 }
 
 enum RoomProxyAction {

--- a/UnitTests/Sources/HomeScreenViewModelTests.swift
+++ b/UnitTests/Sources/HomeScreenViewModelTests.swift
@@ -105,7 +105,7 @@ class HomeScreenViewModelTests: XCTestCase {
     func testLeaveRoomError() async throws {
         let mockRoomId = "1"
         let room: RoomProxyMock = .init(with: .init(id: mockRoomId, name: "Some room"))
-        room.leaveRoomClosure = { .failure(.failedLeavingRoom) }
+        room.leaveRoomClosure = { .failure(.sdkError(ClientProxyMockError.generic)) }
         
         clientProxy.roomForIdentifierClosure = { _ in room }
 

--- a/UnitTests/Sources/RoomDetailsViewModelTests.swift
+++ b/UnitTests/Sources/RoomDetailsViewModelTests.swift
@@ -138,7 +138,7 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
             defer {
                 expectation.fulfill()
             }
-            return .failure(.failedLeavingRoom)
+            return .failure(.sdkError(ClientProxyMockError.generic))
         }
         context.send(viewAction: .confirmLeave)
         await fulfillment(of: [expectation])
@@ -207,7 +207,7 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
         let recipient = RoomMemberProxyMock.mockDan
         let mockedMembers: [RoomMemberProxyMock] = [.mockMe, recipient]
         let clientProxy = ClientProxyMock(.init())
-        clientProxy.ignoreUserReturnValue = .failure(.failedIgnoringUser)
+        clientProxy.ignoreUserReturnValue = .failure(.sdkError(ClientProxyMockError.generic))
         roomProxyMock = RoomProxyMock(with: .init(name: "Test", isDirect: true, isEncrypted: true, members: mockedMembers))
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                clientProxy: clientProxy,
@@ -276,7 +276,7 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
         let recipient = RoomMemberProxyMock.mockIgnored
         let mockedMembers: [RoomMemberProxyMock] = [.mockMe, recipient]
         let clientProxy = ClientProxyMock(.init())
-        clientProxy.unignoreUserReturnValue = .failure(.failedUnignoringUser)
+        clientProxy.unignoreUserReturnValue = .failure(.sdkError(ClientProxyMockError.generic))
         roomProxyMock = RoomProxyMock(with: .init(name: "Test", isDirect: true, isEncrypted: true, members: mockedMembers))
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                clientProxy: clientProxy,

--- a/UnitTests/Sources/RoomMemberDetailsViewModelTests.swift
+++ b/UnitTests/Sources/RoomMemberDetailsViewModelTests.swift
@@ -87,7 +87,7 @@ class RoomMemberDetailsViewModelTests: XCTestCase {
     func testIgnoreFailure() async throws {
         roomMemberProxyMock = RoomMemberProxyMock.mockAlice
         let clientProxy = ClientProxyMock(.init())
-        clientProxy.ignoreUserReturnValue = .failure(.failedIgnoringUser)
+        clientProxy.ignoreUserReturnValue = .failure(.sdkError(ClientProxyMockError.generic))
         viewModel = RoomMemberDetailsScreenViewModel(userID: roomMemberProxyMock.userID,
                                                      roomProxy: roomProxyMock,
                                                      clientProxy: clientProxy,
@@ -158,7 +158,7 @@ class RoomMemberDetailsViewModelTests: XCTestCase {
     func testUnignoreFailure() async throws {
         roomMemberProxyMock = RoomMemberProxyMock.mockIgnored
         let clientProxy = ClientProxyMock(.init())
-        clientProxy.unignoreUserReturnValue = .failure(.failedUnignoringUser)
+        clientProxy.unignoreUserReturnValue = .failure(.sdkError(ClientProxyMockError.generic))
         viewModel = RoomMemberDetailsScreenViewModel(userID: roomMemberProxyMock.userID,
                                                      roomProxy: roomProxyMock,
                                                      clientProxy: clientProxy,

--- a/UnitTests/Sources/UserDiscoveryService/UserDiscoveryServiceTest.swift
+++ b/UnitTests/Sources/UserDiscoveryService/UserDiscoveryServiceTest.swift
@@ -71,7 +71,7 @@ class UserDiscoveryServiceTest: XCTestCase {
     }
     
     func testLocalResultShowsOnSearchError() async {
-        clientProxy.searchUsersSearchTermLimitReturnValue = .failure(.failedSearchingUsers)
+        clientProxy.searchUsersSearchTermLimitReturnValue = .failure(.sdkError(ClientProxyMockError.generic))
         clientProxy.profileForReturnValue = .success(.init(userID: "@some:matrix.org"))
         
         let results = await (try? search(query: "@a:b.com").get()) ?? []
@@ -81,7 +81,7 @@ class UserDiscoveryServiceTest: XCTestCase {
     }
     
     func testSearchErrorTriggers() async {
-        clientProxy.searchUsersSearchTermLimitReturnValue = .failure(.failedSearchingUsers)
+        clientProxy.searchUsersSearchTermLimitReturnValue = .failure(.sdkError(ClientProxyMockError.generic))
         clientProxy.profileForReturnValue = .success(.init(userID: "@some:matrix.org"))
         
         switch await search(query: "some query") {
@@ -108,7 +108,7 @@ class UserDiscoveryServiceTest: XCTestCase {
     
     func testSearchResultsShowWhenGetProfileFails() async {
         clientProxy.searchUsersSearchTermLimitReturnValue = .success(.init(results: searchResults, limited: true))
-        clientProxy.profileForReturnValue = .failure(.failedGettingUserProfile)
+        clientProxy.profileForReturnValue = .failure(.sdkError(ClientProxyMockError.generic))
         
         let results = await (try? search(query: "@a:b.com").get()) ?? []
         


### PR DESCRIPTION
- proxy errors have been getting repetitive and not particularly useful
- differentiate between sdk and client errors and keep what provides value
- add error logs everywhere a failure occurs