### PR TITLE
Fix macOS timeline context menu missing the Remove item.

### DIFF
--- a/ElementX/Sources/Mocks/RoomProxyMock.swift
+++ b/ElementX/Sources/Mocks/RoomProxyMock.swift
@@ -115,6 +115,7 @@ extension RoomProxyMock {
         }
         canUserInviteUserIDReturnValue = .success(configuration.canUserInvite)
         canUserRedactOtherUserIDReturnValue = .success(false)
+        canUserRedactOwnUserIDReturnValue = .success(false)
         canUserKickUserIDClosure = { [weak self] userID in
             .success(self?.membersPublisher.value.first { $0.userID == userID }?.role ?? .user != .user)
         }

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -814,7 +814,7 @@ extension RoomScreenViewModel {
 }
 
 private struct RoomContextKey: EnvironmentKey {
-    @MainActor static let defaultValue = RoomScreenViewModel.mock.context
+    @MainActor static let defaultValue: RoomScreenViewModel.Context? = nil
 }
 
 private struct FocussedEventID: EnvironmentKey {
@@ -823,7 +823,7 @@ private struct FocussedEventID: EnvironmentKey {
 
 extension EnvironmentValues {
     /// Used to access and inject the room context without observing it
-    var roomContext: RoomScreenViewModel.Context {
+    var roomContext: RoomScreenViewModel.Context? {
         get { self[RoomContextKey.self] }
         set { self[RoomContextKey.self] = newValue }
     }

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemView.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemView.swift
@@ -16,7 +16,7 @@
 import SwiftUI
 
 struct RoomTimelineItemView: View {
-    @Environment(\.roomContext) var context: RoomScreenViewModel.Context
+    @Environment(\.roomContext) var context
     @ObservedObject var viewState: RoomTimelineItemViewState
     
     var body: some View {
@@ -25,10 +25,10 @@ struct RoomTimelineItemView: View {
             .animation(.elementDefault, value: viewState.type)
             .environment(\.timelineGroupStyle, viewState.groupStyle)
             .onAppear {
-                context.send(viewAction: .itemAppeared(itemID: viewState.identifier))
+                context?.send(viewAction: .itemAppeared(itemID: viewState.identifier))
             }
             .onDisappear {
-                context.send(viewAction: .itemDisappeared(itemID: viewState.identifier))
+                context?.send(viewAction: .itemDisappeared(itemID: viewState.identifier))
             }
     }
 
@@ -73,7 +73,7 @@ struct RoomTimelineItemView: View {
         case .poll(let item):
             PollRoomTimelineView(timelineItem: item)
         case .voice(let item):
-            VoiceMessageRoomTimelineView(timelineItem: item, playerState: context.viewState.audioPlayerStateProvider?(item.id) ?? AudioPlayerState(id: .timelineItemIdentifier(item.id), duration: 0))
+            VoiceMessageRoomTimelineView(timelineItem: item, playerState: context?.viewState.audioPlayerStateProvider?(item.id) ?? AudioPlayerState(id: .timelineItemIdentifier(item.id), duration: 0))
         case .callInvite(let item):
             CallInviteRoomTimelineView(timelineItem: item)
         }


### PR DESCRIPTION
The necessary permissions were only being checked when presenting the long press menu.

Also makes the room context optional in the environment as:
a) the changes were crashing in the mock when opening a room.
b) that default value has been annoying us in various ways and only a single file uses it anyway so was simple enough to handle.