### PR TITLE
fix

### DIFF
--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomStateEventStringBuilder.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomStateEventStringBuilder.swift
@@ -60,7 +60,7 @@ struct RoomStateEventStringBuilder {
                 return L10n.stateEventRoomInvite(senderDisplayName, member)
             }
         case .invitationAccepted:
-            return memberIsYou ? L10n.stateEventRoomInviteAcceptedByYou : L10n.stateEventRoomInviteAccepted(senderDisplayName)
+            return memberIsYou ? L10n.stateEventRoomInviteAcceptedByYou : L10n.stateEventRoomInviteAccepted(member)
         case .invitationRejected:
             return memberIsYou ? L10n.stateEventRoomRejectByYou : L10n.stateEventRoomReject(senderDisplayName)
         case .invitationRevoked:


### PR DESCRIPTION
The sender display name may be missing for some state events, in this case the member and the sender were the same user, but only the member contained the display name (since the value is parsed from the JSON of the event direcftly) while the sender display name is not yet defined in the room