### PR TITLE
Gracefuly handle selecting the same room multiple times

### DIFF
--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -267,8 +267,14 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
                 presentHomeScreen()
                 attemptStartingOnboarding()
                 
-            case(.roomList, .selectRoom(let roomID, let showingRoomDetails), .roomList):
-                Task { await self.startRoomFlow(roomID: roomID, showingRoomDetails: showingRoomDetails, animated: animated) }
+            case(.roomList(let selectedRoomID), .selectRoom(let roomID, let showingRoomDetails), .roomList):
+                if selectedRoomID == roomID {
+                    if let roomFlowCoordinator {
+                        roomFlowCoordinator.handleAppRoute(.room(roomID: roomID), animated: animated)
+                    }
+                } else {
+                    Task { await self.startRoomFlow(roomID: roomID, showingRoomDetails: showingRoomDetails, animated: animated) }
+                }
             case(.roomList, .deselectRoom, .roomList):
                 dismissRoomFlow(animated: animated)
                 

--- a/ElementX/Sources/Screens/ComposerToolbar/View/MessageComposerTextField.swift
+++ b/ElementX/Sources/Screens/ComposerToolbar/View/MessageComposerTextField.swift
@@ -61,6 +61,8 @@ private struct UITextViewWrapper: UIViewRepresentable {
         // Need to use TextKit 1 for mentions
         let textView = ElementTextView(usingTextLayoutManager: false)
         textView.isMultiline = $isMultiline
+        textView.delegate = context.coordinator
+        textView.elementDelegate = context.coordinator
         textView.textColor = .compound.textPrimary
         textView.isEditable = true
         textView.font = font
@@ -73,9 +75,6 @@ private struct UITextViewWrapper: UIViewRepresentable {
         textView.keyboardType = .default
 
         textView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        
-        textView.delegate = context.coordinator
-        textView.elementDelegate = context.coordinator
 
         return textView
     }
@@ -91,14 +90,6 @@ private struct UITextViewWrapper: UIViewRepresentable {
     }
 
     func updateUIView(_ textView: UITextView, context: UIViewRepresentableContext<UITextViewWrapper>) {
-        // Attempted fix for element-hq/element-x-ios/issues/2653 which we can't reproduce
-        // but it feels like the degate doesn't get called and the binding doesn't update upwards
-        // The textView is changed but none of the UI depending on the binding are.
-        if let textView = textView as? ElementTextView {
-            textView.delegate = context.coordinator
-            textView.elementDelegate = context.coordinator
-        }
-        
         if textView.text != text {
             textView.text = text
 

--- a/UnitTests/Sources/RoomFlowCoordinatorTests.swift
+++ b/UnitTests/Sources/RoomFlowCoordinatorTests.swift
@@ -162,6 +162,8 @@ class RoomFlowCoordinatorTests: XCTestCase {
         try await clearRoute(expectedActions: [.finished])
         XCTAssertNil(navigationStackCoordinator.rootCoordinator)
         
+        await setupRoomFlowCoordinator(roomType: .invited(roomID: "InvitedRoomID"))
+        
         try await process(route: .room(roomID: "InvitedRoomID"))
         XCTAssert(navigationStackCoordinator.rootCoordinator is JoinRoomScreenCoordinator)
         XCTAssertEqual(navigationStackCoordinator.stackCoordinators.count, 0)
@@ -188,7 +190,8 @@ class RoomFlowCoordinatorTests: XCTestCase {
         try await clearRoute(expectedActions: [.finished])
         XCTAssertNil(navigationStackCoordinator.stackCoordinators.last, "A child room flow should remove the join room scren on dismissal")
         
-        navigationStackCoordinator.popToRoot()
+        await setupRoomFlowCoordinator(asChildFlow: true, roomType: .invited(roomID: "InvitedRoomID"))
+        navigationStackCoordinator.setRootCoordinator(BlankFormCoordinator())
         
         try await process(route: .room(roomID: "InvitedRoomID"))
         XCTAssertTrue(navigationStackCoordinator.rootCoordinator is BlankFormCoordinator, "A child room flow should push onto the stack, leaving the root alone.")

--- a/changelog.d/2653.bugfix
+++ b/changelog.d/2653.bugfix
@@ -1,0 +1,1 @@
+Fix deeplinking/navigating into the same room multiple times


### PR DESCRIPTION
- add support for deeplinking/navigating into the same room multiple times
    - fix bugs around the view <-> view models going out of sync
    - unwind the stack if the room is already presented
- revert attempted composer fix (navigation was the real cause)