### PR TITLE
Add Event Routes to the flows

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -206,6 +206,18 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
                 } else {
                     handleAppRoute(.childRoomAlias(alias))
                 }
+            case .event(let roomID, let eventID):
+                if isExternalURL {
+                    handleAppRoute(route)
+                } else {
+                    handleAppRoute(.childEvent(roomID: roomID, eventID: eventID))
+                }
+            case .eventOnRoomAlias(let alias, let eventID):
+                if isExternalURL {
+                    handleAppRoute(route)
+                } else {
+                    handleAppRoute(.childEventOnRoomAlias(alias: alias, eventID: eventID))
+                }
             default:
                 break
             }

--- a/ElementX/Sources/Application/Navigation/AppRoutes.swift
+++ b/ElementX/Sources/Application/Navigation/AppRoutes.swift
@@ -24,16 +24,24 @@ enum AppRoute: Equatable {
     case roomList
     /// A room, shown as the root of the stack (popping any child rooms).
     case room(roomID: String)
-    /// A room, shown as the root of the stack (popping any child rooms).
+    /// The same as ``room`` but using a room alias.
     case roomAlias(String)
     /// A room, pushed as a child of any existing rooms on the stack.
     case childRoom(roomID: String)
-    /// A room, pushed as a child of any existing rooms on the stack.
+    /// The same as ``childRoom`` but using a room alias.
     case childRoomAlias(String)
     /// The information about a particular room.
     case roomDetails(roomID: String)
     /// The profile of a member within the current room.
     case roomMemberDetails(userID: String)
+    /// An event within a room, shown as the root of the stack (popping any child rooms).
+    case event(roomID: String, eventID: String)
+    /// The same as ``event`` but using a room alias.
+    case eventOnRoomAlias(alias: String, eventID: String)
+    /// An event within a room, either within the last child on the stack or pushing a new child if needed.
+    case childEvent(roomID: String, eventID: String)
+    /// The same as ``childEvent`` but using a room alias.
+    case childEventOnRoomAlias(alias: String, eventID: String)
     /// The profile of a matrix user (outside of a room).
     case userProfile(userID: String)
     /// An Element Call link generated outside of a chat room.
@@ -133,6 +141,12 @@ struct MatrixPermalinkParser: URLParser {
             return .roomAlias(alias)
         case .user(let id):
             return .userProfile(userID: id)
+        case .eventOnRoomId(let roomID, let eventID):
+            // return .event(roomID: roomID, eventID: eventID)
+            return nil
+        case .eventOnRoomAlias(let alias, let eventID):
+            // return .eventOnRoomAlias(alias: alias, eventID: eventID)
+            return nil
         default:
             return nil
         }

--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinatorStateMachine.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinatorStateMachine.swift
@@ -74,9 +74,11 @@ class UserSessionFlowCoordinatorStateMachine {
         /// Start the user session flows.
         case start
         
+        enum SelectRoomFocus: Hashable { case roomDetails, eventID(String) }
         /// Request presentation for a particular room
-        /// - Parameter roomID:the room identifier
-        case selectRoom(roomID: String, showingRoomDetails: Bool)
+        /// - Parameter roomID: The room identifier
+        /// - Parameter entryPoint: The starting point for the presented room.
+        case selectRoom(roomID: String, entryPoint: RoomFlowCoordinatorEntryPoint)
         /// The room screen has been dismissed
         case deselectRoom
         

--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinatorStateMachine.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinatorStateMachine.swift
@@ -74,7 +74,6 @@ class UserSessionFlowCoordinatorStateMachine {
         /// Start the user session flows.
         case start
         
-        enum SelectRoomFocus: Hashable { case roomDetails, eventID(String) }
         /// Request presentation for a particular room
         /// - Parameter roomID: The room identifier
         /// - Parameter entryPoint: The starting point for the presented room.

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
@@ -21,6 +21,7 @@ import WysiwygComposer
 
 struct RoomScreenCoordinatorParameters {
     let roomProxy: RoomProxyProtocol
+    var focussedEventID: String?
     let timelineController: RoomTimelineControllerProtocol
     let mediaProvider: MediaProviderProtocol
     let mediaPlayerProvider: MediaPlayerProviderProtocol
@@ -59,6 +60,7 @@ final class RoomScreenCoordinator: CoordinatorProtocol {
     
     init(parameters: RoomScreenCoordinatorParameters) {
         viewModel = RoomScreenViewModel(roomProxy: parameters.roomProxy,
+                                        focussedEventID: parameters.focussedEventID,
                                         timelineController: parameters.timelineController,
                                         mediaProvider: parameters.mediaProvider,
                                         mediaPlayerProvider: parameters.mediaPlayerProvider,
@@ -127,6 +129,10 @@ final class RoomScreenCoordinator: CoordinatorProtocol {
                 viewModel.process(composerAction: action)
             }
             .store(in: &cancellables)
+    }
+    
+    func focusOnEvent(eventID: String) {
+        Task { await viewModel.focusOnEvent(eventID: eventID) }
     }
     
     func stop() {

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -49,6 +49,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
     private var paginateBackwardsTask: Task<Void, Never>?
 
     init(roomProxy: RoomProxyProtocol,
+         focussedEventID: String? = nil,
          timelineController: RoomTimelineControllerProtocol,
          mediaProvider: MediaProviderProtocol,
          mediaPlayerProvider: MediaPlayerProviderProtocol,
@@ -89,6 +90,11 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
                                                          hasOngoingCall: roomProxy.hasOngoingCall,
                                                          bindings: .init(reactionsCollapsed: [:])),
                    imageProvider: mediaProvider)
+        
+        // This may change to load the detached timeline directly.
+        if let focussedEventID {
+            Task { await focusOnEvent(eventID: focussedEventID) }
+        }
         
         setupSubscriptions()
         setupDirectRoomSubscriptionsIfNeeded()
@@ -207,6 +213,8 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
             }
         }
     }
+    
+    func focusOnEvent(eventID: String) async { }
     
     // MARK: - Private
     

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModelProtocol.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModelProtocol.swift
@@ -23,5 +23,7 @@ protocol RoomScreenViewModelProtocol {
     var actions: AnyPublisher<RoomScreenViewModelAction, Never> { get }
     var context: RoomScreenViewModelType.Context { get }
     func process(composerAction: ComposerToolbarViewModelAction)
+    /// Updates the timeline to show and highlight the item with the corresponding event ID.
+    func focusOnEvent(eventID: String) async
     func stop()
 }


### PR DESCRIPTION
This is the first PR to support event permalinks. It only adds the routes, which are neither called nor do anything when handled.