### PR TITLE
Fix the font when editing a message with RTE off.

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/MessageComposerTextField.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/MessageComposerTextField.swift
@@ -95,6 +95,10 @@ private struct UITextViewWrapper: UIViewRepresentable {
         if textView.attributedText != text {
             textView.attributedText = text
             
+            // Re-apply the default font when setting text for e.g. edits.
+            textView.font = font
+            textView.textColor = .compound.textPrimary
+            
             // Prevent the textView from randomly using the tint color
             textView.typingAttributes = [.font: font,
                                          .foregroundColor: UIColor(.compound.textPrimary)]


### PR DESCRIPTION
The font and colour originally set in `makeUIView` were being forgotten when setting a new string, so we reset them after setting the text.