### PR TITLE
Fix interminable room directory search next page loading loops when r…

### DIFF
--- a/ElementX/Sources/Screens/RoomDirectorySearchScreen/RoomDirectorySearchScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomDirectorySearchScreen/RoomDirectorySearchScreenViewModel.swift
@@ -104,6 +104,10 @@ class RoomDirectorySearchScreenViewModel: RoomDirectorySearchScreenViewModelType
     }
     
     private func loadNextPage() {
+        guard !state.isLoading else {
+            return
+        }
+        
         Task {
             state.isLoading = true
             let _ = await roomDirectorySearchProxy.nextPage()

--- a/ElementX/Sources/Screens/RoomDirectorySearchScreen/View/RoomDirectorySearchScreen.swift
+++ b/ElementX/Sources/Screens/RoomDirectorySearchScreen/View/RoomDirectorySearchScreen.swift
@@ -40,14 +40,12 @@ struct RoomDirectorySearchScreen: View {
                                 .foregroundColor(.compound.textSecondary)
                                 .frame(maxWidth: .infinity)
                                 .accessibilityIdentifier(A11yIdentifiers.startChatScreen.searchNoResults)
-                        } else {
-                            // This needs to be in the else as when you start a search, the results are cleared making the footer visible.
-                            // We only want to trigger the pagination when the state is not loading.
-                            emptyRectangle
-                                .onAppear {
-                                    context.send(viewAction: .reachedBottom)
-                                }
                         }
+                        
+                        emptyRectangle
+                            .onAppear {
+                                context.send(viewAction: .reachedBottom)
+                            }
                     }
                     .listRowSeparator(.hidden)
                 }


### PR DESCRIPTION
…esults don't fill the screen

[This commit](https://github.com/element-hq/element-x-ios/commit/aaa8af2996be0d5e46ce1132dba871b988cc27d2) might be of interest.