### PR TITLE
Public room search tweaks

### DIFF
--- a/ElementX/Sources/Screens/RoomDirectorySearchScreen/RoomDirectorySearchScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomDirectorySearchScreen/RoomDirectorySearchScreenViewModel.swift
@@ -93,6 +93,10 @@ class RoomDirectorySearchScreenViewModel: RoomDirectorySearchScreenViewModelType
                                                                       title: L10n.screenRoomDirectorySearchLoadingError,
                                                                       iconName: "xmark"))
             }
+            
+            // Add a small delay to allow the rooms to be published,
+            // otherwise you see the No Results text briefly.
+            try? await Task.sleep(for: .milliseconds(50))
             state.isLoading = false
         }
     }

--- a/ElementX/Sources/Screens/RoomDirectorySearchScreen/View/RoomDirectoryCell.swift
+++ b/ElementX/Sources/Screens/RoomDirectorySearchScreen/View/RoomDirectoryCell.swift
@@ -37,17 +37,10 @@ struct RoomDirectorySearchCell: View {
     }
 
     var body: some View {
-        if result.canBeJoined {
-            ListRow(label: .avatar(title: result.name ?? result.alias ?? result.id,
-                                   description: description,
-                                   icon: avatar),
-                    details: .label(title: L10n.actionJoin, icon: EmptyView()),
-                    kind: .navigationLink(action: joinAction))
-        } else {
-            ListRow(label: .avatar(title: result.name ?? result.alias ?? result.id,
-                                   description: description,
-                                   icon: avatar), kind: .label)
-        }
+        ListRow(label: .avatar(title: result.name ?? result.alias ?? result.id,
+                               description: description,
+                               icon: avatar),
+                kind: result.canBeJoined ? .navigationLink(action: joinAction) : .label)
     }
     
     private var avatar: some View {
@@ -70,7 +63,7 @@ struct RoomDirectorySearchCell_Previews: PreviewProvider, TestablePreview {
                                                   name: "Test title",
                                                   topic: "test description",
                                                   avatarURL: nil,
-                                                  canBeJoined: false),
+                                                  canBeJoined: true),
                                     imageProvider: MockMediaProvider()) { }
             
             RoomDirectorySearchCell(result: .init(id: "!test_id_2:matrix.org",
@@ -78,7 +71,7 @@ struct RoomDirectorySearchCell_Previews: PreviewProvider, TestablePreview {
                                                   name: nil,
                                                   topic: "test description",
                                                   avatarURL: nil,
-                                                  canBeJoined: false),
+                                                  canBeJoined: true),
                                     imageProvider: MockMediaProvider()) { }
             
             RoomDirectorySearchCell(result: .init(id: "!test_id_3:example.com",
@@ -86,7 +79,7 @@ struct RoomDirectorySearchCell_Previews: PreviewProvider, TestablePreview {
                                                   name: "Test title no topic",
                                                   topic: nil,
                                                   avatarURL: nil,
-                                                  canBeJoined: false),
+                                                  canBeJoined: true),
                                     imageProvider: MockMediaProvider()) { }
             
             RoomDirectorySearchCell(result: .init(id: "!test_id_4:example.com",
@@ -94,7 +87,7 @@ struct RoomDirectorySearchCell_Previews: PreviewProvider, TestablePreview {
                                                   name: nil,
                                                   topic: nil,
                                                   avatarURL: nil,
-                                                  canBeJoined: false),
+                                                  canBeJoined: true),
                                     imageProvider: MockMediaProvider()) { }
             
             RoomDirectorySearchCell(result: .init(id: "!test_id_5:example.com",
@@ -129,5 +122,6 @@ struct RoomDirectorySearchCell_Previews: PreviewProvider, TestablePreview {
                                                   canBeJoined: false),
                                     imageProvider: MockMediaProvider()) { }
         }
+        .compoundList()
     }
 }

