### PR TITLE
Add support for showing the native OS incoming call screen when starting new Element Calls

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -296,6 +296,7 @@
 		4799A852132F1744E2825994 /* CreateRoomViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340179A0FC1AD4AEDA7FC134 /* CreateRoomViewModelProtocol.swift */; };
 		47FF70C051A991FB65CDBCF3 /* RoomScreenInteractionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0135A608FFAD86E6674EE730 /* RoomScreenInteractionHandler.swift */; };
 		4807E8F51DB54F56B25E1C7E /* AppLockSetupSettingsScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8C38663020DF2EB2D13F5E /* AppLockSetupSettingsScreenViewModel.swift */; };
+		48416BBEB8DDF3E4DED0EDB6 /* ElementCallServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC8B21E86B137BE4E91F82A /* ElementCallServiceProtocol.swift */; };
 		484202C5D50983442D24D061 /* AttributedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BD6ED18E2EB61E28C340AD /* AttributedString.swift */; };
 		489BB6A733D3DA0FE7062650 /* IdentityConfirmationScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C71B9802433F1B4252291BB /* IdentityConfirmationScreenViewModelProtocol.swift */; };
 		491D62ACD19E6F134B1766AF /* RoomNotificationSettingsUserDefinedScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3203C6566DC17B7AECC1B7FD /* RoomNotificationSettingsUserDefinedScreen.swift */; };
@@ -361,6 +362,7 @@
 		565868808A1DA565707394ED /* CurrentValuePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 127C8472672A5BA09EF1ACF8 /* CurrentValuePublisher.swift */; };
 		56F0A22972A3BB519DA2261C /* HomeScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F5530B2212862FA4BEFF2D /* HomeScreenViewModelProtocol.swift */; };
 		5710AAB27D5D866292C1FE06 /* SessionVerificationScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF848B41DAF1066F3054D4A1 /* SessionVerificationScreenModels.swift */; };
+		5732395A4F71F51F9C754C5A /* ElementCallService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AE897D86784CCA5E4E9227 /* ElementCallService.swift */; };
 		5780E444F405AA1304E1C23E /* DeveloperOptionsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E521D6C2BF8DF0DFB35146 /* DeveloperOptionsScreen.swift */; };
 		57E115A8C33E599DE564F8C3 /* TimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEB27575FEBCF414D4DEE31 /* TimelineView.swift */; };
 		588411C8FD72B2A2DFE5F7DE /* XCUIElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = E992D7B8BE54B2AB454613AF /* XCUIElement.swift */; };
@@ -441,6 +443,7 @@
 		6AECC84BE14A13440120FED8 /* NSESettingsProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB4F169D653296023ED65E6 /* NSESettingsProtocol.swift */; };
 		6B05AA5D9BBCD6D8D63B80EB /* TimelineItemAccessibilityModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C6F3DAD167F972702C8893 /* TimelineItemAccessibilityModifier.swift */; };
 		6B31508C6334C617360C2EAB /* RoomMemberDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC589E641AE46EFB2962534D /* RoomMemberDetailsViewModelTests.swift */; };
+		6B67AC7AA41136FC9804C136 /* ElementCallServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC8B21E86B137BE4E91F82A /* ElementCallServiceProtocol.swift */; };
 		6BAD956B909A6E29F6CC6E7C /* ButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC23C63849452BC86EA2852 /* ButtonStyle.swift */; };
 		6BB6944443C421C722ED1E7D /* portrait_test_video.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = F2D513D2477B57F90E98EEC0 /* portrait_test_video.mp4 */; };
 		6C34237AFB808E38FC8776B9 /* RoomStateEventStringBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D55702474F279D910D2D162 /* RoomStateEventStringBuilder.swift */; };
