### PR TITLE
Always encrypt the db for new users.

### DIFF
--- a/ElementX/Sources/Services/Authentication/AuthenticationServiceProxy.swift
+++ b/ElementX/Sources/Services/Authentication/AuthenticationServiceProxy.swift
@@ -27,12 +27,7 @@ class AuthenticationServiceProxy: AuthenticationServiceProxyProtocol {
     var homeserver: CurrentValuePublisher<LoginHomeserver, Never> { homeserverSubject.asCurrentValuePublisher() }
     
     init(userSessionStore: UserSessionStoreProtocol, encryptionKeyProvider: EncryptionKeyProviderProtocol, appSettings: AppSettings) {
-        let passphrase = appSettings.isDevelopmentBuild ? encryptionKeyProvider.generateKey().base64EncodedString() : nil
-        if passphrase != nil {
-            MXLog.info("Testing database encryption in development build.")
-        }
-        
-        self.passphrase = passphrase
+        passphrase = encryptionKeyProvider.generateKey().base64EncodedString()
         self.userSessionStore = userSessionStore
         
         homeserverSubject = .init(LoginHomeserver(address: appSettings.defaultHomeserverAddress,


### PR DESCRIPTION
Enable db encryption on all builds of the app.