### PR TITLE
Add device keys to rageshakes

### DIFF
--- a/ElementX/Sources/FlowCoordinators/AuthenticationFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/AuthenticationFlowCoordinator.swift
@@ -126,8 +126,7 @@ class AuthenticationFlowCoordinator: FlowCoordinatorProtocol {
         bugReportFlowCoordinator = BugReportFlowCoordinator(parameters: .init(presentationMode: .sheet(navigationStackCoordinator),
                                                                               userIndicatorController: userIndicatorController,
                                                                               bugReportService: bugReportService,
-                                                                              userID: nil,
-                                                                              deviceID: nil))
+                                                                              userSession: nil))
         bugReportFlowCoordinator?.start()
     }
     

--- a/ElementX/Sources/FlowCoordinators/BugReportFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/BugReportFlowCoordinator.swift
@@ -25,8 +25,7 @@ struct BugReportFlowCoordinatorParameters {
     let presentationMode: PresentationMode
     let userIndicatorController: UserIndicatorControllerProtocol
     let bugReportService: BugReportServiceProtocol
-    let userID: String?
-    let deviceID: String?
+    let userSession: UserSessionProtocol?
 }
 
 class BugReportFlowCoordinator: FlowCoordinatorProtocol {
@@ -64,8 +63,7 @@ class BugReportFlowCoordinator: FlowCoordinatorProtocol {
     
     private func presentBugReportScreen() {
         let params = BugReportScreenCoordinatorParameters(bugReportService: parameters.bugReportService,
-                                                          userID: parameters.userID,
-                                                          deviceID: parameters.deviceID,
+                                                          userSession: parameters.userSession,
                                                           userIndicatorController: parameters.userIndicatorController,
                                                           screenshot: nil,
                                                           isModallyPresented: isModallyPresented)

--- a/ElementX/Sources/FlowCoordinators/SettingsFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/SettingsFlowCoordinator.swift
@@ -123,8 +123,7 @@ class SettingsFlowCoordinator: FlowCoordinatorProtocol {
                     bugReportFlowCoordinator = BugReportFlowCoordinator(parameters: .init(presentationMode: .push(navigationStackCoordinator),
                                                                                           userIndicatorController: parameters.userIndicatorController,
                                                                                           bugReportService: parameters.bugReportService,
-                                                                                          userID: parameters.userSession.userID,
-                                                                                          deviceID: parameters.userSession.deviceID))
+                                                                                          userSession: parameters.userSession))
                     bugReportFlowCoordinator?.start()
                 case .about:
                     presentLegalInformationScreen()

--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -307,8 +307,7 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
                 bugReportFlowCoordinator = BugReportFlowCoordinator(parameters: .init(presentationMode: .sheet(sidebarNavigationStackCoordinator),
                                                                                       userIndicatorController: ServiceLocator.shared.userIndicatorController,
                                                                                       bugReportService: bugReportService,
-                                                                                      userID: userSession.userID,
-                                                                                      deviceID: userSession.deviceID))
+                                                                                      userSession: userSession))
                 bugReportFlowCoordinator?.start()
             case (.feedbackScreen, .dismissedFeedbackScreen, .roomList):
                 break

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -3799,6 +3799,134 @@ class ClientProxyMock: ClientProxyProtocol {
             return recentConversationCounterpartsReturnValue
         }
     }
