### PR TITLE
Add reaction toggles to macOS timeline context menu.

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenInteractionHandler.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenInteractionHandler.swift
@@ -257,6 +257,9 @@ class RoomScreenInteractionHandler {
             actionsSubject.send(.displayReportContent(itemID: itemID, senderID: eventTimelineItem.sender.id))
         case .react:
             showEmojiPicker(for: itemID)
+        case .toggleReaction(let key):
+            guard let eventID = itemID.eventID else { return }
+            Task { await roomProxy.timeline.toggleReaction(key, to: eventID) }
         case .endPoll(let pollStartID):
             endPoll(pollStartID: pollStartID)
         }

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineItemMenu.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineItemMenu.swift
@@ -15,9 +15,11 @@
 //
 
 import Compound
+import SFSafeSymbols
 import SwiftUI
 
 struct TimelineItemMenuActions {
+    let reactions: [TimelineItemMenuReaction]
     let actions: [TimelineItemMenuAction]
     let debugActions: [TimelineItemMenuAction]
     
@@ -28,6 +30,13 @@ struct TimelineItemMenuActions {
         
         self.actions = actions
         self.debugActions = debugActions
+        reactions = [
+            .init(key: "👍️", symbol: .handThumbsup),
+            .init(key: "👎️", symbol: .handThumbsdown),
+            .init(key: "🔥", symbol: .flame),
+            .init(key: "❤️", symbol: .heart),
+            .init(key: "👏", symbol: .handsClap)
+        ]
     }
     
     var canReply: Bool {
@@ -41,6 +50,11 @@ struct TimelineItemMenuActions {
     }
 }
 
+struct TimelineItemMenuReaction {
+    let key: String
+    let symbol: SFSymbol
+}
+
 enum TimelineItemMenuAction: Identifiable, Hashable {
     case copy
     case edit
@@ -52,6 +66,7 @@ enum TimelineItemMenuAction: Identifiable, Hashable {
     case retryDecryption(sessionID: String)
     case report
     case react
+    case toggleReaction(key: String)
     case endPoll(pollStartID: String)
     
     var id: Self { self }
@@ -119,6 +134,9 @@ enum TimelineItemMenuAction: Identifiable, Hashable {
         case .report:
             Label(L10n.actionReportContent, icon: \.chatProblem)
         case .react:
+            Label(L10n.actionReact, icon: \.reactionAdd)
+        case .toggleReaction:
+            // Unused label - manually created in TimelineItemMacContextMenu.
             Label(L10n.actionReact, icon: \.reactionAdd)
         case .endPoll:
             Label(L10n.actionEndPoll, icon: \.pollsEnd)
@@ -216,11 +234,9 @@ struct TimelineItemMenu: View {
     private var reactionsSection: some View {
         ScrollView(.horizontal) {
             HStack(alignment: .center, spacing: 8) {
-                reactionButton(for: "👍️")
-                reactionButton(for: "👎️")
-                reactionButton(for: "🔥")
-                reactionButton(for: "❤️")
-                reactionButton(for: "👏")
+                ForEach(actions.reactions, id: \.key) {
+                    reactionButton(for: $0.key)
+                }
                 
                 Button {
                     dismiss()


### PR DESCRIPTION
This change only affects macOS
| Unselected | Selected |
| - | - |
| <img width="243" alt="D5A92DF8-A0D0-4D1A-B9F2-2D5FAFCC1C35" src="https://github.com/element-hq/element-x-ios/assets/6060466/750f07c6-3f8e-4c84-a0a8-ad7b5bfddb97"> | <img width="243" alt="243FC1C4-361F-43E3-BEE6-A11E026FB925" src="https://github.com/element-hq/element-x-ios/assets/6060466/df11087a-02d0-48ac-96ba-48ec44001023"> |
