### PR TITLE
Codecov: Add token for codecov-action@v3 to fix coverage report

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -83,5 +83,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
           flags: integrationtests
 

--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -61,5 +61,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
           flags: uitests
     

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -62,4 +62,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests


### PR DESCRIPTION
Moving to v4 is blocked because of a fundamental issue with https://github.com/codecov/codecov-action/issues/1279 on our mac runners and because the reported coverage is [decreasing with v4](https://app.codecov.io/gh/element-hq/element-x-ios/pull/2719/flags)

Will replace #2719.