+    //MARK: - ed25519Base64
+
+    var ed25519Base64UnderlyingCallsCount = 0
+    var ed25519Base64CallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return ed25519Base64UnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = ed25519Base64UnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                ed25519Base64UnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    ed25519Base64UnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var ed25519Base64Called: Bool {
+        return ed25519Base64CallsCount > 0
+    }
+
+    var ed25519Base64UnderlyingReturnValue: String?
+    var ed25519Base64ReturnValue: String? {
+        get {
+            if Thread.isMainThread {
+                return ed25519Base64UnderlyingReturnValue
+            } else {
+                var returnValue: String?? = nil
+                DispatchQueue.main.sync {
+                    returnValue = ed25519Base64UnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                ed25519Base64UnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    ed25519Base64UnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    var ed25519Base64Closure: (() async -> String?)?
+
+    func ed25519Base64() async -> String? {
+        ed25519Base64CallsCount += 1
+        if let ed25519Base64Closure = ed25519Base64Closure {
+            return await ed25519Base64Closure()
+        } else {
+            return ed25519Base64ReturnValue
+        }
+    }
+    //MARK: - curve25519Base64
+
+    var curve25519Base64UnderlyingCallsCount = 0
+    var curve25519Base64CallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return curve25519Base64UnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = curve25519Base64UnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                curve25519Base64UnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    curve25519Base64UnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var curve25519Base64Called: Bool {
+        return curve25519Base64CallsCount > 0
+    }
+
+    var curve25519Base64UnderlyingReturnValue: String?
+    var curve25519Base64ReturnValue: String? {
+        get {
+            if Thread.isMainThread {
+                return curve25519Base64UnderlyingReturnValue
+            } else {
+                var returnValue: String?? = nil
+                DispatchQueue.main.sync {
+                    returnValue = curve25519Base64UnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                curve25519Base64UnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    curve25519Base64UnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    var curve25519Base64Closure: (() async -> String?)?
+
+    func curve25519Base64() async -> String? {
+        curve25519Base64CallsCount += 1
+        if let curve25519Base64Closure = curve25519Base64Closure {
+            return await curve25519Base64Closure()
+        } else {
+            return curve25519Base64ReturnValue
+        }
+    }
     //MARK: - loadMediaContentForSource
 
     var loadMediaContentForSourceThrowableError: Error?

--- a/ElementX/Sources/Screens/BugReportScreen/BugReportScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/BugReportScreen/BugReportScreenCoordinator.swift
@@ -25,8 +25,7 @@ enum BugReportScreenCoordinatorAction {
 
 struct BugReportScreenCoordinatorParameters {
     let bugReportService: BugReportServiceProtocol
-    let userID: String?
-    let deviceID: String?
+    let userSession: UserSessionProtocol?
     
     let userIndicatorController: UserIndicatorControllerProtocol?
     let screenshot: UIImage?
@@ -47,8 +46,7 @@ final class BugReportScreenCoordinator: CoordinatorProtocol {
         self.parameters = parameters
         
         viewModel = BugReportScreenViewModel(bugReportService: parameters.bugReportService,
-                                             userID: parameters.userID,
-                                             deviceID: parameters.deviceID,
+                                             userSession: parameters.userSession,
                                              screenshot: parameters.screenshot,
                                              isModallyPresented: parameters.isModallyPresented)
     }

--- a/ElementX/Sources/Screens/BugReportScreen/BugReportScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/BugReportScreen/BugReportScreenCoordinator.swift
@@ -46,7 +46,7 @@ final class BugReportScreenCoordinator: CoordinatorProtocol {
         self.parameters = parameters
         
         viewModel = BugReportScreenViewModel(bugReportService: parameters.bugReportService,
-                                             userSession: parameters.userSession,
+                                             clientProxy: parameters.userSession?.clientProxy,
                                              screenshot: parameters.screenshot,
                                              isModallyPresented: parameters.isModallyPresented)
     }

--- a/ElementX/Sources/Screens/BugReportScreen/BugReportScreenViewModel.swift
+++ b/ElementX/Sources/Screens/BugReportScreen/BugReportScreenViewModel.swift
@@ -21,8 +21,7 @@ typealias BugReportScreenViewModelType = StateStoreViewModel<BugReportScreenView
 
 class BugReportScreenViewModel: BugReportScreenViewModelType, BugReportScreenViewModelProtocol {
     private let bugReportService: BugReportServiceProtocol
-    private let userID: String?
-    private let deviceID: String?
+    private let userSession: UserSessionProtocol?
     
     private let actionsSubject: PassthroughSubject<BugReportScreenViewModelAction, Never> = .init()
     // periphery:ignore - when set to nil this is automatically cancelled
@@ -33,13 +32,11 @@ class BugReportScreenViewModel: BugReportScreenViewModelType, BugReportScreenVie
     }
     
     init(bugReportService: BugReportServiceProtocol,
-         userID: String?,
-         deviceID: String?,
+         userSession: UserSessionProtocol?,
          screenshot: UIImage?,
          isModallyPresented: Bool) {
         self.bugReportService = bugReportService
-        self.userID = userID
-        self.deviceID = deviceID
+        self.userSession = userSession
         
         let bindings = BugReportScreenViewStateBindings(reportText: "", sendingLogsEnabled: true, canContact: false)
         super.init(initialViewState: BugReportScreenViewState(screenshot: screenshot,
@@ -86,8 +83,12 @@ class BugReportScreenViewModel: BugReportScreenViewModelType, BugReportScreenVie
                 // Continue anyway without the screenshot.
             }
         }
-        let bugReport = BugReport(userID: userID,
-                                  deviceID: deviceID,
+        let ed25519 = await userSession?.clientProxy.ed25519Base64()
+        let curve25519 = await userSession?.clientProxy.curve25519Base64()
+        let bugReport = BugReport(userID: userSession?.userID,
+                                  deviceID: userSession?.deviceID,
+                                  ed25519: ed25519,
+                                  curve25519: curve25519,
                                   text: context.reportText,
                                   includeLogs: context.sendingLogsEnabled,
                                   canContact: context.canContact,

--- a/ElementX/Sources/Screens/BugReportScreen/BugReportScreenViewModel.swift
+++ b/ElementX/Sources/Screens/BugReportScreen/BugReportScreenViewModel.swift
@@ -21,7 +21,7 @@ typealias BugReportScreenViewModelType = StateStoreViewModel<BugReportScreenView
 
 class BugReportScreenViewModel: BugReportScreenViewModelType, BugReportScreenViewModelProtocol {
     private let bugReportService: BugReportServiceProtocol
-    private let userSession: UserSessionProtocol?
+    private let clientProxy: ClientProxyProtocol?
     
     private let actionsSubject: PassthroughSubject<BugReportScreenViewModelAction, Never> = .init()
     // periphery:ignore - when set to nil this is automatically cancelled
@@ -32,11 +32,11 @@ class BugReportScreenViewModel: BugReportScreenViewModelType, BugReportScreenVie
     }
     
     init(bugReportService: BugReportServiceProtocol,
-         userSession: UserSessionProtocol?,
+         clientProxy: ClientProxyProtocol?,
          screenshot: UIImage?,
          isModallyPresented: Bool) {
         self.bugReportService = bugReportService
-        self.userSession = userSession
+        self.clientProxy = clientProxy
         
         let bindings = BugReportScreenViewStateBindings(reportText: "", sendingLogsEnabled: true, canContact: false)
         super.init(initialViewState: BugReportScreenViewState(screenshot: screenshot,
@@ -83,10 +83,10 @@ class BugReportScreenViewModel: BugReportScreenViewModelType, BugReportScreenVie
                 // Continue anyway without the screenshot.
             }
         }
-        let ed25519 = await userSession?.clientProxy.ed25519Base64()
-        let curve25519 = await userSession?.clientProxy.curve25519Base64()
-        let bugReport = BugReport(userID: userSession?.userID,
-                                  deviceID: userSession?.deviceID,
+        let ed25519 = await clientProxy?.ed25519Base64()
+        let curve25519 = await clientProxy?.curve25519Base64()
+        let bugReport = BugReport(userID: clientProxy?.userID,
+                                  deviceID: clientProxy?.deviceID,
                                   ed25519: ed25519,
                                   curve25519: curve25519,
                                   text: context.reportText,

--- a/ElementX/Sources/Screens/BugReportScreen/View/BugReportScreen.swift
+++ b/ElementX/Sources/Screens/BugReportScreen/View/BugReportScreen.swift
@@ -150,11 +150,8 @@ struct BugReport_Previews: PreviewProvider, TestablePreview {
     static var previews: some View {
         NavigationStack {
             let clientProxy = ClientProxyMock(.init(userID: "@mock:client.com", roomSummaryProvider: RoomSummaryProviderMock(.init(state: .loaded(.mockRooms)))))
-            let userSession = MockUserSession(clientProxy: clientProxy,
-                                              mediaProvider: MockMediaProvider(),
-                                              voiceMessageMediaManager: VoiceMessageMediaManagerMock())
             BugReportScreen(context: BugReportScreenViewModel(bugReportService: BugReportServiceMock(),
-                                                              userSession: userSession,
+                                                              clientProxy: clientProxy,
                                                               screenshot: nil,
                                                               isModallyPresented: false).context)
                 .previewDisplayName("Without Screenshot")
@@ -162,11 +159,8 @@ struct BugReport_Previews: PreviewProvider, TestablePreview {
         
         NavigationStack {
             let clientProxy = ClientProxyMock(.init(userID: "@mock:client.com", roomSummaryProvider: RoomSummaryProviderMock(.init(state: .loaded(.mockRooms)))))
-            let userSession = MockUserSession(clientProxy: clientProxy,
-                                              mediaProvider: MockMediaProvider(),
-                                              voiceMessageMediaManager: VoiceMessageMediaManagerMock())
             BugReportScreen(context: BugReportScreenViewModel(bugReportService: BugReportServiceMock(),
-                                                              userSession: userSession,
+                                                              clientProxy: clientProxy,
                                                               screenshot: Asset.Images.appLogo.image,
                                                               isModallyPresented: false).context)
                 .previewDisplayName("With Screenshot")

--- a/ElementX/Sources/Screens/BugReportScreen/View/BugReportScreen.swift
+++ b/ElementX/Sources/Screens/BugReportScreen/View/BugReportScreen.swift
@@ -149,18 +149,24 @@ struct BugReportScreen: View {
 struct BugReport_Previews: PreviewProvider, TestablePreview {
     static var previews: some View {
         NavigationStack {
+            let clientProxy = ClientProxyMock(.init(userID: "@mock:client.com", roomSummaryProvider: RoomSummaryProviderMock(.init(state: .loaded(.mockRooms)))))
+            let userSession = MockUserSession(clientProxy: clientProxy,
+                                              mediaProvider: MockMediaProvider(),
+                                              voiceMessageMediaManager: VoiceMessageMediaManagerMock())
             BugReportScreen(context: BugReportScreenViewModel(bugReportService: BugReportServiceMock(),
-                                                              userID: "@mock.client.com",
-                                                              deviceID: nil,
+                                                              userSession: userSession,
                                                               screenshot: nil,
                                                               isModallyPresented: false).context)
                 .previewDisplayName("Without Screenshot")
         }
         
         NavigationStack {
+            let clientProxy = ClientProxyMock(.init(userID: "@mock:client.com", roomSummaryProvider: RoomSummaryProviderMock(.init(state: .loaded(.mockRooms)))))
+            let userSession = MockUserSession(clientProxy: clientProxy,
+                                              mediaProvider: MockMediaProvider(),
+                                              voiceMessageMediaManager: VoiceMessageMediaManagerMock())
             BugReportScreen(context: BugReportScreenViewModel(bugReportService: BugReportServiceMock(),
-                                                              userID: "@mock.client.com",
-                                                              deviceID: nil,
+                                                              userSession: userSession,
                                                               screenshot: Asset.Images.appLogo.image,
                                                               isModallyPresented: false).context)
                 .previewDisplayName("With Screenshot")

--- a/ElementX/Sources/Services/BugReport/BugReportService.swift
+++ b/ElementX/Sources/Services/BugReport/BugReportService.swift
@@ -127,6 +127,11 @@ class BugReportService: NSObject, BugReportServiceProtocol {
             params.append(.init(key: "device_id", type: .text(value: deviceID)))
         }
         
+        if let ed25519 = bugReport.ed25519, let curve25519 = bugReport.curve25519 {
+            let compactKeys = "curve25519:\(curve25519), ed25519:\(ed25519)"
+            params.append(.init(key: "device_keys", type: .text(value: compactKeys)))
+        }
+        
         params.append(contentsOf: defaultParams)
         
         for label in bugReport.githubLabels {

--- a/ElementX/Sources/Services/BugReport/BugReportServiceProtocol.swift
+++ b/ElementX/Sources/Services/BugReport/BugReportServiceProtocol.swift
@@ -21,6 +21,8 @@ import UIKit
 struct BugReport: Equatable {
     let userID: String?
     let deviceID: String?
+    let ed25519: String?
+    let curve25519: String?
     let text: String
     let includeLogs: Bool
     let canContact: Bool

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -803,6 +803,16 @@ class ClientProxy: ClientProxyProtocol {
             }
         }
     }
+    
+    // MARK: - Encryption
+    
+    func ed25519Base64() async -> String? {
+        await client.encryption().ed25519Key()
+    }
+    
+    func curve25519Base64() async -> String? {
+        await client.encryption().curve25519Key()
+    }
 }
 
 extension ClientProxy: MediaLoaderProtocol {

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -174,4 +174,9 @@ protocol ClientProxyProtocol: AnyObject, MediaLoaderProtocol {
     func recentlyVisitedRooms() async -> Result<[String], ClientProxyError>
     
     func recentConversationCounterparts() async -> [UserProfileProxy]
+    
+    // MARK: - Encryption Info
+    
+    func ed25519Base64() async -> String?
+    func curve25519Base64() async -> String?
 }

--- a/ElementX/Sources/UITests/UITestsAppCoordinator.swift
+++ b/ElementX/Sources/UITests/UITestsAppCoordinator.swift
@@ -228,9 +228,12 @@ class MockScreen: Identifiable {
             return navigationStackCoordinator
         case .bugReport:
             let navigationStackCoordinator = NavigationStackCoordinator()
+            let clientProxy = ClientProxyMock(.init(userID: "@mock:client.com", roomSummaryProvider: RoomSummaryProviderMock(.init(state: .loaded(.mockRooms)))))
+            let userSession = MockUserSession(clientProxy: clientProxy,
+                                              mediaProvider: MockMediaProvider(),
+                                              voiceMessageMediaManager: VoiceMessageMediaManagerMock())
             let coordinator = BugReportScreenCoordinator(parameters: .init(bugReportService: BugReportServiceMock(),
-                                                                           userID: "@mock:client.com",
-                                                                           deviceID: nil,
+                                                                           userSession: userSession,
                                                                            userIndicatorController: nil,
                                                                            screenshot: nil,
                                                                            isModallyPresented: true))

--- a/UnitTests/Sources/BugReportServiceTests.swift
+++ b/UnitTests/Sources/BugReportServiceTests.swift
@@ -37,6 +37,8 @@ class BugReportServiceTests: XCTestCase {
     func testSubmitBugReportWithMockService() async throws {
         let bugReport = BugReport(userID: "@mock:client.com",
                                   deviceID: nil,
+                                  ed25519: nil,
+                                  curve25519: nil,
                                   text: "i cannot send message",
                                   includeLogs: true,
                                   canContact: false,
@@ -67,6 +69,8 @@ class BugReportServiceTests: XCTestCase {
 
         let bugReport = BugReport(userID: "@mock:client.com",
                                   deviceID: nil,
+                                  ed25519: nil,
+                                  curve25519: nil,
                                   text: "i cannot send message",
                                   includeLogs: true,
                                   canContact: false,

--- a/changelog.d/2550.misc
+++ b/changelog.d/2550.misc
@@ -1,0 +1,1 @@
+Rageshake | Add device public curve25519 and ed25519 keys info to rageshake.


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-x-ios/issues/2550

Draft because depends on https://github.com/matrix-org/matrix-rust-sdk/pull/3420

Sample RS containing the device keys https://github.com/element-hq/element-x-ios-rageshakes/issues/1807

We want to add curve25519/ed25519 device keys in rageshakes to help debugging unable to decrypt issues.
Will appear like that in the RS
```
device_keys: curve25519:GJ1N4ps7v9+1SXMZ6fNXCk/skwBrVaDbepCJ9lZ5HyY, ed25519:rurFYehF4BKjkCGrTQhIrZb1LuQlbDKXOrF42f39dh8
```

This info was not available in the bindings, so added it (see rust PR), they can be accessed via `client.encryption().ed25519Key()`

Previously the `BugReportScreenCoordinatorParameters` was just having a list of params for `userID`, `deviceID`. Couldn't just add the 2 new ones easilly because they require an async call. So now the userSessionProtocol is passed as a parameter, the Rageshake submit code can then just access what it needs (userId, deviceId, curve25519, ed25519). 
I think it make sense to pass it anyhow, because there could be more things to get from the userSession when submitting a rageshake.


### Pull Request Checklist

- [ ] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
