### PR TITLE
Move message forwarding out of the flow coordinator.

### DIFF
--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -10333,6 +10333,11 @@ class SessionVerificationControllerProxyMock: SessionVerificationControllerProxy
     }
 }
 class TimelineProxyMock: TimelineProxyProtocol {
+    var roomID: String {
+        get { return underlyingRoomID }
+        set(value) { underlyingRoomID = value }
+    }
+    var underlyingRoomID: String!
     var actions: AnyPublisher<TimelineProxyAction, Never> {
         get { return underlyingActions }
         set(value) { underlyingActions = value }

--- a/ElementX/Sources/Mocks/RoomProxyMock.swift
+++ b/ElementX/Sources/Mocks/RoomProxyMock.swift
@@ -30,23 +30,25 @@ struct RoomProxyMockConfiguration {
     var hasOngoingCall = true
     var canonicalAlias: String?
     
-    var timeline = {
-        let mock = TimelineProxyMock()
-        mock.underlyingActions = Empty(completeImmediately: false).eraseToAnyPublisher()
-        mock.timelineStartReached = false
-        
-        let timelineProvider = RoomTimelineProviderMock()
-        timelineProvider.underlyingMembershipChangePublisher = PassthroughSubject().eraseToAnyPublisher()
-        mock.underlyingTimelineProvider = timelineProvider
-        return mock
-    }()
-    
     var members: [RoomMemberProxyMock] = .allMembers
     var ownUserID = RoomMemberProxyMock.mockMe.userID
     
     var canUserInvite = true
     var canUserTriggerRoomNotification = false
     var canUserJoinCall = true
+    
+    func makeTimeline() -> TimelineProxyMock {
+        let mock = TimelineProxyMock()
+        mock.roomID = id
+        mock.underlyingActions = Empty(completeImmediately: false).eraseToAnyPublisher()
+        mock.timelineStartReached = false
+        mock.sendMessageEventContentReturnValue = .success(())
+        
+        let timelineProvider = RoomTimelineProviderMock()
+        timelineProvider.underlyingMembershipChangePublisher = PassthroughSubject().eraseToAnyPublisher()
+        mock.underlyingTimelineProvider = timelineProvider
+        return mock
+    }
 }
 
 enum RoomProxyMockError: Error {
@@ -69,7 +71,7 @@ extension RoomProxyMock {
         hasOngoingCall = configuration.hasOngoingCall
         canonicalAlias = configuration.canonicalAlias
         
-        timeline = configuration.timeline
+        timeline = configuration.makeTimeline()
         
         ownUserID = configuration.ownUserID
         membership = .joined

--- a/ElementX/Sources/Screens/MessageForwardingScreen/MessageForwardingScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/MessageForwardingScreen/MessageForwardingScreenCoordinator.swift
@@ -18,14 +18,17 @@ import Combine
 import SwiftUI
 
 struct MessageForwardingScreenCoordinatorParameters {
+    let sourceEventID: String
+    let sourceTimeline: TimelineProxyProtocol
+    let clientProxy: ClientProxyProtocol
     let roomSummaryProvider: RoomSummaryProviderProtocol
     let mediaProvider: MediaProviderProtocol
-    let sourceRoomID: String
+    let userIndicatorController: UserIndicatorControllerProtocol
 }
 
 enum MessageForwardingScreenCoordinatorAction {
     case dismiss
-    case send(roomID: String)
+    case sent(roomID: String)
 }
 
 final class MessageForwardingScreenCoordinator: CoordinatorProtocol {
@@ -38,9 +41,12 @@ final class MessageForwardingScreenCoordinator: CoordinatorProtocol {
     }
     
     init(parameters: MessageForwardingScreenCoordinatorParameters) {
-        viewModel = MessageForwardingScreenViewModel(roomSummaryProvider: parameters.roomSummaryProvider,
-                                                     mediaProvider: parameters.mediaProvider,
-                                                     sourceRoomID: parameters.sourceRoomID)
+        viewModel = MessageForwardingScreenViewModel(sourceEventID: parameters.sourceEventID,
+                                                     sourceTimeline: parameters.sourceTimeline,
+                                                     clientProxy: parameters.clientProxy,
+                                                     roomSummaryProvider: parameters.roomSummaryProvider,
+                                                     userIndicatorController: parameters.userIndicatorController,
+                                                     mediaProvider: parameters.mediaProvider)
     }
     
     func start() {
@@ -48,8 +54,8 @@ final class MessageForwardingScreenCoordinator: CoordinatorProtocol {
             switch action {
             case .dismiss:
                 self?.actionsSubject.send(.dismiss)
-            case .send(let roomID):
-                self?.actionsSubject.send(.send(roomID: roomID))
+            case .sent(let roomID):
+                self?.actionsSubject.send(.sent(roomID: roomID))
             }
         }
         .store(in: &cancellables)

--- a/ElementX/Sources/Screens/MessageForwardingScreen/MessageForwardingScreenModels.swift
+++ b/ElementX/Sources/Screens/MessageForwardingScreen/MessageForwardingScreenModels.swift
@@ -18,7 +18,7 @@ import Foundation
 
 enum MessageForwardingScreenViewModelAction {
     case dismiss
-    case send(roomID: String)
+    case sent(roomID: String)
 }
 
 struct MessageForwardingScreenViewState: BindableState {

--- a/ElementX/Sources/Screens/MessageForwardingScreen/View/MessageForwardingScreen.swift
+++ b/ElementX/Sources/Screens/MessageForwardingScreen/View/MessageForwardingScreen.swift
@@ -104,9 +104,12 @@ private struct MessageForwardingListRow: View {
 struct MessageForwardingScreen_Previews: PreviewProvider, TestablePreview {
     static var previews: some View {
         let summaryProvider = RoomSummaryProviderMock(.init(state: .loaded(.mockRooms)))
-        let viewModel = MessageForwardingScreenViewModel(roomSummaryProvider: summaryProvider,
-                                                         mediaProvider: MockMediaProvider(),
-                                                         sourceRoomID: "")
+        let viewModel = MessageForwardingScreenViewModel(sourceEventID: "",
+                                                         sourceTimeline: TimelineProxyMock(),
+                                                         clientProxy: ClientProxyMock(),
+                                                         roomSummaryProvider: summaryProvider,
+                                                         userIndicatorController: UserIndicatorControllerMock(),
+                                                         mediaProvider: MockMediaProvider())
         
         NavigationStack {
             MessageForwardingScreen(context: viewModel.context)

--- a/ElementX/Sources/Services/Room/RoomProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomProxy.swift
@@ -61,7 +61,7 @@ class RoomProxy: RoomProxyProtocol {
         self.room = room
         
         do {
-            timeline = try await TimelineProxy(timeline: room.timeline())
+            timeline = try await TimelineProxy(timeline: room.timeline(), roomID: room.id())
         } catch {
             MXLog.error("Failed creating timeline with error: \(error)")
             return nil

--- a/ElementX/Sources/Services/Timeline/TimelineProxy.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineProxy.swift
@@ -19,6 +19,7 @@ import Foundation
 import MatrixRustSDK
 
 final class TimelineProxy: TimelineProxyProtocol {
+    let roomID: String
     private let timeline: Timeline
     
     private let lowPriorityDispatchQueue = DispatchQueue(label: "io.element.elementx.roomproxy.low_priority", qos: .utility)
@@ -51,7 +52,8 @@ final class TimelineProxy: TimelineProxyProtocol {
         roomTimelineObservationToken?.cancel()
     }
     
-    init(timeline: Timeline) {
+    init(timeline: Timeline, roomID: String) {
+        self.roomID = roomID
         self.timeline = timeline
     }
     

--- a/ElementX/Sources/Services/Timeline/TimelineProxyProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineProxyProtocol.swift
@@ -39,6 +39,8 @@ enum TimelineProxyAction {
 
 // sourcery: AutoMockable
 protocol TimelineProxyProtocol {
+    var roomID: String { get }
+    
     var actions: AnyPublisher<TimelineProxyAction, Never> { get }
     
     var timelineProvider: RoomTimelineProviderProtocol { get }


### PR DESCRIPTION
Tidies up the flow coordinator and helps us pass the active timeline to fetch the content from at a later date.

Follow-up to come for polls.