### PR TITLE
Update Compound.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,6 @@ Git LFS is used to store UI test snapshots. `swift run tools setup-project` will
 
 ```
 git lfs install
-ln -s "$(which git-lfs)" "$(git --exec-path)/git-lfs"
 ```
 
 ### Snapshot Tests

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -7287,7 +7287,7 @@
 			repositoryURL = "https://github.com/BarredEwe/Prefire";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.0.4;
+				minimumVersion = 2.7.0;
 			};
 		};
 		395DE6AE429B7ACC7C7FE31D /* XCRemoteSwiftPackageReference "KZFileWatchers" */ = {
@@ -7367,7 +7367,7 @@
 			repositoryURL = "https://github.com/siteline/SwiftUI-Introspect";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.9.0;
+				minimumVersion = 1.1.4;
 			};
 		};
 		A08925A9D5E3770DEB9D8509 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
@@ -7455,7 +7455,7 @@
 			repositoryURL = "https://github.com/element-hq/compound-ios";
 			requirement = {
 				kind = revision;
-				revision = c1b9c32fef5f98f90bd1856cce327770297226b1;
+				revision = 3cafe19060a31cb68aa4f530d2a37b3e5beac554;
 			};
 		};
 		F76A08D0EA29A07A54F4EB4D /* XCRemoteSwiftPackageReference "swift-collections" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/compound-design-tokens",
       "state" : {
-        "revision" : "c3fff1f2b042295cd5f4bcf8d4fe68ec47ca4061",
-        "version" : "1.2.0"
+        "revision" : "5086370e2c8d6d23c761369c0ac6c3aef33fc5d6",
+        "version" : "1.3.0"
       }
     },
     {
@@ -14,7 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/compound-ios",
       "state" : {
-        "revision" : "c1b9c32fef5f98f90bd1856cce327770297226b1"
+        "revision" : "3cafe19060a31cb68aa4f530d2a37b3e5beac554"
       }
     },
     {
@@ -175,8 +175,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/BarredEwe/Prefire",
       "state" : {
-        "revision" : "608e7992dedc5ee409e59b3580010371ff0cef57",
-        "version" : "2.0.4"
+        "revision" : "1ea1d76bb3c115a630c5d5d5f5d1c330f2f49982",
+        "version" : "2.7.0"
       }
     },
     {
@@ -193,8 +193,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SFSafeSymbols/SFSafeSymbols",
       "state" : {
-        "revision" : "7cca2d60925876b5953a2cf7341cd80fbeac983c",
-        "version" : "4.1.1"
+        "revision" : "afd0a1da4ed62bab1413caa6dd6b60a7a7089ed2",
+        "version" : "5.2.0"
       }
     },
     {
@@ -265,8 +265,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/siteline/SwiftUI-Introspect",
       "state" : {
-        "revision" : "b94da693e57eaf79d16464b8b7c90d09cba4e290",
-        "version" : "0.9.2"
+        "revision" : "7dc5b287f8040e4ad5038739850b758e78f77808",
+        "version" : "1.1.4"
       }
     },
     {

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreenRoomList.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreenRoomList.swift
@@ -50,13 +50,13 @@ struct HomeScreenRoomList: View {
                             Button {
                                 context.send(viewAction: .markRoomAsRead(roomIdentifier: room.id))
                             } label: {
-                                Text(L10n.screenRoomlistMarkAsRead)
+                                Label(L10n.screenRoomlistMarkAsRead, icon: \.markAsRead)
                             }
                         } else {
                             Button {
                                 context.send(viewAction: .markRoomAsUnread(roomIdentifier: room.id))
                             } label: {
-                                Text(L10n.screenRoomlistMarkAsUnread)
+                                Label(L10n.screenRoomlistMarkAsUnread, icon: \.markAsUnread)
                             }
                         }
                         

--- a/PreviewTests/.prefire.yml
+++ b/PreviewTests/.prefire.yml
@@ -1,6 +1,6 @@
 test_configuration:
   - template_file_path: PreviewTests.stencil
-  - simulator_device: "iPhone15,2"
+  - simulator_device: "iPhone15"
   - required_os: 17
   - snapshot_devices:
       - iPhone 15

--- a/PreviewTests/__Snapshots__/PreviewTests/test_reactionsSummaryView-iPad-pseudo.1.png
+++ b/PreviewTests/__Snapshots__/PreviewTests/test_reactionsSummaryView-iPad-pseudo.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:78801ac3fc6c23257de1dea47d53fde740fd03497d027b70d94c77ab8a93ab38
-size 173820
+oid sha256:0ffac280e3d862a461df5ee10af10e6c2551a47d80643ffb77613c1db31e2b5b
+size 174042

--- a/PreviewTests/__Snapshots__/PreviewTests/test_reactionsSummaryView-iPhone-15-pseudo.1.png
+++ b/PreviewTests/__Snapshots__/PreviewTests/test_reactionsSummaryView-iPhone-15-pseudo.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4d5cff7a9c0cf44d7ad61390e1012d0f45e551e51d1518201be285b708dba9b5
-size 75015
+oid sha256:2f4d352f6c43ba6143e1906de0a7d501e161e7671cd3e6de02beb4d3d5dd9e72
+size 74627

--- a/PreviewTests/__Snapshots__/PreviewTests/test_roomPollsHistoryScreen-iPad-pseudo.polls.png
+++ b/PreviewTests/__Snapshots__/PreviewTests/test_roomPollsHistoryScreen-iPad-pseudo.polls.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:16a78dc803c0f2d4aed87131b646953c7ac16a672d89ee901939e3b8784f8a88
-size 296838
+oid sha256:4c210514466bcc8520e22ba0e692376fb582ec36fffcfdeb2db8d9763c19cc36
+size 301092

--- a/PreviewTests/__Snapshots__/PreviewTests/test_roomPollsHistoryScreen-iPhone-15-pseudo.polls.png
+++ b/PreviewTests/__Snapshots__/PreviewTests/test_roomPollsHistoryScreen-iPhone-15-pseudo.polls.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:000e76bb745e5933b8f70c7ab331181ca0e62fcf01f6ac093fa7c7a9c749fd95
-size 204894
+oid sha256:ce225a98d4dc3f06fffce49d17c42516fcbe1128aff4c75423ef01fe15976988
+size 207420

--- a/project.yml
+++ b/project.yml
@@ -53,7 +53,7 @@ packages:
     # path: ../matrix-rust-sdk
   Compound:
     url: https://github.com/element-hq/compound-ios
-    revision: c1b9c32fef5f98f90bd1856cce327770297226b1
+    revision: 3cafe19060a31cb68aa4f530d2a37b3e5beac554
     # path: ../compound-ios
   AnalyticsEvents:
     url: https://github.com/matrix-org/matrix-analytics-events
@@ -110,7 +110,7 @@ packages:
     minorVersion: 3.2.5
   Prefire:
     url: https://github.com/BarredEwe/Prefire
-    minorVersion: 2.0.4
+    minorVersion: 2.7.0
   Sentry:
     url: https://github.com/getsentry/sentry-cocoa
     minorVersion: 8.13.0
@@ -122,7 +122,7 @@ packages:
     minorVersion: 6.0.0
   SwiftUIIntrospect:
     url: https://github.com/siteline/SwiftUI-Introspect
-    minorVersion: 0.9.0
+    minorVersion: 1.1.4
   Version:
     url: https://github.com/mxcl/Version
     minorVersion: 2.0.0


### PR DESCRIPTION
This PR makes the following changes:
- Update Compound to the latest revision (the snapshots are no longer in Git LFS, see [#84](https://github.com/element-hq/compound-ios/pull/84)).
- Update Introspect and Prefire packages to match Compound (it would be nice if we could remove these from project.yml seeing as they're pulled in by Compound but I got an error about trying to add them in target.yml).
- Use the new markAsRead/Unread icons when long-pressing a room.