### PR TITLE
Add matrix.to site association

### DIFF
--- a/ElementX/SupportingFiles/ElementX.entitlements
+++ b/ElementX/SupportingFiles/ElementX.entitlements
@@ -13,6 +13,7 @@
 		<string>applinks:mobile.element.io</string>
 		<string>applinks:call.element.io</string>
 		<string>applinks:call.element.dev</string>
+		<string>applinks:matrix.to</string>
 		<string>webcredentials:*.element.io</string>
 	</array>
 	<key>com.apple.developer.usernotifications.communication</key>


### PR DESCRIPTION
Doesn't work yet, still waiting for the CDN to catch up: https://app-site-association.cdn-apple.com/a/v1/matrix.to