### PR TITLE
Avoid races between enabling the send queue and receiving back a stat…

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -665,7 +665,6 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
         let reachabilityNotificationIdentifier = "io.element.elementx.reachability.notification"
         ServiceLocator.shared.networkMonitor
             .reachabilityPublisher
-            .removeDuplicates()
             .sink { reachability in
                 MXLog.info("Reachability changed to \(reachability)")
                 

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -173,11 +173,10 @@ class ClientProxy: ClientProxyProtocol {
         })
         
         sendQueueStatusSubject
-            .removeDuplicates()
             .combineLatest(networkMonitor.reachabilityPublisher)
             .debounce(for: 1.0, scheduler: DispatchQueue.main)
             .sink { enabled, reachability in
-                MXLog.info("Send queue status changed to enabled: \(enabled)")
+                MXLog.info("Send queue status changed to enabled: \(enabled), reachability: \(reachability)")
                 
                 if enabled == false, reachability == .reachable {
                     MXLog.info("Enabling all send queues")


### PR DESCRIPTION
…us update, stop dropping duplicates both here and on reachability status printing.

Fixes https://github.com/element-hq/element-x-ios/issues/2952