### PR TITLE
Add renovate groups.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,19 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules" : [
+    {
+      "matchManagers": ["github-actions"],
+      "groupName" : "GitHub Actions"
+    },
+    {
+      "matchManagers": ["swift", "cocoapods"],
+      "groupName" : "Swift"
+    },
+    {
+      "matchManagers": ["bundler"],
+      "groupName" : "Ruby"
+    }
   ]
 }


### PR DESCRIPTION
Similar to https://github.com/element-hq/compound-ios/pull/80, this should reduce the number of PRs opened at once.

See https://docs.renovatebot.com/configuration-options/#groupname