### PR TITLE
Bump posthog SDK version to 3.2.0

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -7352,7 +7352,7 @@
 			repositoryURL = "https://github.com/PostHog/posthog-ios";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.0.3;
+				minimumVersion = 3.2.4;
 			};
 		};
 		9A472EE0218FE7DCF5283429 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -166,8 +166,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/PostHog/posthog-ios",
       "state" : {
-        "revision" : "9298825fe26899a58b976d400254e0b050daa578",
-        "version" : "2.0.5"
+        "revision" : "d127599034e08f12f340e5e2da13090a894d55d6",
+        "version" : "3.2.4"
       }
     },
     {

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -6625,23 +6625,18 @@ class OrientationManagerMock: OrientationManagerProtocol {
     }
 }
 class PHGPostHogMock: PHGPostHogProtocol {
-    var enabled: Bool {
-        get { return underlyingEnabled }
-        set(value) { underlyingEnabled = value }
-    }
-    var underlyingEnabled: Bool!
 
-    //MARK: - enable
+    //MARK: - optIn
 
-    var enableUnderlyingCallsCount = 0
-    var enableCallsCount: Int {
+    var optInUnderlyingCallsCount = 0
+    var optInCallsCount: Int {
         get {
             if Thread.isMainThread {
-                return enableUnderlyingCallsCount
+                return optInUnderlyingCallsCount
             } else {
                 var returnValue: Int? = nil
                 DispatchQueue.main.sync {
-                    returnValue = enableUnderlyingCallsCount
+                    returnValue = optInUnderlyingCallsCount
                 }
 
                 return returnValue!
@@ -6649,34 +6644,34 @@ class PHGPostHogMock: PHGPostHogProtocol {
         }
         set {
             if Thread.isMainThread {
-                enableUnderlyingCallsCount = newValue
+                optInUnderlyingCallsCount = newValue
             } else {
                 DispatchQueue.main.sync {
-                    enableUnderlyingCallsCount = newValue
+                    optInUnderlyingCallsCount = newValue
                 }
             }
         }
     }
-    var enableCalled: Bool {
-        return enableCallsCount > 0
+    var optInCalled: Bool {
+        return optInCallsCount > 0
     }
-    var enableClosure: (() -> Void)?
+    var optInClosure: (() -> Void)?
 
-    func enable() {
-        enableCallsCount += 1
-        enableClosure?()
+    func optIn() {
+        optInCallsCount += 1
+        optInClosure?()
     }
-    //MARK: - disable
+    //MARK: - optOut
 
-    var disableUnderlyingCallsCount = 0
-    var disableCallsCount: Int {
+    var optOutUnderlyingCallsCount = 0
+    var optOutCallsCount: Int {
         get {
             if Thread.isMainThread {
-                return disableUnderlyingCallsCount
+                return optOutUnderlyingCallsCount
             } else {
                 var returnValue: Int? = nil
                 DispatchQueue.main.sync {
-                    returnValue = disableUnderlyingCallsCount
+                    returnValue = optOutUnderlyingCallsCount
                 }
 
                 return returnValue!
@@ -6684,22 +6679,22 @@ class PHGPostHogMock: PHGPostHogProtocol {
         }
         set {
             if Thread.isMainThread {
-                disableUnderlyingCallsCount = newValue
+                optOutUnderlyingCallsCount = newValue
             } else {
                 DispatchQueue.main.sync {
-                    disableUnderlyingCallsCount = newValue
+                    optOutUnderlyingCallsCount = newValue
                 }
             }
         }
     }
-    var disableCalled: Bool {
-        return disableCallsCount > 0
+    var optOutCalled: Bool {
+        return optOutCallsCount > 0
     }
-    var disableClosure: (() -> Void)?
+    var optOutClosure: (() -> Void)?
 
-    func disable() {
-        disableCallsCount += 1
-        disableClosure?()
+    func optOut() {
+        optOutCallsCount += 1
+        optOutClosure?()
     }
     //MARK: - reset
 

--- a/ElementX/Sources/Mocks/PHGPostHogMock.swift
+++ b/ElementX/Sources/Mocks/PHGPostHogMock.swift
@@ -19,9 +19,8 @@ import PostHog
 
 extension PHGPostHogMock {
     func configureMockBehavior() {
-        enableClosure = {
-            self.enabled = true
-        }
+        // We don't need custom configuration anymore since update of the posthog SDK
+        // Keeping boilerplate code in case needed later?
     }
 }
 
@@ -32,7 +31,7 @@ class MockPostHogFactory: PostHogFactory {
         self.mock = mock
     }
     
-    func createPostHog(config: PHGPostHogConfiguration) -> ElementX.PHGPostHogProtocol {
+    func createPostHog(config: PostHogConfig) -> ElementX.PHGPostHogProtocol {
         mock
     }
 }

--- a/ElementX/Sources/Services/Analytics/PHGPostHogConfiguration.swift
+++ b/ElementX/Sources/Services/Analytics/PHGPostHogConfiguration.swift
@@ -16,12 +16,13 @@
 
 import PostHog
 
-extension PHGPostHogConfiguration {
-    static func standard(analyticsConfiguration: AnalyticsConfiguration) -> PHGPostHogConfiguration? {
+extension PostHogConfig {
+    static func standard(analyticsConfiguration: AnalyticsConfiguration) -> PostHogConfig? {
         guard analyticsConfiguration.isEnabled else { return nil }
         
-        let postHogConfiguration = PHGPostHogConfiguration(apiKey: analyticsConfiguration.apiKey, host: analyticsConfiguration.host)
-        postHogConfiguration.shouldSendDeviceID = false
+        let postHogConfiguration = PostHogConfig(apiKey: analyticsConfiguration.apiKey, host: analyticsConfiguration.host)
+        // We capture screens manually
+        postHogConfiguration.captureScreenViews = false
         
         return postHogConfiguration
     }

--- a/ElementX/Sources/Services/Analytics/PHGPostHogProtocol.swift
+++ b/ElementX/Sources/Services/Analytics/PHGPostHogProtocol.swift
@@ -19,11 +19,9 @@ import PostHog
 
 // sourcery: AutoMockable
 protocol PHGPostHogProtocol {
-    var enabled: Bool { get }
+    func optIn()
     
-    func enable()
-    
-    func disable()
+    func optOut()
     
     func reset()
     
@@ -33,13 +31,14 @@ protocol PHGPostHogProtocol {
 }
 
 protocol PostHogFactory {
-    func createPostHog(config: PHGPostHogConfiguration) -> PHGPostHogProtocol
+    func createPostHog(config: PostHogConfig) -> PHGPostHogProtocol
 }
 
 class DefaultPostHogFactory: PostHogFactory {
-    func createPostHog(config: PHGPostHogConfiguration) -> PHGPostHogProtocol {
-        PHGPostHog(configuration: config)
+    func createPostHog(config: PostHogConfig) -> PHGPostHogProtocol {
+        PostHogSDK.shared.setup(config)
+        return PostHogSDK.shared
     }
 }
 
-extension PHGPostHog: PHGPostHogProtocol { }
+extension PostHogSDK: PHGPostHogProtocol { }

--- a/ElementX/Sources/Services/Analytics/PostHogAnalyticsClient.swift
+++ b/ElementX/Sources/Services/Analytics/PostHogAnalyticsClient.swift
@@ -38,11 +38,11 @@ class PostHogAnalyticsClient: AnalyticsClientProtocol {
     /// Not persisted for now, should be set on start.
     private var superProperties: AnalyticsEvent.SuperProperties?
     
-    var isRunning: Bool { postHog?.enabled ?? false }
+    var isRunning: Bool { postHog != nil }
     
     func start(analyticsConfiguration: AnalyticsConfiguration) {
         // Only start if analytics have been configured in BuildSettings
-        guard let configuration = PHGPostHogConfiguration.standard(analyticsConfiguration: analyticsConfiguration) else { return }
+        guard let configuration = PostHogConfig.standard(analyticsConfiguration: analyticsConfiguration) else { return }
         
         if postHog == nil {
             postHog = posthogFactory.createPostHog(config: configuration)
@@ -50,7 +50,7 @@ class PostHogAnalyticsClient: AnalyticsClientProtocol {
         // Add super property cryptoSDK to the captured events, to allow easy
         // filtering of events across different client by using same filter.
         superProperties = AnalyticsEvent.SuperProperties(appPlatform: nil, cryptoSDK: .Rust, cryptoSDKVersion: nil)
-        postHog?.enable()
+        postHog?.optIn()
     }
     
     func reset() {
@@ -59,8 +59,8 @@ class PostHogAnalyticsClient: AnalyticsClientProtocol {
     }
     
     func stop() {
-        postHog?.disable()
-        
+        postHog?.optOut()
+        postHog = nil
         // As of PostHog 1.4.4, setting the client to nil here doesn't release
         // it. Keep it around to avoid having multiple instances if the user re-enables
     }

--- a/UnitTests/Sources/AnalyticsTests.swift
+++ b/UnitTests/Sources/AnalyticsTests.swift
@@ -265,4 +265,38 @@ class AnalyticsTests: XCTestCase {
         XCTAssertEqual(capturedEvent2?.properties?["appPlatform"] as? String, "A thing")
         XCTAssertEqual(capturedEvent2?.properties?["cryptoSDKVersion"] as? String, "001")
     }
+    
+    func testShouldNotReportIfNotStarted() {
+        // Given a client with user properties set
+        let client = PostHogAnalyticsClient(posthogFactory: MockPostHogFactory(mock: posthogMock))
+    
+        // No call to start
+        
+        client.screen(AnalyticsEvent.MobileScreen(durationMs: nil, screenName: .Home))
+        
+        XCTAssertEqual(posthogMock.screenPropertiesCalled, false)
+        
+        // It should be the same for any event
+        let someEvent = AnalyticsEvent.Error(context: nil,
+                                             cryptoModule: .Rust,
+                                             cryptoSDK: .Rust,
+                                             domain: .E2EE,
+                                             eventLocalAgeMillis: nil,
+                                             isFederated: nil,
+                                             isMatrixDotOrg: nil,
+                                             name: .OlmKeysNotSentError,
+                                             timeToDecryptMillis: nil,
+                                             userTrustsOwnIdentity: nil,
+                                             wasVisibleToUser: nil)
+        client.capture(someEvent)
+        
+        XCTAssertEqual(posthogMock.capturePropertiesCalled, false)
+        
+        // start now
+        client.start(analyticsConfiguration: appSettings.analyticsConfiguration)
+        XCTAssertEqual(posthogMock.optInCalled, true)
+        
+        client.capture(someEvent)
+        XCTAssertEqual(posthogMock.capturePropertiesCalled, true)
+    }
 }

--- a/project.yml
+++ b/project.yml
@@ -107,7 +107,7 @@ packages:
     minorVersion: 5.13.0
   PostHog:
     url: https://github.com/PostHog/posthog-ios
-    minorVersion: 2.0.3
+    minorVersion: 3.2.4
   Prefire:
     url: https://github.com/BarredEwe/Prefire
     minorVersion: 2.0.4


### PR DESCRIPTION

Bump posthog version to 3.2.0.
We were using a quite old posthog sdk. Updating to the new one mainly because it now support [sessions](https://posthog.com/docs/data/sessions). Allow us to have a per device view instead of only unique users that is merging events from all the devices of the same user.
Element X Android is already using [posthog 3.x](https://github.com/element-hq/element-x-android/blob/86838e7277d7a094496b9d231f06aad99f1e445e/gradle/libs.versions.toml#L183)

### Pull Request Checklist

- [ ] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
