### PR TITLE
Various plain composer tweaks

### DIFF
--- a/ElementX/Sources/Screens/GlobalSearchScreen/View/GlobalSearchScreen.swift
+++ b/ElementX/Sources/Screens/GlobalSearchScreen/View/GlobalSearchScreen.swift
@@ -197,7 +197,10 @@ private class GlobalSearchTextField: UITextField {
     }
 
     override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
-        guard let key = presses.first?.key else { return }
+        guard let key = presses.first?.key else {
+            super.pressesBegan(presses, with: event)
+            return
+        }
         
         if keyPressHandler(key.keyCode) {
             return

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarModels.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarModels.swift
@@ -32,6 +32,7 @@ enum ComposerToolbarVoiceMessageAction {
 
 enum ComposerToolbarViewModelAction {
     case sendMessage(plain: String, html: String?, mode: RoomScreenComposerMode, intentionalMentions: IntentionalMentions)
+    case editLastMessage
     case attach(ComposerAttachmentType)
 
     case handlePasteOrDrop(provider: NSItemProvider)
@@ -47,6 +48,7 @@ enum ComposerToolbarViewModelAction {
 enum ComposerToolbarViewAction {
     case composerAppeared
     case sendMessage
+    case editLastMessage
     case cancelReply
     case cancelEdit
     case attach(ComposerAttachmentType)

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarViewModel.swift
@@ -135,6 +135,8 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
                     sendPlainComposerText()
                 }
             }
+        case .editLastMessage:
+            actionsSubject.send(.editLastMessage)
         case .cancelReply:
             set(mode: .default)
         case .cancelEdit:

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/ComposerToolbar.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/ComposerToolbar.swift
@@ -110,13 +110,6 @@ struct ComposerToolbar: View {
                     RoomAttachmentPicker(context: context)
                 }
                 messageComposer
-                    .environmentObject(context)
-                    .onTapGesture {
-                        guard !composerFocused else { return }
-                        composerFocused = true
-                    }
-                    .padding(.leading, context.composerActionsEnabled ? 7 : 0)
-                    .padding(.trailing, context.composerActionsEnabled ? 4 : 0)
             }
             .opacity(context.viewState.isVoiceMessageModeActivated ? 0 : 1)
             
@@ -177,7 +170,14 @@ struct ComposerToolbar: View {
         } onAppearAction: {
             context.send(viewAction: .composerAppeared)
         }
+        .environmentObject(context)
         .focused($composerFocused)
+        .padding(.leading, context.composerActionsEnabled ? 7 : 0)
+        .padding(.trailing, context.composerActionsEnabled ? 4 : 0)
+        .onTapGesture {
+            guard !composerFocused else { return }
+            composerFocused = true
+        }
         .onChange(of: context.composerFocused) { newValue in
             guard composerFocused != newValue else { return }
             

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/ComposerToolbar.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/ComposerToolbar.swift
@@ -161,12 +161,19 @@ struct ComposerToolbar: View {
                         showResizeGrabber: context.viewState.bindings.composerActionsEnabled,
                         isExpanded: $context.composerExpanded) {
             context.send(viewAction: .sendMessage)
+        } editAction: {
+            context.send(viewAction: .editLastMessage)
         } pasteAction: { provider in
             context.send(viewAction: .handlePasteOrDrop(provider: provider))
-        } replyCancellationAction: {
-            context.send(viewAction: .cancelReply)
-        } editCancellationAction: {
-            context.send(viewAction: .cancelEdit)
+        } cancellationAction: {
+            switch context.viewState.composerMode {
+            case .edit:
+                context.send(viewAction: .cancelEdit)
+            case .reply:
+                context.send(viewAction: .cancelReply)
+            default:
+                break
+            }
         } onAppearAction: {
             context.send(viewAction: .composerAppeared)
         }

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/MessageComposer.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/MessageComposer.swift
@@ -33,7 +33,6 @@ struct MessageComposer: View {
     let editCancellationAction: () -> Void
     let onAppearAction: () -> Void
     
-    @State private var isMultiline = false
     @State private var composerTranslation: CGFloat = 0
     private let composerShape = RoundedRectangle(cornerRadius: 21, style: .circular)
     
@@ -86,7 +85,6 @@ struct MessageComposer: View {
             } else {
                 MessageComposerTextField(placeholder: L10n.richTextEditorComposerPlaceholder,
                                          text: $plainComposerText,
-                                         isMultiline: $isMultiline,
                                          maxHeight: 300,
                                          enterKeyHandler: sendAction,
                                          pasteHandler: pasteAction)

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/MessageComposerTextField.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/MessageComposerTextField.swift
@@ -88,16 +88,16 @@ private struct UITextViewWrapper: UIViewRepresentable {
     }
 
     func updateUIView(_ textView: UITextView, context: UIViewRepresentableContext<UITextViewWrapper>) {
+        // Prevent the textView from inheriting attributes from mention pills
+        textView.typingAttributes = [.font: font,
+                                     .foregroundColor: UIColor(.compound.textPrimary)]
+        
         if textView.attributedText != text {
             textView.attributedText = text
             
             // Re-apply the default font when setting text for e.g. edits.
             textView.font = font
             textView.textColor = .compound.textPrimary
-            
-            // Prevent the textView from randomly using the tint color
-            textView.typingAttributes = [.font: font,
-                                         .foregroundColor: UIColor(.compound.textPrimary)]
             
             if text.string.isEmpty {
                 // text cleared, probably because the written text is sent

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/MessageComposerTextField.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/MessageComposerTextField.swift
@@ -18,7 +18,6 @@ import SwiftUI
 struct MessageComposerTextField: View {
     let placeholder: String
     @Binding var text: NSAttributedString
-    @Binding var isMultiline: Bool
 
     let maxHeight: CGFloat
     let enterKeyHandler: EnterKeyHandler
@@ -26,7 +25,6 @@ struct MessageComposerTextField: View {
 
     var body: some View {
         UITextViewWrapper(text: $text,
-                          isMultiline: $isMultiline,
                           maxHeight: maxHeight,
                           enterKeyHandler: enterKeyHandler,
                           pasteHandler: pasteHandler)
@@ -48,7 +46,6 @@ private struct UITextViewWrapper: UIViewRepresentable {
     @Environment(\.roomContext) private var roomContext
 
     @Binding var text: NSAttributedString
-    @Binding var isMultiline: Bool
 
     let maxHeight: CGFloat
 
@@ -62,7 +59,6 @@ private struct UITextViewWrapper: UIViewRepresentable {
         let textView = ElementTextView(usingTextLayoutManager: false)
         textView.roomContext = roomContext
         
-        textView.isMultiline = $isMultiline
         textView.delegate = context.coordinator
         textView.elementDelegate = context.coordinator
         textView.textColor = .compound.textPrimary
@@ -167,7 +163,6 @@ private protocol ElementTextViewDelegate: AnyObject {
 
 private class ElementTextView: UITextView, PillAttachmentViewProviderDelegate {
     var roomContext: RoomScreenViewModel.Context?
-    var isMultiline: Binding<Bool>?
     
     weak var elementDelegate: ElementTextViewDelegate?
     
@@ -184,23 +179,6 @@ private class ElementTextView: UITextView, PillAttachmentViewProviderDelegate {
 
     @objc func enterKeyPressed(sender: UIKeyCommand) {
         elementDelegate?.textViewDidReceiveEnterKeyPress(self)
-    }
-
-    override func layoutSubviews() {
-        super.layoutSubviews()
-
-        guard let isMultiline, let font else { return }
-
-        let numberOfLines = frame.height / font.lineHeight
-        if numberOfLines > 1.5 {
-            if !isMultiline.wrappedValue {
-                isMultiline.wrappedValue = true
-            }
-        } else {
-            if isMultiline.wrappedValue {
-                isMultiline.wrappedValue = false
-            }
-        }
     }
 
     // Pasting support
@@ -266,18 +244,15 @@ struct MessageComposerTextField_Previews: PreviewProvider, TestablePreview {
 
     struct PreviewWrapper: View {
         @State var text: NSAttributedString
-        @State var isMultiline: Bool
 
         init(text: String) {
             _text = .init(initialValue: .init(string: text, attributes: [.font: UIFont.preferredFont(forTextStyle: .body),
                                                                          .foregroundColor: UIColor(.compound.textPrimary)]))
-            _isMultiline = .init(initialValue: false)
         }
 
         var body: some View {
             MessageComposerTextField(placeholder: "Placeholder",
                                      text: $text,
-                                     isMultiline: $isMultiline,
                                      maxHeight: 300,
                                      enterKeyHandler: { },
                                      pasteHandler: { _ in })

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -787,7 +787,7 @@ extension EnvironmentValues {
         get { self[RoomContextKey.self] }
         set { self[RoomContextKey.self] = newValue }
     }
-    
+
     /// An event ID which will be non-nil when a timeline item should show as focussed.
     var focussedEventID: String? {
         get { self[FocussedEventID.self] }

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -206,6 +206,8 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
                                          mode: mode,
                                          intentionalMentions: intentionalMentions)
             }
+        case .editLastMessage:
+            editLastMessage()
         case .attach(let attachment):
             attach(attachment)
         case .handlePasteOrDrop(let provider):
@@ -262,6 +264,20 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
             state.timelineViewState.focussedEvent = focussedEvent
             hideFocusLoadingIndicator()
         }
+    }
+    
+    private func editLastMessage() {
+        guard let item = timelineController.timelineItems.reversed().first(where: {
+            guard let item = $0 as? EventBasedMessageTimelineItemProtocol else {
+                return false
+            }
+            
+            return item.sender.id == roomProxy.ownUserID && item.isEditable
+        }) else {
+            return
+        }
+        
+        roomScreenInteractionHandler.processTimelineItemMenuAction(.edit, itemID: item.id)
     }
     
     private func attach(_ attachment: ComposerAttachmentType) {

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
@@ -45,7 +45,7 @@ struct RoomScreen: View {
                     }
                     .padding(.top, 8)
                     .background(Color.compound.bgCanvasDefault.ignoresSafeArea())
-                    .environmentObject(context)
+                    .environment(\.roomContext, context)
             }
             .navigationTitle(L10n.screenRoomTitle) // Hidden but used for back button text.
             .navigationBarTitleDisplayMode(.inline)

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/HighlightedTimelineItemModifier.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/HighlightedTimelineItemModifier.swift
@@ -61,6 +61,7 @@ struct HighlightedTimelineItemModifier_Previews: PreviewProvider, TestablePrevie
                 Bubble(text: "Not highlighted")
                     .highlightedTimelineItem(false)
                 
+                // swiftlint:disable line_length
                 Bubble(text: """
                        Bacon ipsum dolor amet brisket bacon hamburger filet mignon ham hock, capicola meatloaf corned beef tongue. Ribeye filet mignon shoulder drumstick doner shank. Landjaeger shankle chislic brisket short loin pig. Frankfurter sirloin jerky bresaola tri-tip cow buffalo. Beef tongue shankle venison, sirloin boudin biltong ham hock corned beef. Sirloin shankle pork belly, strip steak pancetta brisket flank ribeye cow chislic. Pork ham landjaeger, pastrami beef sausage capicola meatball.
                        
@@ -68,6 +69,7 @@ struct HighlightedTimelineItemModifier_Previews: PreviewProvider, TestablePrevie
                        """,
                        isOutgoing: true)
                     .highlightedTimelineItem(true)
+                // swiftlint:enable line_length
             }
         }
         .previewDisplayName("Layout")

--- a/UnitTests/Sources/RoomPollsHistoryScreenViewModelTests.swift
+++ b/UnitTests/Sources/RoomPollsHistoryScreenViewModelTests.swift
@@ -27,7 +27,6 @@ class RoomPollsHistoryScreenViewModelTests: XCTestCase {
     override func setUpWithError() throws {
         interactionHandler = PollInteractionHandlerMock()
         timelineController = MockRoomTimelineController()
-        let roomProxyMockConfiguration = RoomProxyMockConfiguration(name: "Polls")
         viewModel = RoomPollsHistoryScreenViewModel(pollInteractionHandler: interactionHandler,
                                                     roomTimelineController: timelineController,
                                                     userIndicatorController: UserIndicatorControllerMock())

--- a/changelog.d/2765.feature
+++ b/changelog.d/2765.feature
@@ -1,0 +1,1 @@
+Use the keyboard up arrow to edit the last message, use escape to cancel editing or replying.


### PR DESCRIPTION
* always use the right attributes when typing (i.e. deleting the last space before a pill will break the current implementation)
* allow the keyboard up arrow to edit the last message
* allow escape to cancel editing or replying.
* fix mentioned users not having display names within the pills