### PR TITLE
Posthog: use correct API for user properties

### DIFF
--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -6733,15 +6733,15 @@ class PHGPostHogMock: PHGPostHogProtocol {
     }
     //MARK: - capture
 
-    var capturePropertiesUnderlyingCallsCount = 0
-    var capturePropertiesCallsCount: Int {
+    var capturePropertiesUserPropertiesUnderlyingCallsCount = 0
+    var capturePropertiesUserPropertiesCallsCount: Int {
         get {
             if Thread.isMainThread {
-                return capturePropertiesUnderlyingCallsCount
+                return capturePropertiesUserPropertiesUnderlyingCallsCount
             } else {
                 var returnValue: Int? = nil
                 DispatchQueue.main.sync {
-                    returnValue = capturePropertiesUnderlyingCallsCount
+                    returnValue = capturePropertiesUserPropertiesUnderlyingCallsCount
                 }
 
                 return returnValue!
@@ -6749,26 +6749,26 @@ class PHGPostHogMock: PHGPostHogProtocol {
         }
         set {
             if Thread.isMainThread {
-                capturePropertiesUnderlyingCallsCount = newValue
+                capturePropertiesUserPropertiesUnderlyingCallsCount = newValue
             } else {
                 DispatchQueue.main.sync {
-                    capturePropertiesUnderlyingCallsCount = newValue
+                    capturePropertiesUserPropertiesUnderlyingCallsCount = newValue
                 }
             }
         }
     }
-    var capturePropertiesCalled: Bool {
-        return capturePropertiesCallsCount > 0
+    var capturePropertiesUserPropertiesCalled: Bool {
+        return capturePropertiesUserPropertiesCallsCount > 0
     }
-    var capturePropertiesReceivedArguments: (event: String, properties: [String: Any]?)?
-    var capturePropertiesReceivedInvocations: [(event: String, properties: [String: Any]?)] = []
-    var capturePropertiesClosure: ((String, [String: Any]?) -> Void)?
+    var capturePropertiesUserPropertiesReceivedArguments: (event: String, properties: [String: Any]?, userProperties: [String: Any]?)?
+    var capturePropertiesUserPropertiesReceivedInvocations: [(event: String, properties: [String: Any]?, userProperties: [String: Any]?)] = []
+    var capturePropertiesUserPropertiesClosure: ((String, [String: Any]?, [String: Any]?) -> Void)?
 
-    func capture(_ event: String, properties: [String: Any]?) {
-        capturePropertiesCallsCount += 1
-        capturePropertiesReceivedArguments = (event: event, properties: properties)
-        capturePropertiesReceivedInvocations.append((event: event, properties: properties))
-        capturePropertiesClosure?(event, properties)
+    func capture(_ event: String, properties: [String: Any]?, userProperties: [String: Any]?) {
+        capturePropertiesUserPropertiesCallsCount += 1
+        capturePropertiesUserPropertiesReceivedArguments = (event: event, properties: properties, userProperties: userProperties)
+        capturePropertiesUserPropertiesReceivedInvocations.append((event: event, properties: properties, userProperties: userProperties))
+        capturePropertiesUserPropertiesClosure?(event, properties, userProperties)
     }
     //MARK: - screen
 

--- a/ElementX/Sources/Services/Analytics/PHGPostHogProtocol.swift
+++ b/ElementX/Sources/Services/Analytics/PHGPostHogProtocol.swift
@@ -25,7 +25,7 @@ protocol PHGPostHogProtocol {
     
     func reset()
     
-    func capture(_ event: String, properties: [String: Any]?)
+    func capture(_ event: String, properties: [String: Any]?, userProperties: [String: Any]?)
     
     func screen(_ screenTitle: String, properties: [String: Any]?)
 }


### PR DESCRIPTION
Follow up on https://github.com/element-hq/element-x-ios/pull/2788

Posthog SDK has now an API to pass user properties, so no need to manually add them as `$set` in the event properties.
Updated the tests

### Pull Request Checklist

- [ ] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
