### PR TITLE
Bump the SDK and handle breaking changes on timeline diffing

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -7364,7 +7364,7 @@
 			repositoryURL = "https://github.com/element-hq/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 1.0.11;
+				version = 1.0.13;
 			};
 		};
 		701C7BEF8F70F7A83E852DCC /* XCRemoteSwiftPackageReference "GZIP" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -148,8 +148,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/matrix-rust-components-swift",
       "state" : {
-        "revision" : "e1aa005300f7c5d38ac8203a1668df99fff21bd4",
-        "version" : "1.0.11"
+        "revision" : "94373ae0568cf1681c39b1a348601e733d76a7ec",
+        "version" : "1.0.13"
       }
     },
     {

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -52,7 +52,9 @@ class AnalyticsClientMock: AnalyticsClientProtocol {
     func start(analyticsConfiguration: AnalyticsConfiguration) {
         startAnalyticsConfigurationCallsCount += 1
         startAnalyticsConfigurationReceivedAnalyticsConfiguration = analyticsConfiguration
-        startAnalyticsConfigurationReceivedInvocations.append(analyticsConfiguration)
+        DispatchQueue.main.async {
+            self.startAnalyticsConfigurationReceivedInvocations.append(analyticsConfiguration)
+        }
         startAnalyticsConfigurationClosure?(analyticsConfiguration)
     }
     //MARK: - reset
@@ -161,7 +163,9 @@ class AnalyticsClientMock: AnalyticsClientProtocol {
     func capture(_ event: AnalyticsEventProtocol) {
         captureCallsCount += 1
         captureReceivedEvent = event
-        captureReceivedInvocations.append(event)
+        DispatchQueue.main.async {
+            self.captureReceivedInvocations.append(event)
+        }
         captureClosure?(event)
     }
     //MARK: - screen
@@ -200,7 +204,9 @@ class AnalyticsClientMock: AnalyticsClientProtocol {
     func screen(_ event: AnalyticsScreenProtocol) {
         screenCallsCount += 1
         screenReceivedEvent = event
-        screenReceivedInvocations.append(event)
+        DispatchQueue.main.async {
+            self.screenReceivedInvocations.append(event)
+        }
         screenClosure?(event)
     }
     //MARK: - updateUserProperties
@@ -239,7 +245,9 @@ class AnalyticsClientMock: AnalyticsClientProtocol {
     func updateUserProperties(_ event: AnalyticsEvent.UserProperties) {
         updateUserPropertiesCallsCount += 1
         updateUserPropertiesReceivedEvent = event
-        updateUserPropertiesReceivedInvocations.append(event)
+        DispatchQueue.main.async {
+            self.updateUserPropertiesReceivedInvocations.append(event)
+        }
         updateUserPropertiesClosure?(event)
     }
 }
@@ -341,7 +349,9 @@ class AppLockServiceMock: AppLockServiceProtocol {
     func setupPINCode(_ pinCode: String) -> Result<Void, AppLockServiceError> {
         setupPINCodeCallsCount += 1
         setupPINCodeReceivedPinCode = pinCode
-        setupPINCodeReceivedInvocations.append(pinCode)
+        DispatchQueue.main.async {
+            self.setupPINCodeReceivedInvocations.append(pinCode)
+        }
         if let setupPINCodeClosure = setupPINCodeClosure {
             return setupPINCodeClosure(pinCode)
         } else {
@@ -409,7 +419,9 @@ class AppLockServiceMock: AppLockServiceProtocol {
     func validate(_ pinCode: String) -> Result<Void, AppLockServiceError> {
         validateCallsCount += 1
         validateReceivedPinCode = pinCode
-        validateReceivedInvocations.append(pinCode)
+        DispatchQueue.main.async {
+            self.validateReceivedInvocations.append(pinCode)
+        }
         if let validateClosure = validateClosure {
             return validateClosure(pinCode)
         } else {
@@ -646,7 +658,9 @@ class AppLockServiceMock: AppLockServiceProtocol {
     func computeNeedsUnlock(didBecomeActiveAt date: Date) -> Bool {
         computeNeedsUnlockDidBecomeActiveAtCallsCount += 1
         computeNeedsUnlockDidBecomeActiveAtReceivedDate = date
-        computeNeedsUnlockDidBecomeActiveAtReceivedInvocations.append(date)
+        DispatchQueue.main.async {
+            self.computeNeedsUnlockDidBecomeActiveAtReceivedInvocations.append(date)
+        }
         if let computeNeedsUnlockDidBecomeActiveAtClosure = computeNeedsUnlockDidBecomeActiveAtClosure {
             return computeNeedsUnlockDidBecomeActiveAtClosure(date)
         } else {
@@ -714,7 +728,9 @@ class AppLockServiceMock: AppLockServiceProtocol {
     func unlock(with pinCode: String) -> Bool {
         unlockWithCallsCount += 1
         unlockWithReceivedPinCode = pinCode
-        unlockWithReceivedInvocations.append(pinCode)
+        DispatchQueue.main.async {
+            self.unlockWithReceivedInvocations.append(pinCode)
+        }
         if let unlockWithClosure = unlockWithClosure {
             return unlockWithClosure(pinCode)
         } else {
@@ -898,7 +914,9 @@ class AppMediatorMock: AppMediatorProtocol {
     func endBackgroundTask(_ identifier: UIBackgroundTaskIdentifier) {
         endBackgroundTaskCallsCount += 1
         endBackgroundTaskReceivedIdentifier = identifier
-        endBackgroundTaskReceivedInvocations.append(identifier)
+        DispatchQueue.main.async {
+            self.endBackgroundTaskReceivedInvocations.append(identifier)
+        }
         endBackgroundTaskClosure?(identifier)
     }
     //MARK: - open
@@ -937,7 +955,9 @@ class AppMediatorMock: AppMediatorProtocol {
     func open(_ url: URL) {
         openCallsCount += 1
         openReceivedUrl = url
-        openReceivedInvocations.append(url)
+        DispatchQueue.main.async {
+            self.openReceivedInvocations.append(url)
+        }
         openClosure?(url)
     }
     //MARK: - openAppSettings
@@ -1011,7 +1031,9 @@ class AppMediatorMock: AppMediatorProtocol {
     func setIdleTimerDisabled(_ disabled: Bool) {
         setIdleTimerDisabledCallsCount += 1
         setIdleTimerDisabledReceivedDisabled = disabled
-        setIdleTimerDisabledReceivedInvocations.append(disabled)
+        DispatchQueue.main.async {
+            self.setIdleTimerDisabledReceivedInvocations.append(disabled)
+        }
         setIdleTimerDisabledClosure?(disabled)
     }
     //MARK: - requestAuthorizationIfNeeded
@@ -1121,7 +1143,9 @@ class AudioConverterMock: AudioConverterProtocol {
         }
         convertToOpusOggSourceURLDestinationURLCallsCount += 1
         convertToOpusOggSourceURLDestinationURLReceivedArguments = (sourceURL: sourceURL, destinationURL: destinationURL)
-        convertToOpusOggSourceURLDestinationURLReceivedInvocations.append((sourceURL: sourceURL, destinationURL: destinationURL))
+        DispatchQueue.main.async {
+            self.convertToOpusOggSourceURLDestinationURLReceivedInvocations.append((sourceURL: sourceURL, destinationURL: destinationURL))
+        }
         try convertToOpusOggSourceURLDestinationURLClosure?(sourceURL, destinationURL)
     }
     //MARK: - convertToMPEG4AAC
@@ -1164,7 +1188,9 @@ class AudioConverterMock: AudioConverterProtocol {
         }
         convertToMPEG4AACSourceURLDestinationURLCallsCount += 1
         convertToMPEG4AACSourceURLDestinationURLReceivedArguments = (sourceURL: sourceURL, destinationURL: destinationURL)
-        convertToMPEG4AACSourceURLDestinationURLReceivedInvocations.append((sourceURL: sourceURL, destinationURL: destinationURL))
+        DispatchQueue.main.async {
+            self.convertToMPEG4AACSourceURLDestinationURLReceivedInvocations.append((sourceURL: sourceURL, destinationURL: destinationURL))
+        }
         try convertToMPEG4AACSourceURLDestinationURLClosure?(sourceURL, destinationURL)
     }
 }
@@ -1228,7 +1254,9 @@ class AudioPlayerMock: AudioPlayerProtocol {
     func load(mediaSource: MediaSourceProxy, using url: URL, autoplay: Bool) {
         loadMediaSourceUsingAutoplayCallsCount += 1
         loadMediaSourceUsingAutoplayReceivedArguments = (mediaSource: mediaSource, url: url, autoplay: autoplay)
-        loadMediaSourceUsingAutoplayReceivedInvocations.append((mediaSource: mediaSource, url: url, autoplay: autoplay))
+        DispatchQueue.main.async {
+            self.loadMediaSourceUsingAutoplayReceivedInvocations.append((mediaSource: mediaSource, url: url, autoplay: autoplay))
+        }
         loadMediaSourceUsingAutoplayClosure?(mediaSource, url, autoplay)
     }
     //MARK: - reset
@@ -1407,7 +1435,9 @@ class AudioPlayerMock: AudioPlayerProtocol {
     func seek(to progress: Double) async {
         seekToCallsCount += 1
         seekToReceivedProgress = progress
-        seekToReceivedInvocations.append(progress)
+        DispatchQueue.main.async {
+            self.seekToReceivedInvocations.append(progress)
+        }
         await seekToClosure?(progress)
     }
 }
@@ -1465,7 +1495,9 @@ class AudioRecorderMock: AudioRecorderProtocol {
     func record(audioFileURL: URL) async {
         recordAudioFileURLCallsCount += 1
         recordAudioFileURLReceivedAudioFileURL = audioFileURL
-        recordAudioFileURLReceivedInvocations.append(audioFileURL)
+        DispatchQueue.main.async {
+            self.recordAudioFileURLReceivedInvocations.append(audioFileURL)
+        }
         await recordAudioFileURLClosure?(audioFileURL)
     }
     //MARK: - stopRecording
@@ -1641,7 +1673,9 @@ class AudioSessionMock: AudioSessionProtocol {
     func requestRecordPermission(_ response: @escaping (Bool) -> Void) {
         requestRecordPermissionCallsCount += 1
         requestRecordPermissionReceivedResponse = response
-        requestRecordPermissionReceivedInvocations.append(response)
+        DispatchQueue.main.async {
+            self.requestRecordPermissionReceivedInvocations.append(response)
+        }
         requestRecordPermissionClosure?(response)
     }
     //MARK: - setAllowHapticsAndSystemSoundsDuringRecording
@@ -1684,7 +1718,9 @@ class AudioSessionMock: AudioSessionProtocol {
         }
         setAllowHapticsAndSystemSoundsDuringRecordingCallsCount += 1
         setAllowHapticsAndSystemSoundsDuringRecordingReceivedInValue = inValue
-        setAllowHapticsAndSystemSoundsDuringRecordingReceivedInvocations.append(inValue)
+        DispatchQueue.main.async {
+            self.setAllowHapticsAndSystemSoundsDuringRecordingReceivedInvocations.append(inValue)
+        }
         try setAllowHapticsAndSystemSoundsDuringRecordingClosure?(inValue)
     }
     //MARK: - setCategory
@@ -1727,7 +1763,9 @@ class AudioSessionMock: AudioSessionProtocol {
         }
         setCategoryModeOptionsCallsCount += 1
         setCategoryModeOptionsReceivedArguments = (category: category, mode: mode, options: options)
-        setCategoryModeOptionsReceivedInvocations.append((category: category, mode: mode, options: options))
+        DispatchQueue.main.async {
+            self.setCategoryModeOptionsReceivedInvocations.append((category: category, mode: mode, options: options))
+        }
         try setCategoryModeOptionsClosure?(category, mode, options)
     }
     //MARK: - setActive
@@ -1770,7 +1808,9 @@ class AudioSessionMock: AudioSessionProtocol {
         }
         setActiveOptionsCallsCount += 1
         setActiveOptionsReceivedArguments = (active: active, options: options)
-        setActiveOptionsReceivedInvocations.append((active: active, options: options))
+        DispatchQueue.main.async {
+            self.setActiveOptionsReceivedInvocations.append((active: active, options: options))
+        }
         try setActiveOptionsClosure?(active, options)
     }
 }
@@ -1917,7 +1957,9 @@ class BugReportServiceMock: BugReportServiceProtocol {
     func submitBugReport(_ bugReport: BugReport, progressListener: CurrentValueSubject<Double, Never>) async -> Result<SubmitBugReportResponse, BugReportServiceError> {
         submitBugReportProgressListenerCallsCount += 1
         submitBugReportProgressListenerReceivedArguments = (bugReport: bugReport, progressListener: progressListener)
-        submitBugReportProgressListenerReceivedInvocations.append((bugReport: bugReport, progressListener: progressListener))
+        DispatchQueue.main.async {
+            self.submitBugReportProgressListenerReceivedInvocations.append((bugReport: bugReport, progressListener: progressListener))
+        }
         if let submitBugReportProgressListenerClosure = submitBugReportProgressListenerClosure {
             return await submitBugReportProgressListenerClosure(bugReport, progressListener)
         } else {
@@ -2176,7 +2218,9 @@ class ClientProxyMock: ClientProxyProtocol {
     func accountURL(action: AccountManagementAction) async -> URL? {
         accountURLActionCallsCount += 1
         accountURLActionReceivedAction = action
-        accountURLActionReceivedInvocations.append(action)
+        DispatchQueue.main.async {
+            self.accountURLActionReceivedInvocations.append(action)
+        }
         if let accountURLActionClosure = accountURLActionClosure {
             return await accountURLActionClosure(action)
         } else {
@@ -2244,7 +2288,9 @@ class ClientProxyMock: ClientProxyProtocol {
     func createDirectRoomIfNeeded(with userID: String, expectedRoomName: String?) async -> Result<(roomID: String, isNewRoom: Bool), ClientProxyError> {
         createDirectRoomIfNeededWithExpectedRoomNameCallsCount += 1
         createDirectRoomIfNeededWithExpectedRoomNameReceivedArguments = (userID: userID, expectedRoomName: expectedRoomName)
-        createDirectRoomIfNeededWithExpectedRoomNameReceivedInvocations.append((userID: userID, expectedRoomName: expectedRoomName))
+        DispatchQueue.main.async {
+            self.createDirectRoomIfNeededWithExpectedRoomNameReceivedInvocations.append((userID: userID, expectedRoomName: expectedRoomName))
+        }
         if let createDirectRoomIfNeededWithExpectedRoomNameClosure = createDirectRoomIfNeededWithExpectedRoomNameClosure {
             return await createDirectRoomIfNeededWithExpectedRoomNameClosure(userID, expectedRoomName)
         } else {
@@ -2312,7 +2358,9 @@ class ClientProxyMock: ClientProxyProtocol {
     func directRoomForUserID(_ userID: String) async -> Result<String?, ClientProxyError> {
         directRoomForUserIDCallsCount += 1
         directRoomForUserIDReceivedUserID = userID
-        directRoomForUserIDReceivedInvocations.append(userID)
+        DispatchQueue.main.async {
+            self.directRoomForUserIDReceivedInvocations.append(userID)
+        }
         if let directRoomForUserIDClosure = directRoomForUserIDClosure {
             return await directRoomForUserIDClosure(userID)
         } else {
@@ -2380,7 +2428,9 @@ class ClientProxyMock: ClientProxyProtocol {
     func createDirectRoom(with userID: String, expectedRoomName: String?) async -> Result<String, ClientProxyError> {
         createDirectRoomWithExpectedRoomNameCallsCount += 1
         createDirectRoomWithExpectedRoomNameReceivedArguments = (userID: userID, expectedRoomName: expectedRoomName)
-        createDirectRoomWithExpectedRoomNameReceivedInvocations.append((userID: userID, expectedRoomName: expectedRoomName))
+        DispatchQueue.main.async {
+            self.createDirectRoomWithExpectedRoomNameReceivedInvocations.append((userID: userID, expectedRoomName: expectedRoomName))
+        }
         if let createDirectRoomWithExpectedRoomNameClosure = createDirectRoomWithExpectedRoomNameClosure {
             return await createDirectRoomWithExpectedRoomNameClosure(userID, expectedRoomName)
         } else {
@@ -2448,7 +2498,9 @@ class ClientProxyMock: ClientProxyProtocol {
     func createRoom(name: String, topic: String?, isRoomPrivate: Bool, userIDs: [String], avatarURL: URL?) async -> Result<String, ClientProxyError> {
         createRoomNameTopicIsRoomPrivateUserIDsAvatarURLCallsCount += 1
         createRoomNameTopicIsRoomPrivateUserIDsAvatarURLReceivedArguments = (name: name, topic: topic, isRoomPrivate: isRoomPrivate, userIDs: userIDs, avatarURL: avatarURL)
-        createRoomNameTopicIsRoomPrivateUserIDsAvatarURLReceivedInvocations.append((name: name, topic: topic, isRoomPrivate: isRoomPrivate, userIDs: userIDs, avatarURL: avatarURL))
+        DispatchQueue.main.async {
+            self.createRoomNameTopicIsRoomPrivateUserIDsAvatarURLReceivedInvocations.append((name: name, topic: topic, isRoomPrivate: isRoomPrivate, userIDs: userIDs, avatarURL: avatarURL))
+        }
         if let createRoomNameTopicIsRoomPrivateUserIDsAvatarURLClosure = createRoomNameTopicIsRoomPrivateUserIDsAvatarURLClosure {
             return await createRoomNameTopicIsRoomPrivateUserIDsAvatarURLClosure(name, topic, isRoomPrivate, userIDs, avatarURL)
         } else {
@@ -2516,7 +2568,9 @@ class ClientProxyMock: ClientProxyProtocol {
     func joinRoom(_ roomID: String, via: [String]) async -> Result<Void, ClientProxyError> {
         joinRoomViaCallsCount += 1
         joinRoomViaReceivedArguments = (roomID: roomID, via: via)
-        joinRoomViaReceivedInvocations.append((roomID: roomID, via: via))
+        DispatchQueue.main.async {
+            self.joinRoomViaReceivedInvocations.append((roomID: roomID, via: via))
+        }
         if let joinRoomViaClosure = joinRoomViaClosure {
             return await joinRoomViaClosure(roomID, via)
         } else {
@@ -2584,7 +2638,9 @@ class ClientProxyMock: ClientProxyProtocol {
     func uploadMedia(_ media: MediaInfo) async -> Result<String, ClientProxyError> {
         uploadMediaCallsCount += 1
         uploadMediaReceivedMedia = media
-        uploadMediaReceivedInvocations.append(media)
+        DispatchQueue.main.async {
+            self.uploadMediaReceivedInvocations.append(media)
+        }
         if let uploadMediaClosure = uploadMediaClosure {
             return await uploadMediaClosure(media)
         } else {
@@ -2652,7 +2708,9 @@ class ClientProxyMock: ClientProxyProtocol {
     func roomForIdentifier(_ identifier: String) async -> RoomProxyProtocol? {
         roomForIdentifierCallsCount += 1
         roomForIdentifierReceivedIdentifier = identifier
-        roomForIdentifierReceivedInvocations.append(identifier)
+        DispatchQueue.main.async {
+            self.roomForIdentifierReceivedInvocations.append(identifier)
+        }
         if let roomForIdentifierClosure = roomForIdentifierClosure {
             return await roomForIdentifierClosure(identifier)
         } else {
@@ -2720,7 +2778,9 @@ class ClientProxyMock: ClientProxyProtocol {
     func roomPreviewForIdentifier(_ identifier: String, via: [String]) async -> Result<RoomPreviewDetails, ClientProxyError> {
         roomPreviewForIdentifierViaCallsCount += 1
         roomPreviewForIdentifierViaReceivedArguments = (identifier: identifier, via: via)
-        roomPreviewForIdentifierViaReceivedInvocations.append((identifier: identifier, via: via))
+        DispatchQueue.main.async {
+            self.roomPreviewForIdentifierViaReceivedInvocations.append((identifier: identifier, via: via))
+        }
         if let roomPreviewForIdentifierViaClosure = roomPreviewForIdentifierViaClosure {
             return await roomPreviewForIdentifierViaClosure(identifier, via)
         } else {
@@ -2853,7 +2913,9 @@ class ClientProxyMock: ClientProxyProtocol {
     func setUserDisplayName(_ name: String) async -> Result<Void, ClientProxyError> {
         setUserDisplayNameCallsCount += 1
         setUserDisplayNameReceivedName = name
-        setUserDisplayNameReceivedInvocations.append(name)
+        DispatchQueue.main.async {
+            self.setUserDisplayNameReceivedInvocations.append(name)
+        }
         if let setUserDisplayNameClosure = setUserDisplayNameClosure {
             return await setUserDisplayNameClosure(name)
         } else {
@@ -2986,7 +3048,9 @@ class ClientProxyMock: ClientProxyProtocol {
     func setUserAvatar(media: MediaInfo) async -> Result<Void, ClientProxyError> {
         setUserAvatarMediaCallsCount += 1
         setUserAvatarMediaReceivedMedia = media
-        setUserAvatarMediaReceivedInvocations.append(media)
+        DispatchQueue.main.async {
+            self.setUserAvatarMediaReceivedInvocations.append(media)
+        }
         if let setUserAvatarMediaClosure = setUserAvatarMediaClosure {
             return await setUserAvatarMediaClosure(media)
         } else {
@@ -3225,7 +3289,9 @@ class ClientProxyMock: ClientProxyProtocol {
         }
         setPusherWithCallsCount += 1
         setPusherWithReceivedConfiguration = configuration
-        setPusherWithReceivedInvocations.append(configuration)
+        DispatchQueue.main.async {
+            self.setPusherWithReceivedInvocations.append(configuration)
+        }
         try await setPusherWithClosure?(configuration)
     }
     //MARK: - searchUsers
@@ -3289,7 +3355,9 @@ class ClientProxyMock: ClientProxyProtocol {
     func searchUsers(searchTerm: String, limit: UInt) async -> Result<SearchUsersResultsProxy, ClientProxyError> {
         searchUsersSearchTermLimitCallsCount += 1
         searchUsersSearchTermLimitReceivedArguments = (searchTerm: searchTerm, limit: limit)
-        searchUsersSearchTermLimitReceivedInvocations.append((searchTerm: searchTerm, limit: limit))
+        DispatchQueue.main.async {
+            self.searchUsersSearchTermLimitReceivedInvocations.append((searchTerm: searchTerm, limit: limit))
+        }
         if let searchUsersSearchTermLimitClosure = searchUsersSearchTermLimitClosure {
             return await searchUsersSearchTermLimitClosure(searchTerm, limit)
         } else {
@@ -3357,7 +3425,9 @@ class ClientProxyMock: ClientProxyProtocol {
     func profile(for userID: String) async -> Result<UserProfileProxy, ClientProxyError> {
         profileForCallsCount += 1
         profileForReceivedUserID = userID
-        profileForReceivedInvocations.append(userID)
+        DispatchQueue.main.async {
+            self.profileForReceivedInvocations.append(userID)
+        }
         if let profileForClosure = profileForClosure {
             return await profileForClosure(userID)
         } else {
@@ -3489,7 +3559,9 @@ class ClientProxyMock: ClientProxyProtocol {
     func resolveRoomAlias(_ alias: String) async -> Result<ResolvedRoomAlias, ClientProxyError> {
         resolveRoomAliasCallsCount += 1
         resolveRoomAliasReceivedAlias = alias
-        resolveRoomAliasReceivedInvocations.append(alias)
+        DispatchQueue.main.async {
+            self.resolveRoomAliasReceivedInvocations.append(alias)
+        }
         if let resolveRoomAliasClosure = resolveRoomAliasClosure {
             return await resolveRoomAliasClosure(alias)
         } else {
@@ -3557,7 +3629,9 @@ class ClientProxyMock: ClientProxyProtocol {
     func ignoreUser(_ userID: String) async -> Result<Void, ClientProxyError> {
         ignoreUserCallsCount += 1
         ignoreUserReceivedUserID = userID
-        ignoreUserReceivedInvocations.append(userID)
+        DispatchQueue.main.async {
+            self.ignoreUserReceivedInvocations.append(userID)
+        }
         if let ignoreUserClosure = ignoreUserClosure {
             return await ignoreUserClosure(userID)
         } else {
@@ -3625,7 +3699,9 @@ class ClientProxyMock: ClientProxyProtocol {
     func unignoreUser(_ userID: String) async -> Result<Void, ClientProxyError> {
         unignoreUserCallsCount += 1
         unignoreUserReceivedUserID = userID
-        unignoreUserReceivedInvocations.append(userID)
+        DispatchQueue.main.async {
+            self.unignoreUserReceivedInvocations.append(userID)
+        }
         if let unignoreUserClosure = unignoreUserClosure {
             return await unignoreUserClosure(userID)
         } else {
@@ -3693,7 +3769,9 @@ class ClientProxyMock: ClientProxyProtocol {
     func trackRecentlyVisitedRoom(_ roomID: String) async -> Result<Void, ClientProxyError> {
         trackRecentlyVisitedRoomCallsCount += 1
         trackRecentlyVisitedRoomReceivedRoomID = roomID
-        trackRecentlyVisitedRoomReceivedInvocations.append(roomID)
+        DispatchQueue.main.async {
+            self.trackRecentlyVisitedRoomReceivedInvocations.append(roomID)
+        }
         if let trackRecentlyVisitedRoomClosure = trackRecentlyVisitedRoomClosure {
             return await trackRecentlyVisitedRoomClosure(roomID)
         } else {
@@ -4021,7 +4099,9 @@ class ClientProxyMock: ClientProxyProtocol {
         }
         loadMediaContentForSourceCallsCount += 1
         loadMediaContentForSourceReceivedSource = source
-        loadMediaContentForSourceReceivedInvocations.append(source)
+        DispatchQueue.main.async {
+            self.loadMediaContentForSourceReceivedInvocations.append(source)
+        }
         if let loadMediaContentForSourceClosure = loadMediaContentForSourceClosure {
             return try await loadMediaContentForSourceClosure(source)
         } else {
@@ -4093,7 +4173,9 @@ class ClientProxyMock: ClientProxyProtocol {
         }
         loadMediaThumbnailForSourceWidthHeightCallsCount += 1
         loadMediaThumbnailForSourceWidthHeightReceivedArguments = (source: source, width: width, height: height)
-        loadMediaThumbnailForSourceWidthHeightReceivedInvocations.append((source: source, width: width, height: height))
+        DispatchQueue.main.async {
+            self.loadMediaThumbnailForSourceWidthHeightReceivedInvocations.append((source: source, width: width, height: height))
+        }
         if let loadMediaThumbnailForSourceWidthHeightClosure = loadMediaThumbnailForSourceWidthHeightClosure {
             return try await loadMediaThumbnailForSourceWidthHeightClosure(source, width, height)
         } else {
@@ -4165,7 +4247,9 @@ class ClientProxyMock: ClientProxyProtocol {
         }
         loadMediaFileForSourceBodyCallsCount += 1
         loadMediaFileForSourceBodyReceivedArguments = (source: source, body: body)
-        loadMediaFileForSourceBodyReceivedInvocations.append((source: source, body: body))
+        DispatchQueue.main.async {
+            self.loadMediaFileForSourceBodyReceivedInvocations.append((source: source, body: body))
+        }
         if let loadMediaFileForSourceBodyClosure = loadMediaFileForSourceBodyClosure {
             return try await loadMediaFileForSourceBodyClosure(source, body)
         } else {
@@ -4216,7 +4300,9 @@ class CompletionSuggestionServiceMock: CompletionSuggestionServiceProtocol {
     func processTextMessage(_ textMessage: String?) {
         processTextMessageCallsCount += 1
         processTextMessageReceivedTextMessage = textMessage
-        processTextMessageReceivedInvocations.append(textMessage)
+        DispatchQueue.main.async {
+            self.processTextMessageReceivedInvocations.append(textMessage)
+        }
         processTextMessageClosure?(textMessage)
     }
     //MARK: - setSuggestionTrigger
@@ -4255,7 +4341,9 @@ class CompletionSuggestionServiceMock: CompletionSuggestionServiceProtocol {
     func setSuggestionTrigger(_ suggestionTrigger: SuggestionTrigger?) {
         setSuggestionTriggerCallsCount += 1
         setSuggestionTriggerReceivedSuggestionTrigger = suggestionTrigger
-        setSuggestionTriggerReceivedInvocations.append(suggestionTrigger)
+        DispatchQueue.main.async {
+            self.setSuggestionTriggerReceivedInvocations.append(suggestionTrigger)
+        }
         setSuggestionTriggerClosure?(suggestionTrigger)
     }
 }
@@ -4302,7 +4390,9 @@ class ElementCallServiceMock: ElementCallServiceProtocol {
     func setupCallSession(title: String) async {
         setupCallSessionTitleCallsCount += 1
         setupCallSessionTitleReceivedTitle = title
-        setupCallSessionTitleReceivedInvocations.append(title)
+        DispatchQueue.main.async {
+            self.setupCallSessionTitleReceivedInvocations.append(title)
+        }
         await setupCallSessionTitleClosure?(title)
     }
     //MARK: - tearDownCallSession
@@ -4419,7 +4509,9 @@ class ElementCallWidgetDriverMock: ElementCallWidgetDriverProtocol {
     func start(baseURL: URL, clientID: String) async -> Result<URL, ElementCallWidgetDriverError> {
         startBaseURLClientIDCallsCount += 1
         startBaseURLClientIDReceivedArguments = (baseURL: baseURL, clientID: clientID)
-        startBaseURLClientIDReceivedInvocations.append((baseURL: baseURL, clientID: clientID))
+        DispatchQueue.main.async {
+            self.startBaseURLClientIDReceivedInvocations.append((baseURL: baseURL, clientID: clientID))
+        }
         if let startBaseURLClientIDClosure = startBaseURLClientIDClosure {
             return await startBaseURLClientIDClosure(baseURL, clientID)
         } else {
@@ -4487,7 +4579,9 @@ class ElementCallWidgetDriverMock: ElementCallWidgetDriverProtocol {
     func sendMessage(_ message: String) async -> Result<Bool, ElementCallWidgetDriverError> {
         sendMessageCallsCount += 1
         sendMessageReceivedMessage = message
-        sendMessageReceivedInvocations.append(message)
+        DispatchQueue.main.async {
+            self.sendMessageReceivedInvocations.append(message)
+        }
         if let sendMessageClosure = sendMessageClosure {
             return await sendMessageClosure(message)
         } else {
@@ -4533,7 +4627,9 @@ class KeychainControllerMock: KeychainControllerProtocol {
     func setRestorationToken(_ restorationToken: RestorationToken, forUsername: String) {
         setRestorationTokenForUsernameCallsCount += 1
         setRestorationTokenForUsernameReceivedArguments = (restorationToken: restorationToken, forUsername: forUsername)
-        setRestorationTokenForUsernameReceivedInvocations.append((restorationToken: restorationToken, forUsername: forUsername))
+        DispatchQueue.main.async {
+            self.setRestorationTokenForUsernameReceivedInvocations.append((restorationToken: restorationToken, forUsername: forUsername))
+        }
         setRestorationTokenForUsernameClosure?(restorationToken, forUsername)
     }
     //MARK: - restorationTokens
@@ -4636,7 +4732,9 @@ class KeychainControllerMock: KeychainControllerProtocol {
     func removeRestorationTokenForUsername(_ username: String) {
         removeRestorationTokenForUsernameCallsCount += 1
         removeRestorationTokenForUsernameReceivedUsername = username
-        removeRestorationTokenForUsernameReceivedInvocations.append(username)
+        DispatchQueue.main.async {
+            self.removeRestorationTokenForUsernameReceivedInvocations.append(username)
+        }
         removeRestorationTokenForUsernameClosure?(username)
     }
     //MARK: - removeAllRestorationTokens
@@ -4782,7 +4880,9 @@ class KeychainControllerMock: KeychainControllerProtocol {
         }
         setPINCodeCallsCount += 1
         setPINCodeReceivedPinCode = pinCode
-        setPINCodeReceivedInvocations.append(pinCode)
+        DispatchQueue.main.async {
+            self.setPINCodeReceivedInvocations.append(pinCode)
+        }
         try setPINCodeClosure?(pinCode)
     }
     //MARK: - pinCode
@@ -4988,7 +5088,9 @@ class KeychainControllerMock: KeychainControllerProtocol {
         }
         setPINCodeBiometricStateCallsCount += 1
         setPINCodeBiometricStateReceivedState = state
-        setPINCodeBiometricStateReceivedInvocations.append(state)
+        DispatchQueue.main.async {
+            self.setPINCodeBiometricStateReceivedInvocations.append(state)
+        }
         try setPINCodeBiometricStateClosure?(state)
     }
     //MARK: - pinCodeBiometricState
@@ -5146,7 +5248,9 @@ class MediaPlayerMock: MediaPlayerProtocol {
     func load(mediaSource: MediaSourceProxy, using url: URL, autoplay: Bool) {
         loadMediaSourceUsingAutoplayCallsCount += 1
         loadMediaSourceUsingAutoplayReceivedArguments = (mediaSource: mediaSource, url: url, autoplay: autoplay)
-        loadMediaSourceUsingAutoplayReceivedInvocations.append((mediaSource: mediaSource, url: url, autoplay: autoplay))
+        DispatchQueue.main.async {
+            self.loadMediaSourceUsingAutoplayReceivedInvocations.append((mediaSource: mediaSource, url: url, autoplay: autoplay))
+        }
         loadMediaSourceUsingAutoplayClosure?(mediaSource, url, autoplay)
     }
     //MARK: - reset
@@ -5325,7 +5429,9 @@ class MediaPlayerMock: MediaPlayerProtocol {
     func seek(to progress: Double) async {
         seekToCallsCount += 1
         seekToReceivedProgress = progress
-        seekToReceivedInvocations.append(progress)
+        DispatchQueue.main.async {
+            self.seekToReceivedInvocations.append(progress)
+        }
         await seekToClosure?(progress)
     }
 }
@@ -5392,7 +5498,9 @@ class MediaPlayerProviderMock: MediaPlayerProviderProtocol {
     func player(for mediaSource: MediaSourceProxy) -> Result<MediaPlayerProtocol, MediaPlayerProviderError> {
         playerForCallsCount += 1
         playerForReceivedMediaSource = mediaSource
-        playerForReceivedInvocations.append(mediaSource)
+        DispatchQueue.main.async {
+            self.playerForReceivedInvocations.append(mediaSource)
+        }
         if let playerForClosure = playerForClosure {
             return playerForClosure(mediaSource)
         } else {
@@ -5460,7 +5568,9 @@ class MediaPlayerProviderMock: MediaPlayerProviderProtocol {
     func playerState(for id: AudioPlayerStateIdentifier) -> AudioPlayerState? {
         playerStateForCallsCount += 1
         playerStateForReceivedId = id
-        playerStateForReceivedInvocations.append(id)
+        DispatchQueue.main.async {
+            self.playerStateForReceivedInvocations.append(id)
+        }
         if let playerStateForClosure = playerStateForClosure {
             return playerStateForClosure(id)
         } else {
@@ -5503,7 +5613,9 @@ class MediaPlayerProviderMock: MediaPlayerProviderProtocol {
     func register(audioPlayerState: AudioPlayerState) {
         registerAudioPlayerStateCallsCount += 1
         registerAudioPlayerStateReceivedAudioPlayerState = audioPlayerState
-        registerAudioPlayerStateReceivedInvocations.append(audioPlayerState)
+        DispatchQueue.main.async {
+            self.registerAudioPlayerStateReceivedInvocations.append(audioPlayerState)
+        }
         registerAudioPlayerStateClosure?(audioPlayerState)
     }
     //MARK: - unregister
@@ -5542,7 +5654,9 @@ class MediaPlayerProviderMock: MediaPlayerProviderProtocol {
     func unregister(audioPlayerState: AudioPlayerState) {
         unregisterAudioPlayerStateCallsCount += 1
         unregisterAudioPlayerStateReceivedAudioPlayerState = audioPlayerState
-        unregisterAudioPlayerStateReceivedInvocations.append(audioPlayerState)
+        DispatchQueue.main.async {
+            self.unregisterAudioPlayerStateReceivedInvocations.append(audioPlayerState)
+        }
         unregisterAudioPlayerStateClosure?(audioPlayerState)
     }
     //MARK: - detachAllStates
@@ -5581,7 +5695,9 @@ class MediaPlayerProviderMock: MediaPlayerProviderProtocol {
     func detachAllStates(except exception: AudioPlayerState?) async {
         detachAllStatesExceptCallsCount += 1
         detachAllStatesExceptReceivedException = exception
-        detachAllStatesExceptReceivedInvocations.append(exception)
+        DispatchQueue.main.async {
+            self.detachAllStatesExceptReceivedInvocations.append(exception)
+        }
         await detachAllStatesExceptClosure?(exception)
     }
 }
@@ -5631,7 +5747,9 @@ class NotificationCenterMock: NotificationCenterProtocol {
     func post(name aName: NSNotification.Name, object anObject: Any?) {
         postNameObjectCallsCount += 1
         postNameObjectReceivedArguments = (aName: aName, anObject: anObject)
-        postNameObjectReceivedInvocations.append((aName: aName, anObject: anObject))
+        DispatchQueue.main.async {
+            self.postNameObjectReceivedInvocations.append((aName: aName, anObject: anObject))
+        }
         postNameObjectClosure?(aName, anObject)
     }
 }
@@ -5734,7 +5852,9 @@ class NotificationManagerMock: NotificationManagerProtocol {
     func register(with deviceToken: Data) async -> Bool {
         registerWithCallsCount += 1
         registerWithReceivedDeviceToken = deviceToken
-        registerWithReceivedInvocations.append(deviceToken)
+        DispatchQueue.main.async {
+            self.registerWithReceivedInvocations.append(deviceToken)
+        }
         if let registerWithClosure = registerWithClosure {
             return await registerWithClosure(deviceToken)
         } else {
@@ -5777,7 +5897,9 @@ class NotificationManagerMock: NotificationManagerProtocol {
     func registrationFailed(with error: Error) {
         registrationFailedWithCallsCount += 1
         registrationFailedWithReceivedError = error
-        registrationFailedWithReceivedInvocations.append(error)
+        DispatchQueue.main.async {
+            self.registrationFailedWithReceivedInvocations.append(error)
+        }
         registrationFailedWithClosure?(error)
     }
     //MARK: - showLocalNotification
@@ -5816,7 +5938,9 @@ class NotificationManagerMock: NotificationManagerProtocol {
     func showLocalNotification(with title: String, subtitle: String?) async {
         showLocalNotificationWithSubtitleCallsCount += 1
         showLocalNotificationWithSubtitleReceivedArguments = (title: title, subtitle: subtitle)
-        showLocalNotificationWithSubtitleReceivedInvocations.append((title: title, subtitle: subtitle))
+        DispatchQueue.main.async {
+            self.showLocalNotificationWithSubtitleReceivedInvocations.append((title: title, subtitle: subtitle))
+        }
         await showLocalNotificationWithSubtitleClosure?(title, subtitle)
     }
     //MARK: - setUserSession
@@ -5855,7 +5979,9 @@ class NotificationManagerMock: NotificationManagerProtocol {
     func setUserSession(_ userSession: UserSessionProtocol?) {
         setUserSessionCallsCount += 1
         setUserSessionReceivedUserSession = userSession
-        setUserSessionReceivedInvocations.append(userSession)
+        DispatchQueue.main.async {
+            self.setUserSessionReceivedInvocations.append(userSession)
+        }
         setUserSessionClosure?(userSession)
     }
     //MARK: - requestAuthorization
@@ -5929,7 +6055,9 @@ class NotificationManagerMock: NotificationManagerProtocol {
     func removeDeliveredMessageNotifications(for roomID: String) async {
         removeDeliveredMessageNotificationsForCallsCount += 1
         removeDeliveredMessageNotificationsForReceivedRoomID = roomID
-        removeDeliveredMessageNotificationsForReceivedInvocations.append(roomID)
+        DispatchQueue.main.async {
+            self.removeDeliveredMessageNotificationsForReceivedInvocations.append(roomID)
+        }
         await removeDeliveredMessageNotificationsForClosure?(roomID)
     }
     //MARK: - removeDeliveredInviteNotifications
@@ -6040,7 +6168,9 @@ class NotificationSettingsProxyMock: NotificationSettingsProxyProtocol {
         }
         getNotificationSettingsRoomIdIsEncryptedIsOneToOneCallsCount += 1
         getNotificationSettingsRoomIdIsEncryptedIsOneToOneReceivedArguments = (roomId: roomId, isEncrypted: isEncrypted, isOneToOne: isOneToOne)
-        getNotificationSettingsRoomIdIsEncryptedIsOneToOneReceivedInvocations.append((roomId: roomId, isEncrypted: isEncrypted, isOneToOne: isOneToOne))
+        DispatchQueue.main.async {
+            self.getNotificationSettingsRoomIdIsEncryptedIsOneToOneReceivedInvocations.append((roomId: roomId, isEncrypted: isEncrypted, isOneToOne: isOneToOne))
+        }
         if let getNotificationSettingsRoomIdIsEncryptedIsOneToOneClosure = getNotificationSettingsRoomIdIsEncryptedIsOneToOneClosure {
             return try await getNotificationSettingsRoomIdIsEncryptedIsOneToOneClosure(roomId, isEncrypted, isOneToOne)
         } else {
@@ -6087,7 +6217,9 @@ class NotificationSettingsProxyMock: NotificationSettingsProxyProtocol {
         }
         setNotificationModeRoomIdModeCallsCount += 1
         setNotificationModeRoomIdModeReceivedArguments = (roomId: roomId, mode: mode)
-        setNotificationModeRoomIdModeReceivedInvocations.append((roomId: roomId, mode: mode))
+        DispatchQueue.main.async {
+            self.setNotificationModeRoomIdModeReceivedInvocations.append((roomId: roomId, mode: mode))
+        }
         try await setNotificationModeRoomIdModeClosure?(roomId, mode)
     }
     //MARK: - getUserDefinedRoomNotificationMode
@@ -6155,7 +6287,9 @@ class NotificationSettingsProxyMock: NotificationSettingsProxyProtocol {
         }
         getUserDefinedRoomNotificationModeRoomIdCallsCount += 1
         getUserDefinedRoomNotificationModeRoomIdReceivedRoomId = roomId
-        getUserDefinedRoomNotificationModeRoomIdReceivedInvocations.append(roomId)
+        DispatchQueue.main.async {
+            self.getUserDefinedRoomNotificationModeRoomIdReceivedInvocations.append(roomId)
+        }
         if let getUserDefinedRoomNotificationModeRoomIdClosure = getUserDefinedRoomNotificationModeRoomIdClosure {
             return try await getUserDefinedRoomNotificationModeRoomIdClosure(roomId)
         } else {
@@ -6223,7 +6357,9 @@ class NotificationSettingsProxyMock: NotificationSettingsProxyProtocol {
     func getDefaultRoomNotificationMode(isEncrypted: Bool, isOneToOne: Bool) async -> RoomNotificationModeProxy {
         getDefaultRoomNotificationModeIsEncryptedIsOneToOneCallsCount += 1
         getDefaultRoomNotificationModeIsEncryptedIsOneToOneReceivedArguments = (isEncrypted: isEncrypted, isOneToOne: isOneToOne)
-        getDefaultRoomNotificationModeIsEncryptedIsOneToOneReceivedInvocations.append((isEncrypted: isEncrypted, isOneToOne: isOneToOne))
+        DispatchQueue.main.async {
+            self.getDefaultRoomNotificationModeIsEncryptedIsOneToOneReceivedInvocations.append((isEncrypted: isEncrypted, isOneToOne: isOneToOne))
+        }
         if let getDefaultRoomNotificationModeIsEncryptedIsOneToOneClosure = getDefaultRoomNotificationModeIsEncryptedIsOneToOneClosure {
             return await getDefaultRoomNotificationModeIsEncryptedIsOneToOneClosure(isEncrypted, isOneToOne)
         } else {
@@ -6270,7 +6406,9 @@ class NotificationSettingsProxyMock: NotificationSettingsProxyProtocol {
         }
         setDefaultRoomNotificationModeIsEncryptedIsOneToOneModeCallsCount += 1
         setDefaultRoomNotificationModeIsEncryptedIsOneToOneModeReceivedArguments = (isEncrypted: isEncrypted, isOneToOne: isOneToOne, mode: mode)
-        setDefaultRoomNotificationModeIsEncryptedIsOneToOneModeReceivedInvocations.append((isEncrypted: isEncrypted, isOneToOne: isOneToOne, mode: mode))
+        DispatchQueue.main.async {
+            self.setDefaultRoomNotificationModeIsEncryptedIsOneToOneModeReceivedInvocations.append((isEncrypted: isEncrypted, isOneToOne: isOneToOne, mode: mode))
+        }
         try await setDefaultRoomNotificationModeIsEncryptedIsOneToOneModeClosure?(isEncrypted, isOneToOne, mode)
     }
     //MARK: - restoreDefaultNotificationMode
@@ -6313,7 +6451,9 @@ class NotificationSettingsProxyMock: NotificationSettingsProxyProtocol {
         }
         restoreDefaultNotificationModeRoomIdCallsCount += 1
         restoreDefaultNotificationModeRoomIdReceivedRoomId = roomId
-        restoreDefaultNotificationModeRoomIdReceivedInvocations.append(roomId)
+        DispatchQueue.main.async {
+            self.restoreDefaultNotificationModeRoomIdReceivedInvocations.append(roomId)
+        }
         try await restoreDefaultNotificationModeRoomIdClosure?(roomId)
     }
     //MARK: - unmuteRoom
@@ -6356,7 +6496,9 @@ class NotificationSettingsProxyMock: NotificationSettingsProxyProtocol {
         }
         unmuteRoomRoomIdIsEncryptedIsOneToOneCallsCount += 1
         unmuteRoomRoomIdIsEncryptedIsOneToOneReceivedArguments = (roomId: roomId, isEncrypted: isEncrypted, isOneToOne: isOneToOne)
-        unmuteRoomRoomIdIsEncryptedIsOneToOneReceivedInvocations.append((roomId: roomId, isEncrypted: isEncrypted, isOneToOne: isOneToOne))
+        DispatchQueue.main.async {
+            self.unmuteRoomRoomIdIsEncryptedIsOneToOneReceivedInvocations.append((roomId: roomId, isEncrypted: isEncrypted, isOneToOne: isOneToOne))
+        }
         try await unmuteRoomRoomIdIsEncryptedIsOneToOneClosure?(roomId, isEncrypted, isOneToOne)
     }
     //MARK: - isRoomMentionEnabled
@@ -6467,7 +6609,9 @@ class NotificationSettingsProxyMock: NotificationSettingsProxyProtocol {
         }
         setRoomMentionEnabledEnabledCallsCount += 1
         setRoomMentionEnabledEnabledReceivedEnabled = enabled
-        setRoomMentionEnabledEnabledReceivedInvocations.append(enabled)
+        DispatchQueue.main.async {
+            self.setRoomMentionEnabledEnabledReceivedInvocations.append(enabled)
+        }
         try await setRoomMentionEnabledEnabledClosure?(enabled)
     }
     //MARK: - isCallEnabled
@@ -6578,7 +6722,9 @@ class NotificationSettingsProxyMock: NotificationSettingsProxyProtocol {
         }
         setCallEnabledEnabledCallsCount += 1
         setCallEnabledEnabledReceivedEnabled = enabled
-        setCallEnabledEnabledReceivedInvocations.append(enabled)
+        DispatchQueue.main.async {
+            self.setCallEnabledEnabledReceivedInvocations.append(enabled)
+        }
         try await setCallEnabledEnabledClosure?(enabled)
     }
     //MARK: - isInviteForMeEnabled
@@ -6689,7 +6835,9 @@ class NotificationSettingsProxyMock: NotificationSettingsProxyProtocol {
         }
         setInviteForMeEnabledEnabledCallsCount += 1
         setInviteForMeEnabledEnabledReceivedEnabled = enabled
-        setInviteForMeEnabledEnabledReceivedInvocations.append(enabled)
+        DispatchQueue.main.async {
+            self.setInviteForMeEnabledEnabledReceivedInvocations.append(enabled)
+        }
         try await setInviteForMeEnabledEnabledClosure?(enabled)
     }
     //MARK: - getRoomsWithUserDefinedRules
@@ -6863,7 +7011,9 @@ class OrientationManagerMock: OrientationManagerProtocol {
     func setOrientation(_ orientation: UIInterfaceOrientationMask) {
         setOrientationCallsCount += 1
         setOrientationReceivedOrientation = orientation
-        setOrientationReceivedInvocations.append(orientation)
+        DispatchQueue.main.async {
+            self.setOrientationReceivedInvocations.append(orientation)
+        }
         setOrientationClosure?(orientation)
     }
     //MARK: - lockOrientation
@@ -6902,7 +7052,9 @@ class OrientationManagerMock: OrientationManagerProtocol {
     func lockOrientation(_ orientation: UIInterfaceOrientationMask) {
         lockOrientationCallsCount += 1
         lockOrientationReceivedOrientation = orientation
-        lockOrientationReceivedInvocations.append(orientation)
+        DispatchQueue.main.async {
+            self.lockOrientationReceivedInvocations.append(orientation)
+        }
         lockOrientationClosure?(orientation)
     }
 }
@@ -7049,7 +7201,9 @@ class PHGPostHogMock: PHGPostHogProtocol {
     func capture(_ event: String, properties: [String: Any]?, userProperties: [String: Any]?) {
         capturePropertiesUserPropertiesCallsCount += 1
         capturePropertiesUserPropertiesReceivedArguments = (event: event, properties: properties, userProperties: userProperties)
-        capturePropertiesUserPropertiesReceivedInvocations.append((event: event, properties: properties, userProperties: userProperties))
+        DispatchQueue.main.async {
+            self.capturePropertiesUserPropertiesReceivedInvocations.append((event: event, properties: properties, userProperties: userProperties))
+        }
         capturePropertiesUserPropertiesClosure?(event, properties, userProperties)
     }
     //MARK: - screen
@@ -7088,7 +7242,9 @@ class PHGPostHogMock: PHGPostHogProtocol {
     func screen(_ screenTitle: String, properties: [String: Any]?) {
         screenPropertiesCallsCount += 1
         screenPropertiesReceivedArguments = (screenTitle: screenTitle, properties: properties)
-        screenPropertiesReceivedInvocations.append((screenTitle: screenTitle, properties: properties))
+        DispatchQueue.main.async {
+            self.screenPropertiesReceivedInvocations.append((screenTitle: screenTitle, properties: properties))
+        }
         screenPropertiesClosure?(screenTitle, properties)
     }
 }
@@ -7155,7 +7311,9 @@ class PollInteractionHandlerMock: PollInteractionHandlerProtocol {
     func sendPollResponse(pollStartID: String, optionID: String) async -> Result<Void, Error> {
         sendPollResponsePollStartIDOptionIDCallsCount += 1
         sendPollResponsePollStartIDOptionIDReceivedArguments = (pollStartID: pollStartID, optionID: optionID)
-        sendPollResponsePollStartIDOptionIDReceivedInvocations.append((pollStartID: pollStartID, optionID: optionID))
+        DispatchQueue.main.async {
+            self.sendPollResponsePollStartIDOptionIDReceivedInvocations.append((pollStartID: pollStartID, optionID: optionID))
+        }
         if let sendPollResponsePollStartIDOptionIDClosure = sendPollResponsePollStartIDOptionIDClosure {
             return await sendPollResponsePollStartIDOptionIDClosure(pollStartID, optionID)
         } else {
@@ -7223,7 +7381,9 @@ class PollInteractionHandlerMock: PollInteractionHandlerProtocol {
     func endPoll(pollStartID: String) async -> Result<Void, Error> {
         endPollPollStartIDCallsCount += 1
         endPollPollStartIDReceivedPollStartID = pollStartID
-        endPollPollStartIDReceivedInvocations.append(pollStartID)
+        DispatchQueue.main.async {
+            self.endPollPollStartIDReceivedInvocations.append(pollStartID)
+        }
         if let endPollPollStartIDClosure = endPollPollStartIDClosure {
             return await endPollPollStartIDClosure(pollStartID)
         } else {
@@ -7299,7 +7459,9 @@ class QRCodeLoginServiceMock: QRCodeLoginServiceProtocol {
     func loginWithQRCode(data: Data) async -> Result<UserSessionProtocol, QRCodeLoginServiceError> {
         loginWithQRCodeDataCallsCount += 1
         loginWithQRCodeDataReceivedData = data
-        loginWithQRCodeDataReceivedInvocations.append(data)
+        DispatchQueue.main.async {
+            self.loginWithQRCodeDataReceivedInvocations.append(data)
+        }
         if let loginWithQRCodeDataClosure = loginWithQRCodeDataClosure {
             return await loginWithQRCodeDataClosure(data)
         } else {
@@ -7375,7 +7537,9 @@ class RoomDirectorySearchProxyMock: RoomDirectorySearchProxyProtocol {
     func search(query: String?) async -> Result<Void, RoomDirectorySearchError> {
         searchQueryCallsCount += 1
         searchQueryReceivedQuery = query
-        searchQueryReceivedInvocations.append(query)
+        DispatchQueue.main.async {
+            self.searchQueryReceivedInvocations.append(query)
+        }
         if let searchQueryClosure = searchQueryClosure {
             return await searchQueryClosure(query)
         } else {
@@ -7714,7 +7878,9 @@ class RoomProxyMock: RoomProxyProtocol {
     func timelineFocusedOnEvent(eventID: String, numberOfEvents: UInt16) async -> Result<TimelineProxyProtocol, RoomProxyError> {
         timelineFocusedOnEventEventIDNumberOfEventsCallsCount += 1
         timelineFocusedOnEventEventIDNumberOfEventsReceivedArguments = (eventID: eventID, numberOfEvents: numberOfEvents)
-        timelineFocusedOnEventEventIDNumberOfEventsReceivedInvocations.append((eventID: eventID, numberOfEvents: numberOfEvents))
+        DispatchQueue.main.async {
+            self.timelineFocusedOnEventEventIDNumberOfEventsReceivedInvocations.append((eventID: eventID, numberOfEvents: numberOfEvents))
+        }
         if let timelineFocusedOnEventEventIDNumberOfEventsClosure = timelineFocusedOnEventEventIDNumberOfEventsClosure {
             return await timelineFocusedOnEventEventIDNumberOfEventsClosure(eventID, numberOfEvents)
         } else {
@@ -7782,7 +7948,9 @@ class RoomProxyMock: RoomProxyProtocol {
     func redact(_ eventID: String) async -> Result<Void, RoomProxyError> {
         redactCallsCount += 1
         redactReceivedEventID = eventID
-        redactReceivedInvocations.append(eventID)
+        DispatchQueue.main.async {
+            self.redactReceivedInvocations.append(eventID)
+        }
         if let redactClosure = redactClosure {
             return await redactClosure(eventID)
         } else {
@@ -7850,7 +8018,9 @@ class RoomProxyMock: RoomProxyProtocol {
     func reportContent(_ eventID: String, reason: String?) async -> Result<Void, RoomProxyError> {
         reportContentReasonCallsCount += 1
         reportContentReasonReceivedArguments = (eventID: eventID, reason: reason)
-        reportContentReasonReceivedInvocations.append((eventID: eventID, reason: reason))
+        DispatchQueue.main.async {
+            self.reportContentReasonReceivedInvocations.append((eventID: eventID, reason: reason))
+        }
         if let reportContentReasonClosure = reportContentReasonClosure {
             return await reportContentReasonClosure(eventID, reason)
         } else {
@@ -8017,7 +8187,9 @@ class RoomProxyMock: RoomProxyProtocol {
     func getMember(userID: String) async -> Result<RoomMemberProxyProtocol, RoomProxyError> {
         getMemberUserIDCallsCount += 1
         getMemberUserIDReceivedUserID = userID
-        getMemberUserIDReceivedInvocations.append(userID)
+        DispatchQueue.main.async {
+            self.getMemberUserIDReceivedInvocations.append(userID)
+        }
         if let getMemberUserIDClosure = getMemberUserIDClosure {
             return await getMemberUserIDClosure(userID)
         } else {
@@ -8213,7 +8385,9 @@ class RoomProxyMock: RoomProxyProtocol {
     func invite(userID: String) async -> Result<Void, RoomProxyError> {
         inviteUserIDCallsCount += 1
         inviteUserIDReceivedUserID = userID
-        inviteUserIDReceivedInvocations.append(userID)
+        DispatchQueue.main.async {
+            self.inviteUserIDReceivedInvocations.append(userID)
+        }
         if let inviteUserIDClosure = inviteUserIDClosure {
             return await inviteUserIDClosure(userID)
         } else {
@@ -8281,7 +8455,9 @@ class RoomProxyMock: RoomProxyProtocol {
     func setName(_ name: String) async -> Result<Void, RoomProxyError> {
         setNameCallsCount += 1
         setNameReceivedName = name
-        setNameReceivedInvocations.append(name)
+        DispatchQueue.main.async {
+            self.setNameReceivedInvocations.append(name)
+        }
         if let setNameClosure = setNameClosure {
             return await setNameClosure(name)
         } else {
@@ -8349,7 +8525,9 @@ class RoomProxyMock: RoomProxyProtocol {
     func setTopic(_ topic: String) async -> Result<Void, RoomProxyError> {
         setTopicCallsCount += 1
         setTopicReceivedTopic = topic
-        setTopicReceivedInvocations.append(topic)
+        DispatchQueue.main.async {
+            self.setTopicReceivedInvocations.append(topic)
+        }
         if let setTopicClosure = setTopicClosure {
             return await setTopicClosure(topic)
         } else {
@@ -8481,7 +8659,9 @@ class RoomProxyMock: RoomProxyProtocol {
     func uploadAvatar(media: MediaInfo) async -> Result<Void, RoomProxyError> {
         uploadAvatarMediaCallsCount += 1
         uploadAvatarMediaReceivedMedia = media
-        uploadAvatarMediaReceivedInvocations.append(media)
+        DispatchQueue.main.async {
+            self.uploadAvatarMediaReceivedInvocations.append(media)
+        }
         if let uploadAvatarMediaClosure = uploadAvatarMediaClosure {
             return await uploadAvatarMediaClosure(media)
         } else {
@@ -8549,7 +8729,9 @@ class RoomProxyMock: RoomProxyProtocol {
     func markAsRead(receiptType: ReceiptType) async -> Result<Void, RoomProxyError> {
         markAsReadReceiptTypeCallsCount += 1
         markAsReadReceiptTypeReceivedReceiptType = receiptType
-        markAsReadReceiptTypeReceivedInvocations.append(receiptType)
+        DispatchQueue.main.async {
+            self.markAsReadReceiptTypeReceivedInvocations.append(receiptType)
+        }
         if let markAsReadReceiptTypeClosure = markAsReadReceiptTypeClosure {
             return await markAsReadReceiptTypeClosure(receiptType)
         } else {
@@ -8618,7 +8800,9 @@ class RoomProxyMock: RoomProxyProtocol {
     func sendTypingNotification(isTyping: Bool) async -> Result<Void, RoomProxyError> {
         sendTypingNotificationIsTypingCallsCount += 1
         sendTypingNotificationIsTypingReceivedIsTyping = isTyping
-        sendTypingNotificationIsTypingReceivedInvocations.append(isTyping)
+        DispatchQueue.main.async {
+            self.sendTypingNotificationIsTypingReceivedInvocations.append(isTyping)
+        }
         if let sendTypingNotificationIsTypingClosure = sendTypingNotificationIsTypingClosure {
             return await sendTypingNotificationIsTypingClosure(isTyping)
         } else {
@@ -8686,7 +8870,9 @@ class RoomProxyMock: RoomProxyProtocol {
     func flagAsUnread(_ isUnread: Bool) async -> Result<Void, RoomProxyError> {
         flagAsUnreadCallsCount += 1
         flagAsUnreadReceivedIsUnread = isUnread
-        flagAsUnreadReceivedInvocations.append(isUnread)
+        DispatchQueue.main.async {
+            self.flagAsUnreadReceivedInvocations.append(isUnread)
+        }
         if let flagAsUnreadClosure = flagAsUnreadClosure {
             return await flagAsUnreadClosure(isUnread)
         } else {
@@ -8754,7 +8940,9 @@ class RoomProxyMock: RoomProxyProtocol {
     func flagAsFavourite(_ isFavourite: Bool) async -> Result<Void, RoomProxyError> {
         flagAsFavouriteCallsCount += 1
         flagAsFavouriteReceivedIsFavourite = isFavourite
-        flagAsFavouriteReceivedInvocations.append(isFavourite)
+        DispatchQueue.main.async {
+            self.flagAsFavouriteReceivedInvocations.append(isFavourite)
+        }
         if let flagAsFavouriteClosure = flagAsFavouriteClosure {
             return await flagAsFavouriteClosure(isFavourite)
         } else {
@@ -8886,7 +9074,9 @@ class RoomProxyMock: RoomProxyProtocol {
     func applyPowerLevelChanges(_ changes: RoomPowerLevelChanges) async -> Result<Void, RoomProxyError> {
         applyPowerLevelChangesCallsCount += 1
         applyPowerLevelChangesReceivedChanges = changes
-        applyPowerLevelChangesReceivedInvocations.append(changes)
+        DispatchQueue.main.async {
+            self.applyPowerLevelChangesReceivedInvocations.append(changes)
+        }
         if let applyPowerLevelChangesClosure = applyPowerLevelChangesClosure {
             return await applyPowerLevelChangesClosure(changes)
         } else {
@@ -9018,7 +9208,9 @@ class RoomProxyMock: RoomProxyProtocol {
     func suggestedRole(for userID: String) async -> Result<RoomMemberRole, RoomProxyError> {
         suggestedRoleForCallsCount += 1
         suggestedRoleForReceivedUserID = userID
-        suggestedRoleForReceivedInvocations.append(userID)
+        DispatchQueue.main.async {
+            self.suggestedRoleForReceivedInvocations.append(userID)
+        }
         if let suggestedRoleForClosure = suggestedRoleForClosure {
             return await suggestedRoleForClosure(userID)
         } else {
@@ -9086,7 +9278,9 @@ class RoomProxyMock: RoomProxyProtocol {
     func updatePowerLevelsForUsers(_ updates: [(userID: String, powerLevel: Int64)]) async -> Result<Void, RoomProxyError> {
         updatePowerLevelsForUsersCallsCount += 1
         updatePowerLevelsForUsersReceivedUpdates = updates
-        updatePowerLevelsForUsersReceivedInvocations.append(updates)
+        DispatchQueue.main.async {
+            self.updatePowerLevelsForUsersReceivedInvocations.append(updates)
+        }
         if let updatePowerLevelsForUsersClosure = updatePowerLevelsForUsersClosure {
             return await updatePowerLevelsForUsersClosure(updates)
         } else {
@@ -9154,7 +9348,9 @@ class RoomProxyMock: RoomProxyProtocol {
     func canUser(userID: String, sendStateEvent event: StateEventType) async -> Result<Bool, RoomProxyError> {
         canUserUserIDSendStateEventCallsCount += 1
         canUserUserIDSendStateEventReceivedArguments = (userID: userID, event: event)
-        canUserUserIDSendStateEventReceivedInvocations.append((userID: userID, event: event))
+        DispatchQueue.main.async {
+            self.canUserUserIDSendStateEventReceivedInvocations.append((userID: userID, event: event))
+        }
         if let canUserUserIDSendStateEventClosure = canUserUserIDSendStateEventClosure {
             return await canUserUserIDSendStateEventClosure(userID, event)
         } else {
@@ -9222,7 +9418,9 @@ class RoomProxyMock: RoomProxyProtocol {
     func canUserInvite(userID: String) async -> Result<Bool, RoomProxyError> {
         canUserInviteUserIDCallsCount += 1
         canUserInviteUserIDReceivedUserID = userID
-        canUserInviteUserIDReceivedInvocations.append(userID)
+        DispatchQueue.main.async {
+            self.canUserInviteUserIDReceivedInvocations.append(userID)
+        }
         if let canUserInviteUserIDClosure = canUserInviteUserIDClosure {
             return await canUserInviteUserIDClosure(userID)
         } else {
@@ -9290,7 +9488,9 @@ class RoomProxyMock: RoomProxyProtocol {
     func canUserRedactOther(userID: String) async -> Result<Bool, RoomProxyError> {
         canUserRedactOtherUserIDCallsCount += 1
         canUserRedactOtherUserIDReceivedUserID = userID
-        canUserRedactOtherUserIDReceivedInvocations.append(userID)
+        DispatchQueue.main.async {
+            self.canUserRedactOtherUserIDReceivedInvocations.append(userID)
+        }
         if let canUserRedactOtherUserIDClosure = canUserRedactOtherUserIDClosure {
             return await canUserRedactOtherUserIDClosure(userID)
         } else {
@@ -9358,7 +9558,9 @@ class RoomProxyMock: RoomProxyProtocol {
     func canUserRedactOwn(userID: String) async -> Result<Bool, RoomProxyError> {
         canUserRedactOwnUserIDCallsCount += 1
         canUserRedactOwnUserIDReceivedUserID = userID
-        canUserRedactOwnUserIDReceivedInvocations.append(userID)
+        DispatchQueue.main.async {
+            self.canUserRedactOwnUserIDReceivedInvocations.append(userID)
+        }
         if let canUserRedactOwnUserIDClosure = canUserRedactOwnUserIDClosure {
             return await canUserRedactOwnUserIDClosure(userID)
         } else {
@@ -9426,7 +9628,9 @@ class RoomProxyMock: RoomProxyProtocol {
     func canUserKick(userID: String) async -> Result<Bool, RoomProxyError> {
         canUserKickUserIDCallsCount += 1
         canUserKickUserIDReceivedUserID = userID
-        canUserKickUserIDReceivedInvocations.append(userID)
+        DispatchQueue.main.async {
+            self.canUserKickUserIDReceivedInvocations.append(userID)
+        }
         if let canUserKickUserIDClosure = canUserKickUserIDClosure {
             return await canUserKickUserIDClosure(userID)
         } else {
@@ -9494,7 +9698,9 @@ class RoomProxyMock: RoomProxyProtocol {
     func canUserBan(userID: String) async -> Result<Bool, RoomProxyError> {
         canUserBanUserIDCallsCount += 1
         canUserBanUserIDReceivedUserID = userID
-        canUserBanUserIDReceivedInvocations.append(userID)
+        DispatchQueue.main.async {
+            self.canUserBanUserIDReceivedInvocations.append(userID)
+        }
         if let canUserBanUserIDClosure = canUserBanUserIDClosure {
             return await canUserBanUserIDClosure(userID)
         } else {
@@ -9562,7 +9768,9 @@ class RoomProxyMock: RoomProxyProtocol {
     func canUserTriggerRoomNotification(userID: String) async -> Result<Bool, RoomProxyError> {
         canUserTriggerRoomNotificationUserIDCallsCount += 1
         canUserTriggerRoomNotificationUserIDReceivedUserID = userID
-        canUserTriggerRoomNotificationUserIDReceivedInvocations.append(userID)
+        DispatchQueue.main.async {
+            self.canUserTriggerRoomNotificationUserIDReceivedInvocations.append(userID)
+        }
         if let canUserTriggerRoomNotificationUserIDClosure = canUserTriggerRoomNotificationUserIDClosure {
             return await canUserTriggerRoomNotificationUserIDClosure(userID)
         } else {
@@ -9630,7 +9838,9 @@ class RoomProxyMock: RoomProxyProtocol {
     func kickUser(_ userID: String) async -> Result<Void, RoomProxyError> {
         kickUserCallsCount += 1
         kickUserReceivedUserID = userID
-        kickUserReceivedInvocations.append(userID)
+        DispatchQueue.main.async {
+            self.kickUserReceivedInvocations.append(userID)
+        }
         if let kickUserClosure = kickUserClosure {
             return await kickUserClosure(userID)
         } else {
@@ -9698,7 +9908,9 @@ class RoomProxyMock: RoomProxyProtocol {
     func banUser(_ userID: String) async -> Result<Void, RoomProxyError> {
         banUserCallsCount += 1
         banUserReceivedUserID = userID
-        banUserReceivedInvocations.append(userID)
+        DispatchQueue.main.async {
+            self.banUserReceivedInvocations.append(userID)
+        }
         if let banUserClosure = banUserClosure {
             return await banUserClosure(userID)
         } else {
@@ -9766,7 +9978,9 @@ class RoomProxyMock: RoomProxyProtocol {
     func unbanUser(_ userID: String) async -> Result<Void, RoomProxyError> {
         unbanUserCallsCount += 1
         unbanUserReceivedUserID = userID
-        unbanUserReceivedInvocations.append(userID)
+        DispatchQueue.main.async {
+            self.unbanUserReceivedInvocations.append(userID)
+        }
         if let unbanUserClosure = unbanUserClosure {
             return await unbanUserClosure(userID)
         } else {
@@ -9834,7 +10048,9 @@ class RoomProxyMock: RoomProxyProtocol {
     func canUserJoinCall(userID: String) async -> Result<Bool, RoomProxyError> {
         canUserJoinCallUserIDCallsCount += 1
         canUserJoinCallUserIDReceivedUserID = userID
-        canUserJoinCallUserIDReceivedInvocations.append(userID)
+        DispatchQueue.main.async {
+            self.canUserJoinCallUserIDReceivedInvocations.append(userID)
+        }
         if let canUserJoinCallUserIDClosure = canUserJoinCallUserIDClosure {
             return await canUserJoinCallUserIDClosure(userID)
         } else {
@@ -10094,7 +10310,9 @@ class RoomProxyMock: RoomProxyProtocol {
     func matrixToEventPermalink(_ eventID: String) async -> Result<URL, RoomProxyError> {
         matrixToEventPermalinkCallsCount += 1
         matrixToEventPermalinkReceivedEventID = eventID
-        matrixToEventPermalinkReceivedInvocations.append(eventID)
+        DispatchQueue.main.async {
+            self.matrixToEventPermalinkReceivedInvocations.append(eventID)
+        }
         if let matrixToEventPermalinkClosure = matrixToEventPermalinkClosure {
             return await matrixToEventPermalinkClosure(eventID)
         } else {
@@ -10150,7 +10368,9 @@ class RoomSummaryProviderMock: RoomSummaryProviderProtocol {
     func setRoomList(_ roomList: RoomList) {
         setRoomListCallsCount += 1
         setRoomListReceivedRoomList = roomList
-        setRoomListReceivedInvocations.append(roomList)
+        DispatchQueue.main.async {
+            self.setRoomListReceivedInvocations.append(roomList)
+        }
         setRoomListClosure?(roomList)
     }
     //MARK: - updateVisibleRange
@@ -10189,7 +10409,9 @@ class RoomSummaryProviderMock: RoomSummaryProviderProtocol {
     func updateVisibleRange(_ range: Range<Int>) {
         updateVisibleRangeCallsCount += 1
         updateVisibleRangeReceivedRange = range
-        updateVisibleRangeReceivedInvocations.append(range)
+        DispatchQueue.main.async {
+            self.updateVisibleRangeReceivedInvocations.append(range)
+        }
         updateVisibleRangeClosure?(range)
     }
     //MARK: - setFilter
@@ -10228,7 +10450,9 @@ class RoomSummaryProviderMock: RoomSummaryProviderProtocol {
     func setFilter(_ filter: RoomSummaryProviderFilter) {
         setFilterCallsCount += 1
         setFilterReceivedFilter = filter
-        setFilterReceivedInvocations.append(filter)
+        DispatchQueue.main.async {
+            self.setFilterReceivedInvocations.append(filter)
+        }
         setFilterClosure?(filter)
     }
 }
@@ -10295,7 +10519,9 @@ class RoomTimelineControllerFactoryMock: RoomTimelineControllerFactoryProtocol {
     func buildRoomTimelineController(roomProxy: RoomProxyProtocol, initialFocussedEventID: String?, timelineItemFactory: RoomTimelineItemFactoryProtocol) -> RoomTimelineControllerProtocol {
         buildRoomTimelineControllerRoomProxyInitialFocussedEventIDTimelineItemFactoryCallsCount += 1
         buildRoomTimelineControllerRoomProxyInitialFocussedEventIDTimelineItemFactoryReceivedArguments = (roomProxy: roomProxy, initialFocussedEventID: initialFocussedEventID, timelineItemFactory: timelineItemFactory)
-        buildRoomTimelineControllerRoomProxyInitialFocussedEventIDTimelineItemFactoryReceivedInvocations.append((roomProxy: roomProxy, initialFocussedEventID: initialFocussedEventID, timelineItemFactory: timelineItemFactory))
+        DispatchQueue.main.async {
+            self.buildRoomTimelineControllerRoomProxyInitialFocussedEventIDTimelineItemFactoryReceivedInvocations.append((roomProxy: roomProxy, initialFocussedEventID: initialFocussedEventID, timelineItemFactory: timelineItemFactory))
+        }
         if let buildRoomTimelineControllerRoomProxyInitialFocussedEventIDTimelineItemFactoryClosure = buildRoomTimelineControllerRoomProxyInitialFocussedEventIDTimelineItemFactoryClosure {
             return buildRoomTimelineControllerRoomProxyInitialFocussedEventIDTimelineItemFactoryClosure(roomProxy, initialFocussedEventID, timelineItemFactory)
         } else {
@@ -10592,7 +10818,9 @@ class SecureBackupControllerMock: SecureBackupControllerProtocol {
     func confirmRecoveryKey(_ key: String) async -> Result<Void, SecureBackupControllerError> {
         confirmRecoveryKeyCallsCount += 1
         confirmRecoveryKeyReceivedKey = key
-        confirmRecoveryKeyReceivedInvocations.append(key)
+        DispatchQueue.main.async {
+            self.confirmRecoveryKeyReceivedInvocations.append(key)
+        }
         if let confirmRecoveryKeyClosure = confirmRecoveryKeyClosure {
             return await confirmRecoveryKeyClosure(key)
         } else {
@@ -11070,7 +11298,9 @@ class TimelineProxyMock: TimelineProxyProtocol {
     func fetchDetails(for eventID: String) {
         fetchDetailsForCallsCount += 1
         fetchDetailsForReceivedEventID = eventID
-        fetchDetailsForReceivedInvocations.append(eventID)
+        DispatchQueue.main.async {
+            self.fetchDetailsForReceivedInvocations.append(eventID)
+        }
         fetchDetailsForClosure?(eventID)
     }
     //MARK: - messageEventContent
@@ -11134,7 +11364,9 @@ class TimelineProxyMock: TimelineProxyProtocol {
     func messageEventContent(for timelineItemID: TimelineItemIdentifier) async -> RoomMessageEventContentWithoutRelation? {
         messageEventContentForCallsCount += 1
         messageEventContentForReceivedTimelineItemID = timelineItemID
-        messageEventContentForReceivedInvocations.append(timelineItemID)
+        DispatchQueue.main.async {
+            self.messageEventContentForReceivedInvocations.append(timelineItemID)
+        }
         if let messageEventContentForClosure = messageEventContentForClosure {
             return await messageEventContentForClosure(timelineItemID)
         } else {
@@ -11177,7 +11409,9 @@ class TimelineProxyMock: TimelineProxyProtocol {
     func retryDecryption(for sessionID: String) async {
         retryDecryptionForCallsCount += 1
         retryDecryptionForReceivedSessionID = sessionID
-        retryDecryptionForReceivedInvocations.append(sessionID)
+        DispatchQueue.main.async {
+            self.retryDecryptionForReceivedInvocations.append(sessionID)
+        }
         await retryDecryptionForClosure?(sessionID)
     }
     //MARK: - paginateBackwards
@@ -11241,7 +11475,9 @@ class TimelineProxyMock: TimelineProxyProtocol {
     func paginateBackwards(requestSize: UInt16) async -> Result<Void, TimelineProxyError> {
         paginateBackwardsRequestSizeCallsCount += 1
         paginateBackwardsRequestSizeReceivedRequestSize = requestSize
-        paginateBackwardsRequestSizeReceivedInvocations.append(requestSize)
+        DispatchQueue.main.async {
+            self.paginateBackwardsRequestSizeReceivedInvocations.append(requestSize)
+        }
         if let paginateBackwardsRequestSizeClosure = paginateBackwardsRequestSizeClosure {
             return await paginateBackwardsRequestSizeClosure(requestSize)
         } else {
@@ -11309,7 +11545,9 @@ class TimelineProxyMock: TimelineProxyProtocol {
     func paginateForwards(requestSize: UInt16) async -> Result<Void, TimelineProxyError> {
         paginateForwardsRequestSizeCallsCount += 1
         paginateForwardsRequestSizeReceivedRequestSize = requestSize
-        paginateForwardsRequestSizeReceivedInvocations.append(requestSize)
+        DispatchQueue.main.async {
+            self.paginateForwardsRequestSizeReceivedInvocations.append(requestSize)
+        }
         if let paginateForwardsRequestSizeClosure = paginateForwardsRequestSizeClosure {
             return await paginateForwardsRequestSizeClosure(requestSize)
         } else {
@@ -11377,7 +11615,9 @@ class TimelineProxyMock: TimelineProxyProtocol {
     func edit(_ timelineItemID: TimelineItemIdentifier, message: String, html: String?, intentionalMentions: IntentionalMentions) async -> Result<Void, TimelineProxyError> {
         editMessageHtmlIntentionalMentionsCallsCount += 1
         editMessageHtmlIntentionalMentionsReceivedArguments = (timelineItemID: timelineItemID, message: message, html: html, intentionalMentions: intentionalMentions)
-        editMessageHtmlIntentionalMentionsReceivedInvocations.append((timelineItemID: timelineItemID, message: message, html: html, intentionalMentions: intentionalMentions))
+        DispatchQueue.main.async {
+            self.editMessageHtmlIntentionalMentionsReceivedInvocations.append((timelineItemID: timelineItemID, message: message, html: html, intentionalMentions: intentionalMentions))
+        }
         if let editMessageHtmlIntentionalMentionsClosure = editMessageHtmlIntentionalMentionsClosure {
             return await editMessageHtmlIntentionalMentionsClosure(timelineItemID, message, html, intentionalMentions)
         } else {
@@ -11445,7 +11685,9 @@ class TimelineProxyMock: TimelineProxyProtocol {
     func redact(_ timelineItemID: TimelineItemIdentifier, reason: String?) async -> Result<Void, TimelineProxyError> {
         redactReasonCallsCount += 1
         redactReasonReceivedArguments = (timelineItemID: timelineItemID, reason: reason)
-        redactReasonReceivedInvocations.append((timelineItemID: timelineItemID, reason: reason))
+        DispatchQueue.main.async {
+            self.redactReasonReceivedInvocations.append((timelineItemID: timelineItemID, reason: reason))
+        }
         if let redactReasonClosure = redactReasonClosure {
             return await redactReasonClosure(timelineItemID, reason)
         } else {
@@ -11705,7 +11947,9 @@ class TimelineProxyMock: TimelineProxyProtocol {
     func sendLocation(body: String, geoURI: GeoURI, description: String?, zoomLevel: UInt8?, assetType: AssetType?) async -> Result<Void, TimelineProxyError> {
         sendLocationBodyGeoURIDescriptionZoomLevelAssetTypeCallsCount += 1
         sendLocationBodyGeoURIDescriptionZoomLevelAssetTypeReceivedArguments = (body: body, geoURI: geoURI, description: description, zoomLevel: zoomLevel, assetType: assetType)
-        sendLocationBodyGeoURIDescriptionZoomLevelAssetTypeReceivedInvocations.append((body: body, geoURI: geoURI, description: description, zoomLevel: zoomLevel, assetType: assetType))
+        DispatchQueue.main.async {
+            self.sendLocationBodyGeoURIDescriptionZoomLevelAssetTypeReceivedInvocations.append((body: body, geoURI: geoURI, description: description, zoomLevel: zoomLevel, assetType: assetType))
+        }
         if let sendLocationBodyGeoURIDescriptionZoomLevelAssetTypeClosure = sendLocationBodyGeoURIDescriptionZoomLevelAssetTypeClosure {
             return await sendLocationBodyGeoURIDescriptionZoomLevelAssetTypeClosure(body, geoURI, description, zoomLevel, assetType)
         } else {
@@ -11901,7 +12145,9 @@ class TimelineProxyMock: TimelineProxyProtocol {
     func sendReadReceipt(for eventID: String, type: ReceiptType) async -> Result<Void, TimelineProxyError> {
         sendReadReceiptForTypeCallsCount += 1
         sendReadReceiptForTypeReceivedArguments = (eventID: eventID, type: type)
-        sendReadReceiptForTypeReceivedInvocations.append((eventID: eventID, type: type))
+        DispatchQueue.main.async {
+            self.sendReadReceiptForTypeReceivedInvocations.append((eventID: eventID, type: type))
+        }
         if let sendReadReceiptForTypeClosure = sendReadReceiptForTypeClosure {
             return await sendReadReceiptForTypeClosure(eventID, type)
         } else {
@@ -11969,7 +12215,9 @@ class TimelineProxyMock: TimelineProxyProtocol {
     func sendMessageEventContent(_ messageContent: RoomMessageEventContentWithoutRelation) async -> Result<Void, TimelineProxyError> {
         sendMessageEventContentCallsCount += 1
         sendMessageEventContentReceivedMessageContent = messageContent
-        sendMessageEventContentReceivedInvocations.append(messageContent)
+        DispatchQueue.main.async {
+            self.sendMessageEventContentReceivedInvocations.append(messageContent)
+        }
         if let sendMessageEventContentClosure = sendMessageEventContentClosure {
             return await sendMessageEventContentClosure(messageContent)
         } else {
@@ -12037,7 +12285,9 @@ class TimelineProxyMock: TimelineProxyProtocol {
     func sendMessage(_ message: String, html: String?, inReplyTo eventID: String?, intentionalMentions: IntentionalMentions) async -> Result<Void, TimelineProxyError> {
         sendMessageHtmlInReplyToIntentionalMentionsCallsCount += 1
         sendMessageHtmlInReplyToIntentionalMentionsReceivedArguments = (message: message, html: html, eventID: eventID, intentionalMentions: intentionalMentions)
-        sendMessageHtmlInReplyToIntentionalMentionsReceivedInvocations.append((message: message, html: html, eventID: eventID, intentionalMentions: intentionalMentions))
+        DispatchQueue.main.async {
+            self.sendMessageHtmlInReplyToIntentionalMentionsReceivedInvocations.append((message: message, html: html, eventID: eventID, intentionalMentions: intentionalMentions))
+        }
         if let sendMessageHtmlInReplyToIntentionalMentionsClosure = sendMessageHtmlInReplyToIntentionalMentionsClosure {
             return await sendMessageHtmlInReplyToIntentionalMentionsClosure(message, html, eventID, intentionalMentions)
         } else {
@@ -12105,7 +12355,9 @@ class TimelineProxyMock: TimelineProxyProtocol {
     func toggleReaction(_ reaction: String, to eventID: String) async -> Result<Void, TimelineProxyError> {
         toggleReactionToCallsCount += 1
         toggleReactionToReceivedArguments = (reaction: reaction, eventID: eventID)
-        toggleReactionToReceivedInvocations.append((reaction: reaction, eventID: eventID))
+        DispatchQueue.main.async {
+            self.toggleReactionToReceivedInvocations.append((reaction: reaction, eventID: eventID))
+        }
         if let toggleReactionToClosure = toggleReactionToClosure {
             return await toggleReactionToClosure(reaction, eventID)
         } else {
@@ -12173,7 +12425,9 @@ class TimelineProxyMock: TimelineProxyProtocol {
     func createPoll(question: String, answers: [String], pollKind: Poll.Kind) async -> Result<Void, TimelineProxyError> {
         createPollQuestionAnswersPollKindCallsCount += 1
         createPollQuestionAnswersPollKindReceivedArguments = (question: question, answers: answers, pollKind: pollKind)
-        createPollQuestionAnswersPollKindReceivedInvocations.append((question: question, answers: answers, pollKind: pollKind))
+        DispatchQueue.main.async {
+            self.createPollQuestionAnswersPollKindReceivedInvocations.append((question: question, answers: answers, pollKind: pollKind))
+        }
         if let createPollQuestionAnswersPollKindClosure = createPollQuestionAnswersPollKindClosure {
             return await createPollQuestionAnswersPollKindClosure(question, answers, pollKind)
         } else {
@@ -12241,7 +12495,9 @@ class TimelineProxyMock: TimelineProxyProtocol {
     func editPoll(original eventID: String, question: String, answers: [String], pollKind: Poll.Kind) async -> Result<Void, TimelineProxyError> {
         editPollOriginalQuestionAnswersPollKindCallsCount += 1
         editPollOriginalQuestionAnswersPollKindReceivedArguments = (eventID: eventID, question: question, answers: answers, pollKind: pollKind)
-        editPollOriginalQuestionAnswersPollKindReceivedInvocations.append((eventID: eventID, question: question, answers: answers, pollKind: pollKind))
+        DispatchQueue.main.async {
+            self.editPollOriginalQuestionAnswersPollKindReceivedInvocations.append((eventID: eventID, question: question, answers: answers, pollKind: pollKind))
+        }
         if let editPollOriginalQuestionAnswersPollKindClosure = editPollOriginalQuestionAnswersPollKindClosure {
             return await editPollOriginalQuestionAnswersPollKindClosure(eventID, question, answers, pollKind)
         } else {
@@ -12309,7 +12565,9 @@ class TimelineProxyMock: TimelineProxyProtocol {
     func endPoll(pollStartID: String, text: String) async -> Result<Void, TimelineProxyError> {
         endPollPollStartIDTextCallsCount += 1
         endPollPollStartIDTextReceivedArguments = (pollStartID: pollStartID, text: text)
-        endPollPollStartIDTextReceivedInvocations.append((pollStartID: pollStartID, text: text))
+        DispatchQueue.main.async {
+            self.endPollPollStartIDTextReceivedInvocations.append((pollStartID: pollStartID, text: text))
+        }
         if let endPollPollStartIDTextClosure = endPollPollStartIDTextClosure {
             return await endPollPollStartIDTextClosure(pollStartID, text)
         } else {
@@ -12377,7 +12635,9 @@ class TimelineProxyMock: TimelineProxyProtocol {
     func sendPollResponse(pollStartID: String, answers: [String]) async -> Result<Void, TimelineProxyError> {
         sendPollResponsePollStartIDAnswersCallsCount += 1
         sendPollResponsePollStartIDAnswersReceivedArguments = (pollStartID: pollStartID, answers: answers)
-        sendPollResponsePollStartIDAnswersReceivedInvocations.append((pollStartID: pollStartID, answers: answers))
+        DispatchQueue.main.async {
+            self.sendPollResponsePollStartIDAnswersReceivedInvocations.append((pollStartID: pollStartID, answers: answers))
+        }
         if let sendPollResponsePollStartIDAnswersClosure = sendPollResponsePollStartIDAnswersClosure {
             return await sendPollResponsePollStartIDAnswersClosure(pollStartID, answers)
         } else {
@@ -12448,7 +12708,9 @@ class UserDiscoveryServiceMock: UserDiscoveryServiceProtocol {
     func searchProfiles(with searchQuery: String) async -> Result<[UserProfileProxy], UserDiscoveryErrorType> {
         searchProfilesWithCallsCount += 1
         searchProfilesWithReceivedSearchQuery = searchQuery
-        searchProfilesWithReceivedInvocations.append(searchQuery)
+        DispatchQueue.main.async {
+            self.searchProfilesWithReceivedInvocations.append(searchQuery)
+        }
         if let searchProfilesWithClosure = searchProfilesWithClosure {
             return await searchProfilesWithClosure(searchQuery)
         } else {
@@ -12496,7 +12758,9 @@ class UserIndicatorControllerMock: UserIndicatorControllerProtocol {
     func submitIndicator(_ indicator: UserIndicator, delay: Duration?) {
         submitIndicatorDelayCallsCount += 1
         submitIndicatorDelayReceivedArguments = (indicator: indicator, delay: delay)
-        submitIndicatorDelayReceivedInvocations.append((indicator: indicator, delay: delay))
+        DispatchQueue.main.async {
+            self.submitIndicatorDelayReceivedInvocations.append((indicator: indicator, delay: delay))
+        }
         submitIndicatorDelayClosure?(indicator, delay)
     }
     //MARK: - retractIndicatorWithId
@@ -12535,7 +12799,9 @@ class UserIndicatorControllerMock: UserIndicatorControllerProtocol {
     func retractIndicatorWithId(_ id: String) {
         retractIndicatorWithIdCallsCount += 1
         retractIndicatorWithIdReceivedId = id
-        retractIndicatorWithIdReceivedInvocations.append(id)
+        DispatchQueue.main.async {
+            self.retractIndicatorWithIdReceivedInvocations.append(id)
+        }
         retractIndicatorWithIdClosure?(id)
     }
     //MARK: - retractAllIndicators
@@ -12751,7 +13017,9 @@ class UserNotificationCenterMock: UserNotificationCenterProtocol {
         }
         addCallsCount += 1
         addReceivedRequest = request
-        addReceivedInvocations.append(request)
+        DispatchQueue.main.async {
+            self.addReceivedInvocations.append(request)
+        }
         try await addClosure?(request)
     }
     //MARK: - requestAuthorization
@@ -12819,7 +13087,9 @@ class UserNotificationCenterMock: UserNotificationCenterProtocol {
         }
         requestAuthorizationOptionsCallsCount += 1
         requestAuthorizationOptionsReceivedOptions = options
-        requestAuthorizationOptionsReceivedInvocations.append(options)
+        DispatchQueue.main.async {
+            self.requestAuthorizationOptionsReceivedInvocations.append(options)
+        }
         if let requestAuthorizationOptionsClosure = requestAuthorizationOptionsClosure {
             return try await requestAuthorizationOptionsClosure(options)
         } else {
@@ -12926,7 +13196,9 @@ class UserNotificationCenterMock: UserNotificationCenterProtocol {
     func removeDeliveredNotifications(withIdentifiers identifiers: [String]) {
         removeDeliveredNotificationsWithIdentifiersCallsCount += 1
         removeDeliveredNotificationsWithIdentifiersReceivedIdentifiers = identifiers
-        removeDeliveredNotificationsWithIdentifiersReceivedInvocations.append(identifiers)
+        DispatchQueue.main.async {
+            self.removeDeliveredNotificationsWithIdentifiersReceivedInvocations.append(identifiers)
+        }
         removeDeliveredNotificationsWithIdentifiersClosure?(identifiers)
     }
     //MARK: - setNotificationCategories
@@ -12965,7 +13237,9 @@ class UserNotificationCenterMock: UserNotificationCenterProtocol {
     func setNotificationCategories(_ categories: Set<UNNotificationCategory>) {
         setNotificationCategoriesCallsCount += 1
         setNotificationCategoriesReceivedCategories = categories
-        setNotificationCategoriesReceivedInvocations.append(categories)
+        DispatchQueue.main.async {
+            self.setNotificationCategoriesReceivedInvocations.append(categories)
+        }
         setNotificationCategoriesClosure?(categories)
     }
     //MARK: - authorizationStatus
@@ -13129,7 +13403,9 @@ class VoiceMessageCacheMock: VoiceMessageCacheProtocol {
     func fileURL(for mediaSource: MediaSourceProxy) -> URL? {
         fileURLForCallsCount += 1
         fileURLForReceivedMediaSource = mediaSource
-        fileURLForReceivedInvocations.append(mediaSource)
+        DispatchQueue.main.async {
+            self.fileURLForReceivedInvocations.append(mediaSource)
+        }
         if let fileURLForClosure = fileURLForClosure {
             return fileURLForClosure(mediaSource)
         } else {
@@ -13197,7 +13473,9 @@ class VoiceMessageCacheMock: VoiceMessageCacheProtocol {
     func cache(mediaSource: MediaSourceProxy, using fileURL: URL, move: Bool) -> Result<URL, VoiceMessageCacheError> {
         cacheMediaSourceUsingMoveCallsCount += 1
         cacheMediaSourceUsingMoveReceivedArguments = (mediaSource: mediaSource, fileURL: fileURL, move: move)
-        cacheMediaSourceUsingMoveReceivedInvocations.append((mediaSource: mediaSource, fileURL: fileURL, move: move))
+        DispatchQueue.main.async {
+            self.cacheMediaSourceUsingMoveReceivedInvocations.append((mediaSource: mediaSource, fileURL: fileURL, move: move))
+        }
         if let cacheMediaSourceUsingMoveClosure = cacheMediaSourceUsingMoveClosure {
             return cacheMediaSourceUsingMoveClosure(mediaSource, fileURL, move)
         } else {
@@ -13307,7 +13585,9 @@ class VoiceMessageMediaManagerMock: VoiceMessageMediaManagerProtocol {
         }
         loadVoiceMessageFromSourceBodyCallsCount += 1
         loadVoiceMessageFromSourceBodyReceivedArguments = (source: source, body: body)
-        loadVoiceMessageFromSourceBodyReceivedInvocations.append((source: source, body: body))
+        DispatchQueue.main.async {
+            self.loadVoiceMessageFromSourceBodyReceivedInvocations.append((source: source, body: body))
+        }
         if let loadVoiceMessageFromSourceBodyClosure = loadVoiceMessageFromSourceBodyClosure {
             return try await loadVoiceMessageFromSourceBodyClosure(source, body)
         } else {
@@ -13604,7 +13884,9 @@ class VoiceMessageRecorderMock: VoiceMessageRecorderProtocol {
     func seekPlayback(to progress: Double) async {
         seekPlaybackToCallsCount += 1
         seekPlaybackToReceivedProgress = progress
-        seekPlaybackToReceivedInvocations.append(progress)
+        DispatchQueue.main.async {
+            self.seekPlaybackToReceivedInvocations.append(progress)
+        }
         await seekPlaybackToClosure?(progress)
     }
     //MARK: - deleteRecording
@@ -13703,7 +13985,9 @@ class VoiceMessageRecorderMock: VoiceMessageRecorderProtocol {
     func sendVoiceMessage(inRoom roomProxy: RoomProxyProtocol, audioConverter: AudioConverterProtocol) async -> Result<Void, VoiceMessageRecorderError> {
         sendVoiceMessageInRoomAudioConverterCallsCount += 1
         sendVoiceMessageInRoomAudioConverterReceivedArguments = (roomProxy: roomProxy, audioConverter: audioConverter)
-        sendVoiceMessageInRoomAudioConverterReceivedInvocations.append((roomProxy: roomProxy, audioConverter: audioConverter))
+        DispatchQueue.main.async {
+            self.sendVoiceMessageInRoomAudioConverterReceivedInvocations.append((roomProxy: roomProxy, audioConverter: audioConverter))
+        }
         if let sendVoiceMessageInRoomAudioConverterClosure = sendVoiceMessageInRoomAudioConverterClosure {
             return await sendVoiceMessageInRoomAudioConverterClosure(roomProxy, audioConverter)
         } else {
@@ -13824,7 +14108,9 @@ class WindowManagerMock: WindowManagerProtocol {
     func setOrientation(_ orientation: UIInterfaceOrientationMask) {
         setOrientationCallsCount += 1
         setOrientationReceivedOrientation = orientation
-        setOrientationReceivedInvocations.append(orientation)
+        DispatchQueue.main.async {
+            self.setOrientationReceivedInvocations.append(orientation)
+        }
         setOrientationClosure?(orientation)
     }
     //MARK: - lockOrientation
@@ -13863,7 +14149,9 @@ class WindowManagerMock: WindowManagerProtocol {
     func lockOrientation(_ orientation: UIInterfaceOrientationMask) {
         lockOrientationCallsCount += 1
         lockOrientationReceivedOrientation = orientation
-        lockOrientationReceivedInvocations.append(orientation)
+        DispatchQueue.main.async {
+            self.lockOrientationReceivedInvocations.append(orientation)
+        }
         lockOrientationClosure?(orientation)
     }
 }

--- a/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
@@ -10248,6 +10248,46 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
     }
 
+    //MARK: - clearComposerDraft
+
+    open var clearComposerDraftThrowableError: Error?
+    var clearComposerDraftUnderlyingCallsCount = 0
+    open var clearComposerDraftCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return clearComposerDraftUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = clearComposerDraftUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                clearComposerDraftUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    clearComposerDraftUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var clearComposerDraftCalled: Bool {
+        return clearComposerDraftCallsCount > 0
+    }
+    open var clearComposerDraftClosure: (() async throws -> Void)?
+
+    open override func clearComposerDraft() async throws {
+        if let error = clearComposerDraftThrowableError {
+            throw error
+        }
+        clearComposerDraftCallsCount += 1
+        try await clearComposerDraftClosure?()
+    }
+
     //MARK: - discardRoomKey
 
     open var discardRoomKeyThrowableError: Error?
@@ -11393,6 +11433,75 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         try await leaveClosure?()
     }
 
+    //MARK: - loadComposerDraft
+
+    open var loadComposerDraftThrowableError: Error?
+    var loadComposerDraftUnderlyingCallsCount = 0
+    open var loadComposerDraftCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return loadComposerDraftUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = loadComposerDraftUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                loadComposerDraftUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    loadComposerDraftUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var loadComposerDraftCalled: Bool {
+        return loadComposerDraftCallsCount > 0
+    }
+
+    var loadComposerDraftUnderlyingReturnValue: ComposerDraft?
+    open var loadComposerDraftReturnValue: ComposerDraft? {
+        get {
+            if Thread.isMainThread {
+                return loadComposerDraftUnderlyingReturnValue
+            } else {
+                var returnValue: ComposerDraft?? = nil
+                DispatchQueue.main.sync {
+                    returnValue = loadComposerDraftUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                loadComposerDraftUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    loadComposerDraftUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    open var loadComposerDraftClosure: (() async throws -> ComposerDraft?)?
+
+    open override func loadComposerDraft() async throws -> ComposerDraft? {
+        if let error = loadComposerDraftThrowableError {
+            throw error
+        }
+        loadComposerDraftCallsCount += 1
+        if let loadComposerDraftClosure = loadComposerDraftClosure {
+            return try await loadComposerDraftClosure()
+        } else {
+            return loadComposerDraftReturnValue
+        }
+    }
+
     //MARK: - markAsRead
 
     open var markAsReadReceiptTypeThrowableError: Error?
@@ -12395,6 +12504,50 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         } else {
             return roomInfoReturnValue
         }
+    }
+
+    //MARK: - saveComposerDraft
+
+    open var saveComposerDraftDraftThrowableError: Error?
+    var saveComposerDraftDraftUnderlyingCallsCount = 0
+    open var saveComposerDraftDraftCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return saveComposerDraftDraftUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = saveComposerDraftDraftUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                saveComposerDraftDraftUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    saveComposerDraftDraftUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var saveComposerDraftDraftCalled: Bool {
+        return saveComposerDraftDraftCallsCount > 0
+    }
+    open var saveComposerDraftDraftReceivedDraft: ComposerDraft?
+    open var saveComposerDraftDraftReceivedInvocations: [ComposerDraft] = []
+    open var saveComposerDraftDraftClosure: ((ComposerDraft) async throws -> Void)?
+
+    open override func saveComposerDraft(draft: ComposerDraft) async throws {
+        if let error = saveComposerDraftDraftThrowableError {
+            throw error
+        }
+        saveComposerDraftDraftCallsCount += 1
+        saveComposerDraftDraftReceivedDraft = draft
+        saveComposerDraftDraftReceivedInvocations.append(draft)
+        try await saveComposerDraftDraftClosure?(draft)
     }
 
     //MARK: - sendCallNotification
@@ -16621,13 +16774,13 @@ open class TimelineSDKMock: MatrixRustSDK.Timeline {
     open var addListenerListenerReceivedListener: TimelineListener?
     open var addListenerListenerReceivedInvocations: [TimelineListener] = []
 
-    var addListenerListenerUnderlyingReturnValue: RoomTimelineListenerResult!
-    open var addListenerListenerReturnValue: RoomTimelineListenerResult! {
+    var addListenerListenerUnderlyingReturnValue: TaskHandle!
+    open var addListenerListenerReturnValue: TaskHandle! {
         get {
             if Thread.isMainThread {
                 return addListenerListenerUnderlyingReturnValue
             } else {
-                var returnValue: RoomTimelineListenerResult? = nil
+                var returnValue: TaskHandle? = nil
                 DispatchQueue.main.sync {
                     returnValue = addListenerListenerUnderlyingReturnValue
                 }
@@ -16645,9 +16798,9 @@ open class TimelineSDKMock: MatrixRustSDK.Timeline {
             }
         }
     }
-    open var addListenerListenerClosure: ((TimelineListener) async -> RoomTimelineListenerResult)?
+    open var addListenerListenerClosure: ((TimelineListener) async -> TaskHandle)?
 
-    open override func addListener(listener: TimelineListener) async -> RoomTimelineListenerResult {
+    open override func addListener(listener: TimelineListener) async -> TaskHandle {
         addListenerListenerCallsCount += 1
         addListenerListenerReceivedListener = listener
         addListenerListenerReceivedInvocations.append(listener)
@@ -17195,6 +17348,79 @@ open class TimelineSDKMock: MatrixRustSDK.Timeline {
             return await latestEventClosure()
         } else {
             return latestEventReturnValue
+        }
+    }
+
+    //MARK: - loadReplyDetails
+
+    open var loadReplyDetailsEventIdStrThrowableError: Error?
+    var loadReplyDetailsEventIdStrUnderlyingCallsCount = 0
+    open var loadReplyDetailsEventIdStrCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return loadReplyDetailsEventIdStrUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = loadReplyDetailsEventIdStrUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                loadReplyDetailsEventIdStrUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    loadReplyDetailsEventIdStrUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var loadReplyDetailsEventIdStrCalled: Bool {
+        return loadReplyDetailsEventIdStrCallsCount > 0
+    }
+    open var loadReplyDetailsEventIdStrReceivedEventIdStr: String?
+    open var loadReplyDetailsEventIdStrReceivedInvocations: [String] = []
+
+    var loadReplyDetailsEventIdStrUnderlyingReturnValue: InReplyToDetails!
+    open var loadReplyDetailsEventIdStrReturnValue: InReplyToDetails! {
+        get {
+            if Thread.isMainThread {
+                return loadReplyDetailsEventIdStrUnderlyingReturnValue
+            } else {
+                var returnValue: InReplyToDetails? = nil
+                DispatchQueue.main.sync {
+                    returnValue = loadReplyDetailsEventIdStrUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                loadReplyDetailsEventIdStrUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    loadReplyDetailsEventIdStrUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    open var loadReplyDetailsEventIdStrClosure: ((String) async throws -> InReplyToDetails)?
+
+    open override func loadReplyDetails(eventIdStr: String) async throws -> InReplyToDetails {
+        if let error = loadReplyDetailsEventIdStrThrowableError {
+            throw error
+        }
+        loadReplyDetailsEventIdStrCallsCount += 1
+        loadReplyDetailsEventIdStrReceivedEventIdStr = eventIdStr
+        loadReplyDetailsEventIdStrReceivedInvocations.append(eventIdStr)
+        if let loadReplyDetailsEventIdStrClosure = loadReplyDetailsEventIdStrClosure {
+            return try await loadReplyDetailsEventIdStrClosure(eventIdStr)
+        } else {
+            return loadReplyDetailsEventIdStrReturnValue
         }
     }
 

--- a/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
@@ -131,7 +131,9 @@ open class AuthenticationServiceSDKMock: MatrixRustSDK.AuthenticationService {
         }
         configureHomeserverServerNameOrHomeserverUrlCallsCount += 1
         configureHomeserverServerNameOrHomeserverUrlReceivedServerNameOrHomeserverUrl = serverNameOrHomeserverUrl
-        configureHomeserverServerNameOrHomeserverUrlReceivedInvocations.append(serverNameOrHomeserverUrl)
+        DispatchQueue.main.async {
+            self.configureHomeserverServerNameOrHomeserverUrlReceivedInvocations.append(serverNameOrHomeserverUrl)
+        }
         try await configureHomeserverServerNameOrHomeserverUrlClosure?(serverNameOrHomeserverUrl)
     }
 
@@ -265,7 +267,9 @@ open class AuthenticationServiceSDKMock: MatrixRustSDK.AuthenticationService {
         }
         loginUsernamePasswordInitialDeviceNameDeviceIdCallsCount += 1
         loginUsernamePasswordInitialDeviceNameDeviceIdReceivedArguments = (username: username, password: password, initialDeviceName: initialDeviceName, deviceId: deviceId)
-        loginUsernamePasswordInitialDeviceNameDeviceIdReceivedInvocations.append((username: username, password: password, initialDeviceName: initialDeviceName, deviceId: deviceId))
+        DispatchQueue.main.async {
+            self.loginUsernamePasswordInitialDeviceNameDeviceIdReceivedInvocations.append((username: username, password: password, initialDeviceName: initialDeviceName, deviceId: deviceId))
+        }
         if let loginUsernamePasswordInitialDeviceNameDeviceIdClosure = loginUsernamePasswordInitialDeviceNameDeviceIdClosure {
             return try await loginUsernamePasswordInitialDeviceNameDeviceIdClosure(username, password, initialDeviceName, deviceId)
         } else {
@@ -338,7 +342,9 @@ open class AuthenticationServiceSDKMock: MatrixRustSDK.AuthenticationService {
         }
         loginWithOidcCallbackAuthenticationDataCallbackUrlCallsCount += 1
         loginWithOidcCallbackAuthenticationDataCallbackUrlReceivedArguments = (authenticationData: authenticationData, callbackUrl: callbackUrl)
-        loginWithOidcCallbackAuthenticationDataCallbackUrlReceivedInvocations.append((authenticationData: authenticationData, callbackUrl: callbackUrl))
+        DispatchQueue.main.async {
+            self.loginWithOidcCallbackAuthenticationDataCallbackUrlReceivedInvocations.append((authenticationData: authenticationData, callbackUrl: callbackUrl))
+        }
         if let loginWithOidcCallbackAuthenticationDataCallbackUrlClosure = loginWithOidcCallbackAuthenticationDataCallbackUrlClosure {
             return try await loginWithOidcCallbackAuthenticationDataCallbackUrlClosure(authenticationData, callbackUrl)
         } else {
@@ -491,7 +497,9 @@ open class ClientSDKMock: MatrixRustSDK.Client {
         }
         accountDataEventTypeCallsCount += 1
         accountDataEventTypeReceivedEventType = eventType
-        accountDataEventTypeReceivedInvocations.append(eventType)
+        DispatchQueue.main.async {
+            self.accountDataEventTypeReceivedInvocations.append(eventType)
+        }
         if let accountDataEventTypeClosure = accountDataEventTypeClosure {
             return try await accountDataEventTypeClosure(eventType)
         } else {
@@ -564,7 +572,9 @@ open class ClientSDKMock: MatrixRustSDK.Client {
         }
         accountUrlActionCallsCount += 1
         accountUrlActionReceivedAction = action
-        accountUrlActionReceivedInvocations.append(action)
+        DispatchQueue.main.async {
+            self.accountUrlActionReceivedInvocations.append(action)
+        }
         if let accountUrlActionClosure = accountUrlActionClosure {
             return try await accountUrlActionClosure(action)
         } else {
@@ -775,7 +785,9 @@ open class ClientSDKMock: MatrixRustSDK.Client {
         }
         createRoomRequestCallsCount += 1
         createRoomRequestReceivedRequest = request
-        createRoomRequestReceivedInvocations.append(request)
+        DispatchQueue.main.async {
+            self.createRoomRequestReceivedInvocations.append(request)
+        }
         if let createRoomRequestClosure = createRoomRequestClosure {
             return try await createRoomRequestClosure(request)
         } else {
@@ -823,7 +835,9 @@ open class ClientSDKMock: MatrixRustSDK.Client {
         }
         deletePusherIdentifiersCallsCount += 1
         deletePusherIdentifiersReceivedIdentifiers = identifiers
-        deletePusherIdentifiersReceivedInvocations.append(identifiers)
+        DispatchQueue.main.async {
+            self.deletePusherIdentifiersReceivedInvocations.append(identifiers)
+        }
         try await deletePusherIdentifiersClosure?(identifiers)
     }
 
@@ -1001,7 +1015,9 @@ open class ClientSDKMock: MatrixRustSDK.Client {
     open override func enableAllSendQueues(enable: Bool) {
         enableAllSendQueuesEnableCallsCount += 1
         enableAllSendQueuesEnableReceivedEnable = enable
-        enableAllSendQueuesEnableReceivedInvocations.append(enable)
+        DispatchQueue.main.async {
+            self.enableAllSendQueuesEnableReceivedInvocations.append(enable)
+        }
         enableAllSendQueuesEnableClosure?(enable)
     }
 
@@ -1135,7 +1151,9 @@ open class ClientSDKMock: MatrixRustSDK.Client {
         }
         getDmRoomUserIdCallsCount += 1
         getDmRoomUserIdReceivedUserId = userId
-        getDmRoomUserIdReceivedInvocations.append(userId)
+        DispatchQueue.main.async {
+            self.getDmRoomUserIdReceivedInvocations.append(userId)
+        }
         if let getDmRoomUserIdClosure = getDmRoomUserIdClosure {
             return try getDmRoomUserIdClosure(userId)
         } else {
@@ -1208,7 +1226,9 @@ open class ClientSDKMock: MatrixRustSDK.Client {
         }
         getMediaContentMediaSourceCallsCount += 1
         getMediaContentMediaSourceReceivedMediaSource = mediaSource
-        getMediaContentMediaSourceReceivedInvocations.append(mediaSource)
+        DispatchQueue.main.async {
+            self.getMediaContentMediaSourceReceivedInvocations.append(mediaSource)
+        }
         if let getMediaContentMediaSourceClosure = getMediaContentMediaSourceClosure {
             return try await getMediaContentMediaSourceClosure(mediaSource)
         } else {
@@ -1281,7 +1301,9 @@ open class ClientSDKMock: MatrixRustSDK.Client {
         }
         getMediaFileMediaSourceBodyMimeTypeUseCacheTempDirCallsCount += 1
         getMediaFileMediaSourceBodyMimeTypeUseCacheTempDirReceivedArguments = (mediaSource: mediaSource, body: body, mimeType: mimeType, useCache: useCache, tempDir: tempDir)
-        getMediaFileMediaSourceBodyMimeTypeUseCacheTempDirReceivedInvocations.append((mediaSource: mediaSource, body: body, mimeType: mimeType, useCache: useCache, tempDir: tempDir))
+        DispatchQueue.main.async {
+            self.getMediaFileMediaSourceBodyMimeTypeUseCacheTempDirReceivedInvocations.append((mediaSource: mediaSource, body: body, mimeType: mimeType, useCache: useCache, tempDir: tempDir))
+        }
         if let getMediaFileMediaSourceBodyMimeTypeUseCacheTempDirClosure = getMediaFileMediaSourceBodyMimeTypeUseCacheTempDirClosure {
             return try await getMediaFileMediaSourceBodyMimeTypeUseCacheTempDirClosure(mediaSource, body, mimeType, useCache, tempDir)
         } else {
@@ -1354,7 +1376,9 @@ open class ClientSDKMock: MatrixRustSDK.Client {
         }
         getMediaThumbnailMediaSourceWidthHeightCallsCount += 1
         getMediaThumbnailMediaSourceWidthHeightReceivedArguments = (mediaSource: mediaSource, width: width, height: height)
-        getMediaThumbnailMediaSourceWidthHeightReceivedInvocations.append((mediaSource: mediaSource, width: width, height: height))
+        DispatchQueue.main.async {
+            self.getMediaThumbnailMediaSourceWidthHeightReceivedInvocations.append((mediaSource: mediaSource, width: width, height: height))
+        }
         if let getMediaThumbnailMediaSourceWidthHeightClosure = getMediaThumbnailMediaSourceWidthHeightClosure {
             return try await getMediaThumbnailMediaSourceWidthHeightClosure(mediaSource, width, height)
         } else {
@@ -1492,7 +1516,9 @@ open class ClientSDKMock: MatrixRustSDK.Client {
         }
         getProfileUserIdCallsCount += 1
         getProfileUserIdReceivedUserId = userId
-        getProfileUserIdReceivedInvocations.append(userId)
+        DispatchQueue.main.async {
+            self.getProfileUserIdReceivedInvocations.append(userId)
+        }
         if let getProfileUserIdClosure = getProfileUserIdClosure {
             return try await getProfileUserIdClosure(userId)
         } else {
@@ -1634,7 +1660,9 @@ open class ClientSDKMock: MatrixRustSDK.Client {
         }
         getRoomPreviewFromRoomAliasRoomAliasCallsCount += 1
         getRoomPreviewFromRoomAliasRoomAliasReceivedRoomAlias = roomAlias
-        getRoomPreviewFromRoomAliasRoomAliasReceivedInvocations.append(roomAlias)
+        DispatchQueue.main.async {
+            self.getRoomPreviewFromRoomAliasRoomAliasReceivedInvocations.append(roomAlias)
+        }
         if let getRoomPreviewFromRoomAliasRoomAliasClosure = getRoomPreviewFromRoomAliasRoomAliasClosure {
             return try await getRoomPreviewFromRoomAliasRoomAliasClosure(roomAlias)
         } else {
@@ -1707,7 +1735,9 @@ open class ClientSDKMock: MatrixRustSDK.Client {
         }
         getRoomPreviewFromRoomIdRoomIdViaServersCallsCount += 1
         getRoomPreviewFromRoomIdRoomIdViaServersReceivedArguments = (roomId: roomId, viaServers: viaServers)
-        getRoomPreviewFromRoomIdRoomIdViaServersReceivedInvocations.append((roomId: roomId, viaServers: viaServers))
+        DispatchQueue.main.async {
+            self.getRoomPreviewFromRoomIdRoomIdViaServersReceivedInvocations.append((roomId: roomId, viaServers: viaServers))
+        }
         if let getRoomPreviewFromRoomIdRoomIdViaServersClosure = getRoomPreviewFromRoomIdRoomIdViaServersClosure {
             return try await getRoomPreviewFromRoomIdRoomIdViaServersClosure(roomId, viaServers)
         } else {
@@ -1889,7 +1919,9 @@ open class ClientSDKMock: MatrixRustSDK.Client {
         }
         ignoreUserUserIdCallsCount += 1
         ignoreUserUserIdReceivedUserId = userId
-        ignoreUserUserIdReceivedInvocations.append(userId)
+        DispatchQueue.main.async {
+            self.ignoreUserUserIdReceivedInvocations.append(userId)
+        }
         try await ignoreUserUserIdClosure?(userId)
     }
 
@@ -2027,7 +2059,9 @@ open class ClientSDKMock: MatrixRustSDK.Client {
         }
         joinRoomByIdRoomIdCallsCount += 1
         joinRoomByIdRoomIdReceivedRoomId = roomId
-        joinRoomByIdRoomIdReceivedInvocations.append(roomId)
+        DispatchQueue.main.async {
+            self.joinRoomByIdRoomIdReceivedInvocations.append(roomId)
+        }
         if let joinRoomByIdRoomIdClosure = joinRoomByIdRoomIdClosure {
             return try await joinRoomByIdRoomIdClosure(roomId)
         } else {
@@ -2100,7 +2134,9 @@ open class ClientSDKMock: MatrixRustSDK.Client {
         }
         joinRoomByIdOrAliasRoomIdOrAliasServerNamesCallsCount += 1
         joinRoomByIdOrAliasRoomIdOrAliasServerNamesReceivedArguments = (roomIdOrAlias: roomIdOrAlias, serverNames: serverNames)
-        joinRoomByIdOrAliasRoomIdOrAliasServerNamesReceivedInvocations.append((roomIdOrAlias: roomIdOrAlias, serverNames: serverNames))
+        DispatchQueue.main.async {
+            self.joinRoomByIdOrAliasRoomIdOrAliasServerNamesReceivedInvocations.append((roomIdOrAlias: roomIdOrAlias, serverNames: serverNames))
+        }
         if let joinRoomByIdOrAliasRoomIdOrAliasServerNamesClosure = joinRoomByIdOrAliasRoomIdOrAliasServerNamesClosure {
             return try await joinRoomByIdOrAliasRoomIdOrAliasServerNamesClosure(roomIdOrAlias, serverNames)
         } else {
@@ -2148,7 +2184,9 @@ open class ClientSDKMock: MatrixRustSDK.Client {
         }
         loginUsernamePasswordInitialDeviceNameDeviceIdCallsCount += 1
         loginUsernamePasswordInitialDeviceNameDeviceIdReceivedArguments = (username: username, password: password, initialDeviceName: initialDeviceName, deviceId: deviceId)
-        loginUsernamePasswordInitialDeviceNameDeviceIdReceivedInvocations.append((username: username, password: password, initialDeviceName: initialDeviceName, deviceId: deviceId))
+        DispatchQueue.main.async {
+            self.loginUsernamePasswordInitialDeviceNameDeviceIdReceivedInvocations.append((username: username, password: password, initialDeviceName: initialDeviceName, deviceId: deviceId))
+        }
         try await loginUsernamePasswordInitialDeviceNameDeviceIdClosure?(username, password, initialDeviceName, deviceId)
     }
 
@@ -2286,7 +2324,9 @@ open class ClientSDKMock: MatrixRustSDK.Client {
         }
         notificationClientProcessSetupCallsCount += 1
         notificationClientProcessSetupReceivedProcessSetup = processSetup
-        notificationClientProcessSetupReceivedInvocations.append(processSetup)
+        DispatchQueue.main.async {
+            self.notificationClientProcessSetupReceivedInvocations.append(processSetup)
+        }
         if let notificationClientProcessSetupClosure = notificationClientProcessSetupClosure {
             return try await notificationClientProcessSetupClosure(processSetup)
         } else {
@@ -2399,7 +2439,9 @@ open class ClientSDKMock: MatrixRustSDK.Client {
         }
         resolveRoomAliasRoomAliasCallsCount += 1
         resolveRoomAliasRoomAliasReceivedRoomAlias = roomAlias
-        resolveRoomAliasRoomAliasReceivedInvocations.append(roomAlias)
+        DispatchQueue.main.async {
+            self.resolveRoomAliasRoomAliasReceivedInvocations.append(roomAlias)
+        }
         if let resolveRoomAliasRoomAliasClosure = resolveRoomAliasRoomAliasClosure {
             return try await resolveRoomAliasRoomAliasClosure(roomAlias)
         } else {
@@ -2447,7 +2489,9 @@ open class ClientSDKMock: MatrixRustSDK.Client {
         }
         restoreSessionSessionCallsCount += 1
         restoreSessionSessionReceivedSession = session
-        restoreSessionSessionReceivedInvocations.append(session)
+        DispatchQueue.main.async {
+            self.restoreSessionSessionReceivedInvocations.append(session)
+        }
         try await restoreSessionSessionClosure?(session)
     }
 
@@ -2646,7 +2690,9 @@ open class ClientSDKMock: MatrixRustSDK.Client {
         }
         searchUsersSearchTermLimitCallsCount += 1
         searchUsersSearchTermLimitReceivedArguments = (searchTerm: searchTerm, limit: limit)
-        searchUsersSearchTermLimitReceivedInvocations.append((searchTerm: searchTerm, limit: limit))
+        DispatchQueue.main.async {
+            self.searchUsersSearchTermLimitReceivedInvocations.append((searchTerm: searchTerm, limit: limit))
+        }
         if let searchUsersSearchTermLimitClosure = searchUsersSearchTermLimitClosure {
             return try await searchUsersSearchTermLimitClosure(searchTerm, limit)
         } else {
@@ -2763,7 +2809,9 @@ open class ClientSDKMock: MatrixRustSDK.Client {
         }
         setAccountDataEventTypeContentCallsCount += 1
         setAccountDataEventTypeContentReceivedArguments = (eventType: eventType, content: content)
-        setAccountDataEventTypeContentReceivedInvocations.append((eventType: eventType, content: content))
+        DispatchQueue.main.async {
+            self.setAccountDataEventTypeContentReceivedInvocations.append((eventType: eventType, content: content))
+        }
         try await setAccountDataEventTypeContentClosure?(eventType, content)
     }
 
@@ -2828,7 +2876,9 @@ open class ClientSDKMock: MatrixRustSDK.Client {
     open override func setDelegate(delegate: ClientDelegate?) -> TaskHandle? {
         setDelegateDelegateCallsCount += 1
         setDelegateDelegateReceivedDelegate = delegate
-        setDelegateDelegateReceivedInvocations.append(delegate)
+        DispatchQueue.main.async {
+            self.setDelegateDelegateReceivedInvocations.append(delegate)
+        }
         if let setDelegateDelegateClosure = setDelegateDelegateClosure {
             return setDelegateDelegateClosure(delegate)
         } else {
@@ -2876,7 +2926,9 @@ open class ClientSDKMock: MatrixRustSDK.Client {
         }
         setDisplayNameNameCallsCount += 1
         setDisplayNameNameReceivedName = name
-        setDisplayNameNameReceivedInvocations.append(name)
+        DispatchQueue.main.async {
+            self.setDisplayNameNameReceivedInvocations.append(name)
+        }
         try await setDisplayNameNameClosure?(name)
     }
 
@@ -2920,7 +2972,9 @@ open class ClientSDKMock: MatrixRustSDK.Client {
         }
         setPusherIdentifiersKindAppDisplayNameDeviceDisplayNameProfileTagLangCallsCount += 1
         setPusherIdentifiersKindAppDisplayNameDeviceDisplayNameProfileTagLangReceivedArguments = (identifiers: identifiers, kind: kind, appDisplayName: appDisplayName, deviceDisplayName: deviceDisplayName, profileTag: profileTag, lang: lang)
-        setPusherIdentifiersKindAppDisplayNameDeviceDisplayNameProfileTagLangReceivedInvocations.append((identifiers: identifiers, kind: kind, appDisplayName: appDisplayName, deviceDisplayName: deviceDisplayName, profileTag: profileTag, lang: lang))
+        DispatchQueue.main.async {
+            self.setPusherIdentifiersKindAppDisplayNameDeviceDisplayNameProfileTagLangReceivedInvocations.append((identifiers: identifiers, kind: kind, appDisplayName: appDisplayName, deviceDisplayName: deviceDisplayName, profileTag: profileTag, lang: lang))
+        }
         try await setPusherIdentifiersKindAppDisplayNameDeviceDisplayNameProfileTagLangClosure?(identifiers, kind, appDisplayName, deviceDisplayName, profileTag, lang)
     }
 
@@ -2985,7 +3039,9 @@ open class ClientSDKMock: MatrixRustSDK.Client {
     open override func subscribeToIgnoredUsers(listener: IgnoredUsersListener) -> TaskHandle {
         subscribeToIgnoredUsersListenerCallsCount += 1
         subscribeToIgnoredUsersListenerReceivedListener = listener
-        subscribeToIgnoredUsersListenerReceivedInvocations.append(listener)
+        DispatchQueue.main.async {
+            self.subscribeToIgnoredUsersListenerReceivedInvocations.append(listener)
+        }
         if let subscribeToIgnoredUsersListenerClosure = subscribeToIgnoredUsersListenerClosure {
             return subscribeToIgnoredUsersListenerClosure(listener)
         } else {
@@ -3054,7 +3110,9 @@ open class ClientSDKMock: MatrixRustSDK.Client {
     open override func subscribeToSendQueueStatus(listener: SendQueueRoomErrorListener) -> TaskHandle {
         subscribeToSendQueueStatusListenerCallsCount += 1
         subscribeToSendQueueStatusListenerReceivedListener = listener
-        subscribeToSendQueueStatusListenerReceivedInvocations.append(listener)
+        DispatchQueue.main.async {
+            self.subscribeToSendQueueStatusListenerReceivedInvocations.append(listener)
+        }
         if let subscribeToSendQueueStatusListenerClosure = subscribeToSendQueueStatusListenerClosure {
             return subscribeToSendQueueStatusListenerClosure(listener)
         } else {
@@ -3167,7 +3225,9 @@ open class ClientSDKMock: MatrixRustSDK.Client {
         }
         trackRecentlyVisitedRoomRoomCallsCount += 1
         trackRecentlyVisitedRoomRoomReceivedRoom = room
-        trackRecentlyVisitedRoomRoomReceivedInvocations.append(room)
+        DispatchQueue.main.async {
+            self.trackRecentlyVisitedRoomRoomReceivedInvocations.append(room)
+        }
         try await trackRecentlyVisitedRoomRoomClosure?(room)
     }
 
@@ -3211,7 +3271,9 @@ open class ClientSDKMock: MatrixRustSDK.Client {
         }
         unignoreUserUserIdCallsCount += 1
         unignoreUserUserIdReceivedUserId = userId
-        unignoreUserUserIdReceivedInvocations.append(userId)
+        DispatchQueue.main.async {
+            self.unignoreUserUserIdReceivedInvocations.append(userId)
+        }
         try await unignoreUserUserIdClosure?(userId)
     }
 
@@ -3255,7 +3317,9 @@ open class ClientSDKMock: MatrixRustSDK.Client {
         }
         uploadAvatarMimeTypeDataCallsCount += 1
         uploadAvatarMimeTypeDataReceivedArguments = (mimeType: mimeType, data: data)
-        uploadAvatarMimeTypeDataReceivedInvocations.append((mimeType: mimeType, data: data))
+        DispatchQueue.main.async {
+            self.uploadAvatarMimeTypeDataReceivedInvocations.append((mimeType: mimeType, data: data))
+        }
         try await uploadAvatarMimeTypeDataClosure?(mimeType, data)
     }
 
@@ -3324,7 +3388,9 @@ open class ClientSDKMock: MatrixRustSDK.Client {
         }
         uploadMediaMimeTypeDataProgressWatcherCallsCount += 1
         uploadMediaMimeTypeDataProgressWatcherReceivedArguments = (mimeType: mimeType, data: data, progressWatcher: progressWatcher)
-        uploadMediaMimeTypeDataProgressWatcherReceivedInvocations.append((mimeType: mimeType, data: data, progressWatcher: progressWatcher))
+        DispatchQueue.main.async {
+            self.uploadMediaMimeTypeDataProgressWatcherReceivedInvocations.append((mimeType: mimeType, data: data, progressWatcher: progressWatcher))
+        }
         if let uploadMediaMimeTypeDataProgressWatcherClosure = uploadMediaMimeTypeDataProgressWatcherClosure {
             return try await uploadMediaMimeTypeDataProgressWatcherClosure(mimeType, data, progressWatcher)
         } else {
@@ -3473,7 +3539,9 @@ open class ClientBuilderSDKMock: MatrixRustSDK.ClientBuilder {
     open override func addRootCertificates(certificates: [Data]) -> ClientBuilder {
         addRootCertificatesCertificatesCallsCount += 1
         addRootCertificatesCertificatesReceivedCertificates = certificates
-        addRootCertificatesCertificatesReceivedInvocations.append(certificates)
+        DispatchQueue.main.async {
+            self.addRootCertificatesCertificatesReceivedInvocations.append(certificates)
+        }
         if let addRootCertificatesCertificatesClosure = addRootCertificatesCertificatesClosure {
             return addRootCertificatesCertificatesClosure(certificates)
         } else {
@@ -3542,7 +3610,9 @@ open class ClientBuilderSDKMock: MatrixRustSDK.ClientBuilder {
     open override func autoEnableBackups(autoEnableBackups: Bool) -> ClientBuilder {
         autoEnableBackupsAutoEnableBackupsCallsCount += 1
         autoEnableBackupsAutoEnableBackupsReceivedAutoEnableBackups = autoEnableBackups
-        autoEnableBackupsAutoEnableBackupsReceivedInvocations.append(autoEnableBackups)
+        DispatchQueue.main.async {
+            self.autoEnableBackupsAutoEnableBackupsReceivedInvocations.append(autoEnableBackups)
+        }
         if let autoEnableBackupsAutoEnableBackupsClosure = autoEnableBackupsAutoEnableBackupsClosure {
             return autoEnableBackupsAutoEnableBackupsClosure(autoEnableBackups)
         } else {
@@ -3611,7 +3681,9 @@ open class ClientBuilderSDKMock: MatrixRustSDK.ClientBuilder {
     open override func autoEnableCrossSigning(autoEnableCrossSigning: Bool) -> ClientBuilder {
         autoEnableCrossSigningAutoEnableCrossSigningCallsCount += 1
         autoEnableCrossSigningAutoEnableCrossSigningReceivedAutoEnableCrossSigning = autoEnableCrossSigning
-        autoEnableCrossSigningAutoEnableCrossSigningReceivedInvocations.append(autoEnableCrossSigning)
+        DispatchQueue.main.async {
+            self.autoEnableCrossSigningAutoEnableCrossSigningReceivedInvocations.append(autoEnableCrossSigning)
+        }
         if let autoEnableCrossSigningAutoEnableCrossSigningClosure = autoEnableCrossSigningAutoEnableCrossSigningClosure {
             return autoEnableCrossSigningAutoEnableCrossSigningClosure(autoEnableCrossSigning)
         } else {
@@ -3680,7 +3752,9 @@ open class ClientBuilderSDKMock: MatrixRustSDK.ClientBuilder {
     open override func backupDownloadStrategy(backupDownloadStrategy: BackupDownloadStrategy) -> ClientBuilder {
         backupDownloadStrategyBackupDownloadStrategyCallsCount += 1
         backupDownloadStrategyBackupDownloadStrategyReceivedBackupDownloadStrategy = backupDownloadStrategy
-        backupDownloadStrategyBackupDownloadStrategyReceivedInvocations.append(backupDownloadStrategy)
+        DispatchQueue.main.async {
+            self.backupDownloadStrategyBackupDownloadStrategyReceivedInvocations.append(backupDownloadStrategy)
+        }
         if let backupDownloadStrategyBackupDownloadStrategyClosure = backupDownloadStrategyBackupDownloadStrategyClosure {
             return backupDownloadStrategyBackupDownloadStrategyClosure(backupDownloadStrategy)
         } else {
@@ -3822,7 +3896,9 @@ open class ClientBuilderSDKMock: MatrixRustSDK.ClientBuilder {
         }
         buildWithQrCodeQrCodeDataOidcConfigurationProgressListenerCallsCount += 1
         buildWithQrCodeQrCodeDataOidcConfigurationProgressListenerReceivedArguments = (qrCodeData: qrCodeData, oidcConfiguration: oidcConfiguration, progressListener: progressListener)
-        buildWithQrCodeQrCodeDataOidcConfigurationProgressListenerReceivedInvocations.append((qrCodeData: qrCodeData, oidcConfiguration: oidcConfiguration, progressListener: progressListener))
+        DispatchQueue.main.async {
+            self.buildWithQrCodeQrCodeDataOidcConfigurationProgressListenerReceivedInvocations.append((qrCodeData: qrCodeData, oidcConfiguration: oidcConfiguration, progressListener: progressListener))
+        }
         if let buildWithQrCodeQrCodeDataOidcConfigurationProgressListenerClosure = buildWithQrCodeQrCodeDataOidcConfigurationProgressListenerClosure {
             return try await buildWithQrCodeQrCodeDataOidcConfigurationProgressListenerClosure(qrCodeData, oidcConfiguration, progressListener)
         } else {
@@ -4021,7 +4097,9 @@ open class ClientBuilderSDKMock: MatrixRustSDK.ClientBuilder {
     open override func enableCrossProcessRefreshLock(processId: String, sessionDelegate: ClientSessionDelegate) -> ClientBuilder {
         enableCrossProcessRefreshLockProcessIdSessionDelegateCallsCount += 1
         enableCrossProcessRefreshLockProcessIdSessionDelegateReceivedArguments = (processId: processId, sessionDelegate: sessionDelegate)
-        enableCrossProcessRefreshLockProcessIdSessionDelegateReceivedInvocations.append((processId: processId, sessionDelegate: sessionDelegate))
+        DispatchQueue.main.async {
+            self.enableCrossProcessRefreshLockProcessIdSessionDelegateReceivedInvocations.append((processId: processId, sessionDelegate: sessionDelegate))
+        }
         if let enableCrossProcessRefreshLockProcessIdSessionDelegateClosure = enableCrossProcessRefreshLockProcessIdSessionDelegateClosure {
             return enableCrossProcessRefreshLockProcessIdSessionDelegateClosure(processId, sessionDelegate)
         } else {
@@ -4090,7 +4168,9 @@ open class ClientBuilderSDKMock: MatrixRustSDK.ClientBuilder {
     open override func homeserverUrl(url: String) -> ClientBuilder {
         homeserverUrlUrlCallsCount += 1
         homeserverUrlUrlReceivedUrl = url
-        homeserverUrlUrlReceivedInvocations.append(url)
+        DispatchQueue.main.async {
+            self.homeserverUrlUrlReceivedInvocations.append(url)
+        }
         if let homeserverUrlUrlClosure = homeserverUrlUrlClosure {
             return homeserverUrlUrlClosure(url)
         } else {
@@ -4159,7 +4239,9 @@ open class ClientBuilderSDKMock: MatrixRustSDK.ClientBuilder {
     open override func passphrase(passphrase: String?) -> ClientBuilder {
         passphrasePassphraseCallsCount += 1
         passphrasePassphraseReceivedPassphrase = passphrase
-        passphrasePassphraseReceivedInvocations.append(passphrase)
+        DispatchQueue.main.async {
+            self.passphrasePassphraseReceivedInvocations.append(passphrase)
+        }
         if let passphrasePassphraseClosure = passphrasePassphraseClosure {
             return passphrasePassphraseClosure(passphrase)
         } else {
@@ -4228,7 +4310,9 @@ open class ClientBuilderSDKMock: MatrixRustSDK.ClientBuilder {
     open override func proxy(url: String) -> ClientBuilder {
         proxyUrlCallsCount += 1
         proxyUrlReceivedUrl = url
-        proxyUrlReceivedInvocations.append(url)
+        DispatchQueue.main.async {
+            self.proxyUrlReceivedInvocations.append(url)
+        }
         if let proxyUrlClosure = proxyUrlClosure {
             return proxyUrlClosure(url)
         } else {
@@ -4297,7 +4381,9 @@ open class ClientBuilderSDKMock: MatrixRustSDK.ClientBuilder {
     open override func serverName(serverName: String) -> ClientBuilder {
         serverNameServerNameCallsCount += 1
         serverNameServerNameReceivedServerName = serverName
-        serverNameServerNameReceivedInvocations.append(serverName)
+        DispatchQueue.main.async {
+            self.serverNameServerNameReceivedInvocations.append(serverName)
+        }
         if let serverNameServerNameClosure = serverNameServerNameClosure {
             return serverNameServerNameClosure(serverName)
         } else {
@@ -4366,7 +4452,9 @@ open class ClientBuilderSDKMock: MatrixRustSDK.ClientBuilder {
     open override func serverNameOrHomeserverUrl(serverNameOrUrl: String) -> ClientBuilder {
         serverNameOrHomeserverUrlServerNameOrUrlCallsCount += 1
         serverNameOrHomeserverUrlServerNameOrUrlReceivedServerNameOrUrl = serverNameOrUrl
-        serverNameOrHomeserverUrlServerNameOrUrlReceivedInvocations.append(serverNameOrUrl)
+        DispatchQueue.main.async {
+            self.serverNameOrHomeserverUrlServerNameOrUrlReceivedInvocations.append(serverNameOrUrl)
+        }
         if let serverNameOrHomeserverUrlServerNameOrUrlClosure = serverNameOrHomeserverUrlServerNameOrUrlClosure {
             return serverNameOrHomeserverUrlServerNameOrUrlClosure(serverNameOrUrl)
         } else {
@@ -4435,7 +4523,9 @@ open class ClientBuilderSDKMock: MatrixRustSDK.ClientBuilder {
     open override func serverVersions(versions: [String]) -> ClientBuilder {
         serverVersionsVersionsCallsCount += 1
         serverVersionsVersionsReceivedVersions = versions
-        serverVersionsVersionsReceivedInvocations.append(versions)
+        DispatchQueue.main.async {
+            self.serverVersionsVersionsReceivedInvocations.append(versions)
+        }
         if let serverVersionsVersionsClosure = serverVersionsVersionsClosure {
             return serverVersionsVersionsClosure(versions)
         } else {
@@ -4504,7 +4594,9 @@ open class ClientBuilderSDKMock: MatrixRustSDK.ClientBuilder {
     open override func sessionPath(path: String) -> ClientBuilder {
         sessionPathPathCallsCount += 1
         sessionPathPathReceivedPath = path
-        sessionPathPathReceivedInvocations.append(path)
+        DispatchQueue.main.async {
+            self.sessionPathPathReceivedInvocations.append(path)
+        }
         if let sessionPathPathClosure = sessionPathPathClosure {
             return sessionPathPathClosure(path)
         } else {
@@ -4573,7 +4665,9 @@ open class ClientBuilderSDKMock: MatrixRustSDK.ClientBuilder {
     open override func setSessionDelegate(sessionDelegate: ClientSessionDelegate) -> ClientBuilder {
         setSessionDelegateSessionDelegateCallsCount += 1
         setSessionDelegateSessionDelegateReceivedSessionDelegate = sessionDelegate
-        setSessionDelegateSessionDelegateReceivedInvocations.append(sessionDelegate)
+        DispatchQueue.main.async {
+            self.setSessionDelegateSessionDelegateReceivedInvocations.append(sessionDelegate)
+        }
         if let setSessionDelegateSessionDelegateClosure = setSessionDelegateSessionDelegateClosure {
             return setSessionDelegateSessionDelegateClosure(sessionDelegate)
         } else {
@@ -4642,7 +4736,9 @@ open class ClientBuilderSDKMock: MatrixRustSDK.ClientBuilder {
     open override func slidingSyncProxy(slidingSyncProxy: String?) -> ClientBuilder {
         slidingSyncProxySlidingSyncProxyCallsCount += 1
         slidingSyncProxySlidingSyncProxyReceivedSlidingSyncProxy = slidingSyncProxy
-        slidingSyncProxySlidingSyncProxyReceivedInvocations.append(slidingSyncProxy)
+        DispatchQueue.main.async {
+            self.slidingSyncProxySlidingSyncProxyReceivedInvocations.append(slidingSyncProxy)
+        }
         if let slidingSyncProxySlidingSyncProxyClosure = slidingSyncProxySlidingSyncProxyClosure {
             return slidingSyncProxySlidingSyncProxyClosure(slidingSyncProxy)
         } else {
@@ -4711,7 +4807,9 @@ open class ClientBuilderSDKMock: MatrixRustSDK.ClientBuilder {
     open override func userAgent(userAgent: String) -> ClientBuilder {
         userAgentUserAgentCallsCount += 1
         userAgentUserAgentReceivedUserAgent = userAgent
-        userAgentUserAgentReceivedInvocations.append(userAgent)
+        DispatchQueue.main.async {
+            self.userAgentUserAgentReceivedInvocations.append(userAgent)
+        }
         if let userAgentUserAgentClosure = userAgentUserAgentClosure {
             return userAgentUserAgentClosure(userAgent)
         } else {
@@ -4780,7 +4878,9 @@ open class ClientBuilderSDKMock: MatrixRustSDK.ClientBuilder {
     open override func username(username: String) -> ClientBuilder {
         usernameUsernameCallsCount += 1
         usernameUsernameReceivedUsername = username
-        usernameUsernameReceivedInvocations.append(username)
+        DispatchQueue.main.async {
+            self.usernameUsernameReceivedInvocations.append(username)
+        }
         if let usernameUsernameClosure = usernameUsernameClosure {
             return usernameUsernameClosure(username)
         } else {
@@ -4994,7 +5094,9 @@ open class EncryptionSDKMock: MatrixRustSDK.Encryption {
     open override func backupStateListener(listener: BackupStateListener) -> TaskHandle {
         backupStateListenerListenerCallsCount += 1
         backupStateListenerListenerReceivedListener = listener
-        backupStateListenerListenerReceivedInvocations.append(listener)
+        DispatchQueue.main.async {
+            self.backupStateListenerListenerReceivedInvocations.append(listener)
+        }
         if let backupStateListenerListenerClosure = backupStateListenerListenerClosure {
             return backupStateListenerListenerClosure(listener)
         } else {
@@ -5277,7 +5379,9 @@ open class EncryptionSDKMock: MatrixRustSDK.Encryption {
         }
         enableRecoveryWaitForBackupsToUploadProgressListenerCallsCount += 1
         enableRecoveryWaitForBackupsToUploadProgressListenerReceivedArguments = (waitForBackupsToUpload: waitForBackupsToUpload, progressListener: progressListener)
-        enableRecoveryWaitForBackupsToUploadProgressListenerReceivedInvocations.append((waitForBackupsToUpload: waitForBackupsToUpload, progressListener: progressListener))
+        DispatchQueue.main.async {
+            self.enableRecoveryWaitForBackupsToUploadProgressListenerReceivedInvocations.append((waitForBackupsToUpload: waitForBackupsToUpload, progressListener: progressListener))
+        }
         if let enableRecoveryWaitForBackupsToUploadProgressListenerClosure = enableRecoveryWaitForBackupsToUploadProgressListenerClosure {
             return try await enableRecoveryWaitForBackupsToUploadProgressListenerClosure(waitForBackupsToUpload, progressListener)
         } else {
@@ -5394,7 +5498,9 @@ open class EncryptionSDKMock: MatrixRustSDK.Encryption {
         }
         recoverRecoveryKeyCallsCount += 1
         recoverRecoveryKeyReceivedRecoveryKey = recoveryKey
-        recoverRecoveryKeyReceivedInvocations.append(recoveryKey)
+        DispatchQueue.main.async {
+            self.recoverRecoveryKeyReceivedInvocations.append(recoveryKey)
+        }
         try await recoverRecoveryKeyClosure?(recoveryKey)
     }
 
@@ -5463,7 +5569,9 @@ open class EncryptionSDKMock: MatrixRustSDK.Encryption {
         }
         recoverAndResetOldRecoveryKeyCallsCount += 1
         recoverAndResetOldRecoveryKeyReceivedOldRecoveryKey = oldRecoveryKey
-        recoverAndResetOldRecoveryKeyReceivedInvocations.append(oldRecoveryKey)
+        DispatchQueue.main.async {
+            self.recoverAndResetOldRecoveryKeyReceivedInvocations.append(oldRecoveryKey)
+        }
         if let recoverAndResetOldRecoveryKeyClosure = recoverAndResetOldRecoveryKeyClosure {
             return try await recoverAndResetOldRecoveryKeyClosure(oldRecoveryKey)
         } else {
@@ -5597,7 +5705,9 @@ open class EncryptionSDKMock: MatrixRustSDK.Encryption {
     open override func recoveryStateListener(listener: RecoveryStateListener) -> TaskHandle {
         recoveryStateListenerListenerCallsCount += 1
         recoveryStateListenerListenerReceivedListener = listener
-        recoveryStateListenerListenerReceivedInvocations.append(listener)
+        DispatchQueue.main.async {
+            self.recoveryStateListenerListenerReceivedInvocations.append(listener)
+        }
         if let recoveryStateListenerListenerClosure = recoveryStateListenerListenerClosure {
             return recoveryStateListenerListenerClosure(listener)
         } else {
@@ -5800,7 +5910,9 @@ open class EncryptionSDKMock: MatrixRustSDK.Encryption {
     open override func verificationStateListener(listener: VerificationStateListener) -> TaskHandle {
         verificationStateListenerListenerCallsCount += 1
         verificationStateListenerListenerReceivedListener = listener
-        verificationStateListenerListenerReceivedInvocations.append(listener)
+        DispatchQueue.main.async {
+            self.verificationStateListenerListenerReceivedInvocations.append(listener)
+        }
         if let verificationStateListenerListenerClosure = verificationStateListenerListenerClosure {
             return verificationStateListenerListenerClosure(listener)
         } else {
@@ -5848,7 +5960,9 @@ open class EncryptionSDKMock: MatrixRustSDK.Encryption {
         }
         waitForBackupUploadSteadyStateProgressListenerCallsCount += 1
         waitForBackupUploadSteadyStateProgressListenerReceivedProgressListener = progressListener
-        waitForBackupUploadSteadyStateProgressListenerReceivedInvocations.append(progressListener)
+        DispatchQueue.main.async {
+            self.waitForBackupUploadSteadyStateProgressListenerReceivedInvocations.append(progressListener)
+        }
         try await waitForBackupUploadSteadyStateProgressListenerClosure?(progressListener)
     }
 
@@ -7355,7 +7469,9 @@ open class MediaFileHandleSDKMock: MatrixRustSDK.MediaFileHandle {
         }
         persistPathCallsCount += 1
         persistPathReceivedPath = path
-        persistPathReceivedInvocations.append(path)
+        DispatchQueue.main.async {
+            self.persistPathReceivedInvocations.append(path)
+        }
         if let persistPathClosure = persistPathClosure {
             return try persistPathClosure(path)
         } else {
@@ -7984,7 +8100,9 @@ open class NotificationClientSDKMock: MatrixRustSDK.NotificationClient {
         }
         getNotificationRoomIdEventIdCallsCount += 1
         getNotificationRoomIdEventIdReceivedArguments = (roomId: roomId, eventId: eventId)
-        getNotificationRoomIdEventIdReceivedInvocations.append((roomId: roomId, eventId: eventId))
+        DispatchQueue.main.async {
+            self.getNotificationRoomIdEventIdReceivedInvocations.append((roomId: roomId, eventId: eventId))
+        }
         if let getNotificationRoomIdEventIdClosure = getNotificationRoomIdEventIdClosure {
             return try await getNotificationRoomIdEventIdClosure(roomId, eventId)
         } else {
@@ -8259,7 +8377,9 @@ open class NotificationSettingsSDKMock: MatrixRustSDK.NotificationSettings {
     open override func getDefaultRoomNotificationMode(isEncrypted: Bool, isOneToOne: Bool) async -> RoomNotificationMode {
         getDefaultRoomNotificationModeIsEncryptedIsOneToOneCallsCount += 1
         getDefaultRoomNotificationModeIsEncryptedIsOneToOneReceivedArguments = (isEncrypted: isEncrypted, isOneToOne: isOneToOne)
-        getDefaultRoomNotificationModeIsEncryptedIsOneToOneReceivedInvocations.append((isEncrypted: isEncrypted, isOneToOne: isOneToOne))
+        DispatchQueue.main.async {
+            self.getDefaultRoomNotificationModeIsEncryptedIsOneToOneReceivedInvocations.append((isEncrypted: isEncrypted, isOneToOne: isOneToOne))
+        }
         if let getDefaultRoomNotificationModeIsEncryptedIsOneToOneClosure = getDefaultRoomNotificationModeIsEncryptedIsOneToOneClosure {
             return await getDefaultRoomNotificationModeIsEncryptedIsOneToOneClosure(isEncrypted, isOneToOne)
         } else {
@@ -8332,7 +8452,9 @@ open class NotificationSettingsSDKMock: MatrixRustSDK.NotificationSettings {
         }
         getRoomNotificationSettingsRoomIdIsEncryptedIsOneToOneCallsCount += 1
         getRoomNotificationSettingsRoomIdIsEncryptedIsOneToOneReceivedArguments = (roomId: roomId, isEncrypted: isEncrypted, isOneToOne: isOneToOne)
-        getRoomNotificationSettingsRoomIdIsEncryptedIsOneToOneReceivedInvocations.append((roomId: roomId, isEncrypted: isEncrypted, isOneToOne: isOneToOne))
+        DispatchQueue.main.async {
+            self.getRoomNotificationSettingsRoomIdIsEncryptedIsOneToOneReceivedInvocations.append((roomId: roomId, isEncrypted: isEncrypted, isOneToOne: isOneToOne))
+        }
         if let getRoomNotificationSettingsRoomIdIsEncryptedIsOneToOneClosure = getRoomNotificationSettingsRoomIdIsEncryptedIsOneToOneClosure {
             return try await getRoomNotificationSettingsRoomIdIsEncryptedIsOneToOneClosure(roomId, isEncrypted, isOneToOne)
         } else {
@@ -8401,7 +8523,9 @@ open class NotificationSettingsSDKMock: MatrixRustSDK.NotificationSettings {
     open override func getRoomsWithUserDefinedRules(enabled: Bool?) async -> [String] {
         getRoomsWithUserDefinedRulesEnabledCallsCount += 1
         getRoomsWithUserDefinedRulesEnabledReceivedEnabled = enabled
-        getRoomsWithUserDefinedRulesEnabledReceivedInvocations.append(enabled)
+        DispatchQueue.main.async {
+            self.getRoomsWithUserDefinedRulesEnabledReceivedInvocations.append(enabled)
+        }
         if let getRoomsWithUserDefinedRulesEnabledClosure = getRoomsWithUserDefinedRulesEnabledClosure {
             return await getRoomsWithUserDefinedRulesEnabledClosure(enabled)
         } else {
@@ -8474,7 +8598,9 @@ open class NotificationSettingsSDKMock: MatrixRustSDK.NotificationSettings {
         }
         getUserDefinedRoomNotificationModeRoomIdCallsCount += 1
         getUserDefinedRoomNotificationModeRoomIdReceivedRoomId = roomId
-        getUserDefinedRoomNotificationModeRoomIdReceivedInvocations.append(roomId)
+        DispatchQueue.main.async {
+            self.getUserDefinedRoomNotificationModeRoomIdReceivedInvocations.append(roomId)
+        }
         if let getUserDefinedRoomNotificationModeRoomIdClosure = getUserDefinedRoomNotificationModeRoomIdClosure {
             return try await getUserDefinedRoomNotificationModeRoomIdClosure(roomId)
         } else {
@@ -8798,7 +8924,9 @@ open class NotificationSettingsSDKMock: MatrixRustSDK.NotificationSettings {
         }
         restoreDefaultRoomNotificationModeRoomIdCallsCount += 1
         restoreDefaultRoomNotificationModeRoomIdReceivedRoomId = roomId
-        restoreDefaultRoomNotificationModeRoomIdReceivedInvocations.append(roomId)
+        DispatchQueue.main.async {
+            self.restoreDefaultRoomNotificationModeRoomIdReceivedInvocations.append(roomId)
+        }
         try await restoreDefaultRoomNotificationModeRoomIdClosure?(roomId)
     }
 
@@ -8842,7 +8970,9 @@ open class NotificationSettingsSDKMock: MatrixRustSDK.NotificationSettings {
         }
         setCallEnabledEnabledCallsCount += 1
         setCallEnabledEnabledReceivedEnabled = enabled
-        setCallEnabledEnabledReceivedInvocations.append(enabled)
+        DispatchQueue.main.async {
+            self.setCallEnabledEnabledReceivedInvocations.append(enabled)
+        }
         try await setCallEnabledEnabledClosure?(enabled)
     }
 
@@ -8886,7 +9016,9 @@ open class NotificationSettingsSDKMock: MatrixRustSDK.NotificationSettings {
         }
         setDefaultRoomNotificationModeIsEncryptedIsOneToOneModeCallsCount += 1
         setDefaultRoomNotificationModeIsEncryptedIsOneToOneModeReceivedArguments = (isEncrypted: isEncrypted, isOneToOne: isOneToOne, mode: mode)
-        setDefaultRoomNotificationModeIsEncryptedIsOneToOneModeReceivedInvocations.append((isEncrypted: isEncrypted, isOneToOne: isOneToOne, mode: mode))
+        DispatchQueue.main.async {
+            self.setDefaultRoomNotificationModeIsEncryptedIsOneToOneModeReceivedInvocations.append((isEncrypted: isEncrypted, isOneToOne: isOneToOne, mode: mode))
+        }
         try await setDefaultRoomNotificationModeIsEncryptedIsOneToOneModeClosure?(isEncrypted, isOneToOne, mode)
     }
 
@@ -8926,7 +9058,9 @@ open class NotificationSettingsSDKMock: MatrixRustSDK.NotificationSettings {
     open override func setDelegate(delegate: NotificationSettingsDelegate?) {
         setDelegateDelegateCallsCount += 1
         setDelegateDelegateReceivedDelegate = delegate
-        setDelegateDelegateReceivedInvocations.append(delegate)
+        DispatchQueue.main.async {
+            self.setDelegateDelegateReceivedInvocations.append(delegate)
+        }
         setDelegateDelegateClosure?(delegate)
     }
 
@@ -8970,7 +9104,9 @@ open class NotificationSettingsSDKMock: MatrixRustSDK.NotificationSettings {
         }
         setInviteForMeEnabledEnabledCallsCount += 1
         setInviteForMeEnabledEnabledReceivedEnabled = enabled
-        setInviteForMeEnabledEnabledReceivedInvocations.append(enabled)
+        DispatchQueue.main.async {
+            self.setInviteForMeEnabledEnabledReceivedInvocations.append(enabled)
+        }
         try await setInviteForMeEnabledEnabledClosure?(enabled)
     }
 
@@ -9014,7 +9150,9 @@ open class NotificationSettingsSDKMock: MatrixRustSDK.NotificationSettings {
         }
         setRoomMentionEnabledEnabledCallsCount += 1
         setRoomMentionEnabledEnabledReceivedEnabled = enabled
-        setRoomMentionEnabledEnabledReceivedInvocations.append(enabled)
+        DispatchQueue.main.async {
+            self.setRoomMentionEnabledEnabledReceivedInvocations.append(enabled)
+        }
         try await setRoomMentionEnabledEnabledClosure?(enabled)
     }
 
@@ -9058,7 +9196,9 @@ open class NotificationSettingsSDKMock: MatrixRustSDK.NotificationSettings {
         }
         setRoomNotificationModeRoomIdModeCallsCount += 1
         setRoomNotificationModeRoomIdModeReceivedArguments = (roomId: roomId, mode: mode)
-        setRoomNotificationModeRoomIdModeReceivedInvocations.append((roomId: roomId, mode: mode))
+        DispatchQueue.main.async {
+            self.setRoomNotificationModeRoomIdModeReceivedInvocations.append((roomId: roomId, mode: mode))
+        }
         try await setRoomNotificationModeRoomIdModeClosure?(roomId, mode)
     }
 
@@ -9102,7 +9242,9 @@ open class NotificationSettingsSDKMock: MatrixRustSDK.NotificationSettings {
         }
         setUserMentionEnabledEnabledCallsCount += 1
         setUserMentionEnabledEnabledReceivedEnabled = enabled
-        setUserMentionEnabledEnabledReceivedInvocations.append(enabled)
+        DispatchQueue.main.async {
+            self.setUserMentionEnabledEnabledReceivedInvocations.append(enabled)
+        }
         try await setUserMentionEnabledEnabledClosure?(enabled)
     }
 
@@ -9146,7 +9288,9 @@ open class NotificationSettingsSDKMock: MatrixRustSDK.NotificationSettings {
         }
         unmuteRoomRoomIdIsEncryptedIsOneToOneCallsCount += 1
         unmuteRoomRoomIdIsEncryptedIsOneToOneReceivedArguments = (roomId: roomId, isEncrypted: isEncrypted, isOneToOne: isOneToOne)
-        unmuteRoomRoomIdIsEncryptedIsOneToOneReceivedInvocations.append((roomId: roomId, isEncrypted: isEncrypted, isOneToOne: isOneToOne))
+        DispatchQueue.main.async {
+            self.unmuteRoomRoomIdIsEncryptedIsOneToOneReceivedInvocations.append((roomId: roomId, isEncrypted: isEncrypted, isOneToOne: isOneToOne))
+        }
         try await unmuteRoomRoomIdIsEncryptedIsOneToOneClosure?(roomId, isEncrypted, isOneToOne)
     }
 }
@@ -9486,7 +9630,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         applyPowerLevelChangesChangesCallsCount += 1
         applyPowerLevelChangesChangesReceivedChanges = changes
-        applyPowerLevelChangesChangesReceivedInvocations.append(changes)
+        DispatchQueue.main.async {
+            self.applyPowerLevelChangesChangesReceivedInvocations.append(changes)
+        }
         try await applyPowerLevelChangesChangesClosure?(changes)
     }
 
@@ -9595,7 +9741,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         banUserUserIdReasonCallsCount += 1
         banUserUserIdReasonReceivedArguments = (userId: userId, reason: reason)
-        banUserUserIdReasonReceivedInvocations.append((userId: userId, reason: reason))
+        DispatchQueue.main.async {
+            self.banUserUserIdReasonReceivedInvocations.append((userId: userId, reason: reason))
+        }
         try await banUserUserIdReasonClosure?(userId, reason)
     }
 
@@ -9664,7 +9812,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         canUserBanUserIdCallsCount += 1
         canUserBanUserIdReceivedUserId = userId
-        canUserBanUserIdReceivedInvocations.append(userId)
+        DispatchQueue.main.async {
+            self.canUserBanUserIdReceivedInvocations.append(userId)
+        }
         if let canUserBanUserIdClosure = canUserBanUserIdClosure {
             return try await canUserBanUserIdClosure(userId)
         } else {
@@ -9737,7 +9887,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         canUserInviteUserIdCallsCount += 1
         canUserInviteUserIdReceivedUserId = userId
-        canUserInviteUserIdReceivedInvocations.append(userId)
+        DispatchQueue.main.async {
+            self.canUserInviteUserIdReceivedInvocations.append(userId)
+        }
         if let canUserInviteUserIdClosure = canUserInviteUserIdClosure {
             return try await canUserInviteUserIdClosure(userId)
         } else {
@@ -9810,7 +9962,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         canUserKickUserIdCallsCount += 1
         canUserKickUserIdReceivedUserId = userId
-        canUserKickUserIdReceivedInvocations.append(userId)
+        DispatchQueue.main.async {
+            self.canUserKickUserIdReceivedInvocations.append(userId)
+        }
         if let canUserKickUserIdClosure = canUserKickUserIdClosure {
             return try await canUserKickUserIdClosure(userId)
         } else {
@@ -9883,7 +10037,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         canUserRedactOtherUserIdCallsCount += 1
         canUserRedactOtherUserIdReceivedUserId = userId
-        canUserRedactOtherUserIdReceivedInvocations.append(userId)
+        DispatchQueue.main.async {
+            self.canUserRedactOtherUserIdReceivedInvocations.append(userId)
+        }
         if let canUserRedactOtherUserIdClosure = canUserRedactOtherUserIdClosure {
             return try await canUserRedactOtherUserIdClosure(userId)
         } else {
@@ -9956,7 +10112,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         canUserRedactOwnUserIdCallsCount += 1
         canUserRedactOwnUserIdReceivedUserId = userId
-        canUserRedactOwnUserIdReceivedInvocations.append(userId)
+        DispatchQueue.main.async {
+            self.canUserRedactOwnUserIdReceivedInvocations.append(userId)
+        }
         if let canUserRedactOwnUserIdClosure = canUserRedactOwnUserIdClosure {
             return try await canUserRedactOwnUserIdClosure(userId)
         } else {
@@ -10029,7 +10187,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         canUserSendMessageUserIdMessageCallsCount += 1
         canUserSendMessageUserIdMessageReceivedArguments = (userId: userId, message: message)
-        canUserSendMessageUserIdMessageReceivedInvocations.append((userId: userId, message: message))
+        DispatchQueue.main.async {
+            self.canUserSendMessageUserIdMessageReceivedInvocations.append((userId: userId, message: message))
+        }
         if let canUserSendMessageUserIdMessageClosure = canUserSendMessageUserIdMessageClosure {
             return try await canUserSendMessageUserIdMessageClosure(userId, message)
         } else {
@@ -10102,7 +10262,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         canUserSendStateUserIdStateEventCallsCount += 1
         canUserSendStateUserIdStateEventReceivedArguments = (userId: userId, stateEvent: stateEvent)
-        canUserSendStateUserIdStateEventReceivedInvocations.append((userId: userId, stateEvent: stateEvent))
+        DispatchQueue.main.async {
+            self.canUserSendStateUserIdStateEventReceivedInvocations.append((userId: userId, stateEvent: stateEvent))
+        }
         if let canUserSendStateUserIdStateEventClosure = canUserSendStateUserIdStateEventClosure {
             return try await canUserSendStateUserIdStateEventClosure(userId, stateEvent)
         } else {
@@ -10175,7 +10337,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         canUserTriggerRoomNotificationUserIdCallsCount += 1
         canUserTriggerRoomNotificationUserIdReceivedUserId = userId
-        canUserTriggerRoomNotificationUserIdReceivedInvocations.append(userId)
+        DispatchQueue.main.async {
+            self.canUserTriggerRoomNotificationUserIdReceivedInvocations.append(userId)
+        }
         if let canUserTriggerRoomNotificationUserIdClosure = canUserTriggerRoomNotificationUserIdClosure {
             return try await canUserTriggerRoomNotificationUserIdClosure(userId)
         } else {
@@ -10429,7 +10593,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
     open override func enableSendQueue(enable: Bool) {
         enableSendQueueEnableCallsCount += 1
         enableSendQueueEnableReceivedEnable = enable
-        enableSendQueueEnableReceivedInvocations.append(enable)
+        DispatchQueue.main.async {
+            self.enableSendQueueEnableReceivedInvocations.append(enable)
+        }
         enableSendQueueEnableClosure?(enable)
     }
 
@@ -10672,7 +10838,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         ignoreUserUserIdCallsCount += 1
         ignoreUserUserIdReceivedUserId = userId
-        ignoreUserUserIdReceivedInvocations.append(userId)
+        DispatchQueue.main.async {
+            self.ignoreUserUserIdReceivedInvocations.append(userId)
+        }
         try await ignoreUserUserIdClosure?(userId)
     }
 
@@ -10716,7 +10884,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         inviteUserByIdUserIdCallsCount += 1
         inviteUserByIdUserIdReceivedUserId = userId
-        inviteUserByIdUserIdReceivedInvocations.append(userId)
+        DispatchQueue.main.async {
+            self.inviteUserByIdUserIdReceivedInvocations.append(userId)
+        }
         try await inviteUserByIdUserIdClosure?(userId)
     }
 
@@ -11389,7 +11559,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         kickUserUserIdReasonCallsCount += 1
         kickUserUserIdReasonReceivedArguments = (userId: userId, reason: reason)
-        kickUserUserIdReasonReceivedInvocations.append((userId: userId, reason: reason))
+        DispatchQueue.main.async {
+            self.kickUserUserIdReasonReceivedInvocations.append((userId: userId, reason: reason))
+        }
         try await kickUserUserIdReasonClosure?(userId, reason)
     }
 
@@ -11542,7 +11714,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         markAsReadReceiptTypeCallsCount += 1
         markAsReadReceiptTypeReceivedReceiptType = receiptType
-        markAsReadReceiptTypeReceivedInvocations.append(receiptType)
+        DispatchQueue.main.async {
+            self.markAsReadReceiptTypeReceivedInvocations.append(receiptType)
+        }
         try await markAsReadReceiptTypeClosure?(receiptType)
     }
 
@@ -11611,7 +11785,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         matrixToEventPermalinkEventIdCallsCount += 1
         matrixToEventPermalinkEventIdReceivedEventId = eventId
-        matrixToEventPermalinkEventIdReceivedInvocations.append(eventId)
+        DispatchQueue.main.async {
+            self.matrixToEventPermalinkEventIdReceivedInvocations.append(eventId)
+        }
         if let matrixToEventPermalinkEventIdClosure = matrixToEventPermalinkEventIdClosure {
             return try await matrixToEventPermalinkEventIdClosure(eventId)
         } else {
@@ -11753,7 +11929,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         memberUserIdCallsCount += 1
         memberUserIdReceivedUserId = userId
-        memberUserIdReceivedInvocations.append(userId)
+        DispatchQueue.main.async {
+            self.memberUserIdReceivedInvocations.append(userId)
+        }
         if let memberUserIdClosure = memberUserIdClosure {
             return try await memberUserIdClosure(userId)
         } else {
@@ -11826,7 +12004,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         memberAvatarUrlUserIdCallsCount += 1
         memberAvatarUrlUserIdReceivedUserId = userId
-        memberAvatarUrlUserIdReceivedInvocations.append(userId)
+        DispatchQueue.main.async {
+            self.memberAvatarUrlUserIdReceivedInvocations.append(userId)
+        }
         if let memberAvatarUrlUserIdClosure = memberAvatarUrlUserIdClosure {
             return try await memberAvatarUrlUserIdClosure(userId)
         } else {
@@ -11899,7 +12079,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         memberDisplayNameUserIdCallsCount += 1
         memberDisplayNameUserIdReceivedUserId = userId
-        memberDisplayNameUserIdReceivedInvocations.append(userId)
+        DispatchQueue.main.async {
+            self.memberDisplayNameUserIdReceivedInvocations.append(userId)
+        }
         if let memberDisplayNameUserIdClosure = memberDisplayNameUserIdClosure {
             return try await memberDisplayNameUserIdClosure(userId)
         } else {
@@ -12280,7 +12462,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         redactEventIdReasonCallsCount += 1
         redactEventIdReasonReceivedArguments = (eventId: eventId, reason: reason)
-        redactEventIdReasonReceivedInvocations.append((eventId: eventId, reason: reason))
+        DispatchQueue.main.async {
+            self.redactEventIdReasonReceivedInvocations.append((eventId: eventId, reason: reason))
+        }
         try await redactEventIdReasonClosure?(eventId, reason)
     }
 
@@ -12364,7 +12548,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         reportContentEventIdScoreReasonCallsCount += 1
         reportContentEventIdScoreReasonReceivedArguments = (eventId: eventId, score: score, reason: reason)
-        reportContentEventIdScoreReasonReceivedInvocations.append((eventId: eventId, score: score, reason: reason))
+        DispatchQueue.main.async {
+            self.reportContentEventIdScoreReasonReceivedInvocations.append((eventId: eventId, score: score, reason: reason))
+        }
         try await reportContentEventIdScoreReasonClosure?(eventId, score, reason)
     }
 
@@ -12546,7 +12732,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         saveComposerDraftDraftCallsCount += 1
         saveComposerDraftDraftReceivedDraft = draft
-        saveComposerDraftDraftReceivedInvocations.append(draft)
+        DispatchQueue.main.async {
+            self.saveComposerDraftDraftReceivedInvocations.append(draft)
+        }
         try await saveComposerDraftDraftClosure?(draft)
     }
 
@@ -12590,7 +12778,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         sendCallNotificationCallIdApplicationNotifyTypeMentionsCallsCount += 1
         sendCallNotificationCallIdApplicationNotifyTypeMentionsReceivedArguments = (callId: callId, application: application, notifyType: notifyType, mentions: mentions)
-        sendCallNotificationCallIdApplicationNotifyTypeMentionsReceivedInvocations.append((callId: callId, application: application, notifyType: notifyType, mentions: mentions))
+        DispatchQueue.main.async {
+            self.sendCallNotificationCallIdApplicationNotifyTypeMentionsReceivedInvocations.append((callId: callId, application: application, notifyType: notifyType, mentions: mentions))
+        }
         try await sendCallNotificationCallIdApplicationNotifyTypeMentionsClosure?(callId, application, notifyType, mentions)
     }
 
@@ -12674,7 +12864,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         setIsFavouriteIsFavouriteTagOrderCallsCount += 1
         setIsFavouriteIsFavouriteTagOrderReceivedArguments = (isFavourite: isFavourite, tagOrder: tagOrder)
-        setIsFavouriteIsFavouriteTagOrderReceivedInvocations.append((isFavourite: isFavourite, tagOrder: tagOrder))
+        DispatchQueue.main.async {
+            self.setIsFavouriteIsFavouriteTagOrderReceivedInvocations.append((isFavourite: isFavourite, tagOrder: tagOrder))
+        }
         try await setIsFavouriteIsFavouriteTagOrderClosure?(isFavourite, tagOrder)
     }
 
@@ -12718,7 +12910,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         setIsLowPriorityIsLowPriorityTagOrderCallsCount += 1
         setIsLowPriorityIsLowPriorityTagOrderReceivedArguments = (isLowPriority: isLowPriority, tagOrder: tagOrder)
-        setIsLowPriorityIsLowPriorityTagOrderReceivedInvocations.append((isLowPriority: isLowPriority, tagOrder: tagOrder))
+        DispatchQueue.main.async {
+            self.setIsLowPriorityIsLowPriorityTagOrderReceivedInvocations.append((isLowPriority: isLowPriority, tagOrder: tagOrder))
+        }
         try await setIsLowPriorityIsLowPriorityTagOrderClosure?(isLowPriority, tagOrder)
     }
 
@@ -12762,7 +12956,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         setNameNameCallsCount += 1
         setNameNameReceivedName = name
-        setNameNameReceivedInvocations.append(name)
+        DispatchQueue.main.async {
+            self.setNameNameReceivedInvocations.append(name)
+        }
         try await setNameNameClosure?(name)
     }
 
@@ -12806,7 +13002,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         setTopicTopicCallsCount += 1
         setTopicTopicReceivedTopic = topic
-        setTopicTopicReceivedInvocations.append(topic)
+        DispatchQueue.main.async {
+            self.setTopicTopicReceivedInvocations.append(topic)
+        }
         try await setTopicTopicClosure?(topic)
     }
 
@@ -12850,7 +13048,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         setUnreadFlagNewValueCallsCount += 1
         setUnreadFlagNewValueReceivedNewValue = newValue
-        setUnreadFlagNewValueReceivedInvocations.append(newValue)
+        DispatchQueue.main.async {
+            self.setUnreadFlagNewValueReceivedInvocations.append(newValue)
+        }
         try await setUnreadFlagNewValueClosure?(newValue)
     }
 
@@ -12915,7 +13115,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
     open override func subscribeToRoomInfoUpdates(listener: RoomInfoListener) -> TaskHandle {
         subscribeToRoomInfoUpdatesListenerCallsCount += 1
         subscribeToRoomInfoUpdatesListenerReceivedListener = listener
-        subscribeToRoomInfoUpdatesListenerReceivedInvocations.append(listener)
+        DispatchQueue.main.async {
+            self.subscribeToRoomInfoUpdatesListenerReceivedInvocations.append(listener)
+        }
         if let subscribeToRoomInfoUpdatesListenerClosure = subscribeToRoomInfoUpdatesListenerClosure {
             return subscribeToRoomInfoUpdatesListenerClosure(listener)
         } else {
@@ -12984,7 +13186,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
     open override func subscribeToTypingNotifications(listener: TypingNotificationsListener) -> TaskHandle {
         subscribeToTypingNotificationsListenerCallsCount += 1
         subscribeToTypingNotificationsListenerReceivedListener = listener
-        subscribeToTypingNotificationsListenerReceivedInvocations.append(listener)
+        DispatchQueue.main.async {
+            self.subscribeToTypingNotificationsListenerReceivedInvocations.append(listener)
+        }
         if let subscribeToTypingNotificationsListenerClosure = subscribeToTypingNotificationsListenerClosure {
             return subscribeToTypingNotificationsListenerClosure(listener)
         } else {
@@ -13057,7 +13261,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         suggestedRoleForUserUserIdCallsCount += 1
         suggestedRoleForUserUserIdReceivedUserId = userId
-        suggestedRoleForUserUserIdReceivedInvocations.append(userId)
+        DispatchQueue.main.async {
+            self.suggestedRoleForUserUserIdReceivedInvocations.append(userId)
+        }
         if let suggestedRoleForUserUserIdClosure = suggestedRoleForUserUserIdClosure {
             return try await suggestedRoleForUserUserIdClosure(userId)
         } else {
@@ -13199,7 +13405,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         timelineFocusedOnEventEventIdNumContextEventsInternalIdPrefixCallsCount += 1
         timelineFocusedOnEventEventIdNumContextEventsInternalIdPrefixReceivedArguments = (eventId: eventId, numContextEvents: numContextEvents, internalIdPrefix: internalIdPrefix)
-        timelineFocusedOnEventEventIdNumContextEventsInternalIdPrefixReceivedInvocations.append((eventId: eventId, numContextEvents: numContextEvents, internalIdPrefix: internalIdPrefix))
+        DispatchQueue.main.async {
+            self.timelineFocusedOnEventEventIdNumContextEventsInternalIdPrefixReceivedInvocations.append((eventId: eventId, numContextEvents: numContextEvents, internalIdPrefix: internalIdPrefix))
+        }
         if let timelineFocusedOnEventEventIdNumContextEventsInternalIdPrefixClosure = timelineFocusedOnEventEventIdNumContextEventsInternalIdPrefixClosure {
             return try await timelineFocusedOnEventEventIdNumContextEventsInternalIdPrefixClosure(eventId, numContextEvents, internalIdPrefix)
         } else {
@@ -13312,7 +13520,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         typingNoticeIsTypingCallsCount += 1
         typingNoticeIsTypingReceivedIsTyping = isTyping
-        typingNoticeIsTypingReceivedInvocations.append(isTyping)
+        DispatchQueue.main.async {
+            self.typingNoticeIsTypingReceivedInvocations.append(isTyping)
+        }
         try await typingNoticeIsTypingClosure?(isTyping)
     }
 
@@ -13356,7 +13566,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         unbanUserUserIdReasonCallsCount += 1
         unbanUserUserIdReasonReceivedArguments = (userId: userId, reason: reason)
-        unbanUserUserIdReasonReceivedInvocations.append((userId: userId, reason: reason))
+        DispatchQueue.main.async {
+            self.unbanUserUserIdReasonReceivedInvocations.append((userId: userId, reason: reason))
+        }
         try await unbanUserUserIdReasonClosure?(userId, reason)
     }
 
@@ -13400,7 +13612,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         updatePowerLevelsForUsersUpdatesCallsCount += 1
         updatePowerLevelsForUsersUpdatesReceivedUpdates = updates
-        updatePowerLevelsForUsersUpdatesReceivedInvocations.append(updates)
+        DispatchQueue.main.async {
+            self.updatePowerLevelsForUsersUpdatesReceivedInvocations.append(updates)
+        }
         try await updatePowerLevelsForUsersUpdatesClosure?(updates)
     }
 
@@ -13444,7 +13658,9 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         uploadAvatarMimeTypeDataMediaInfoCallsCount += 1
         uploadAvatarMimeTypeDataMediaInfoReceivedArguments = (mimeType: mimeType, data: data, mediaInfo: mediaInfo)
-        uploadAvatarMimeTypeDataMediaInfoReceivedInvocations.append((mimeType: mimeType, data: data, mediaInfo: mediaInfo))
+        DispatchQueue.main.async {
+            self.uploadAvatarMimeTypeDataMediaInfoReceivedInvocations.append((mimeType: mimeType, data: data, mediaInfo: mediaInfo))
+        }
         try await uploadAvatarMimeTypeDataMediaInfoClosure?(mimeType, data, mediaInfo)
     }
 }
@@ -13698,7 +13914,9 @@ open class RoomDirectorySearchSDKMock: MatrixRustSDK.RoomDirectorySearch {
     open override func results(listener: RoomDirectorySearchEntriesListener) async -> TaskHandle {
         resultsListenerCallsCount += 1
         resultsListenerReceivedListener = listener
-        resultsListenerReceivedInvocations.append(listener)
+        DispatchQueue.main.async {
+            self.resultsListenerReceivedInvocations.append(listener)
+        }
         if let resultsListenerClosure = resultsListenerClosure {
             return await resultsListenerClosure(listener)
         } else {
@@ -13746,7 +13964,9 @@ open class RoomDirectorySearchSDKMock: MatrixRustSDK.RoomDirectorySearch {
         }
         searchFilterBatchSizeCallsCount += 1
         searchFilterBatchSizeReceivedArguments = (filter: filter, batchSize: batchSize)
-        searchFilterBatchSizeReceivedInvocations.append((filter: filter, batchSize: batchSize))
+        DispatchQueue.main.async {
+            self.searchFilterBatchSizeReceivedInvocations.append((filter: filter, batchSize: batchSize))
+        }
         try await searchFilterBatchSizeClosure?(filter, batchSize)
     }
 }
@@ -13822,7 +14042,9 @@ open class RoomListSDKMock: MatrixRustSDK.RoomList {
     open override func entries(listener: RoomListEntriesListener) -> RoomListEntriesResult {
         entriesListenerCallsCount += 1
         entriesListenerReceivedListener = listener
-        entriesListenerReceivedInvocations.append(listener)
+        DispatchQueue.main.async {
+            self.entriesListenerReceivedInvocations.append(listener)
+        }
         if let entriesListenerClosure = entriesListenerClosure {
             return entriesListenerClosure(listener)
         } else {
@@ -13891,7 +14113,9 @@ open class RoomListSDKMock: MatrixRustSDK.RoomList {
     open override func entriesWithDynamicAdapters(pageSize: UInt32, listener: RoomListEntriesListener) -> RoomListEntriesWithDynamicAdaptersResult {
         entriesWithDynamicAdaptersPageSizeListenerCallsCount += 1
         entriesWithDynamicAdaptersPageSizeListenerReceivedArguments = (pageSize: pageSize, listener: listener)
-        entriesWithDynamicAdaptersPageSizeListenerReceivedInvocations.append((pageSize: pageSize, listener: listener))
+        DispatchQueue.main.async {
+            self.entriesWithDynamicAdaptersPageSizeListenerReceivedInvocations.append((pageSize: pageSize, listener: listener))
+        }
         if let entriesWithDynamicAdaptersPageSizeListenerClosure = entriesWithDynamicAdaptersPageSizeListenerClosure {
             return entriesWithDynamicAdaptersPageSizeListenerClosure(pageSize, listener)
         } else {
@@ -13964,7 +14188,9 @@ open class RoomListSDKMock: MatrixRustSDK.RoomList {
         }
         loadingStateListenerCallsCount += 1
         loadingStateListenerReceivedListener = listener
-        loadingStateListenerReceivedInvocations.append(listener)
+        DispatchQueue.main.async {
+            self.loadingStateListenerReceivedInvocations.append(listener)
+        }
         if let loadingStateListenerClosure = loadingStateListenerClosure {
             return try loadingStateListenerClosure(listener)
         } else {
@@ -14037,7 +14263,9 @@ open class RoomListSDKMock: MatrixRustSDK.RoomList {
         }
         roomRoomIdCallsCount += 1
         roomRoomIdReceivedRoomId = roomId
-        roomRoomIdReceivedInvocations.append(roomId)
+        DispatchQueue.main.async {
+            self.roomRoomIdReceivedInvocations.append(roomId)
+        }
         if let roomRoomIdClosure = roomRoomIdClosure {
             return try await roomRoomIdClosure(roomId)
         } else {
@@ -14189,7 +14417,9 @@ open class RoomListDynamicEntriesControllerSDKMock: MatrixRustSDK.RoomListDynami
     open override func setFilter(kind: RoomListEntriesDynamicFilterKind) -> Bool {
         setFilterKindCallsCount += 1
         setFilterKindReceivedKind = kind
-        setFilterKindReceivedInvocations.append(kind)
+        DispatchQueue.main.async {
+            self.setFilterKindReceivedInvocations.append(kind)
+        }
         if let setFilterKindClosure = setFilterKindClosure {
             return setFilterKindClosure(kind)
         } else {
@@ -14577,7 +14807,9 @@ open class RoomListItemSDKMock: MatrixRustSDK.RoomListItem {
         }
         initTimelineEventTypeFilterInternalIdPrefixCallsCount += 1
         initTimelineEventTypeFilterInternalIdPrefixReceivedArguments = (eventTypeFilter: eventTypeFilter, internalIdPrefix: internalIdPrefix)
-        initTimelineEventTypeFilterInternalIdPrefixReceivedInvocations.append((eventTypeFilter: eventTypeFilter, internalIdPrefix: internalIdPrefix))
+        DispatchQueue.main.async {
+            self.initTimelineEventTypeFilterInternalIdPrefixReceivedInvocations.append((eventTypeFilter: eventTypeFilter, internalIdPrefix: internalIdPrefix))
+        }
         try await initTimelineEventTypeFilterInternalIdPrefixClosure?(eventTypeFilter, internalIdPrefix)
     }
 
@@ -14881,7 +15113,9 @@ open class RoomListItemSDKMock: MatrixRustSDK.RoomListItem {
     open override func subscribe(settings: RoomSubscription?) {
         subscribeSettingsCallsCount += 1
         subscribeSettingsReceivedSettings = settings
-        subscribeSettingsReceivedInvocations.append(settings)
+        DispatchQueue.main.async {
+            self.subscribeSettingsReceivedInvocations.append(settings)
+        }
         subscribeSettingsClosure?(settings)
     }
 
@@ -15041,7 +15275,9 @@ open class RoomListServiceSDKMock: MatrixRustSDK.RoomListService {
         }
         applyInputInputCallsCount += 1
         applyInputInputReceivedInput = input
-        applyInputInputReceivedInvocations.append(input)
+        DispatchQueue.main.async {
+            self.applyInputInputReceivedInvocations.append(input)
+        }
         try await applyInputInputClosure?(input)
     }
 
@@ -15110,7 +15346,9 @@ open class RoomListServiceSDKMock: MatrixRustSDK.RoomListService {
         }
         roomRoomIdCallsCount += 1
         roomRoomIdReceivedRoomId = roomId
-        roomRoomIdReceivedInvocations.append(roomId)
+        DispatchQueue.main.async {
+            self.roomRoomIdReceivedInvocations.append(roomId)
+        }
         if let roomRoomIdClosure = roomRoomIdClosure {
             return try await roomRoomIdClosure(roomId)
         } else {
@@ -15179,7 +15417,9 @@ open class RoomListServiceSDKMock: MatrixRustSDK.RoomListService {
     open override func state(listener: RoomListServiceStateListener) -> TaskHandle {
         stateListenerCallsCount += 1
         stateListenerReceivedListener = listener
-        stateListenerReceivedInvocations.append(listener)
+        DispatchQueue.main.async {
+            self.stateListenerReceivedInvocations.append(listener)
+        }
         if let stateListenerClosure = stateListenerClosure {
             return stateListenerClosure(listener)
         } else {
@@ -15248,7 +15488,9 @@ open class RoomListServiceSDKMock: MatrixRustSDK.RoomListService {
     open override func syncIndicator(delayBeforeShowingInMs: UInt32, delayBeforeHidingInMs: UInt32, listener: RoomListServiceSyncIndicatorListener) -> TaskHandle {
         syncIndicatorDelayBeforeShowingInMsDelayBeforeHidingInMsListenerCallsCount += 1
         syncIndicatorDelayBeforeShowingInMsDelayBeforeHidingInMsListenerReceivedArguments = (delayBeforeShowingInMs: delayBeforeShowingInMs, delayBeforeHidingInMs: delayBeforeHidingInMs, listener: listener)
-        syncIndicatorDelayBeforeShowingInMsDelayBeforeHidingInMsListenerReceivedInvocations.append((delayBeforeShowingInMs: delayBeforeShowingInMs, delayBeforeHidingInMs: delayBeforeHidingInMs, listener: listener))
+        DispatchQueue.main.async {
+            self.syncIndicatorDelayBeforeShowingInMsDelayBeforeHidingInMsListenerReceivedInvocations.append((delayBeforeShowingInMs: delayBeforeShowingInMs, delayBeforeHidingInMs: delayBeforeHidingInMs, listener: listener))
+        }
         if let syncIndicatorDelayBeforeShowingInMsDelayBeforeHidingInMsListenerClosure = syncIndicatorDelayBeforeShowingInMsDelayBeforeHidingInMsListenerClosure {
             return syncIndicatorDelayBeforeShowingInMsDelayBeforeHidingInMsListenerClosure(delayBeforeShowingInMs, delayBeforeHidingInMs, listener)
         } else {
@@ -15393,7 +15635,9 @@ open class RoomMembersIteratorSDKMock: MatrixRustSDK.RoomMembersIterator {
     open override func nextChunk(chunkSize: UInt32) -> [RoomMember]? {
         nextChunkChunkSizeCallsCount += 1
         nextChunkChunkSizeReceivedChunkSize = chunkSize
-        nextChunkChunkSizeReceivedInvocations.append(chunkSize)
+        DispatchQueue.main.async {
+            self.nextChunkChunkSizeReceivedInvocations.append(chunkSize)
+        }
         if let nextChunkChunkSizeClosure = nextChunkChunkSizeClosure {
             return nextChunkChunkSizeClosure(chunkSize)
         } else {
@@ -15473,7 +15717,9 @@ open class RoomMessageEventContentWithoutRelationSDKMock: MatrixRustSDK.RoomMess
     open override func withMentions(mentions: Mentions) -> RoomMessageEventContentWithoutRelation {
         withMentionsMentionsCallsCount += 1
         withMentionsMentionsReceivedMentions = mentions
-        withMentionsMentionsReceivedInvocations.append(mentions)
+        DispatchQueue.main.async {
+            self.withMentionsMentionsReceivedInvocations.append(mentions)
+        }
         if let withMentionsMentionsClosure = withMentionsMentionsClosure {
             return withMentionsMentionsClosure(mentions)
         } else {
@@ -15844,7 +16090,9 @@ open class SessionVerificationControllerSDKMock: MatrixRustSDK.SessionVerificati
     open override func setDelegate(delegate: SessionVerificationControllerDelegate?) {
         setDelegateDelegateCallsCount += 1
         setDelegateDelegateReceivedDelegate = delegate
-        setDelegateDelegateReceivedInvocations.append(delegate)
+        DispatchQueue.main.async {
+            self.setDelegateDelegateReceivedInvocations.append(delegate)
+        }
         setDelegateDelegateClosure?(delegate)
     }
 
@@ -16353,7 +16601,9 @@ open class SyncServiceSDKMock: MatrixRustSDK.SyncService {
     open override func state(listener: SyncServiceStateObserver) -> TaskHandle {
         stateListenerCallsCount += 1
         stateListenerReceivedListener = listener
-        stateListenerReceivedInvocations.append(listener)
+        DispatchQueue.main.async {
+            self.stateListenerReceivedInvocations.append(listener)
+        }
         if let stateListenerClosure = stateListenerClosure {
             return stateListenerClosure(listener)
         } else {
@@ -16542,7 +16792,9 @@ open class SyncServiceBuilderSDKMock: MatrixRustSDK.SyncServiceBuilder {
     open override func withCrossProcessLock(appIdentifier: String?) -> SyncServiceBuilder {
         withCrossProcessLockAppIdentifierCallsCount += 1
         withCrossProcessLockAppIdentifierReceivedAppIdentifier = appIdentifier
-        withCrossProcessLockAppIdentifierReceivedInvocations.append(appIdentifier)
+        DispatchQueue.main.async {
+            self.withCrossProcessLockAppIdentifierReceivedInvocations.append(appIdentifier)
+        }
         if let withCrossProcessLockAppIdentifierClosure = withCrossProcessLockAppIdentifierClosure {
             return withCrossProcessLockAppIdentifierClosure(appIdentifier)
         } else {
@@ -16611,7 +16863,9 @@ open class SyncServiceBuilderSDKMock: MatrixRustSDK.SyncServiceBuilder {
     open override func withUtdHook(delegate: UnableToDecryptDelegate) async -> SyncServiceBuilder {
         withUtdHookDelegateCallsCount += 1
         withUtdHookDelegateReceivedDelegate = delegate
-        withUtdHookDelegateReceivedInvocations.append(delegate)
+        DispatchQueue.main.async {
+            self.withUtdHookDelegateReceivedInvocations.append(delegate)
+        }
         if let withUtdHookDelegateClosure = withUtdHookDelegateClosure {
             return await withUtdHookDelegateClosure(delegate)
         } else {
@@ -16803,7 +17057,9 @@ open class TimelineSDKMock: MatrixRustSDK.Timeline {
     open override func addListener(listener: TimelineListener) async -> TaskHandle {
         addListenerListenerCallsCount += 1
         addListenerListenerReceivedListener = listener
-        addListenerListenerReceivedInvocations.append(listener)
+        DispatchQueue.main.async {
+            self.addListenerListenerReceivedInvocations.append(listener)
+        }
         if let addListenerListenerClosure = addListenerListenerClosure {
             return await addListenerListenerClosure(listener)
         } else {
@@ -16851,7 +17107,9 @@ open class TimelineSDKMock: MatrixRustSDK.Timeline {
         }
         createPollQuestionAnswersMaxSelectionsPollKindCallsCount += 1
         createPollQuestionAnswersMaxSelectionsPollKindReceivedArguments = (question: question, answers: answers, maxSelections: maxSelections, pollKind: pollKind)
-        createPollQuestionAnswersMaxSelectionsPollKindReceivedInvocations.append((question: question, answers: answers, maxSelections: maxSelections, pollKind: pollKind))
+        DispatchQueue.main.async {
+            self.createPollQuestionAnswersMaxSelectionsPollKindReceivedInvocations.append((question: question, answers: answers, maxSelections: maxSelections, pollKind: pollKind))
+        }
         try await createPollQuestionAnswersMaxSelectionsPollKindClosure?(question, answers, maxSelections, pollKind)
     }
 
@@ -16895,7 +17153,9 @@ open class TimelineSDKMock: MatrixRustSDK.Timeline {
         }
         editNewContentEditItemCallsCount += 1
         editNewContentEditItemReceivedArguments = (newContent: newContent, editItem: editItem)
-        editNewContentEditItemReceivedInvocations.append((newContent: newContent, editItem: editItem))
+        DispatchQueue.main.async {
+            self.editNewContentEditItemReceivedInvocations.append((newContent: newContent, editItem: editItem))
+        }
         try await editNewContentEditItemClosure?(newContent, editItem)
     }
 
@@ -16939,7 +17199,9 @@ open class TimelineSDKMock: MatrixRustSDK.Timeline {
         }
         editPollQuestionAnswersMaxSelectionsPollKindEditItemCallsCount += 1
         editPollQuestionAnswersMaxSelectionsPollKindEditItemReceivedArguments = (question: question, answers: answers, maxSelections: maxSelections, pollKind: pollKind, editItem: editItem)
-        editPollQuestionAnswersMaxSelectionsPollKindEditItemReceivedInvocations.append((question: question, answers: answers, maxSelections: maxSelections, pollKind: pollKind, editItem: editItem))
+        DispatchQueue.main.async {
+            self.editPollQuestionAnswersMaxSelectionsPollKindEditItemReceivedInvocations.append((question: question, answers: answers, maxSelections: maxSelections, pollKind: pollKind, editItem: editItem))
+        }
         try await editPollQuestionAnswersMaxSelectionsPollKindEditItemClosure?(question, answers, maxSelections, pollKind, editItem)
     }
 
@@ -16983,7 +17245,9 @@ open class TimelineSDKMock: MatrixRustSDK.Timeline {
         }
         endPollPollStartIdTextCallsCount += 1
         endPollPollStartIdTextReceivedArguments = (pollStartId: pollStartId, text: text)
-        endPollPollStartIdTextReceivedInvocations.append((pollStartId: pollStartId, text: text))
+        DispatchQueue.main.async {
+            self.endPollPollStartIdTextReceivedInvocations.append((pollStartId: pollStartId, text: text))
+        }
         try endPollPollStartIdTextClosure?(pollStartId, text)
     }
 
@@ -17027,7 +17291,9 @@ open class TimelineSDKMock: MatrixRustSDK.Timeline {
         }
         fetchDetailsForEventEventIdCallsCount += 1
         fetchDetailsForEventEventIdReceivedEventId = eventId
-        fetchDetailsForEventEventIdReceivedInvocations.append(eventId)
+        DispatchQueue.main.async {
+            self.fetchDetailsForEventEventIdReceivedInvocations.append(eventId)
+        }
         try await fetchDetailsForEventEventIdClosure?(eventId)
     }
 
@@ -17132,7 +17398,9 @@ open class TimelineSDKMock: MatrixRustSDK.Timeline {
         }
         focusedPaginateForwardsNumEventsCallsCount += 1
         focusedPaginateForwardsNumEventsReceivedNumEvents = numEvents
-        focusedPaginateForwardsNumEventsReceivedInvocations.append(numEvents)
+        DispatchQueue.main.async {
+            self.focusedPaginateForwardsNumEventsReceivedInvocations.append(numEvents)
+        }
         if let focusedPaginateForwardsNumEventsClosure = focusedPaginateForwardsNumEventsClosure {
             return try await focusedPaginateForwardsNumEventsClosure(numEvents)
         } else {
@@ -17205,7 +17473,9 @@ open class TimelineSDKMock: MatrixRustSDK.Timeline {
         }
         getEventTimelineItemByEventIdEventIdCallsCount += 1
         getEventTimelineItemByEventIdEventIdReceivedEventId = eventId
-        getEventTimelineItemByEventIdEventIdReceivedInvocations.append(eventId)
+        DispatchQueue.main.async {
+            self.getEventTimelineItemByEventIdEventIdReceivedInvocations.append(eventId)
+        }
         if let getEventTimelineItemByEventIdEventIdClosure = getEventTimelineItemByEventIdEventIdClosure {
             return try await getEventTimelineItemByEventIdEventIdClosure(eventId)
         } else {
@@ -17278,7 +17548,9 @@ open class TimelineSDKMock: MatrixRustSDK.Timeline {
         }
         getEventTimelineItemByTransactionIdTransactionIdCallsCount += 1
         getEventTimelineItemByTransactionIdTransactionIdReceivedTransactionId = transactionId
-        getEventTimelineItemByTransactionIdTransactionIdReceivedInvocations.append(transactionId)
+        DispatchQueue.main.async {
+            self.getEventTimelineItemByTransactionIdTransactionIdReceivedInvocations.append(transactionId)
+        }
         if let getEventTimelineItemByTransactionIdTransactionIdClosure = getEventTimelineItemByTransactionIdTransactionIdClosure {
             return try await getEventTimelineItemByTransactionIdTransactionIdClosure(transactionId)
         } else {
@@ -17416,7 +17688,9 @@ open class TimelineSDKMock: MatrixRustSDK.Timeline {
         }
         loadReplyDetailsEventIdStrCallsCount += 1
         loadReplyDetailsEventIdStrReceivedEventIdStr = eventIdStr
-        loadReplyDetailsEventIdStrReceivedInvocations.append(eventIdStr)
+        DispatchQueue.main.async {
+            self.loadReplyDetailsEventIdStrReceivedInvocations.append(eventIdStr)
+        }
         if let loadReplyDetailsEventIdStrClosure = loadReplyDetailsEventIdStrClosure {
             return try await loadReplyDetailsEventIdStrClosure(eventIdStr)
         } else {
@@ -17464,7 +17738,9 @@ open class TimelineSDKMock: MatrixRustSDK.Timeline {
         }
         markAsReadReceiptTypeCallsCount += 1
         markAsReadReceiptTypeReceivedReceiptType = receiptType
-        markAsReadReceiptTypeReceivedInvocations.append(receiptType)
+        DispatchQueue.main.async {
+            self.markAsReadReceiptTypeReceivedInvocations.append(receiptType)
+        }
         try await markAsReadReceiptTypeClosure?(receiptType)
     }
 
@@ -17533,7 +17809,9 @@ open class TimelineSDKMock: MatrixRustSDK.Timeline {
         }
         paginateBackwardsNumEventsCallsCount += 1
         paginateBackwardsNumEventsReceivedNumEvents = numEvents
-        paginateBackwardsNumEventsReceivedInvocations.append(numEvents)
+        DispatchQueue.main.async {
+            self.paginateBackwardsNumEventsReceivedInvocations.append(numEvents)
+        }
         if let paginateBackwardsNumEventsClosure = paginateBackwardsNumEventsClosure {
             return try await paginateBackwardsNumEventsClosure(numEvents)
         } else {
@@ -17606,7 +17884,9 @@ open class TimelineSDKMock: MatrixRustSDK.Timeline {
         }
         redactEventItemReasonCallsCount += 1
         redactEventItemReasonReceivedArguments = (item: item, reason: reason)
-        redactEventItemReasonReceivedInvocations.append((item: item, reason: reason))
+        DispatchQueue.main.async {
+            self.redactEventItemReasonReceivedInvocations.append((item: item, reason: reason))
+        }
         if let redactEventItemReasonClosure = redactEventItemReasonClosure {
             return try await redactEventItemReasonClosure(item, reason)
         } else {
@@ -17650,7 +17930,9 @@ open class TimelineSDKMock: MatrixRustSDK.Timeline {
     open override func retryDecryption(sessionIds: [String]) {
         retryDecryptionSessionIdsCallsCount += 1
         retryDecryptionSessionIdsReceivedSessionIds = sessionIds
-        retryDecryptionSessionIdsReceivedInvocations.append(sessionIds)
+        DispatchQueue.main.async {
+            self.retryDecryptionSessionIdsReceivedInvocations.append(sessionIds)
+        }
         retryDecryptionSessionIdsClosure?(sessionIds)
     }
 
@@ -17719,7 +18001,9 @@ open class TimelineSDKMock: MatrixRustSDK.Timeline {
         }
         sendMsgCallsCount += 1
         sendMsgReceivedMsg = msg
-        sendMsgReceivedInvocations.append(msg)
+        DispatchQueue.main.async {
+            self.sendMsgReceivedInvocations.append(msg)
+        }
         if let sendMsgClosure = sendMsgClosure {
             return try await sendMsgClosure(msg)
         } else {
@@ -17788,7 +18072,9 @@ open class TimelineSDKMock: MatrixRustSDK.Timeline {
     open override func sendAudio(url: String, audioInfo: AudioInfo, caption: String?, formattedCaption: FormattedBody?, progressWatcher: ProgressWatcher?) -> SendAttachmentJoinHandle {
         sendAudioUrlAudioInfoCaptionFormattedCaptionProgressWatcherCallsCount += 1
         sendAudioUrlAudioInfoCaptionFormattedCaptionProgressWatcherReceivedArguments = (url: url, audioInfo: audioInfo, caption: caption, formattedCaption: formattedCaption, progressWatcher: progressWatcher)
-        sendAudioUrlAudioInfoCaptionFormattedCaptionProgressWatcherReceivedInvocations.append((url: url, audioInfo: audioInfo, caption: caption, formattedCaption: formattedCaption, progressWatcher: progressWatcher))
+        DispatchQueue.main.async {
+            self.sendAudioUrlAudioInfoCaptionFormattedCaptionProgressWatcherReceivedInvocations.append((url: url, audioInfo: audioInfo, caption: caption, formattedCaption: formattedCaption, progressWatcher: progressWatcher))
+        }
         if let sendAudioUrlAudioInfoCaptionFormattedCaptionProgressWatcherClosure = sendAudioUrlAudioInfoCaptionFormattedCaptionProgressWatcherClosure {
             return sendAudioUrlAudioInfoCaptionFormattedCaptionProgressWatcherClosure(url, audioInfo, caption, formattedCaption, progressWatcher)
         } else {
@@ -17857,7 +18143,9 @@ open class TimelineSDKMock: MatrixRustSDK.Timeline {
     open override func sendFile(url: String, fileInfo: FileInfo, progressWatcher: ProgressWatcher?) -> SendAttachmentJoinHandle {
         sendFileUrlFileInfoProgressWatcherCallsCount += 1
         sendFileUrlFileInfoProgressWatcherReceivedArguments = (url: url, fileInfo: fileInfo, progressWatcher: progressWatcher)
-        sendFileUrlFileInfoProgressWatcherReceivedInvocations.append((url: url, fileInfo: fileInfo, progressWatcher: progressWatcher))
+        DispatchQueue.main.async {
+            self.sendFileUrlFileInfoProgressWatcherReceivedInvocations.append((url: url, fileInfo: fileInfo, progressWatcher: progressWatcher))
+        }
         if let sendFileUrlFileInfoProgressWatcherClosure = sendFileUrlFileInfoProgressWatcherClosure {
             return sendFileUrlFileInfoProgressWatcherClosure(url, fileInfo, progressWatcher)
         } else {
@@ -17926,7 +18214,9 @@ open class TimelineSDKMock: MatrixRustSDK.Timeline {
     open override func sendImage(url: String, thumbnailUrl: String?, imageInfo: ImageInfo, caption: String?, formattedCaption: FormattedBody?, progressWatcher: ProgressWatcher?) -> SendAttachmentJoinHandle {
         sendImageUrlThumbnailUrlImageInfoCaptionFormattedCaptionProgressWatcherCallsCount += 1
         sendImageUrlThumbnailUrlImageInfoCaptionFormattedCaptionProgressWatcherReceivedArguments = (url: url, thumbnailUrl: thumbnailUrl, imageInfo: imageInfo, caption: caption, formattedCaption: formattedCaption, progressWatcher: progressWatcher)
-        sendImageUrlThumbnailUrlImageInfoCaptionFormattedCaptionProgressWatcherReceivedInvocations.append((url: url, thumbnailUrl: thumbnailUrl, imageInfo: imageInfo, caption: caption, formattedCaption: formattedCaption, progressWatcher: progressWatcher))
+        DispatchQueue.main.async {
+            self.sendImageUrlThumbnailUrlImageInfoCaptionFormattedCaptionProgressWatcherReceivedInvocations.append((url: url, thumbnailUrl: thumbnailUrl, imageInfo: imageInfo, caption: caption, formattedCaption: formattedCaption, progressWatcher: progressWatcher))
+        }
         if let sendImageUrlThumbnailUrlImageInfoCaptionFormattedCaptionProgressWatcherClosure = sendImageUrlThumbnailUrlImageInfoCaptionFormattedCaptionProgressWatcherClosure {
             return sendImageUrlThumbnailUrlImageInfoCaptionFormattedCaptionProgressWatcherClosure(url, thumbnailUrl, imageInfo, caption, formattedCaption, progressWatcher)
         } else {
@@ -17970,7 +18260,9 @@ open class TimelineSDKMock: MatrixRustSDK.Timeline {
     open override func sendLocation(body: String, geoUri: String, description: String?, zoomLevel: UInt8?, assetType: AssetType?) async {
         sendLocationBodyGeoUriDescriptionZoomLevelAssetTypeCallsCount += 1
         sendLocationBodyGeoUriDescriptionZoomLevelAssetTypeReceivedArguments = (body: body, geoUri: geoUri, description: description, zoomLevel: zoomLevel, assetType: assetType)
-        sendLocationBodyGeoUriDescriptionZoomLevelAssetTypeReceivedInvocations.append((body: body, geoUri: geoUri, description: description, zoomLevel: zoomLevel, assetType: assetType))
+        DispatchQueue.main.async {
+            self.sendLocationBodyGeoUriDescriptionZoomLevelAssetTypeReceivedInvocations.append((body: body, geoUri: geoUri, description: description, zoomLevel: zoomLevel, assetType: assetType))
+        }
         await sendLocationBodyGeoUriDescriptionZoomLevelAssetTypeClosure?(body, geoUri, description, zoomLevel, assetType)
     }
 
@@ -18014,7 +18306,9 @@ open class TimelineSDKMock: MatrixRustSDK.Timeline {
         }
         sendPollResponsePollStartIdAnswersCallsCount += 1
         sendPollResponsePollStartIdAnswersReceivedArguments = (pollStartId: pollStartId, answers: answers)
-        sendPollResponsePollStartIdAnswersReceivedInvocations.append((pollStartId: pollStartId, answers: answers))
+        DispatchQueue.main.async {
+            self.sendPollResponsePollStartIdAnswersReceivedInvocations.append((pollStartId: pollStartId, answers: answers))
+        }
         try await sendPollResponsePollStartIdAnswersClosure?(pollStartId, answers)
     }
 
@@ -18058,7 +18352,9 @@ open class TimelineSDKMock: MatrixRustSDK.Timeline {
         }
         sendReadReceiptReceiptTypeEventIdCallsCount += 1
         sendReadReceiptReceiptTypeEventIdReceivedArguments = (receiptType: receiptType, eventId: eventId)
-        sendReadReceiptReceiptTypeEventIdReceivedInvocations.append((receiptType: receiptType, eventId: eventId))
+        DispatchQueue.main.async {
+            self.sendReadReceiptReceiptTypeEventIdReceivedInvocations.append((receiptType: receiptType, eventId: eventId))
+        }
         try await sendReadReceiptReceiptTypeEventIdClosure?(receiptType, eventId)
     }
 
@@ -18102,7 +18398,9 @@ open class TimelineSDKMock: MatrixRustSDK.Timeline {
         }
         sendReplyMsgReplyItemCallsCount += 1
         sendReplyMsgReplyItemReceivedArguments = (msg: msg, replyItem: replyItem)
-        sendReplyMsgReplyItemReceivedInvocations.append((msg: msg, replyItem: replyItem))
+        DispatchQueue.main.async {
+            self.sendReplyMsgReplyItemReceivedInvocations.append((msg: msg, replyItem: replyItem))
+        }
         try await sendReplyMsgReplyItemClosure?(msg, replyItem)
     }
 
@@ -18167,7 +18465,9 @@ open class TimelineSDKMock: MatrixRustSDK.Timeline {
     open override func sendVideo(url: String, thumbnailUrl: String?, videoInfo: VideoInfo, caption: String?, formattedCaption: FormattedBody?, progressWatcher: ProgressWatcher?) -> SendAttachmentJoinHandle {
         sendVideoUrlThumbnailUrlVideoInfoCaptionFormattedCaptionProgressWatcherCallsCount += 1
         sendVideoUrlThumbnailUrlVideoInfoCaptionFormattedCaptionProgressWatcherReceivedArguments = (url: url, thumbnailUrl: thumbnailUrl, videoInfo: videoInfo, caption: caption, formattedCaption: formattedCaption, progressWatcher: progressWatcher)
-        sendVideoUrlThumbnailUrlVideoInfoCaptionFormattedCaptionProgressWatcherReceivedInvocations.append((url: url, thumbnailUrl: thumbnailUrl, videoInfo: videoInfo, caption: caption, formattedCaption: formattedCaption, progressWatcher: progressWatcher))
+        DispatchQueue.main.async {
+            self.sendVideoUrlThumbnailUrlVideoInfoCaptionFormattedCaptionProgressWatcherReceivedInvocations.append((url: url, thumbnailUrl: thumbnailUrl, videoInfo: videoInfo, caption: caption, formattedCaption: formattedCaption, progressWatcher: progressWatcher))
+        }
         if let sendVideoUrlThumbnailUrlVideoInfoCaptionFormattedCaptionProgressWatcherClosure = sendVideoUrlThumbnailUrlVideoInfoCaptionFormattedCaptionProgressWatcherClosure {
             return sendVideoUrlThumbnailUrlVideoInfoCaptionFormattedCaptionProgressWatcherClosure(url, thumbnailUrl, videoInfo, caption, formattedCaption, progressWatcher)
         } else {
@@ -18236,7 +18536,9 @@ open class TimelineSDKMock: MatrixRustSDK.Timeline {
     open override func sendVoiceMessage(url: String, audioInfo: AudioInfo, waveform: [UInt16], caption: String?, formattedCaption: FormattedBody?, progressWatcher: ProgressWatcher?) -> SendAttachmentJoinHandle {
         sendVoiceMessageUrlAudioInfoWaveformCaptionFormattedCaptionProgressWatcherCallsCount += 1
         sendVoiceMessageUrlAudioInfoWaveformCaptionFormattedCaptionProgressWatcherReceivedArguments = (url: url, audioInfo: audioInfo, waveform: waveform, caption: caption, formattedCaption: formattedCaption, progressWatcher: progressWatcher)
-        sendVoiceMessageUrlAudioInfoWaveformCaptionFormattedCaptionProgressWatcherReceivedInvocations.append((url: url, audioInfo: audioInfo, waveform: waveform, caption: caption, formattedCaption: formattedCaption, progressWatcher: progressWatcher))
+        DispatchQueue.main.async {
+            self.sendVoiceMessageUrlAudioInfoWaveformCaptionFormattedCaptionProgressWatcherReceivedInvocations.append((url: url, audioInfo: audioInfo, waveform: waveform, caption: caption, formattedCaption: formattedCaption, progressWatcher: progressWatcher))
+        }
         if let sendVoiceMessageUrlAudioInfoWaveformCaptionFormattedCaptionProgressWatcherClosure = sendVoiceMessageUrlAudioInfoWaveformCaptionFormattedCaptionProgressWatcherClosure {
             return sendVoiceMessageUrlAudioInfoWaveformCaptionFormattedCaptionProgressWatcherClosure(url, audioInfo, waveform, caption, formattedCaption, progressWatcher)
         } else {
@@ -18309,7 +18611,9 @@ open class TimelineSDKMock: MatrixRustSDK.Timeline {
         }
         subscribeToBackPaginationStatusListenerCallsCount += 1
         subscribeToBackPaginationStatusListenerReceivedListener = listener
-        subscribeToBackPaginationStatusListenerReceivedInvocations.append(listener)
+        DispatchQueue.main.async {
+            self.subscribeToBackPaginationStatusListenerReceivedInvocations.append(listener)
+        }
         if let subscribeToBackPaginationStatusListenerClosure = subscribeToBackPaginationStatusListenerClosure {
             return try await subscribeToBackPaginationStatusListenerClosure(listener)
         } else {
@@ -18357,7 +18661,9 @@ open class TimelineSDKMock: MatrixRustSDK.Timeline {
         }
         toggleReactionEventIdKeyCallsCount += 1
         toggleReactionEventIdKeyReceivedArguments = (eventId: eventId, key: key)
-        toggleReactionEventIdKeyReceivedInvocations.append((eventId: eventId, key: key))
+        DispatchQueue.main.async {
+            self.toggleReactionEventIdKeyReceivedInvocations.append((eventId: eventId, key: key))
+        }
         try await toggleReactionEventIdKeyClosure?(eventId, key)
     }
 }
@@ -19846,7 +20152,9 @@ open class WidgetDriverSDKMock: MatrixRustSDK.WidgetDriver {
     open override func run(room: Room, capabilitiesProvider: WidgetCapabilitiesProvider) async {
         runRoomCapabilitiesProviderCallsCount += 1
         runRoomCapabilitiesProviderReceivedArguments = (room: room, capabilitiesProvider: capabilitiesProvider)
-        runRoomCapabilitiesProviderReceivedInvocations.append((room: room, capabilitiesProvider: capabilitiesProvider))
+        DispatchQueue.main.async {
+            self.runRoomCapabilitiesProviderReceivedInvocations.append((room: room, capabilitiesProvider: capabilitiesProvider))
+        }
         await runRoomCapabilitiesProviderClosure?(room, capabilitiesProvider)
     }
 }
@@ -19987,7 +20295,9 @@ open class WidgetDriverHandleSDKMock: MatrixRustSDK.WidgetDriverHandle {
     open override func send(msg: String) async -> Bool {
         sendMsgCallsCount += 1
         sendMsgReceivedMsg = msg
-        sendMsgReceivedInvocations.append(msg)
+        DispatchQueue.main.async {
+            self.sendMsgReceivedInvocations.append(msg)
+        }
         if let sendMsgClosure = sendMsgClosure {
             return await sendMsgClosure(msg)
         } else {

--- a/ElementX/Sources/Services/Timeline/RoomTimelineProvider.swift
+++ b/ElementX/Sources/Services/Timeline/RoomTimelineProvider.swift
@@ -21,6 +21,8 @@ import MatrixRustSDK
 class RoomTimelineProvider: RoomTimelineProviderProtocol {
     private var cancellables = Set<AnyCancellable>()
     private let serialDispatchQueue: DispatchQueue
+    
+    private var roomTimelineObservationToken: TaskHandle?
 
     private let paginationStateSubject = CurrentValueSubject<PaginationState, Never>(.default)
     var paginationState: PaginationState {
@@ -28,8 +30,10 @@ class RoomTimelineProvider: RoomTimelineProviderProtocol {
     }
 
     private let itemProxiesSubject: CurrentValueSubject<[TimelineItemProxy], Never>
-    var itemProxies: [TimelineItemProxy] {
-        itemProxiesSubject.value
+    private(set) var itemProxies: [TimelineItemProxy] = [] {
+        didSet {
+            itemProxiesSubject.send(itemProxies)
+        }
     }
 
     var updatePublisher: AnyPublisher<([TimelineItemProxy], PaginationState), Never> {
@@ -45,28 +49,29 @@ class RoomTimelineProvider: RoomTimelineProviderProtocol {
         membershipChangeSubject
             .eraseToAnyPublisher()
     }
+    
+    deinit {
+        roomTimelineObservationToken?.cancel()
+    }
 
-    init(currentItems: [TimelineItem],
-         isLive: Bool,
-         updatePublisher: AnyPublisher<[TimelineDiff], Never>,
-         paginationStatePublisher: AnyPublisher<PaginationState, Never>) {
+    init(timeline: Timeline, isLive: Bool, paginationStatePublisher: AnyPublisher<PaginationState, Never>) {
         serialDispatchQueue = DispatchQueue(label: "io.element.elementx.roomtimelineprovider", qos: .utility)
-        itemProxiesSubject = CurrentValueSubject<[TimelineItemProxy], Never>(currentItems.map(TimelineItemProxy.init))
+        itemProxiesSubject = CurrentValueSubject<[TimelineItemProxy], Never>([])
         self.isLive = isLive
         
-        // Manually call it here as the didSet doesn't work from constructors
-        itemProxiesSubject.send(itemProxies)
-
-        updatePublisher
-            .receive(on: serialDispatchQueue)
-            .sink { [weak self] in self?.updateItemsWithDiffs($0) }
-            .store(in: &cancellables)
-
         paginationStatePublisher
             .sink { [weak self] in
                 self?.paginationStateSubject.send($0)
             }
             .store(in: &cancellables)
+        
+        Task {
+            roomTimelineObservationToken = await timeline.addListener(listener: RoomTimelineListener { [weak self] timelineDiffs in
+                self?.serialDispatchQueue.sync {
+                    self?.updateItemsWithDiffs(timelineDiffs)
+                }
+            })
+        }
     }
     
     // MARK: - Private
@@ -80,22 +85,19 @@ class RoomTimelineProvider: RoomTimelineProviderProtocol {
         
         MXLog.verbose("Received timeline diff")
         
-        let items = diffs
-            .reduce(itemProxies) { currentItems, diff in
-                guard let collectionDiff = buildDiff(from: diff, on: currentItems) else {
-                    MXLog.error("Failed building CollectionDifference from \(diff)")
-                    return currentItems
-                }
-                
-                guard let updatedItems = currentItems.applying(collectionDiff) else {
-                    MXLog.error("Failed applying diff: \(collectionDiff)")
-                    return currentItems
-                }
-                
-                return updatedItems
+        itemProxies = diffs.reduce(itemProxies) { currentItems, diff in
+            guard let collectionDiff = buildDiff(from: diff, on: currentItems) else {
+                MXLog.error("Failed building CollectionDifference from \(diff)")
+                return currentItems
             }
-
-        itemProxiesSubject.send(items)
+            
+            guard let updatedItems = currentItems.applying(collectionDiff) else {
+                MXLog.error("Failed applying diff: \(collectionDiff)")
+                return currentItems
+            }
+            
+            return updatedItems
+        }
         
         MXLog.verbose("Finished applying diffs, current items (\(itemProxies.count)) : \(itemProxies.map(\.debugIdentifier))")
     }
@@ -250,4 +252,16 @@ enum DebugIdentifier {
     case event(timelineID: String, eventID: String?, transactionID: String?)
     case virtual(timelineID: String, dscription: String)
     case unknown(timelineID: String)
+}
+
+private final class RoomTimelineListener: TimelineListener {
+    private let onUpdateClosure: ([TimelineDiff]) -> Void
+   
+    init(_ onUpdateClosure: @escaping ([TimelineDiff]) -> Void) {
+        self.onUpdateClosure = onUpdateClosure
+    }
+    
+    func onUpdate(diff: [TimelineDiff]) {
+        onUpdateClosure(diff)
+    }
 }

--- a/ElementX/Sources/Services/Timeline/TimelineProxy.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineProxy.swift
@@ -22,14 +22,9 @@ final class TimelineProxy: TimelineProxyProtocol {
     private let timeline: Timeline
     
     private var backPaginationStatusObservationToken: TaskHandle?
-    private var roomTimelineObservationToken: TaskHandle?
-    
-    // periphery:ignore - retaining purpose
-    private var timelineListener: RoomTimelineListener?
     
     private let backPaginationSubscriptionSubject = CurrentValueSubject<PaginationStatus, Never>(.idle)
     private let forwardPaginationStatusSubject = CurrentValueSubject<PaginationStatus, Never>(.timelineEndReached)
-    private let timelineUpdatesSubject = PassthroughSubject<[TimelineDiff], Never>()
     
     let isLive: Bool
    
@@ -40,7 +35,6 @@ final class TimelineProxy: TimelineProxyProtocol {
     
     deinit {
         backPaginationStatusObservationToken?.cancel()
-        roomTimelineObservationToken?.cancel()
     }
     
     init(timeline: Timeline, isLive: Bool) {
@@ -54,15 +48,6 @@ final class TimelineProxy: TimelineProxyProtocol {
             return
         }
         
-        let timelineListener = RoomTimelineListener { [weak self] timelineDiffs in
-            self?.timelineUpdatesSubject.send(timelineDiffs)
-        }
-        
-        self.timelineListener = timelineListener
-        
-        let result = await timeline.addListener(listener: timelineListener)
-        roomTimelineObservationToken = result.itemsStream
-        
         let paginationStatePublisher = backPaginationSubscriptionSubject
             .combineLatest(forwardPaginationStatusSubject)
             .map { PaginationState(backward: $0.0, forward: $0.1) }
@@ -70,10 +55,7 @@ final class TimelineProxy: TimelineProxyProtocol {
         
         await subscribeToPagination()
         
-        innerTimelineProvider = await RoomTimelineProvider(currentItems: result.items,
-                                                           isLive: isLive,
-                                                           updatePublisher: timelineUpdatesSubject.eraseToAnyPublisher(),
-                                                           paginationStatePublisher: paginationStatePublisher)
+        innerTimelineProvider = await RoomTimelineProvider(timeline: timeline, isLive: isLive, paginationStatePublisher: paginationStatePublisher)
     }
     
     func fetchDetails(for eventID: String) {
@@ -530,18 +512,6 @@ final class TimelineProxy: TimelineProxyProtocol {
         
         // Forward pagination doesn't support observation, set the initial state ourself.
         forwardPaginationStatusSubject.send(isLive ? .timelineEndReached : .idle)
-    }
-}
-
-private final class RoomTimelineListener: TimelineListener {
-    private let onUpdateClosure: ([TimelineDiff]) -> Void
-   
-    init(_ onUpdateClosure: @escaping ([TimelineDiff]) -> Void) {
-        self.onUpdateClosure = onUpdateClosure
-    }
-    
-    func onUpdate(diff: [TimelineDiff]) {
-        onUpdateClosure(diff)
     }
 }
 

--- a/Tools/Sourcery/AutoMockable.stencil
+++ b/Tools/Sourcery/AutoMockable.stencil
@@ -24,11 +24,15 @@ import {{ import }}
     {% endset %}
     {% if method.parameters.count == 1 and not hasNonEscapingClosures %}
         {% call swiftifyMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name |  replace:"`","" | upperFirstLetter  }} = {{ param.name | replace:"`","" }}{% endfor %}
-        {% call swiftifyMethodName method.selectorName %}ReceivedInvocations.append({% for param in method.parameters %}{{ param.name }}){% endfor %}
+        DispatchQueue.main.async {
+            self.{% call swiftifyMethodName method.selectorName %}ReceivedInvocations.append({% for param in method.parameters %}{{ param.name }}){% endfor %}
+        }
     {% else %}
     {% if not method.parameters.count == 0 and not hasNonEscapingClosures %}
         {% call swiftifyMethodName method.selectorName %}ReceivedArguments = ({% for param in method.parameters %}{{ param.name | replace:"`","" }}: {{ param.name | replace:"`",""  }}{% if not forloop.last%}, {% endif %}{% endfor %})
-        {% call swiftifyMethodName method.selectorName %}ReceivedInvocations.append(({% for param in method.parameters %}{{ param.name | replace:"`","" }}: {{ param.name | replace:"`",""  }}{% if not forloop.last%}, {% endif %}{% endfor %}))
+        DispatchQueue.main.async {
+            self.{% call swiftifyMethodName method.selectorName %}ReceivedInvocations.append(({% for param in method.parameters %}{{ param.name | replace:"`","" }}: {{ param.name | replace:"`",""  }}{% if not forloop.last%}, {% endif %}{% endfor %}))
+        }
     {% endif %}
     {% endif %}
 {% endmacro %}

--- a/Tools/Sourcery/SDKAutoMockable.stencil
+++ b/Tools/Sourcery/SDKAutoMockable.stencil
@@ -24,11 +24,15 @@ import {{ import }}
     {% endset %}
     {% if method.parameters.count == 1 and not hasNonEscapingClosures %}
         {% call swiftifyMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name |  replace:"`","" | upperFirstLetter  }} = {{ param.name | replace:"`","" }}{% endfor %}
-        {% call swiftifyMethodName method.selectorName %}ReceivedInvocations.append({% for param in method.parameters %}{{ param.name }}){% endfor %}
+        DispatchQueue.main.async {
+            self.{% call swiftifyMethodName method.selectorName %}ReceivedInvocations.append({% for param in method.parameters %}{{ param.name }}){% endfor %}
+        }
     {% else %}
     {% if not method.parameters.count == 0 and not hasNonEscapingClosures %}
         {% call swiftifyMethodName method.selectorName %}ReceivedArguments = ({% for param in method.parameters %}{{ param.name | replace:"`","" }}: {{ param.name | replace:"`",""  }}{% if not forloop.last%}, {% endif %}{% endfor %})
-        {% call swiftifyMethodName method.selectorName %}ReceivedInvocations.append(({% for param in method.parameters %}{{ param.name | replace:"`","" }}: {{ param.name | replace:"`",""  }}{% if not forloop.last%}, {% endif %}{% endfor %}))
+        DispatchQueue.main.async {
+            self.{% call swiftifyMethodName method.selectorName %}ReceivedInvocations.append(({% for param in method.parameters %}{{ param.name | replace:"`","" }}: {{ param.name | replace:"`",""  }}{% if not forloop.last%}, {% endif %}{% endfor %}))
+        }
     {% endif %}
     {% endif %}
 {% endmacro %}

--- a/UnitTests/Sources/ComposerToolbarViewModelTests.swift
+++ b/UnitTests/Sources/ComposerToolbarViewModelTests.swift
@@ -118,9 +118,11 @@ class ComposerToolbarViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.state.suggestions, suggestions)
     }
     
-    func testSuggestionTrigger() {
+    func testSuggestionTrigger() async {
         wysiwygViewModel.setMarkdownContent("@test")
         wysiwygViewModel.setMarkdownContent("#not_implemented_yay")
+        
+        await Task.yield()
         
         // The first one is nil because when initialised the view model is empty
         XCTAssertEqual(completionSuggestionServiceMock.setSuggestionTriggerReceivedInvocations, [nil, .init(type: .user, text: "test", range: .init(location: 0, length: 5)), nil])

--- a/project.yml
+++ b/project.yml
@@ -49,7 +49,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/element-hq/matrix-rust-components-swift
-    exactVersion: 1.0.11
+    exactVersion: 1.0.13
     # path: ../matrix-rust-sdk
   Compound:
     url: https://github.com/element-hq/compound-ios


### PR DESCRIPTION
- avoid race conditions between when a timeline listener starts publishing to the `updatePublisher` and when they are consumed (and in which order)
- subscribe to the timeline directly in the TimelineProvider and correctly process updates serially
- update the AutoUpdatingRoomTimelineProviderMock to use an SDK TimlineMock and listener to publish updates