@@ -1331,6 +1334,7 @@
 		32C5DAA1773F57653BF1C4F9 /* SoftLogoutViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoftLogoutViewModelTests.swift; sourceTree = "<group>"; };
 		330AF4D121C3396F7A14B21D /* id */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = id; path = id.lproj/SAS.strings; sourceTree = "<group>"; };
 		3368395F06AA180138E185B6 /* PollFormScreenUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollFormScreenUITests.swift; sourceTree = "<group>"; };
+		33AE897D86784CCA5E4E9227 /* ElementCallService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementCallService.swift; sourceTree = "<group>"; };
 		33E49C5C6F802B4D94CA78D1 /* ro */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ro; path = ro.lproj/Localizable.strings; sourceTree = "<group>"; };
 		340179A0FC1AD4AEDA7FC134 /* CreateRoomViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateRoomViewModelProtocol.swift; sourceTree = "<group>"; };
 		342BEBC3C5FC3F9943C41C4C /* TemplateScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateScreenViewModelProtocol.swift; sourceTree = "<group>"; };
@@ -1558,6 +1562,7 @@
 		6F3DFE5B444F131648066F05 /* StateStoreViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateStoreViewModel.swift; sourceTree = "<group>"; };
 		6F6E6EDC4BBF962B2ED595A4 /* MessageForwardingScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageForwardingScreenViewModelTests.swift; sourceTree = "<group>"; };
 		6FC5015B9634698BDB8701AF /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = it; path = it.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		6FC8B21E86B137BE4E91F82A /* ElementCallServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementCallServiceProtocol.swift; sourceTree = "<group>"; };
 		7023EB4F3B7C7D1FBA68638B /* TimelineItemDebugView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineItemDebugView.swift; sourceTree = "<group>"; };
 		7061BE2C0BF427C38AEDEF5E /* SecureBackupRecoveryKeyScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureBackupRecoveryKeyScreenViewModel.swift; sourceTree = "<group>"; };
 		70C86696AC9521F8ED88FBEB /* MediaUploadPreviewScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaUploadPreviewScreen.swift; sourceTree = "<group>"; };
@@ -4021,6 +4026,8 @@
 		92E99C57D7F92ED16F73282C /* ElementCall */ = {
 			isa = PBXGroup;
 			children = (
+				33AE897D86784CCA5E4E9227 /* ElementCallService.swift */,
+				6FC8B21E86B137BE4E91F82A /* ElementCallServiceProtocol.swift */,
 				309AD8BAE6437C31BA7157BF /* ElementCallWidgetDriver.swift */,
 				A6C11AD9813045E44F950410 /* ElementCallWidgetDriverProtocol.swift */,
 			);
@@ -5623,6 +5630,7 @@
 				B5618E3C948584E5C1F67033 /* DTHTMLElement+AttributedStringBuilder.swift in Sources */,
 				DFCA89C4EC2A5332ED6B441F /* DataProtectionManager.swift in Sources */,
 				24A75F72EEB7561B82D726FD /* Date.swift in Sources */,
+				6B67AC7AA41136FC9804C136 /* ElementCallServiceProtocol.swift in Sources */,
 				CFEC53440C572CEEABC4A6A0 /* ElementXAttributeScope.swift in Sources */,
 				A33784831AD880A670CAA9F9 /* FileManager.swift in Sources */,
 				59F940FCBE6BC343AECEF75E /* ImageCache.swift in Sources */,
@@ -5972,6 +5980,8 @@
 				2955F4C160CFD7794D819C64 /* EffectsScene.swift in Sources */,
 				AE1160076F663BF14E0E893A /* EffectsView.swift in Sources */,
 				FE4593FC2A02AAF92E089565 /* ElementAnimations.swift in Sources */,
+				5732395A4F71F51F9C754C5A /* ElementCallService.swift in Sources */,
+				48416BBEB8DDF3E4DED0EDB6 /* ElementCallServiceProtocol.swift in Sources */,
 				07CC13C5729C24255348CBBD /* ElementCallWidgetDriver.swift in Sources */,
 				370AF5BFCD4384DD455479B6 /* ElementCallWidgetDriverProtocol.swift in Sources */,
 				7C1A7B594B2F8143F0DD0005 /* ElementXAttributeScope.swift in Sources */,
@@ -7313,7 +7323,7 @@
 			repositoryURL = "https://github.com/element-hq/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 1.0.2;
+				version = 1.0.3;
 			};
 		};
 		701C7BEF8F70F7A83E852DCC /* XCRemoteSwiftPackageReference "GZIP" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -3,7 +3,7 @@
     {
       "identity" : "compound-design-tokens",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/element-hq/compound-design-tokens",
+      "location" : "https://github.com/element-hq/compound-design-tokens.git",
       "state" : {
         "revision" : "c3fff1f2b042295cd5f4bcf8d4fe68ec47ca4061",
         "version" : "1.2.0"
@@ -139,8 +139,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/matrix-rust-components-swift",
       "state" : {
-        "revision" : "e87ffe044e74a74930386c2185f5fbcfce3c7877",
-        "version" : "1.0.2"
+        "revision" : "4e74b98191dbbc36025b23baa6cc272298e59de5",
+        "version" : "1.0.3"
       }
     },
     {
@@ -191,7 +191,7 @@
     {
       "identity" : "sfsafesymbols",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SFSafeSymbols/SFSafeSymbols",
+      "location" : "https://github.com/SFSafeSymbols/SFSafeSymbols.git",
       "state" : {
         "revision" : "7cca2d60925876b5953a2cf7341cd80fbeac983c",
         "version" : "4.1.1"

--- a/ElementX/Sources/Application/Navigation/AppRoutes.swift
+++ b/ElementX/Sources/Application/Navigation/AppRoutes.swift
@@ -44,6 +44,8 @@ enum AppRoute: Equatable {
     case childEventOnRoomAlias(eventID: String, alias: String)
     /// The profile of a matrix user (outside of a room).
     case userProfile(userID: String)
+    /// An Element Call running in a particular room
+    case call(roomID: String)
     /// An Element Call link generated outside of a chat room.
     case genericCallLink(url: URL)
     /// The settings screen.

--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -168,7 +168,7 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
             }
         case .roomAlias, .childRoomAlias, .eventOnRoomAlias, .childEventOnRoomAlias:
             break // These are converted to a room ID route one level above.
-        case .roomList, .userProfile, .genericCallLink, .oidcCallback, .settings, .chatBackupSettings:
+        case .roomList, .userProfile, .call, .genericCallLink, .oidcCallback, .settings, .chatBackupSettings:
             break // These routes can't be handled.
         }
     }

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -4313,6 +4313,11 @@ class ElementCallServiceMock: ElementCallServiceProtocol {
     }
 }
 class ElementCallWidgetDriverMock: ElementCallWidgetDriverProtocol {
+    var widgetID: String {
+        get { return underlyingWidgetID }
+        set(value) { underlyingWidgetID = value }
+    }
+    var underlyingWidgetID: String!
     var messagePublisher: PassthroughSubject<String, Never> {
         get { return underlyingMessagePublisher }
         set(value) { underlyingMessagePublisher = value }

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -4230,6 +4230,88 @@ class CompletionSuggestionServiceMock: CompletionSuggestionServiceProtocol {
         setSuggestionTriggerClosure?(suggestionTrigger)
     }
 }
+class ElementCallServiceMock: ElementCallServiceProtocol {
+    var actions: AnyPublisher<ElementCallServiceAction, Never> {
+        get { return underlyingActions }
+        set(value) { underlyingActions = value }
+    }
+    var underlyingActions: AnyPublisher<ElementCallServiceAction, Never>!
+
+    //MARK: - setupCallSession
+
+    var setupCallSessionTitleUnderlyingCallsCount = 0
+    var setupCallSessionTitleCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return setupCallSessionTitleUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = setupCallSessionTitleUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                setupCallSessionTitleUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    setupCallSessionTitleUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var setupCallSessionTitleCalled: Bool {
+        return setupCallSessionTitleCallsCount > 0
+    }
+    var setupCallSessionTitleReceivedTitle: String?
+    var setupCallSessionTitleReceivedInvocations: [String] = []
+    var setupCallSessionTitleClosure: ((String) async -> Void)?
+
+    func setupCallSession(title: String) async {
+        setupCallSessionTitleCallsCount += 1
+        setupCallSessionTitleReceivedTitle = title
+        setupCallSessionTitleReceivedInvocations.append(title)
+        await setupCallSessionTitleClosure?(title)
+    }
+    //MARK: - tearDownCallSession
+
+    var tearDownCallSessionUnderlyingCallsCount = 0
+    var tearDownCallSessionCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return tearDownCallSessionUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = tearDownCallSessionUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                tearDownCallSessionUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    tearDownCallSessionUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var tearDownCallSessionCalled: Bool {
+        return tearDownCallSessionCallsCount > 0
+    }
+    var tearDownCallSessionClosure: (() -> Void)?
+
+    func tearDownCallSession() {
+        tearDownCallSessionCallsCount += 1
+        tearDownCallSessionClosure?()
+    }
+}
 class ElementCallWidgetDriverMock: ElementCallWidgetDriverProtocol {
     var messagePublisher: PassthroughSubject<String, Never> {
         get { return underlyingMessagePublisher }
@@ -9778,6 +9860,70 @@ class RoomProxyMock: RoomProxyProtocol {
             return elementCallWidgetDriverClosure()
         } else {
             return elementCallWidgetDriverReturnValue
+        }
+    }
+    //MARK: - sendCallNotificationIfNeeeded
+
+    var sendCallNotificationIfNeeededUnderlyingCallsCount = 0
+    var sendCallNotificationIfNeeededCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return sendCallNotificationIfNeeededUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = sendCallNotificationIfNeeededUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                sendCallNotificationIfNeeededUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    sendCallNotificationIfNeeededUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var sendCallNotificationIfNeeededCalled: Bool {
+        return sendCallNotificationIfNeeededCallsCount > 0
+    }
+
+    var sendCallNotificationIfNeeededUnderlyingReturnValue: Result<Void, RoomProxyError>!
+    var sendCallNotificationIfNeeededReturnValue: Result<Void, RoomProxyError>! {
+        get {
+            if Thread.isMainThread {
+                return sendCallNotificationIfNeeededUnderlyingReturnValue
+            } else {
+                var returnValue: Result<Void, RoomProxyError>? = nil
+                DispatchQueue.main.sync {
+                    returnValue = sendCallNotificationIfNeeededUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                sendCallNotificationIfNeeededUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    sendCallNotificationIfNeeededUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    var sendCallNotificationIfNeeededClosure: (() async -> Result<Void, RoomProxyError>)?
+
+    func sendCallNotificationIfNeeeded() async -> Result<Void, RoomProxyError> {
+        sendCallNotificationIfNeeededCallsCount += 1
+        if let sendCallNotificationIfNeeededClosure = sendCallNotificationIfNeeededClosure {
+            return await sendCallNotificationIfNeeededClosure()
+        } else {
+            return sendCallNotificationIfNeeededReturnValue
         }
     }
     //MARK: - matrixToPermalink

--- a/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilder.swift
+++ b/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilder.swift
@@ -143,6 +143,7 @@ struct AttributedStringBuilder: AttributedStringBuilderProtocol {
         attributedString.removeAttribute(.foregroundColor, range: .init(location: 0, length: attributedString.length))
     }
     
+    // swiftlint:disable:next cyclomatic_complexity
     private func addLinksAndMentions(_ attributedString: NSMutableAttributedString) {
         let string = attributedString.string
         

--- a/ElementX/Sources/Screens/CallScreen/CallScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenCoordinator.swift
@@ -18,10 +18,9 @@ import Combine
 import SwiftUI
 
 struct CallScreenCoordinatorParameters {
+    let elementCallService: ElementCallServiceProtocol
     let roomProxy: RoomProxyProtocol
-    /// Which Element Call instance should be used
     let callBaseURL: URL
-    /// A way to identify the current client against Element Call
     let clientID: String
 }
 
@@ -39,7 +38,8 @@ final class CallScreenCoordinator: CoordinatorProtocol {
     }
     
     init(parameters: CallScreenCoordinatorParameters) {
-        viewModel = CallScreenViewModel(roomProxy: parameters.roomProxy,
+        viewModel = CallScreenViewModel(elementCallService: parameters.elementCallService,
+                                        roomProxy: parameters.roomProxy,
                                         callBaseURL: parameters.callBaseURL,
                                         clientID: parameters.clientID)
     }

--- a/ElementX/Sources/Screens/CallScreen/CallScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenCoordinator.swift
@@ -55,6 +55,10 @@ final class CallScreenCoordinator: CoordinatorProtocol {
         }
         .store(in: &cancellables)
     }
+    
+    func stop() {
+        viewModel.stop()
+    }
         
     func toPresentable() -> AnyView {
         AnyView(CallScreen(context: viewModel.context))

--- a/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
@@ -14,7 +14,6 @@
 // limitations under the License.
 //
 
-import AVFoundation
 import CallKit
 import Combine
 import SwiftUI
@@ -22,15 +21,10 @@ import SwiftUI
 typealias CallScreenViewModelType = StateStoreViewModel<CallScreenViewState, CallScreenViewAction>
 
 class CallScreenViewModel: CallScreenViewModelType, CallScreenViewModelProtocol {
+    private let elementCallService: ElementCallServiceProtocol
     private let roomProxy: RoomProxyProtocol
     
     private let widgetDriver: ElementCallWidgetDriverProtocol
-    
-    private let callController = CXCallController()
-    // periphery: ignore - call kit magic do not remove
-    private let callProvider = CXProvider(configuration: .init())
-    
-    private let callID = UUID()
     
     private let actionsSubject: PassthroughSubject<CallScreenViewModelAction, Never> = .init()
     var actions: AnyPublisher<CallScreenViewModelAction, Never> {
@@ -38,17 +32,20 @@ class CallScreenViewModel: CallScreenViewModelType, CallScreenViewModelProtocol 
     }
     
     deinit {
-        tearDownVoIPSession(callID: callID)
+        elementCallService.tearDownCallSession()
     }
     
     /// Designated initialiser
     /// - Parameters:
+    ///   - elementCallService: service responsible for setting up CallKit
     ///   - roomProxy: The room in which the call should be created
     ///   - callBaseURL: Which Element Call instance should be used
     ///   - clientID: Something to identify the current client on the Element Call side
-    init(roomProxy: RoomProxyProtocol,
+    init(elementCallService: ElementCallServiceProtocol,
+         roomProxy: RoomProxyProtocol,
          callBaseURL: URL,
          clientID: String) {
+        self.elementCallService = elementCallService
         self.roomProxy = roomProxy
         
         widgetDriver = roomProxy.elementCallWidgetDriver()
@@ -109,11 +106,9 @@ class CallScreenViewModel: CallScreenViewModelType, CallScreenViewModelProtocol 
                 return
             }
             
-            do {
-                try await setupVoIPSession(callID: callID)
-            } catch {
-                MXLog.error("Failed setting up VoIP session with error: \(error)")
-            }
+            await elementCallService.setupCallSession(title: roomProxy.roomTitle)
+            
+            let _ = await roomProxy.sendCallNotificationIfNeeeded()
         }
     }
     
@@ -123,20 +118,6 @@ class CallScreenViewModel: CallScreenViewModelType, CallScreenViewModelProtocol 
             guard let url else { return }
             MXLog.info("URL changed to: \(url)")
         }
-    }
-    
-    // MARK: - CXCallObserverDelegate
-    
-    // periphery: ignore - call kit magic do not remove
-    func callObserver(_ callObserver: CXCallObserver, callChanged call: CXCall) {
-        MXLog.info("Call changed: \(call)")
-    }
-    
-    // MARK: - CXProviderDelegate
-    
-    // periphery: ignore - call kit magic do not remove
-    func providerDidReset(_ provider: CXProvider) {
-        MXLog.info("Call provider did reset: \(provider)")
     }
     
     // MARK: - Private
@@ -159,35 +140,5 @@ class CallScreenViewModel: CallScreenViewModelType, CallScreenViewModelProtocol 
             false,
           );
         """
-    }
-    
-    private func setupVoIPSession(callID: UUID) async throws {
-        try AVAudioSession.sharedInstance().setCategory(.playAndRecord, mode: .videoChat, options: [])
-        try AVAudioSession.sharedInstance().setActive(true, options: .notifyOthersOnDeactivation)
-        
-        let handle = CXHandle(type: .generic, value: roomProxy.roomTitle)
-        let startCallAction = CXStartCallAction(call: callID, handle: handle)
-        startCallAction.isVideo = true
-        
-        let transaction = CXTransaction(action: startCallAction)
-        
-        try await callController.request(transaction)
-    }
-    
-    private nonisolated func tearDownVoIPSession(callID: UUID?) {
-        guard let callID else {
-            return
-        }
-        
-        try? AVAudioSession.sharedInstance().setActive(false)
-            
-        let endCallAction = CXEndCallAction(call: callID)
-        let transaction = CXTransaction(action: endCallAction)
-        
-        callController.request(transaction) { error in
-            if let error {
-                MXLog.error("Failed transaction with error: \(error)")
-            }
-        }
     }
 }

--- a/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
@@ -31,10 +31,6 @@ class CallScreenViewModel: CallScreenViewModelType, CallScreenViewModelProtocol 
         actionsSubject.eraseToAnyPublisher()
     }
     
-    deinit {
-        elementCallService.tearDownCallSession()
-    }
-    
     /// Designated initialiser
     /// - Parameters:
     ///   - elementCallService: service responsible for setting up CallKit
@@ -120,7 +116,28 @@ class CallScreenViewModel: CallScreenViewModelType, CallScreenViewModelProtocol 
         }
     }
     
+    func stop() {
+        Task {
+            await hangUp()
+        }
+        
+        elementCallService.tearDownCallSession()
+    }
+    
     // MARK: - Private
+    
+    private func hangUp() async {
+        let hangUpMessage = """
+        "api":"toWidget",
+        "widgetId":"\(widgetDriver.widgetID)",
+        "requestId":"widgetapi-\(UUID())",
+        "action":"im.vector.hangup",
+        "data":{}
+        """
+        
+        let result = await widgetDriver.sendMessage(hangUpMessage)
+        MXLog.error("Result yo: \(result)")
+    }
 
     private static let eventHandlerName = "elementx"
     

--- a/ElementX/Sources/Screens/CallScreen/CallScreenViewModelProtocol.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenViewModelProtocol.swift
@@ -20,4 +20,6 @@ import Combine
 protocol CallScreenViewModelProtocol {
     var actions: AnyPublisher<CallScreenViewModelAction, Never> { get }
     var context: CallScreenViewModelType.Context { get }
+    
+    func stop()
 }

--- a/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
+++ b/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
@@ -167,7 +167,8 @@ struct CallScreen_Previews: PreviewProvider {
         
         roomProxy.elementCallWidgetDriverReturnValue = widgetDriver
         
-        return CallScreenViewModel(roomProxy: roomProxy,
+        return CallScreenViewModel(elementCallService: ElementCallServiceMock(),
+                                   roomProxy: roomProxy,
                                    callBaseURL: "https://call.element.io",
                                    clientID: "io.element.elementx")
     }()

--- a/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
+++ b/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
@@ -53,8 +53,8 @@ private struct WebView: UIViewRepresentable {
     }
     
     @MainActor
-    class Coordinator: NSObject, WKScriptMessageHandler, WKUIDelegate, WKNavigationDelegate {
-        private let viewModelContext: CallScreenViewModel.Context
+    class Coordinator: NSObject, WKUIDelegate, WKNavigationDelegate {
+        private weak var viewModelContext: CallScreenViewModel.Context?
         
         private(set) var webView: WKWebView!
         
@@ -73,7 +73,7 @@ private struct WebView: UIViewRepresentable {
             let configuration = WKWebViewConfiguration()
             
             let userContentController = WKUserContentController()
-            userContentController.add(self, name: viewModelContext.viewState.messageHandler)
+            userContentController.add(WKScriptMessageHandlerWrapper(self), name: viewModelContext.viewState.messageHandler)
             
             configuration.userContentController = userContentController
             configuration.allowsInlineMediaPlayback = true
@@ -98,8 +98,8 @@ private struct WebView: UIViewRepresentable {
             // After testing different scenarios it seems that when using async/await version of these
             // methods wkwebView expects JavaScript to return with a value (something other than Void),
             // if there is no value returning from the JavaScript that you evaluate you will have a crash.
-            try await withCheckedThrowingContinuation { continuaton in
-                webView.evaluateJavaScript(script) { result, error in
+            try await withCheckedThrowingContinuation { [weak self] continuaton in
+                self?.webView.evaluateJavaScript(script) { result, error in
                     if let error {
                         continuaton.resume(throwing: error)
                     } else {
@@ -109,12 +109,10 @@ private struct WebView: UIViewRepresentable {
             }
         }
         
-        // MARK: - WKScriptMessageHandler
-        
         nonisolated func userContentController(_ userContentController: WKUserContentController,
                                                didReceive message: WKScriptMessage) {
-            Task { @MainActor in
-                viewModelContext.javaScriptMessageHandler?(message.body)
+            Task { @MainActor [weak self] in
+                self?.viewModelContext?.javaScriptMessageHandler?(message.body)
             }
         }
         
@@ -148,8 +146,24 @@ private struct WebView: UIViewRepresentable {
         
         nonisolated func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
             Task { @MainActor in
-                viewModelContext.send(viewAction: .urlChanged(webView.url))
+                viewModelContext?.send(viewAction: .urlChanged(webView.url))
             }
+        }
+    }
+    
+    /// Avoids retain loops between the configuration and webView coordinator
+    private class WKScriptMessageHandlerWrapper: NSObject, WKScriptMessageHandler {
+        private weak var coordinator: Coordinator?
+        
+        init(_ coordinator: Coordinator) {
+            self.coordinator = coordinator
+        }
+        
+        // MARK: - WKScriptMessageHandler
+        
+        nonisolated func userContentController(_ userContentController: WKUserContentController,
+                                               didReceive message: WKScriptMessage) {
+            coordinator?.userContentController(userContentController, didReceive: message)
         }
     }
 }

--- a/ElementX/Sources/Services/ElementCall/ElementCallService.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallService.swift
@@ -1,0 +1,158 @@
+//
+// Copyright 2024 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import AVFoundation
+import CallKit
+import Combine
+import Foundation
+import PushKit
+
+class ElementCallService: NSObject, ElementCallServiceProtocol, PKPushRegistryDelegate, CXProviderDelegate {
+    private let pushRegistry: PKPushRegistry
+    
+    private let callController = CXCallController()
+
+    private var callProvider: CXProvider?
+    private var ongoingCallID: UUID?
+    
+    private var incomingCallRoomID: String?
+    
+    private let actionsSubject: PassthroughSubject<ElementCallServiceAction, Never> = .init()
+    var actions: AnyPublisher<ElementCallServiceAction, Never> {
+        actionsSubject.eraseToAnyPublisher()
+    }
+    
+    override init() {
+        pushRegistry = PKPushRegistry(queue: nil)
+        
+        super.init()
+        
+        pushRegistry.delegate = self
+        pushRegistry.desiredPushTypes = [.voIP]
+    }
+    
+    func setupCallSession(title: String) async {
+        guard ongoingCallID == nil else {
+            return
+        }
+        
+        let callID = UUID()
+        ongoingCallID = callID
+        
+        let handle = CXHandle(type: .generic, value: title)
+        let startCallAction = CXStartCallAction(call: callID, handle: handle)
+        startCallAction.isVideo = true
+        
+        let transaction = CXTransaction(action: startCallAction)
+        
+        do {
+            try await callController.request(transaction)
+            try AVAudioSession.sharedInstance().setCategory(.playAndRecord, mode: .videoChat, options: [])
+            try AVAudioSession.sharedInstance().setActive(true, options: .notifyOthersOnDeactivation)
+        } catch {
+            MXLog.error("Failed setting up VoIP session with error: \(error)")
+            tearDownCallSession()
+        }
+    }
+    
+    func tearDownCallSession() {
+        guard let ongoingCallID else {
+            return
+        }
+        
+        try? AVAudioSession.sharedInstance().setActive(false)
+            
+        let endCallAction = CXEndCallAction(call: ongoingCallID)
+        let transaction = CXTransaction(action: endCallAction)
+        
+        callController.request(transaction) { error in
+            if let error {
+                MXLog.error("Failed transaction with error: \(error)")
+            }
+        }
+    }
+
+    // MARK: - PKPushRegistryDelegate
+    
+    func pushRegistry(_ registry: PKPushRegistry, didUpdate pushCredentials: PKPushCredentials, for type: PKPushType) { }
+    
+    func pushRegistry(_ registry: PKPushRegistry, didReceiveIncomingPushWith payload: PKPushPayload, for type: PKPushType, completion: @escaping () -> Void) {
+        guard let roomID = payload.dictionaryPayload[ElementCallServiceNotificationKey.roomID.rawValue] as? String else {
+            MXLog.error("Somethnig went wrong, missing room identifier for incoming voip call: \(payload)")
+            return
+        }
+        
+        let callID = UUID()
+        ongoingCallID = callID
+        
+        incomingCallRoomID = roomID
+        
+        let configuration = CXProviderConfiguration()
+        configuration.supportsVideo = true
+        configuration.includesCallsInRecents = false
+        
+        let update = CXCallUpdate()
+        update.hasVideo = true
+        
+        update.localizedCallerName = payload.dictionaryPayload[ElementCallServiceNotificationKey.roomDisplayName.rawValue] as? String
+        
+        if let senderDisplayName = payload.dictionaryPayload[ElementCallServiceNotificationKey.senderDisplayName.rawValue] as? String {
+            update.remoteHandle = .init(type: .generic, value: senderDisplayName)
+        } else if let senderID = payload.dictionaryPayload[ElementCallServiceNotificationKey.senderID.rawValue] as? String {
+            update.remoteHandle = .init(type: .generic, value: senderID)
+        } else {
+            MXLog.error("Something went wrong, both the user display name and ID are nil")
+        }
+        
+        let callProvider = CXProvider(configuration: configuration)
+        callProvider.setDelegate(self, queue: nil)
+        callProvider.reportNewIncomingCall(with: callID, update: update) { error in
+            if let error {
+                MXLog.error("Failed reporting new incoming call with error: \(error)")
+            }
+            
+            completion()
+        }
+    }
+    
+    // MARK: - CXProviderDelegate
+    
+    func providerDidReset(_ provider: CXProvider) {
+        MXLog.info("Call provider did reset: \(provider)")
+    }
+    
+    func provider(_ provider: CXProvider, perform action: CXAnswerCallAction) {
+        if let incomingCallRoomID {
+            actionsSubject.send(.answerCall(roomID: incomingCallRoomID))
+            self.incomingCallRoomID = nil
+        } else {
+            MXLog.error("Failed answering incoming call, missing room ID")
+        }
+        
+        action.fulfill()
+    }
+    
+    func provider(_ provider: CXProvider, perform action: CXEndCallAction) {
+        if let incomingCallRoomID {
+            actionsSubject.send(.declineCall(roomID: incomingCallRoomID))
+            self.incomingCallRoomID = nil
+        } else {
+            MXLog.error("Failed declining incoming call, missing room ID")
+        }
+
+        action.fulfill()
+    }
+}

--- a/ElementX/Sources/Services/ElementCall/ElementCallServiceProtocol.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallServiceProtocol.swift
@@ -1,0 +1,40 @@
+//
+// Copyright 2024 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Combine
+
+enum ElementCallServiceAction {
+    case answerCall(roomID: String)
+    case declineCall(roomID: String)
+}
+
+enum ElementCallServiceNotificationKey: String {
+    case roomID
+    case roomDisplayName
+    case senderID
+    case senderDisplayName
+}
+
+let ElementCallServiceNotificationDiscardDelta = 10.0
+
+// sourcery: AutoMockable
+protocol ElementCallServiceProtocol {
+    var actions: AnyPublisher<ElementCallServiceAction, Never> { get }
+    
+    func setupCallSession(title: String) async
+    
+    func tearDownCallSession()
+}

--- a/ElementX/Sources/Services/ElementCall/ElementCallWidgetDriver.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallWidgetDriver.swift
@@ -41,6 +41,7 @@ class ElementCallWidgetDriver: WidgetCapabilitiesProvider, ElementCallWidgetDriv
     private let room: RoomProtocol
     private var widgetDriver: WidgetDriverAndHandle?
     
+    let widgetID = UUID().uuidString
     let messagePublisher = PassthroughSubject<String, Never>()
     
     private let actionsSubject: PassthroughSubject<ElementCallWidgetDriverAction, Never> = .init()
@@ -60,7 +61,7 @@ class ElementCallWidgetDriver: WidgetCapabilitiesProvider, ElementCallWidgetDriv
         let useEncryption = (try? room.isEncrypted()) ?? false
         
         guard let widgetSettings = try? newVirtualElementCallWidget(props: .init(elementCallUrl: baseURL.absoluteString,
-                                                                                 widgetId: UUID().uuidString,
+                                                                                 widgetId: widgetID,
                                                                                  parentUrl: nil,
                                                                                  hideHeader: nil,
                                                                                  preload: nil,

--- a/ElementX/Sources/Services/ElementCall/ElementCallWidgetDriverProtocol.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallWidgetDriverProtocol.swift
@@ -32,6 +32,8 @@ enum ElementCallWidgetDriverAction {
 
 // sourcery: AutoMockable
 protocol ElementCallWidgetDriverProtocol {
+    var widgetID: String { get }
+    
     var messagePublisher: PassthroughSubject<String, Never> { get }
     var actions: AnyPublisher<ElementCallWidgetDriverAction, Never> { get }
     

--- a/ElementX/Sources/Services/Room/RoomProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomProxy.swift
@@ -521,6 +521,16 @@ class RoomProxy: RoomProxyProtocol {
         ElementCallWidgetDriver(room: room)
     }
     
+    func sendCallNotificationIfNeeeded() async -> Result<Void, RoomProxyError> {
+        do {
+            try await room.sendCallNotificationIfNeeded()
+            return .success(())
+        } catch {
+            MXLog.error("Failed room call notification with error: \(error)")
+            return .failure(.sdkError(error))
+        }
+    }
+    
     // MARK: - Permalinks
     
     func matrixToPermalink() async -> Result<URL, RoomProxyError> {

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -129,6 +129,8 @@ protocol RoomProxyProtocol {
     
     func elementCallWidgetDriver() -> ElementCallWidgetDriverProtocol
     
+    func sendCallNotificationIfNeeeded() async -> Result<Void, RoomProxyError>
+    
     // MARK: - Permalinks
     
     func matrixToPermalink() async -> Result<URL, RoomProxyError>

--- a/ElementX/Sources/UITests/UITestsAppCoordinator.swift
+++ b/ElementX/Sources/UITests/UITestsAppCoordinator.swift
@@ -505,6 +505,7 @@ class MockScreen: Identifiable {
                                                              appLockService: AppLockService(keychainController: KeychainControllerMock(),
                                                                                             appSettings: ServiceLocator.shared.settings),
                                                              bugReportService: BugReportServiceMock(),
+                                                             elementCallService: ElementCallServiceMock(),
                                                              roomTimelineControllerFactory: RoomTimelineControllerFactoryMock(configuration: .init()),
                                                              appMediator: AppMediatorMock.default,
                                                              appSettings: appSettings,

--- a/ElementX/SupportingFiles/Info.plist
+++ b/ElementX/SupportingFiles/Info.plist
@@ -80,8 +80,9 @@
 	</array>
 	<key>UIBackgroundModes</key>
 	<array>
-		<string>fetch</string>
 		<string>audio</string>
+		<string>fetch</string>
+		<string>processing</string>
 		<string>voip</string>
 	</array>
 	<key>UILaunchScreen</key>

--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -90,8 +90,9 @@ targets:
         NSLocationWhenInUseUsageDescription: Grant location access so that $(APP_DISPLAY_NAME) can share your location.
         NSFaceIDUsageDescription: Face ID is used to access your app.
         UIBackgroundModes: [
-          fetch,
           audio,
+          fetch,
+          processing,
           voip
         ]
         BGTaskSchedulerPermittedIdentifiers: [

--- a/NSE/Sources/NotificationContentBuilder.swift
+++ b/NSE/Sources/NotificationContentBuilder.swift
@@ -46,6 +46,8 @@ struct NotificationContentBuilder {
                     return try await processPollStartEvent(notificationItem: notificationItem, pollQuestion: question, mediaProvider: mediaProvider)
                 case .callInvite:
                     return try await processCallInviteEvent(notificationItem: notificationItem, mediaProvider: mediaProvider)
+                case .callNotify:
+                    return try await processCallNotifyEvent(notificationItem: notificationItem, mediaProvider: mediaProvider)
                 default:
                     return processEmpty(notificationItem: notificationItem)
                 }
@@ -134,6 +136,12 @@ struct NotificationContentBuilder {
     private func processCallInviteEvent(notificationItem: NotificationItemProxyProtocol, mediaProvider: MediaProviderProtocol?) async throws -> UNMutableNotificationContent {
         let notification = try await processCommonRoomMessage(notificationItem: notificationItem, mediaProvider: mediaProvider)
         notification.body = L10n.commonCallInvite
+        return notification
+    }
+    
+    private func processCallNotifyEvent(notificationItem: NotificationItemProxyProtocol, mediaProvider: MediaProviderProtocol?) async throws -> UNMutableNotificationContent {
+        let notification = try await processCommonRoomMessage(notificationItem: notificationItem, mediaProvider: mediaProvider)
+        notification.body = L10n.commonCallStarted
         return notification
     }
 

--- a/NSE/Sources/NotificationServiceExtension.swift
+++ b/NSE/Sources/NotificationServiceExtension.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+import CallKit
 import Intents
 import MatrixRustSDK
 import UserNotifications
@@ -104,6 +105,10 @@ class NotificationServiceExtension: UNNotificationServiceExtension {
                 return discard(unreadCount: unreadCount)
             }
             
+            guard await shouldHandleCallNotification(itemProxy) else {
+                return discard(unreadCount: unreadCount)
+            }
+            
             // After the first processing, update the modified content
             modifiedContent = try await notificationContentBuilder.content(for: itemProxy, mediaProvider: nil)
             
@@ -172,5 +177,49 @@ class NotificationServiceExtension: UNNotificationServiceExtension {
         cleanUp()
         NSELogger.logMemory(with: tag)
         MXLog.info("\(tag) deinit")
+    }
+    
+    private func shouldHandleCallNotification(_ itemProxy: NotificationItemProxyProtocol) async -> Bool {
+        // Handle incoming VoIP calls, show the native OS call screen
+        // https://developer.apple.com/documentation/callkit/sending-end-to-end-encrypted-voip-calls
+        //
+        // The way this works is the following:
+        // - the NSE receives the notification and decrypts it
+        // - checks if it's still time relevant (max 10 seconds old) and whether it should ring
+        // - otherwise it goes on to show it as a normal notification
+        // - if it should ring then it discards the notification but invokes `reportNewIncomingVoIPPushPayload`
+        // so that the main app can handle it
+        // - the main app picks this up in `PKPushRegistry.didReceiveIncomingPushWith` and
+        // `CXProvider.reportNewIncomingCall` to show the system UI and handle actions on it.
+        // N.B. this flow works properly only when background processing capabilities are enabled
+        
+        guard case let .timeline(event) = itemProxy.event,
+              case let .messageLike(content) = try? event.eventType(),
+              case let .callNotify(notificationType) = content,
+              notificationType == .ring else {
+            return true
+        }
+        
+        let timestamp = Date(timeIntervalSince1970: TimeInterval(event.timestamp() / 1000))
+        guard abs(timestamp.timeIntervalSinceNow) < ElementCallServiceNotificationDiscardDelta else {
+            MXLog.info("Call notification is too old, handling as push notification")
+            return true
+        }
+        
+        var payload = [ElementCallServiceNotificationKey.roomID.rawValue: itemProxy.roomID,
+                       ElementCallServiceNotificationKey.roomDisplayName.rawValue: itemProxy.roomDisplayName,
+                       ElementCallServiceNotificationKey.senderID.rawValue: itemProxy.senderID]
+        if let senderDisplayName = itemProxy.senderDisplayName {
+            payload[ElementCallServiceNotificationKey.senderDisplayName.rawValue] = senderDisplayName
+        }
+        
+        do {
+            try await CXProvider.reportNewIncomingVoIPPushPayload(payload)
+        } catch {
+            MXLog.error("Failed reporting voip call with error: \(error). Handling as push notification")
+            return true
+        }
+        
+        return false
     }
 }

--- a/NSE/SupportingFiles/target.yml
+++ b/NSE/SupportingFiles/target.yml
@@ -104,4 +104,5 @@ targets:
     - path: ../../ElementX/Sources/Services/Notification/Proxy
     - path: ../../ElementX/Sources/Services/Room/RoomSummary/RoomMessageEventStringBuilder.swift
     - path: ../../ElementX/Sources/Services/UserSession/RestorationToken.swift
+    - path: ../../ElementX/Sources/Services/ElementCall/ElementCallServiceProtocol.swift
     - path: ../../ElementX/Sources/Application/AppSettings.swift

--- a/UnitTests/Sources/UserSessionFlowCoordinatorTests.swift
+++ b/UnitTests/Sources/UserSessionFlowCoordinatorTests.swift
@@ -51,6 +51,7 @@ class UserSessionFlowCoordinatorTests: XCTestCase {
                                                                 navigationRootCoordinator: navigationRootCoordinator,
                                                                 appLockService: AppLockServiceMock(),
                                                                 bugReportService: BugReportServiceMock(),
+                                                                elementCallService: ElementCallServiceMock(),
                                                                 roomTimelineControllerFactory: timelineControllerFactory,
                                                                 appMediator: AppMediatorMock.default,
                                                                 appSettings: ServiceLocator.shared.settings,

--- a/project.yml
+++ b/project.yml
@@ -49,7 +49,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/element-hq/matrix-rust-components-swift
-    exactVersion: 1.0.2
+    exactVersion: 1.0.3
     # path: ../matrix-rust-sdk
   Compound:
     url: https://github.com/element-hq/compound-ios


### PR DESCRIPTION
Handle incoming VoIP calls, show the native OS call screen as per https://developer.apple.com/documentation/callkit/sending-end-to-end-encrypted-voip-calls
Defined through https://github.com/matrix-org/matrix-spec-proposals/pull/4075

Fixes https://github.com/element-hq/element-x-ios/issues/2876

Requires https://github.com/matrix-org/matrix-rust-sdk/pull/3434

The way this works is the following:
- the NSE receives the notification and decrypts it
- checks if it's still time relevant (max 10 seconds old) and whether it should ring
- otherwise it goes on to show it as a normal notification
- if it should ring then it discards the notification but invokes `reportNewIncomingVoIPPushPayload`
so that the main app can handle it
- the main app picks this up in `PKPushRegistry.didReceiveIncomingPushWith` and
`CXProvider.reportNewIncomingCall` to show the system UI and handle actions on it.

N.B. this flow works properly only when background processing capabilities are enabled

![IMG_2432](https://github.com/element-hq/element-x-ios/assets/637564/6833c570-3548-42fd-bca9-7a3065eff6f1)