--- a/ElementX/Sources/Screens/RoomDirectorySearchScreen/View/RoomDirectorySearchScreen.swift
+++ b/ElementX/Sources/Screens/RoomDirectorySearchScreen/View/RoomDirectorySearchScreen.swift
@@ -34,13 +34,20 @@ struct RoomDirectorySearchScreen: View {
                         if context.viewState.isLoading {
                             ProgressView()
                                 .frame(maxWidth: .infinity)
+                        } else if context.viewState.rooms.isEmpty {
+                            Text(L10n.commonNoResults)
+                                .font(.compound.bodyLG)
+                                .foregroundColor(.compound.textSecondary)
+                                .frame(maxWidth: .infinity)
+                                .accessibilityIdentifier(A11yIdentifiers.startChatScreen.searchNoResults)
+                        } else {
+                            emptyRectangle
+                                .onAppear {
+                                    context.send(viewAction: .reachedBottom)
+                                }
                         }
-                        
-                        emptyRectangle
-                            .onAppear {
-                                context.send(viewAction: .reachedBottom)
-                            }
                     }
+                    .listRowSeparator(.hidden)
                 }
             }
             .listStyle(.plain)
@@ -70,7 +77,7 @@ struct RoomDirectorySearchScreen: View {
 
 // MARK: - Previews
 
-struct RoomDirectorySearchScreenScreen_Previews: PreviewProvider, TestablePreview {
+struct RoomDirectorySearchScreen_Previews: PreviewProvider, TestablePreview {
     static let viewModel: RoomDirectorySearchScreenViewModel = {
         let results = [RoomDirectorySearchResult(id: "test_1",
                                                  alias: "#test_1:example.com",

--- a/ElementX/Sources/Screens/RoomDirectorySearchScreen/View/RoomDirectorySearchScreen.swift
+++ b/ElementX/Sources/Screens/RoomDirectorySearchScreen/View/RoomDirectorySearchScreen.swift
@@ -41,6 +41,8 @@ struct RoomDirectorySearchScreen: View {
                                 .frame(maxWidth: .infinity)
                                 .accessibilityIdentifier(A11yIdentifiers.startChatScreen.searchNoResults)
                         } else {
+                            // This needs to be in the else as when you start a search, the results are cleared making the footer visible.
+                            // We only want to trigger the pagination when the state is not loading.
                             emptyRectangle
                                 .onAppear {
                                     context.send(viewAction: .reachedBottom)

--- a/PreviewTests/__Snapshots__/PreviewTests/test_roomDirectorySearchCell-iPad-en-GB.1.png
+++ b/PreviewTests/__Snapshots__/PreviewTests/test_roomDirectorySearchCell-iPad-en-GB.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e313574042e1aa4c4252f5a4f4a5a2b3b567963217b1f0b14b94fa3ea5555b3e
-size 210853
+oid sha256:2cfc85144f0fbe433cfae77759714992525535d85b36e9412dd9ef0ebdd9792c
+size 211164

--- a/PreviewTests/__Snapshots__/PreviewTests/test_roomDirectorySearchCell-iPad-pseudo.1.png
+++ b/PreviewTests/__Snapshots__/PreviewTests/test_roomDirectorySearchCell-iPad-pseudo.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e313574042e1aa4c4252f5a4f4a5a2b3b567963217b1f0b14b94fa3ea5555b3e
-size 210853
+oid sha256:2cfc85144f0fbe433cfae77759714992525535d85b36e9412dd9ef0ebdd9792c
+size 211164

--- a/PreviewTests/__Snapshots__/PreviewTests/test_roomDirectorySearchCell-iPhone-15-en-GB.1.png
+++ b/PreviewTests/__Snapshots__/PreviewTests/test_roomDirectorySearchCell-iPhone-15-en-GB.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9dfc605661458f731da9bbcdf338535e123c4843e2643e63d3c57c01c5189c95
-size 149275
+oid sha256:a0e872fefa99c08fccfd7caa3d7203fb0de40ff147f9cfc38f20392b1ceba88c
+size 150392

--- a/PreviewTests/__Snapshots__/PreviewTests/test_roomDirectorySearchCell-iPhone-15-pseudo.1.png
+++ b/PreviewTests/__Snapshots__/PreviewTests/test_roomDirectorySearchCell-iPhone-15-pseudo.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9dfc605661458f731da9bbcdf338535e123c4843e2643e63d3c57c01c5189c95
-size 149275
+oid sha256:a0e872fefa99c08fccfd7caa3d7203fb0de40ff147f9cfc38f20392b1ceba88c
+size 150392

--- a/PreviewTests/__Snapshots__/PreviewTests/test_roomDirectorySearchScreen-iPad-en-GB.1.png
+++ b/PreviewTests/__Snapshots__/PreviewTests/test_roomDirectorySearchScreen-iPad-en-GB.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:896454ae71d809adc90153e06e18cb4de1aed40b0ac0cd55d5a9e77a486d257a
+size 109534

--- a/PreviewTests/__Snapshots__/PreviewTests/test_roomDirectorySearchScreen-iPad-pseudo.1.png
+++ b/PreviewTests/__Snapshots__/PreviewTests/test_roomDirectorySearchScreen-iPad-pseudo.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e59ad65dbbc88ccdf4f0ad75eaf46d7c5a8490f3a6efe4f193eaacf4b76ef74
+size 122499

--- a/PreviewTests/__Snapshots__/PreviewTests/test_roomDirectorySearchScreen-iPhone-15-en-GB.1.png
+++ b/PreviewTests/__Snapshots__/PreviewTests/test_roomDirectorySearchScreen-iPhone-15-en-GB.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5482cb5e317a68c7d93167a28a8931aad764cdb736096428db5e2b0c3b19dfd
+size 64828

--- a/PreviewTests/__Snapshots__/PreviewTests/test_roomDirectorySearchScreen-iPhone-15-pseudo.1.png
+++ b/PreviewTests/__Snapshots__/PreviewTests/test_roomDirectorySearchScreen-iPhone-15-pseudo.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6056af78f50c6e2f7d0b10c1c99959d7b099637224b6b760097d5e4234442167
+size 73402

--- a/PreviewTests/__Snapshots__/PreviewTests/test_roomDirectorySearchScreenScreen-iPad-en-GB.1.png
+++ b/PreviewTests/__Snapshots__/PreviewTests/test_roomDirectorySearchScreenScreen-iPad-en-GB.1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f31e5f39b635c8e4d63934933aae0bf25c7ed33d6b0f3d0bb9105cd86f0a6898
-size 111743

--- a/PreviewTests/__Snapshots__/PreviewTests/test_roomDirectorySearchScreenScreen-iPad-pseudo.1.png
+++ b/PreviewTests/__Snapshots__/PreviewTests/test_roomDirectorySearchScreenScreen-iPad-pseudo.1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d3331568faafd4c05eb768f5bf4be9b119ebd87be1f8829f1c84465aaf2aea1f
-size 126969

--- a/PreviewTests/__Snapshots__/PreviewTests/test_roomDirectorySearchScreenScreen-iPhone-15-en-GB.1.png
+++ b/PreviewTests/__Snapshots__/PreviewTests/test_roomDirectorySearchScreenScreen-iPhone-15-en-GB.1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2d79c4687de4aae775d00f1442ae37697967f8b7d449eb4730a838e16adfb7be
-size 66836

--- a/PreviewTests/__Snapshots__/PreviewTests/test_roomDirectorySearchScreenScreen-iPhone-15-pseudo.1.png
+++ b/PreviewTests/__Snapshots__/PreviewTests/test_roomDirectorySearchScreenScreen-iPhone-15-pseudo.1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9cf8c4e574758e34a7e4dee7bf1fa4f9c414a37c6c0558073db9a2fd555e32dc
-size 77410


### PR DESCRIPTION
- Remove the "Join" button.
- Hide the extra bottom separator.
- Show an empty search result.
- Fix a bug where we would paginate and search simultaneously.

Closes #2744.