### PR TITLE
Allow timeline messages text selection on both the Mac and on iOS (no…

### DIFF
--- a/ElementX/Sources/Other/Pills/MessageText.swift
+++ b/ElementX/Sources/Other/Pills/MessageText.swift
@@ -81,7 +81,6 @@ struct MessageText: UIViewRepresentable {
         textView.adjustsFontForContentSizeCategory = true
 
         // Required to allow tapping links
-        // We disable selection at delegate level
         textView.isSelectable = true
         textView.isUserInteractionEnabled = true
         
@@ -133,10 +132,6 @@ struct MessageText: UIViewRepresentable {
 
         init(openURLAction: OpenURLAction) {
             self.openURLAction = openURLAction
-        }
-        
-        func textViewDidChangeSelection(_ textView: UITextView) {
-            textView.selectedTextRange = nil
         }
         
         func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {

--- a/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemBubbledStylerView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemBubbledStylerView.swift
@@ -128,9 +128,6 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
     
     var messageBubble: some View {
         styledContent
-            .onTapGesture(count: 2) {
-                context.send(viewAction: .displayEmojiPicker(itemID: timelineItem.id))
-            }
             .onTapGesture {
                 context.send(viewAction: .itemTapped(itemID: timelineItem.id))
             }

--- a/changelog.d/2924.change
+++ b/changelog.d/2924.change
@@ -1,0 +1,1 @@
+Allow timeline messages text selection on both the Mac and on iOS (not on long press but a double tap)


### PR DESCRIPTION
…t on long press but a double tap)

- remove double tap to show the emoji picker as it clashes with the selection and was introduced before the rich timeline item menu was introduced