### PR TITLE
Use a Client in AuthenticationService now that the Rust one has been removed.

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -151,6 +151,7 @@
 		2335D1AB954C151FD8779F45 /* RoomPermissionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0096BC5DA86AF6B6E5742AC /* RoomPermissionsTests.swift */; };
 		23701DE32ACD6FD40AA992C3 /* MediaUploadingPreprocessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE203026B9AD3DB412439866 /* MediaUploadingPreprocessorTests.swift */; };
 		237FC70AA257B935F53316BA /* SessionVerificationControllerProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C55D7E514F9DE4E3D72FDCAD /* SessionVerificationControllerProxy.swift */; };
+		238D561CA231339C6D4D06F3 /* ClientBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1C33355FFB0F0953C35036 /* ClientBuilder.swift */; };
 		241CDEFE23819867D9B39066 /* RoomChangePermissionsScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AE75941583A033A9EDC9FE0 /* RoomChangePermissionsScreenViewModel.swift */; };
 		244407B18B2F2D6466BA5961 /* RoomChangeRolesScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82DFA1B7B088D033E0794B82 /* RoomChangeRolesScreenCoordinator.swift */; };
 		24A1BBADAC43DC3F3A7347DA /* AnalyticsPromptScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = E53BFB7E4F329621C844E8C3 /* AnalyticsPromptScreen.swift */; };
@@ -363,6 +364,7 @@
 		562EFB9AB62B38830D9AA778 /* TimelineMediaFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933B074F006F8E930DB98B4E /* TimelineMediaFrame.swift */; };
 		564BF06B3E93D6DD55F903B2 /* CreateRoomCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C618CA2B6C8758B06C88013C /* CreateRoomCoordinator.swift */; };
 		565868808A1DA565707394ED /* CurrentValuePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 127C8472672A5BA09EF1ACF8 /* CurrentValuePublisher.swift */; };
+		56DACDD379A86A1F5DEFE7BE /* AuthenticationServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E75948AA1FE1D1A7809931F /* AuthenticationServiceProtocol.swift */; };
 		56F0A22972A3BB519DA2261C /* HomeScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F5530B2212862FA4BEFF2D /* HomeScreenViewModelProtocol.swift */; };
 		5710AAB27D5D866292C1FE06 /* SessionVerificationScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF848B41DAF1066F3054D4A1 /* SessionVerificationScreenModels.swift */; };
 		5732395A4F71F51F9C754C5A /* ElementCallService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AE897D86784CCA5E4E9227 /* ElementCallService.swift */; };
@@ -414,7 +416,6 @@
 		64D05250CEDE8B604119F6E6 /* Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 981663D961C94270FA035FD0 /* Alert.swift */; };
 		64E541F88F35BD126C4AFCA1 /* AppLockScreenPINKeypad.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38345442415E07A931197C55 /* AppLockScreenPINKeypad.swift */; };
 		64F43D7390DA2A0AFD6BA911 /* VideoRoomTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1941C8817E6B6971BA4415F5 /* VideoRoomTimelineView.swift */; };
-		64FF5CB4E35971255872E1BB /* AuthenticationServiceProxyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F0CB536D1C3CC15AA740CC6 /* AuthenticationServiceProxyProtocol.swift */; };
 		651341E67C3514F9811A1EC1 /* LoginScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05F598B1B346DAF223651C91 /* LoginScreenCoordinator.swift */; };
 		652ACCF104A8CEF30788963C /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1423AB065857FA546444DB15 /* NotificationManager.swift */; };
 		6530865EB9A8C0F0AF0216DA /* ServerSelectionScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9501D11B4258DFA33BA3B40F /* ServerSelectionScreenModels.swift */; };
@@ -506,6 +507,7 @@
 		77FACC29F98FE2E65BBB6A5F /* ServerSelectionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 054F469E433864CC6FE6EE8E /* ServerSelectionUITests.swift */; };
 		7807B1DEE32617896886A8E5 /* FormattingToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE1E6FAA3719E9B7A2D5510B /* FormattingToolbar.swift */; };
 		784592335560C2E91D32D177 /* DeveloperOptionsScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B098A612DCB5A7358EECD5 /* DeveloperOptionsScreenModels.swift */; };
+		7856DE3EA4580AE0329986EB /* ComposerDraftServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E600B315B920B9687F8EE1B /* ComposerDraftServiceMock.swift */; };
 		795A854F63301DC6B46217B9 /* AccessibilityIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BB8DDE245ED86C489BA983 /* AccessibilityIdentifiers.swift */; };
 		79741C1953269FF1A211D246 /* RoomPollsHistoryScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E14FF533D25A0692F7CEB0 /* RoomPollsHistoryScreenViewModel.swift */; };
 		7A02EB29F3B993AB20E0A198 /* RoomPollsHistoryScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C8C368A611B9CB79C7F5FA /* RoomPollsHistoryScreen.swift */; };
@@ -531,7 +533,6 @@
 		7E2BB42805C59DB57E95610F /* PillView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7773CBFDBD458E0B7E270507 /* PillView.swift */; };
 		7E91BAC17963ED41208F489B /* UserSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E8BDC092D817B68CD9040C5 /* UserSessionStore.swift */; };
 		7ECF12D5DCD69F67BD3E3842 /* RoomTimelineControllerFactoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18FE0CDF1FFA92EA7EE17B0B /* RoomTimelineControllerFactoryProtocol.swift */; };
-		7F08F4BC1312075E2B5EAEFA /* AuthenticationServiceProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF48AF076424DBC1615C74AD /* AuthenticationServiceProxy.swift */; };
 		7F61F9ACD5EC9E845EF3EFBF /* BugReportServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFFD3200F9960D4996159F10 /* BugReportServiceTests.swift */; };
 		7F7EA51A9A43125A8CB6AC90 /* NotificationSettingsScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46D560DDA3B20C82766ACFAD /* NotificationSettingsScreenViewModel.swift */; };
 		7F941B063C94E1718DFC2CF3 /* RoomChangeRolesScreenRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E6EB7960BC9D0F7396B3BD /* RoomChangeRolesScreenRow.swift */; };
@@ -643,6 +644,7 @@
 		97969EF0B9C412CD38E5CA93 /* AppLockScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4005D82E9D27BAF006A8FE1 /* AppLockScreenViewModel.swift */; };
 		981853650217B6C8ECDD998C /* NavigationRootCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F875D71347DC81EAE7687446 /* NavigationRootCoordinatorTests.swift */; };
 		983896D611ABF52A5C37498D /* RoomSummaryProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB3227C7A74B734924942E9 /* RoomSummaryProvider.swift */; };
+		9847B056C1A216C314D21E68 /* AuthenticationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A1AB5A84D843B6AC8D5F1E /* AuthenticationService.swift */; };
 		988BA75A182738150894A23F /* UserIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8AE4B3273BA189FDCD4055C /* UserIndicator.swift */; };
 		9905C1B1C6EFE38F3A6533F3 /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33B3F17996DFDF5F0181512 /* Data.swift */; };
 		9912F9EB2D6589141A2957B4 /* AppLockScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C44BBC892499BE45B074F89 /* AppLockScreenCoordinator.swift */; };
@@ -709,7 +711,6 @@
 		A6DEC1ADEC8FEEC206A0FA37 /* AttributedStringBuilderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72F37B5DA798C9AE436F2C2C /* AttributedStringBuilderProtocol.swift */; };
 		A6F345328CCC5C9B0DAE2257 /* LogViewerScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BB05221D7D941CC82DC8480 /* LogViewerScreenViewModel.swift */; };
 		A722F426FD81FC67706BB1E0 /* CustomLayoutLabelStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42236480CF0431535EBE8387 /* CustomLayoutLabelStyle.swift */; };
-		A7374E0A2C259C8000FBE861 /* ComposerDraftServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7374E092C259C8000FBE861 /* ComposerDraftServiceMock.swift */; };
 		A74438ED16F8683A4B793E6A /* AnalyticsSettingsScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BCE3FAF40932AC7C7639AC4 /* AnalyticsSettingsScreenViewModel.swift */; };
 		A7D48E44D485B143AADDB77D /* Strings+Untranslated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A18F6CE4D694D21E4EA9B25 /* Strings+Untranslated.swift */; };
 		A7FD7B992E6EE6E5A8429197 /* RoomSummaryDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142808B69851451AC32A2CEA /* RoomSummaryDetails.swift */; };
@@ -841,6 +842,7 @@
 		C7774720A4B2E34693E3227C /* RoomNotificationSettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8896CDD20CA2D87EA3B848A1 /* RoomNotificationSettingsScreen.swift */; };
 		C7ABEBECDC513F7887DACF66 /* ProgressMaskModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68010886142843705E342645 /* ProgressMaskModifier.swift */; };
 		C7CFDB4929DDD9A3B5BA085D /* BugReportViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB7ED3A898B07976F3AA90F /* BugReportViewModelTests.swift */; };
+		C80E06ED97CE52704A46C148 /* ClientBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1C33355FFB0F0953C35036 /* ClientBuilder.swift */; };
 		C85C7A201E4CFDA477ACEBEB /* AppLockSetupSettingsScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8610C1D21565C950BCA6A454 /* AppLockSetupSettingsScreenViewModelProtocol.swift */; };
 		C8A9C595038AFA2D707AC8C1 /* NotificationPermissionsScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E69F67D2A70ABD08CA6D54 /* NotificationPermissionsScreenViewModelProtocol.swift */; };
 		C8BD80891BAD688EF2C15CDB /* MediaUploadPreviewScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74DD0855F2F76D47E5555082 /* MediaUploadPreviewScreenCoordinator.swift */; };
@@ -1149,12 +1151,12 @@
 		033DB41C51865A2E83174E87 /* target.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = target.yml; sourceTree = "<group>"; };
 		035177BCD8E8308B098AC3C2 /* WindowManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowManager.swift; sourceTree = "<group>"; };
 		0376C429FAB1687C3D905F3E /* MockCoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCoder.swift; sourceTree = "<group>"; };
-		0392E3FDE372C9B56FEEED8B /* test_voice_message.m4a */ = {isa = PBXFileReference; lastKnownFileType = file; path = test_voice_message.m4a; sourceTree = "<group>"; };
+		0392E3FDE372C9B56FEEED8B /* test_voice_message.m4a */ = {isa = PBXFileReference; path = test_voice_message.m4a; sourceTree = "<group>"; };
 		03DD998E523D4EC93C7ED703 /* RoomNotificationSettingsScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomNotificationSettingsScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		03FABD73FD8086EFAB699F42 /* MediaUploadPreviewScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaUploadPreviewScreenViewModelTests.swift; sourceTree = "<group>"; };
 		044E501B8331B339874D1B96 /* CompoundIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompoundIcon.swift; sourceTree = "<group>"; };
 		045253F9967A535EE5B16691 /* Label.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Label.swift; sourceTree = "<group>"; };
-		048A21188AB19349D026BECD /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		048A21188AB19349D026BECD /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		04BB8DDE245ED86C489BA983 /* AccessibilityIdentifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityIdentifiers.swift; sourceTree = "<group>"; };
 		04DF593C3F7AF4B2FBAEB05D /* FileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManager.swift; sourceTree = "<group>"; };
 		0516C69708D5CBDE1A8E77EC /* RoomDirectorySearchProxyProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomDirectorySearchProxyProtocol.swift; sourceTree = "<group>"; };
@@ -1213,7 +1215,7 @@
 		127C8472672A5BA09EF1ACF8 /* CurrentValuePublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentValuePublisher.swift; sourceTree = "<group>"; };
 		128501375217576AF0FE3E92 /* RoomAttachmentPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomAttachmentPicker.swift; sourceTree = "<group>"; };
 		12F1E7F9C2BE8BB751037826 /* WaitlistScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitlistScreenCoordinator.swift; sourceTree = "<group>"; };
-		1304D9191300873EADA52D6E /* IntegrationTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = IntegrationTests.xctestplan; sourceTree = "<group>"; };
+		1304D9191300873EADA52D6E /* IntegrationTests.xctestplan */ = {isa = PBXFileReference; path = IntegrationTests.xctestplan; sourceTree = "<group>"; };
 		130ED565A078F7E0B59D9D25 /* UNTextInputNotificationResponse+Creator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UNTextInputNotificationResponse+Creator.swift"; sourceTree = "<group>"; };
 		136F80A613B55BDD071DCEA5 /* JoinRoomScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinRoomScreenModels.swift; sourceTree = "<group>"; };
 		13802897C7AFA360EA74C0B0 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
@@ -1302,7 +1304,7 @@
 		25F7FE40EF7490A7E09D7BE6 /* NotificationItemProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationItemProxy.swift; sourceTree = "<group>"; };
 		25F8664F1FB95AF3C4202478 /* PollFormScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollFormScreenCoordinator.swift; sourceTree = "<group>"; };
 		260004737C573A56FA01E86E /* Encodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Encodable.swift; sourceTree = "<group>"; };
-		267BB1D5B08A9511F894CB57 /* PreviewTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = PreviewTests.xctestplan; sourceTree = "<group>"; };
+		267BB1D5B08A9511F894CB57 /* PreviewTests.xctestplan */ = {isa = PBXFileReference; path = PreviewTests.xctestplan; sourceTree = "<group>"; };
 		26B0A96B8FE4849227945067 /* VoiceMessageRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceMessageRecorder.swift; sourceTree = "<group>"; };
 		26EAAB54C6CE91D64B69A9F8 /* AppLockServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockServiceProtocol.swift; sourceTree = "<group>"; };
 		2721D7B051F0159AA919DA05 /* RoomChangePermissionsScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomChangePermissionsScreenViewModelProtocol.swift; sourceTree = "<group>"; };
@@ -1362,7 +1364,7 @@
 		3558A15CFB934F9229301527 /* RestorationToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestorationToken.swift; sourceTree = "<group>"; };
 		35AFCF4C05DEED04E3DB1A16 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		35FA991289149D31F4286747 /* UserPreference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPreference.swift; sourceTree = "<group>"; };
-		36DA824791172B9821EACBED /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		36DA824791172B9821EACBED /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		36FD673E24FBFCFDF398716A /* RoomMemberProxyMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomMemberProxyMock.swift; sourceTree = "<group>"; };
 		376D941BF8BB294389C0DE24 /* MapTilerURLBuildersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapTilerURLBuildersTests.swift; sourceTree = "<group>"; };
 		37A243E04B58DC6E41FDCD82 /* EmojiItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiItem.swift; sourceTree = "<group>"; };
@@ -1461,8 +1463,8 @@
 		4D3A7375AB22721C436EB056 /* ComposerToolbarModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerToolbarModels.swift; sourceTree = "<group>"; };
 		4E2245243369B99216C7D84E /* ImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
 		4E47F18A9A077E351CEA10D4 /* TextBasedRoomTimelineViewProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBasedRoomTimelineViewProtocol.swift; sourceTree = "<group>"; };
+		4E600B315B920B9687F8EE1B /* ComposerDraftServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerDraftServiceMock.swift; sourceTree = "<group>"; };
 		4E625B0EB2F86B37C14EF7E6 /* SettingsScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScreenViewModel.swift; sourceTree = "<group>"; };
-		4F0CB536D1C3CC15AA740CC6 /* AuthenticationServiceProxyProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationServiceProxyProtocol.swift; sourceTree = "<group>"; };
 		4F5F0662483ED69791D63B16 /* et */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = et; path = et.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		4FA29BAE9B0F2D90E57B261C /* UserSessionFlowCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSessionFlowCoordinatorTests.swift; sourceTree = "<group>"; };
 		4FCB2126C091EEF2454B4D56 /* RoomFlowCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomFlowCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -1521,6 +1523,7 @@
 		5D82F234B3576BD6268C7950 /* ScaledFrameModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScaledFrameModifier.swift; sourceTree = "<group>"; };
 		5D99730313BEBF08CDE81EE3 /* EmojiDetection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiDetection.swift; sourceTree = "<group>"; };
 		5DE8D25D6A91030175D52A20 /* RoomTimelineItemProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomTimelineItemProperties.swift; sourceTree = "<group>"; };
+		5E75948AA1FE1D1A7809931F /* AuthenticationServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationServiceProtocol.swift; sourceTree = "<group>"; };
 		5E9CBF577B9711CFBB4FA40D /* VoiceMessageRecordingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceMessageRecordingView.swift; sourceTree = "<group>"; };
 		5EB2CAA266B921D128C35710 /* LegalInformationScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegalInformationScreenCoordinator.swift; sourceTree = "<group>"; };
 		5F12E996BFBEB43815189ABF /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = uk; path = uk.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
@@ -1698,7 +1701,7 @@
 		8D55702474F279D910D2D162 /* RoomStateEventStringBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomStateEventStringBuilder.swift; sourceTree = "<group>"; };
 		8D8169443E5AC5FF71BFB3DB /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/Localizable.strings; sourceTree = "<group>"; };
 		8DC2C9E0E15C79BBDA80F0A2 /* TimelineStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineStyle.swift; sourceTree = "<group>"; };
-		8E088F2A1B9EC529D3221931 /* UITests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UITests.xctestplan; sourceTree = "<group>"; };
+		8E088F2A1B9EC529D3221931 /* UITests.xctestplan */ = {isa = PBXFileReference; path = UITests.xctestplan; sourceTree = "<group>"; };
 		8F21ED7205048668BEB44A38 /* AppActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppActivityView.swift; sourceTree = "<group>"; };
 		8F6210134203BE1F2DD5C679 /* RoomDirectoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomDirectoryCell.swift; sourceTree = "<group>"; };
 		8F841F219ACDFC1D3F42FEFB /* RoomChangeRolesScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomChangeRolesScreenViewModelTests.swift; sourceTree = "<group>"; };
@@ -1741,6 +1744,7 @@
 		99637028A8BD2843A35A92D4 /* ResetRecoveryKeyScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetRecoveryKeyScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		9A008E57D52B07B78DFAD1BB /* RoomFlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomFlowCoordinator.swift; sourceTree = "<group>"; };
 		9A028783CFFF861C5E44FFB1 /* BadgeLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeLabel.swift; sourceTree = "<group>"; };
+		9A1C33355FFB0F0953C35036 /* ClientBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientBuilder.swift; sourceTree = "<group>"; };
 		9A22A05E472533ED3C5A31B3 /* NavigationModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationModule.swift; sourceTree = "<group>"; };
 		9A2AC7BE17C05CF7D2A22338 /* landscape_test_video.mov */ = {isa = PBXFileReference; lastKnownFileType = video.quicktime; path = landscape_test_video.mov; sourceTree = "<group>"; };
 		9A68BCE6438873D2661D93D0 /* BugReportServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugReportServiceProtocol.swift; sourceTree = "<group>"; };
@@ -1790,7 +1794,6 @@
 		A69869844D2B6F5BD9AABF85 /* OIDCConfigurationProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OIDCConfigurationProxy.swift; sourceTree = "<group>"; };
 		A6B891A6DA826E2461DBB40F /* PHGPostHogConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PHGPostHogConfiguration.swift; sourceTree = "<group>"; };
 		A6C11AD9813045E44F950410 /* ElementCallWidgetDriverProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementCallWidgetDriverProtocol.swift; sourceTree = "<group>"; };
-		A7374E092C259C8000FBE861 /* ComposerDraftServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerDraftServiceMock.swift; sourceTree = "<group>"; };
 		A73A07BAEDD74C48795A996A /* AsyncSequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncSequence.swift; sourceTree = "<group>"; };
 		A7C4EA55DA62F9D0F984A2AE /* CollapsibleTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleTimelineItem.swift; sourceTree = "<group>"; };
 		A7D452AF7B5F7E3A0A7DB54C /* SessionVerificationScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionVerificationScreenViewModelProtocol.swift; sourceTree = "<group>"; };
@@ -1859,7 +1862,7 @@
 		B53AC78E49A297AC1D72A7CF /* AppMediator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppMediator.swift; sourceTree = "<group>"; };
 		B590BD4507D4F0A377FDE01A /* LoadableAvatarImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadableAvatarImage.swift; sourceTree = "<group>"; };
 		B5B243E7818E5E9F6A4EDC7A /* NoticeRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeRoomTimelineView.swift; sourceTree = "<group>"; };
-		B61C339A2FDDBD067FF6635C /* ConfettiScene.scn */ = {isa = PBXFileReference; lastKnownFileType = file.bplist; path = ConfettiScene.scn; sourceTree = "<group>"; };
+		B61C339A2FDDBD067FF6635C /* ConfettiScene.scn */ = {isa = PBXFileReference; path = ConfettiScene.scn; sourceTree = "<group>"; };
 		B6311F21F911E23BE4DF51B4 /* ReadMarkerRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadMarkerRoomTimelineView.swift; sourceTree = "<group>"; };
 		B63B69F9A2BC74DD40DC75C8 /* AdvancedSettingsScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsScreenViewModel.swift; sourceTree = "<group>"; };
 		B6404166CBF5CC88673FF9E2 /* RoomDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomDetails.swift; sourceTree = "<group>"; };
@@ -1973,8 +1976,7 @@
 		CEA520B4F65D162E555C8761 /* RoomSummaryDetailsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomSummaryDetailsTests.swift; sourceTree = "<group>"; };
 		CEE0E6043EFCF6FD2A341861 /* TimelineReplyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineReplyView.swift; sourceTree = "<group>"; };
 		CEE20623EB4A9B88FB29F2BA /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/SAS.strings; sourceTree = "<group>"; };
-		CEE41494C837AA403A06A5D9 /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UnitTests.xctestplan; sourceTree = "<group>"; };
-		CF48AF076424DBC1615C74AD /* AuthenticationServiceProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationServiceProxy.swift; sourceTree = "<group>"; };
+		CEE41494C837AA403A06A5D9 /* UnitTests.xctestplan */ = {isa = PBXFileReference; path = UnitTests.xctestplan; sourceTree = "<group>"; };
 		D071F86CD47582B9196C9D16 /* UserDiscoverySection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDiscoverySection.swift; sourceTree = "<group>"; };
 		D086854995173E897F993C26 /* AdvancedSettingsScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		D09A267106B9585D3D0CFC0D /* ClientError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientError.swift; sourceTree = "<group>"; };
@@ -2097,7 +2099,7 @@
 		ED044D00F2176681CC02CD54 /* HomeScreenRoomCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenRoomCell.swift; sourceTree = "<group>"; };
 		ED1D792EB82506A19A72C8DE /* RoomTimelineItemProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomTimelineItemProtocol.swift; sourceTree = "<group>"; };
 		ED33988DA4FD4FC666800106 /* SessionVerificationScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionVerificationScreenViewModel.swift; sourceTree = "<group>"; };
-		ED482057AE39D5C6D9C5F3D8 /* message.caf */ = {isa = PBXFileReference; lastKnownFileType = file; path = message.caf; sourceTree = "<group>"; };
+		ED482057AE39D5C6D9C5F3D8 /* message.caf */ = {isa = PBXFileReference; path = message.caf; sourceTree = "<group>"; };
 		ED60E4D2CD678E1EBF16F77A /* BlockedUsersScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedUsersScreen.swift; sourceTree = "<group>"; };
 		ED983D4DCA5AFA6E1ED96099 /* StateRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateRoomTimelineView.swift; sourceTree = "<group>"; };
 		EDAA4472821985BF868CC21C /* ServerSelectionViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSelectionViewModelTests.swift; sourceTree = "<group>"; };
@@ -2120,12 +2122,13 @@
 		F174A5627CDB3CAF280D1880 /* EmojiPickerScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiPickerScreenModels.swift; sourceTree = "<group>"; };
 		F17EFA1D3D09FC2F9C5E1CB2 /* MediaProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaProvider.swift; sourceTree = "<group>"; };
 		F1B8500C152BC59445647DA8 /* UnsupportedRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedRoomTimelineItem.swift; sourceTree = "<group>"; };
-		F2D513D2477B57F90E98EEC0 /* portrait_test_video.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = portrait_test_video.mp4; sourceTree = "<group>"; };
+		F2D513D2477B57F90E98EEC0 /* portrait_test_video.mp4 */ = {isa = PBXFileReference; path = portrait_test_video.mp4; sourceTree = "<group>"; };
 		F2E4EF80DFB8FE7C4469B15D /* RoomDirectorySearchScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomDirectorySearchScreen.swift; sourceTree = "<group>"; };
 		F31F59030205A6F65B057E1A /* MatrixEntityRegexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatrixEntityRegexTests.swift; sourceTree = "<group>"; };
 		F348B5F2C12F9D4F4B4D3884 /* VideoRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoRoomTimelineItem.swift; sourceTree = "<group>"; };
 		F36C0A6D59717193F49EA986 /* UserSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSessionTests.swift; sourceTree = "<group>"; };
 		F37FA1A5D55633E1942B153B /* CallScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallScreenCoordinator.swift; sourceTree = "<group>"; };
+		F3A1AB5A84D843B6AC8D5F1E /* AuthenticationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationService.swift; sourceTree = "<group>"; };
 		F3C7252B3461D06175D975A4 /* et */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = et; path = et.lproj/SAS.strings; sourceTree = "<group>"; };
 		F3EAE3E9D5EF4A6D5D9C6CFD /* EmojiPickerScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiPickerScreenViewModel.swift; sourceTree = "<group>"; };
 		F4469F6AE311BDC439B3A5EC /* UserSessionMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSessionMock.swift; sourceTree = "<group>"; };
@@ -2687,6 +2690,7 @@
 				69CB8242D69B7E4D0B32E18D /* AggregatedReactionMock.swift */,
 				3BAC027034248429A438886B /* AppMediatorMock.swift */,
 				E2F96CCBEAAA7F2185BFA354 /* ClientProxyMock.swift */,
+				4E600B315B920B9687F8EE1B /* ComposerDraftServiceMock.swift */,
 				382B50F7E379B3DBBD174364 /* NotificationSettingsProxyMock.swift */,
 				B2AD8A56CD37E23071A2F4BF /* PHGPostHogMock.swift */,
 				D38391154120264910D19528 /* PollMock.swift */,
@@ -2702,7 +2706,6 @@
 				7893780A1FD6E3F38B3E9049 /* UserIndicatorControllerMock.swift */,
 				AAD01F7FC2BBAC7351948595 /* UserProfile+Mock.swift */,
 				F4469F6AE311BDC439B3A5EC /* UserSessionMock.swift */,
-				A7374E092C259C8000FBE861 /* ComposerDraftServiceMock.swift */,
 				B23135B06B044CB811139D2F /* Generated */,
 			);
 			path = Mocks;
@@ -3012,6 +3015,7 @@
 				52BD6ED18E2EB61E28C340AD /* AttributedString.swift */,
 				3339B1DDB1341E833D2555BC /* AVMetadataMachineReadableCodeObject.swift */,
 				B6E89E530A8E92EC44301CA1 /* Bundle.swift */,
+				9A1C33355FFB0F0953C35036 /* ClientBuilder.swift */,
 				A9FAFE1C2149E6AC8156ED2B /* Collection.swift */,
 				E2B1CC9AA154F4D5435BF60A /* Comparable.swift */,
 				044E501B8331B339874D1B96 /* CompoundIcon.swift */,
@@ -4382,8 +4386,8 @@
 		AAFDD509929A0CCF8BCE51EB /* Authentication */ = {
 			isa = PBXGroup;
 			children = (
-				CF48AF076424DBC1615C74AD /* AuthenticationServiceProxy.swift */,
-				4F0CB536D1C3CC15AA740CC6 /* AuthenticationServiceProxyProtocol.swift */,
+				F3A1AB5A84D843B6AC8D5F1E /* AuthenticationService.swift */,
+				5E75948AA1FE1D1A7809931F /* AuthenticationServiceProtocol.swift */,
 				65C2B80DD0BF6F10BB5FA922 /* MockAuthenticationServiceProxy.swift */,
 				A69869844D2B6F5BD9AABF85 /* OIDCConfigurationProxy.swift */,
 			);
@@ -5672,6 +5676,7 @@
 				BA43D782BE85C7F5F20C624A /* AttributedStringBuilderProtocol.swift in Sources */,
 				968A5B890004526AB58A217C /* AvatarSize.swift in Sources */,
 				9A3B0CDF097E3838FB1B9595 /* Bundle.swift in Sources */,
+				238D561CA231339C6D4D06F3 /* ClientBuilder.swift in Sources */,
 				B5618E3C948584E5C1F67033 /* DTHTMLElement+AttributedStringBuilder.swift in Sources */,
 				DFCA89C4EC2A5332ED6B441F /* DataProtectionManager.swift in Sources */,
 				24A75F72EEB7561B82D726FD /* Date.swift in Sources */,
@@ -5942,8 +5947,8 @@
 				E62EC30B39354A391E32A126 /* AudioRoomTimelineView.swift in Sources */,
 				9278EC51D24E57445B290521 /* AudioSessionProtocol.swift in Sources */,
 				67E9926C4572C54F59FCA91A /* AuthenticationFlowCoordinator.swift in Sources */,
-				7F08F4BC1312075E2B5EAEFA /* AuthenticationServiceProxy.swift in Sources */,
-				64FF5CB4E35971255872E1BB /* AuthenticationServiceProxyProtocol.swift in Sources */,
+				9847B056C1A216C314D21E68 /* AuthenticationService.swift in Sources */,
+				56DACDD379A86A1F5DEFE7BE /* AuthenticationServiceProtocol.swift in Sources */,
 				9C55746D8F6A3E35CFCF4A7A /* AuthenticationStartLogo.swift in Sources */,
 				7A170A5A4A352954BB2A1B96 /* AuthenticationStartScreen.swift in Sources */,
 				E4F924DECC66389C1C810550 /* AuthenticationStartScreenBackgroundImage.swift in Sources */,
@@ -5987,6 +5992,7 @@
 				84CAE3E96D93194DA06B9194 /* CallScreenViewModelProtocol.swift in Sources */,
 				BB6BF528BC7F5B87E08C4F18 /* CameraPicker.swift in Sources */,
 				E14E469CD97550D0FC58F3CA /* CancellableTask.swift in Sources */,
+				C80E06ED97CE52704A46C148 /* ClientBuilder.swift in Sources */,
 				6A0E7551E0D1793245F34CDD /* ClientError.swift in Sources */,
 				1950A80CD198BED283DFC2CE /* ClientProxy.swift in Sources */,
 				DDFBDEE1DC32BDD5488F898C /* ClientProxyMock.swift in Sources */,
@@ -6000,6 +6006,7 @@
 				EAB3C1F0BC7F671ED8BDF82D /* CompletionSuggestionServiceProtocol.swift in Sources */,
 				16E4F1B8B9BFE1367F96DDA7 /* CompletionSuggestionView.swift in Sources */,
 				3AA9E878FDCFF85664AC071F /* ComposerDraftService.swift in Sources */,
+				7856DE3EA4580AE0329986EB /* ComposerDraftServiceMock.swift in Sources */,
 				CB6956565D858C523E3E3B16 /* ComposerDraftServiceProtocol.swift in Sources */,
 				937985546F708339711ECDFC /* ComposerToolbar.swift in Sources */,
 				94E15D018D70563FA4AB4E5A /* ComposerToolbarModels.swift in Sources */,
@@ -6160,7 +6167,6 @@
 				C9BE065FA7D4E77E4C61CB69 /* MapLibreModels.swift in Sources */,
 				E2DDA49BD62F03F180A42E30 /* MapLibreStaticMapView.swift in Sources */,
 				D181AC8FF236B7F91C0A8C28 /* MapTiler.swift in Sources */,
-				A7374E0A2C259C8000FBE861 /* ComposerDraftServiceMock.swift in Sources */,
 				FCDA202B246F75BA28E10C5F /* MapTilerAuthorization.swift in Sources */,
 				D6661A94DBD97658B2ADBD6A /* MapTilerStaticMap.swift in Sources */,
 				7B5DAB915357BE596529BF25 /* MapTilerStaticMapProtocol.swift in Sources */,
@@ -6847,7 +6853,9 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = "$(MARKETING_VERSION)";
-				OTHER_SWIFT_FLAGS = "-DIS_NSE";
+				OTHER_SWIFT_FLAGS = (
+					"-DIS_NSE",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "${BASE_BUNDLE_IDENTIFIER}.nse";
 				PRODUCT_DISPLAY_NAME = "$(APP_DISPLAY_NAME)";
 				PRODUCT_NAME = NSE;
@@ -6896,7 +6904,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = "$(MARKETING_VERSION)";
-				OTHER_SWIFT_FLAGS = "-DIS_MAIN_APP";
+				OTHER_SWIFT_FLAGS = (
+					"-DIS_MAIN_APP",
+				);
 				PILLS_UT_TYPE_IDENTIFIER = "$(BASE_BUNDLE_IDENTIFIER).pills";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(BASE_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(APP_NAME)";
@@ -6922,7 +6932,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = "$(MARKETING_VERSION)";
-				OTHER_SWIFT_FLAGS = "-DIS_MAIN_APP";
+				OTHER_SWIFT_FLAGS = (
+					"-DIS_MAIN_APP",
+				);
 				PILLS_UT_TYPE_IDENTIFIER = "$(BASE_BUNDLE_IDENTIFIER).pills";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(BASE_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(APP_NAME)";
@@ -7167,7 +7179,9 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = "$(MARKETING_VERSION)";
-				OTHER_SWIFT_FLAGS = "-DIS_NSE";
+				OTHER_SWIFT_FLAGS = (
+					"-DIS_NSE",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "${BASE_BUNDLE_IDENTIFIER}.nse";
 				PRODUCT_DISPLAY_NAME = "$(APP_DISPLAY_NAME)";
 				PRODUCT_NAME = NSE;
@@ -7384,7 +7398,7 @@
 			repositoryURL = "https://github.com/element-hq/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 1.0.17;
+				version = 1.0.18;
 			};
 		};
 		701C7BEF8F70F7A83E852DCC /* XCRemoteSwiftPackageReference "GZIP" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -148,8 +148,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/matrix-rust-components-swift",
       "state" : {
-        "revision" : "f000a92169e856fba82c1bc0dd305b71e76b4bc9",
-        "version" : "1.0.17"
+        "revision" : "2b20dbcf1d5bf23f8801f4376207c84b404f2016",
+        "version" : "1.0.18"
       }
     },
     {

--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -449,9 +449,9 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
     
     private func startAuthentication() {
         let encryptionKeyProvider = EncryptionKeyProvider()
-        let authenticationService = AuthenticationServiceProxy(userSessionStore: userSessionStore,
-                                                               encryptionKeyProvider: encryptionKeyProvider,
-                                                               appSettings: appSettings)
+        let authenticationService = AuthenticationService(userSessionStore: userSessionStore,
+                                                          encryptionKeyProvider: encryptionKeyProvider,
+                                                          appSettings: appSettings)
         let qrCodeLoginService = QRCodeLoginService(oidcConfiguration: appSettings.oidcConfiguration.rustValue,
                                                     encryptionKeyProvider: encryptionKeyProvider,
                                                     userSessionStore: userSessionStore)
@@ -480,9 +480,9 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
                                                           userDisplayName: userSession.clientProxy.userDisplayNamePublisher.value ?? "",
                                                           deviceID: userSession.clientProxy.deviceID)
             
-            let authenticationService = AuthenticationServiceProxy(userSessionStore: userSessionStore,
-                                                                   encryptionKeyProvider: EncryptionKeyProvider(),
-                                                                   appSettings: appSettings)
+            let authenticationService = AuthenticationService(userSessionStore: userSessionStore,
+                                                              encryptionKeyProvider: EncryptionKeyProvider(),
+                                                              appSettings: appSettings)
             _ = await authenticationService.configure(for: userSession.clientProxy.homeserver)
             
             let parameters = SoftLogoutScreenCoordinatorParameters(authenticationService: authenticationService,

--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -452,9 +452,9 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
         let authenticationService = AuthenticationService(userSessionStore: userSessionStore,
                                                           encryptionKeyProvider: encryptionKeyProvider,
                                                           appSettings: appSettings)
-        let qrCodeLoginService = QRCodeLoginService(oidcConfiguration: appSettings.oidcConfiguration.rustValue,
-                                                    encryptionKeyProvider: encryptionKeyProvider,
-                                                    userSessionStore: userSessionStore)
+        let qrCodeLoginService = QRCodeLoginService(encryptionKeyProvider: encryptionKeyProvider,
+                                                    userSessionStore: userSessionStore,
+                                                    appSettings: appSettings)
         
         authenticationFlowCoordinator = AuthenticationFlowCoordinator(authenticationService: authenticationService,
                                                                       qrCodeLoginService: qrCodeLoginService,

--- a/ElementX/Sources/FlowCoordinators/AuthenticationFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/AuthenticationFlowCoordinator.swift
@@ -23,7 +23,7 @@ protocol AuthenticationFlowCoordinatorDelegate: AnyObject {
 }
 
 class AuthenticationFlowCoordinator: FlowCoordinatorProtocol {
-    private let authenticationService: AuthenticationServiceProxyProtocol
+    private let authenticationService: AuthenticationServiceProtocol
     private let bugReportService: BugReportServiceProtocol
     private let navigationRootCoordinator: NavigationRootCoordinator
     private let navigationStackCoordinator: NavigationStackCoordinator
@@ -42,7 +42,7 @@ class AuthenticationFlowCoordinator: FlowCoordinatorProtocol {
     
     weak var delegate: AuthenticationFlowCoordinatorDelegate?
     
-    init(authenticationService: AuthenticationServiceProxyProtocol,
+    init(authenticationService: AuthenticationServiceProtocol,
          qrCodeLoginService: QRCodeLoginServiceProtocol,
          bugReportService: BugReportServiceProtocol,
          navigationRootCoordinator: NavigationRootCoordinator,

--- a/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
@@ -80,347 +80,6 @@ open class AbortSendHandleSDKMock: MatrixRustSDK.AbortSendHandle {
         }
     }
 }
-open class AuthenticationServiceSDKMock: MatrixRustSDK.AuthenticationService {
-    init() {
-        super.init(noPointer: .init())
-    }
-
-    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
-        fatalError("init(unsafeFromRawPointer:) has not been implemented")
-    }
-
-    fileprivate var pointer: UnsafeMutableRawPointer!
-
-    //MARK: - configureHomeserver
-
-    open var configureHomeserverServerNameOrHomeserverUrlThrowableError: Error?
-    var configureHomeserverServerNameOrHomeserverUrlUnderlyingCallsCount = 0
-    open var configureHomeserverServerNameOrHomeserverUrlCallsCount: Int {
-        get {
-            if Thread.isMainThread {
-                return configureHomeserverServerNameOrHomeserverUrlUnderlyingCallsCount
-            } else {
-                var returnValue: Int? = nil
-                DispatchQueue.main.sync {
-                    returnValue = configureHomeserverServerNameOrHomeserverUrlUnderlyingCallsCount
-                }
-
-                return returnValue!
-            }
-        }
-        set {
-            if Thread.isMainThread {
-                configureHomeserverServerNameOrHomeserverUrlUnderlyingCallsCount = newValue
-            } else {
-                DispatchQueue.main.sync {
-                    configureHomeserverServerNameOrHomeserverUrlUnderlyingCallsCount = newValue
-                }
-            }
-        }
-    }
-    open var configureHomeserverServerNameOrHomeserverUrlCalled: Bool {
-        return configureHomeserverServerNameOrHomeserverUrlCallsCount > 0
-    }
-    open var configureHomeserverServerNameOrHomeserverUrlReceivedServerNameOrHomeserverUrl: String?
-    open var configureHomeserverServerNameOrHomeserverUrlReceivedInvocations: [String] = []
-    open var configureHomeserverServerNameOrHomeserverUrlClosure: ((String) async throws -> Void)?
-
-    open override func configureHomeserver(serverNameOrHomeserverUrl: String) async throws {
-        if let error = configureHomeserverServerNameOrHomeserverUrlThrowableError {
-            throw error
-        }
-        configureHomeserverServerNameOrHomeserverUrlCallsCount += 1
-        configureHomeserverServerNameOrHomeserverUrlReceivedServerNameOrHomeserverUrl = serverNameOrHomeserverUrl
-        DispatchQueue.main.async {
-            self.configureHomeserverServerNameOrHomeserverUrlReceivedInvocations.append(serverNameOrHomeserverUrl)
-        }
-        try await configureHomeserverServerNameOrHomeserverUrlClosure?(serverNameOrHomeserverUrl)
-    }
-
-    //MARK: - homeserverDetails
-
-    var homeserverDetailsUnderlyingCallsCount = 0
-    open var homeserverDetailsCallsCount: Int {
-        get {
-            if Thread.isMainThread {
-                return homeserverDetailsUnderlyingCallsCount
-            } else {
-                var returnValue: Int? = nil
-                DispatchQueue.main.sync {
-                    returnValue = homeserverDetailsUnderlyingCallsCount
-                }
-
-                return returnValue!
-            }
-        }
-        set {
-            if Thread.isMainThread {
-                homeserverDetailsUnderlyingCallsCount = newValue
-            } else {
-                DispatchQueue.main.sync {
-                    homeserverDetailsUnderlyingCallsCount = newValue
-                }
-            }
-        }
-    }
-    open var homeserverDetailsCalled: Bool {
-        return homeserverDetailsCallsCount > 0
-    }
-
-    var homeserverDetailsUnderlyingReturnValue: HomeserverLoginDetails?
-    open var homeserverDetailsReturnValue: HomeserverLoginDetails? {
-        get {
-            if Thread.isMainThread {
-                return homeserverDetailsUnderlyingReturnValue
-            } else {
-                var returnValue: HomeserverLoginDetails?? = nil
-                DispatchQueue.main.sync {
-                    returnValue = homeserverDetailsUnderlyingReturnValue
-                }
-
-                return returnValue!
-            }
-        }
-        set {
-            if Thread.isMainThread {
-                homeserverDetailsUnderlyingReturnValue = newValue
-            } else {
-                DispatchQueue.main.sync {
-                    homeserverDetailsUnderlyingReturnValue = newValue
-                }
-            }
-        }
-    }
-    open var homeserverDetailsClosure: (() -> HomeserverLoginDetails?)?
-
-    open override func homeserverDetails() -> HomeserverLoginDetails? {
-        homeserverDetailsCallsCount += 1
-        if let homeserverDetailsClosure = homeserverDetailsClosure {
-            return homeserverDetailsClosure()
-        } else {
-            return homeserverDetailsReturnValue
-        }
-    }
-
-    //MARK: - login
-
-    open var loginUsernamePasswordInitialDeviceNameDeviceIdThrowableError: Error?
-    var loginUsernamePasswordInitialDeviceNameDeviceIdUnderlyingCallsCount = 0
-    open var loginUsernamePasswordInitialDeviceNameDeviceIdCallsCount: Int {
-        get {
-            if Thread.isMainThread {
-                return loginUsernamePasswordInitialDeviceNameDeviceIdUnderlyingCallsCount
-            } else {
-                var returnValue: Int? = nil
-                DispatchQueue.main.sync {
-                    returnValue = loginUsernamePasswordInitialDeviceNameDeviceIdUnderlyingCallsCount
-                }
-
-                return returnValue!
-            }
-        }
-        set {
-            if Thread.isMainThread {
-                loginUsernamePasswordInitialDeviceNameDeviceIdUnderlyingCallsCount = newValue
-            } else {
-                DispatchQueue.main.sync {
-                    loginUsernamePasswordInitialDeviceNameDeviceIdUnderlyingCallsCount = newValue
-                }
-            }
-        }
-    }
-    open var loginUsernamePasswordInitialDeviceNameDeviceIdCalled: Bool {
-        return loginUsernamePasswordInitialDeviceNameDeviceIdCallsCount > 0
-    }
-    open var loginUsernamePasswordInitialDeviceNameDeviceIdReceivedArguments: (username: String, password: String, initialDeviceName: String?, deviceId: String?)?
-    open var loginUsernamePasswordInitialDeviceNameDeviceIdReceivedInvocations: [(username: String, password: String, initialDeviceName: String?, deviceId: String?)] = []
-
-    var loginUsernamePasswordInitialDeviceNameDeviceIdUnderlyingReturnValue: Client!
-    open var loginUsernamePasswordInitialDeviceNameDeviceIdReturnValue: Client! {
-        get {
-            if Thread.isMainThread {
-                return loginUsernamePasswordInitialDeviceNameDeviceIdUnderlyingReturnValue
-            } else {
-                var returnValue: Client? = nil
-                DispatchQueue.main.sync {
-                    returnValue = loginUsernamePasswordInitialDeviceNameDeviceIdUnderlyingReturnValue
-                }
-
-                return returnValue!
-            }
-        }
-        set {
-            if Thread.isMainThread {
-                loginUsernamePasswordInitialDeviceNameDeviceIdUnderlyingReturnValue = newValue
-            } else {
-                DispatchQueue.main.sync {
-                    loginUsernamePasswordInitialDeviceNameDeviceIdUnderlyingReturnValue = newValue
-                }
-            }
-        }
-    }
-    open var loginUsernamePasswordInitialDeviceNameDeviceIdClosure: ((String, String, String?, String?) async throws -> Client)?
-
-    open override func login(username: String, password: String, initialDeviceName: String?, deviceId: String?) async throws -> Client {
-        if let error = loginUsernamePasswordInitialDeviceNameDeviceIdThrowableError {
-            throw error
-        }
-        loginUsernamePasswordInitialDeviceNameDeviceIdCallsCount += 1
-        loginUsernamePasswordInitialDeviceNameDeviceIdReceivedArguments = (username: username, password: password, initialDeviceName: initialDeviceName, deviceId: deviceId)
-        DispatchQueue.main.async {
-            self.loginUsernamePasswordInitialDeviceNameDeviceIdReceivedInvocations.append((username: username, password: password, initialDeviceName: initialDeviceName, deviceId: deviceId))
-        }
-        if let loginUsernamePasswordInitialDeviceNameDeviceIdClosure = loginUsernamePasswordInitialDeviceNameDeviceIdClosure {
-            return try await loginUsernamePasswordInitialDeviceNameDeviceIdClosure(username, password, initialDeviceName, deviceId)
-        } else {
-            return loginUsernamePasswordInitialDeviceNameDeviceIdReturnValue
-        }
-    }
-
-    //MARK: - loginWithOidcCallback
-
-    open var loginWithOidcCallbackAuthenticationDataCallbackUrlThrowableError: Error?
-    var loginWithOidcCallbackAuthenticationDataCallbackUrlUnderlyingCallsCount = 0
-    open var loginWithOidcCallbackAuthenticationDataCallbackUrlCallsCount: Int {
-        get {
-            if Thread.isMainThread {
-                return loginWithOidcCallbackAuthenticationDataCallbackUrlUnderlyingCallsCount
-            } else {
-                var returnValue: Int? = nil
-                DispatchQueue.main.sync {
-                    returnValue = loginWithOidcCallbackAuthenticationDataCallbackUrlUnderlyingCallsCount
-                }
-
-                return returnValue!
-            }
-        }
-        set {
-            if Thread.isMainThread {
-                loginWithOidcCallbackAuthenticationDataCallbackUrlUnderlyingCallsCount = newValue
-            } else {
-                DispatchQueue.main.sync {
-                    loginWithOidcCallbackAuthenticationDataCallbackUrlUnderlyingCallsCount = newValue
-                }
-            }
-        }
-    }
-    open var loginWithOidcCallbackAuthenticationDataCallbackUrlCalled: Bool {
-        return loginWithOidcCallbackAuthenticationDataCallbackUrlCallsCount > 0
-    }
-    open var loginWithOidcCallbackAuthenticationDataCallbackUrlReceivedArguments: (authenticationData: OidcAuthenticationData, callbackUrl: String)?
-    open var loginWithOidcCallbackAuthenticationDataCallbackUrlReceivedInvocations: [(authenticationData: OidcAuthenticationData, callbackUrl: String)] = []
-
-    var loginWithOidcCallbackAuthenticationDataCallbackUrlUnderlyingReturnValue: Client!
-    open var loginWithOidcCallbackAuthenticationDataCallbackUrlReturnValue: Client! {
-        get {
-            if Thread.isMainThread {
-                return loginWithOidcCallbackAuthenticationDataCallbackUrlUnderlyingReturnValue
-            } else {
-                var returnValue: Client? = nil
-                DispatchQueue.main.sync {
-                    returnValue = loginWithOidcCallbackAuthenticationDataCallbackUrlUnderlyingReturnValue
-                }
-
-                return returnValue!
-            }
-        }
-        set {
-            if Thread.isMainThread {
-                loginWithOidcCallbackAuthenticationDataCallbackUrlUnderlyingReturnValue = newValue
-            } else {
-                DispatchQueue.main.sync {
-                    loginWithOidcCallbackAuthenticationDataCallbackUrlUnderlyingReturnValue = newValue
-                }
-            }
-        }
-    }
-    open var loginWithOidcCallbackAuthenticationDataCallbackUrlClosure: ((OidcAuthenticationData, String) async throws -> Client)?
-
-    open override func loginWithOidcCallback(authenticationData: OidcAuthenticationData, callbackUrl: String) async throws -> Client {
-        if let error = loginWithOidcCallbackAuthenticationDataCallbackUrlThrowableError {
-            throw error
-        }
-        loginWithOidcCallbackAuthenticationDataCallbackUrlCallsCount += 1
-        loginWithOidcCallbackAuthenticationDataCallbackUrlReceivedArguments = (authenticationData: authenticationData, callbackUrl: callbackUrl)
-        DispatchQueue.main.async {
-            self.loginWithOidcCallbackAuthenticationDataCallbackUrlReceivedInvocations.append((authenticationData: authenticationData, callbackUrl: callbackUrl))
-        }
-        if let loginWithOidcCallbackAuthenticationDataCallbackUrlClosure = loginWithOidcCallbackAuthenticationDataCallbackUrlClosure {
-            return try await loginWithOidcCallbackAuthenticationDataCallbackUrlClosure(authenticationData, callbackUrl)
-        } else {
-            return loginWithOidcCallbackAuthenticationDataCallbackUrlReturnValue
-        }
-    }
-
-    //MARK: - urlForOidcLogin
-
-    open var urlForOidcLoginThrowableError: Error?
-    var urlForOidcLoginUnderlyingCallsCount = 0
-    open var urlForOidcLoginCallsCount: Int {
-        get {
-            if Thread.isMainThread {
-                return urlForOidcLoginUnderlyingCallsCount
-            } else {
-                var returnValue: Int? = nil
-                DispatchQueue.main.sync {
-                    returnValue = urlForOidcLoginUnderlyingCallsCount
-                }
-
-                return returnValue!
-            }
-        }
-        set {
-            if Thread.isMainThread {
-                urlForOidcLoginUnderlyingCallsCount = newValue
-            } else {
-                DispatchQueue.main.sync {
-                    urlForOidcLoginUnderlyingCallsCount = newValue
-                }
-            }
-        }
-    }
-    open var urlForOidcLoginCalled: Bool {
-        return urlForOidcLoginCallsCount > 0
-    }
-
-    var urlForOidcLoginUnderlyingReturnValue: OidcAuthenticationData!
-    open var urlForOidcLoginReturnValue: OidcAuthenticationData! {
-        get {
-            if Thread.isMainThread {
-                return urlForOidcLoginUnderlyingReturnValue
-            } else {
-                var returnValue: OidcAuthenticationData? = nil
-                DispatchQueue.main.sync {
-                    returnValue = urlForOidcLoginUnderlyingReturnValue
-                }
-
-                return returnValue!
-            }
-        }
-        set {
-            if Thread.isMainThread {
-                urlForOidcLoginUnderlyingReturnValue = newValue
-            } else {
-                DispatchQueue.main.sync {
-                    urlForOidcLoginUnderlyingReturnValue = newValue
-                }
-            }
-        }
-    }
-    open var urlForOidcLoginClosure: (() async throws -> OidcAuthenticationData)?
-
-    open override func urlForOidcLogin() async throws -> OidcAuthenticationData {
-        if let error = urlForOidcLoginThrowableError {
-            throw error
-        }
-        urlForOidcLoginCallsCount += 1
-        if let urlForOidcLoginClosure = urlForOidcLoginClosure {
-            return try await urlForOidcLoginClosure()
-        } else {
-            return urlForOidcLoginReturnValue
-        }
-    }
-}
 open class ClientSDKMock: MatrixRustSDK.Client {
     init() {
         super.init(noPointer: .init())
@@ -431,6 +90,48 @@ open class ClientSDKMock: MatrixRustSDK.Client {
     }
 
     fileprivate var pointer: UnsafeMutableRawPointer!
+
+    //MARK: - abortOidcLogin
+
+    var abortOidcLoginAuthorizationDataUnderlyingCallsCount = 0
+    open var abortOidcLoginAuthorizationDataCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return abortOidcLoginAuthorizationDataUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = abortOidcLoginAuthorizationDataUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                abortOidcLoginAuthorizationDataUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    abortOidcLoginAuthorizationDataUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var abortOidcLoginAuthorizationDataCalled: Bool {
+        return abortOidcLoginAuthorizationDataCallsCount > 0
+    }
+    open var abortOidcLoginAuthorizationDataReceivedAuthorizationData: OidcAuthorizationData?
+    open var abortOidcLoginAuthorizationDataReceivedInvocations: [OidcAuthorizationData] = []
+    open var abortOidcLoginAuthorizationDataClosure: ((OidcAuthorizationData) async -> Void)?
+
+    open override func abortOidcLogin(authorizationData: OidcAuthorizationData) async {
+        abortOidcLoginAuthorizationDataCallsCount += 1
+        abortOidcLoginAuthorizationDataReceivedAuthorizationData = authorizationData
+        DispatchQueue.main.async {
+            self.abortOidcLoginAuthorizationDataReceivedInvocations.append(authorizationData)
+        }
+        await abortOidcLoginAuthorizationDataClosure?(authorizationData)
+    }
 
     //MARK: - accountData
 
@@ -1879,6 +1580,71 @@ open class ClientSDKMock: MatrixRustSDK.Client {
         }
     }
 
+    //MARK: - homeserverLoginDetails
+
+    var homeserverLoginDetailsUnderlyingCallsCount = 0
+    open var homeserverLoginDetailsCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return homeserverLoginDetailsUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = homeserverLoginDetailsUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                homeserverLoginDetailsUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    homeserverLoginDetailsUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var homeserverLoginDetailsCalled: Bool {
+        return homeserverLoginDetailsCallsCount > 0
+    }
+
+    var homeserverLoginDetailsUnderlyingReturnValue: HomeserverLoginDetails!
+    open var homeserverLoginDetailsReturnValue: HomeserverLoginDetails! {
+        get {
+            if Thread.isMainThread {
+                return homeserverLoginDetailsUnderlyingReturnValue
+            } else {
+                var returnValue: HomeserverLoginDetails? = nil
+                DispatchQueue.main.sync {
+                    returnValue = homeserverLoginDetailsUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                homeserverLoginDetailsUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    homeserverLoginDetailsUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    open var homeserverLoginDetailsClosure: (() async -> HomeserverLoginDetails)?
+
+    open override func homeserverLoginDetails() async -> HomeserverLoginDetails {
+        homeserverLoginDetailsCallsCount += 1
+        if let homeserverLoginDetailsClosure = homeserverLoginDetailsClosure {
+            return await homeserverLoginDetailsClosure()
+        } else {
+            return homeserverLoginDetailsReturnValue
+        }
+    }
+
     //MARK: - ignoreUser
 
     open var ignoreUserUserIdThrowableError: Error?
@@ -2188,6 +1954,52 @@ open class ClientSDKMock: MatrixRustSDK.Client {
             self.loginUsernamePasswordInitialDeviceNameDeviceIdReceivedInvocations.append((username: username, password: password, initialDeviceName: initialDeviceName, deviceId: deviceId))
         }
         try await loginUsernamePasswordInitialDeviceNameDeviceIdClosure?(username, password, initialDeviceName, deviceId)
+    }
+
+    //MARK: - loginWithOidcCallback
+
+    open var loginWithOidcCallbackAuthorizationDataCallbackUrlThrowableError: Error?
+    var loginWithOidcCallbackAuthorizationDataCallbackUrlUnderlyingCallsCount = 0
+    open var loginWithOidcCallbackAuthorizationDataCallbackUrlCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return loginWithOidcCallbackAuthorizationDataCallbackUrlUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = loginWithOidcCallbackAuthorizationDataCallbackUrlUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                loginWithOidcCallbackAuthorizationDataCallbackUrlUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    loginWithOidcCallbackAuthorizationDataCallbackUrlUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var loginWithOidcCallbackAuthorizationDataCallbackUrlCalled: Bool {
+        return loginWithOidcCallbackAuthorizationDataCallbackUrlCallsCount > 0
+    }
+    open var loginWithOidcCallbackAuthorizationDataCallbackUrlReceivedArguments: (authorizationData: OidcAuthorizationData, callbackUrl: String)?
+    open var loginWithOidcCallbackAuthorizationDataCallbackUrlReceivedInvocations: [(authorizationData: OidcAuthorizationData, callbackUrl: String)] = []
+    open var loginWithOidcCallbackAuthorizationDataCallbackUrlClosure: ((OidcAuthorizationData, String) async throws -> Void)?
+
+    open override func loginWithOidcCallback(authorizationData: OidcAuthorizationData, callbackUrl: String) async throws {
+        if let error = loginWithOidcCallbackAuthorizationDataCallbackUrlThrowableError {
+            throw error
+        }
+        loginWithOidcCallbackAuthorizationDataCallbackUrlCallsCount += 1
+        loginWithOidcCallbackAuthorizationDataCallbackUrlReceivedArguments = (authorizationData: authorizationData, callbackUrl: callbackUrl)
+        DispatchQueue.main.async {
+            self.loginWithOidcCallbackAuthorizationDataCallbackUrlReceivedInvocations.append((authorizationData: authorizationData, callbackUrl: callbackUrl))
+        }
+        try await loginWithOidcCallbackAuthorizationDataCallbackUrlClosure?(authorizationData, callbackUrl)
     }
 
     //MARK: - logout
@@ -3398,6 +3210,81 @@ open class ClientSDKMock: MatrixRustSDK.Client {
         }
     }
 
+    //MARK: - urlForOidcLogin
+
+    open var urlForOidcLoginOidcConfigurationThrowableError: Error?
+    var urlForOidcLoginOidcConfigurationUnderlyingCallsCount = 0
+    open var urlForOidcLoginOidcConfigurationCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return urlForOidcLoginOidcConfigurationUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = urlForOidcLoginOidcConfigurationUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                urlForOidcLoginOidcConfigurationUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    urlForOidcLoginOidcConfigurationUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var urlForOidcLoginOidcConfigurationCalled: Bool {
+        return urlForOidcLoginOidcConfigurationCallsCount > 0
+    }
+    open var urlForOidcLoginOidcConfigurationReceivedOidcConfiguration: OidcConfiguration?
+    open var urlForOidcLoginOidcConfigurationReceivedInvocations: [OidcConfiguration] = []
+
+    var urlForOidcLoginOidcConfigurationUnderlyingReturnValue: OidcAuthorizationData!
+    open var urlForOidcLoginOidcConfigurationReturnValue: OidcAuthorizationData! {
+        get {
+            if Thread.isMainThread {
+                return urlForOidcLoginOidcConfigurationUnderlyingReturnValue
+            } else {
+                var returnValue: OidcAuthorizationData? = nil
+                DispatchQueue.main.sync {
+                    returnValue = urlForOidcLoginOidcConfigurationUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                urlForOidcLoginOidcConfigurationUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    urlForOidcLoginOidcConfigurationUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    open var urlForOidcLoginOidcConfigurationClosure: ((OidcConfiguration) async throws -> OidcAuthorizationData)?
+
+    open override func urlForOidcLogin(oidcConfiguration: OidcConfiguration) async throws -> OidcAuthorizationData {
+        if let error = urlForOidcLoginOidcConfigurationThrowableError {
+            throw error
+        }
+        urlForOidcLoginOidcConfigurationCallsCount += 1
+        urlForOidcLoginOidcConfigurationReceivedOidcConfiguration = oidcConfiguration
+        DispatchQueue.main.async {
+            self.urlForOidcLoginOidcConfigurationReceivedInvocations.append(oidcConfiguration)
+        }
+        if let urlForOidcLoginOidcConfigurationClosure = urlForOidcLoginOidcConfigurationClosure {
+            return try await urlForOidcLoginOidcConfigurationClosure(oidcConfiguration)
+        } else {
+            return urlForOidcLoginOidcConfigurationReturnValue
+        }
+    }
+
     //MARK: - userId
 
     open var userIdThrowableError: Error?
@@ -4317,6 +4204,71 @@ open class ClientBuilderSDKMock: MatrixRustSDK.ClientBuilder {
             return proxyUrlClosure(url)
         } else {
             return proxyUrlReturnValue
+        }
+    }
+
+    //MARK: - requiresSlidingSync
+
+    var requiresSlidingSyncUnderlyingCallsCount = 0
+    open var requiresSlidingSyncCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return requiresSlidingSyncUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = requiresSlidingSyncUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                requiresSlidingSyncUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    requiresSlidingSyncUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var requiresSlidingSyncCalled: Bool {
+        return requiresSlidingSyncCallsCount > 0
+    }
+
+    var requiresSlidingSyncUnderlyingReturnValue: ClientBuilder!
+    open var requiresSlidingSyncReturnValue: ClientBuilder! {
+        get {
+            if Thread.isMainThread {
+                return requiresSlidingSyncUnderlyingReturnValue
+            } else {
+                var returnValue: ClientBuilder? = nil
+                DispatchQueue.main.sync {
+                    returnValue = requiresSlidingSyncUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                requiresSlidingSyncUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    requiresSlidingSyncUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    open var requiresSlidingSyncClosure: (() -> ClientBuilder)?
+
+    open override func requiresSlidingSync() -> ClientBuilder {
+        requiresSlidingSyncCallsCount += 1
+        if let requiresSlidingSyncClosure = requiresSlidingSyncClosure {
+            return requiresSlidingSyncClosure()
+        } else {
+            return requiresSlidingSyncReturnValue
         }
     }
 
@@ -9292,82 +9244,6 @@ open class NotificationSettingsSDKMock: MatrixRustSDK.NotificationSettings {
             self.unmuteRoomRoomIdIsEncryptedIsOneToOneReceivedInvocations.append((roomId: roomId, isEncrypted: isEncrypted, isOneToOne: isOneToOne))
         }
         try await unmuteRoomRoomIdIsEncryptedIsOneToOneClosure?(roomId, isEncrypted, isOneToOne)
-    }
-}
-open class OidcAuthenticationDataSDKMock: MatrixRustSDK.OidcAuthenticationData {
-    init() {
-        super.init(noPointer: .init())
-    }
-
-    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
-        fatalError("init(unsafeFromRawPointer:) has not been implemented")
-    }
-
-    fileprivate var pointer: UnsafeMutableRawPointer!
-
-    //MARK: - loginUrl
-
-    var loginUrlUnderlyingCallsCount = 0
-    open var loginUrlCallsCount: Int {
-        get {
-            if Thread.isMainThread {
-                return loginUrlUnderlyingCallsCount
-            } else {
-                var returnValue: Int? = nil
-                DispatchQueue.main.sync {
-                    returnValue = loginUrlUnderlyingCallsCount
-                }
-
-                return returnValue!
-            }
-        }
-        set {
-            if Thread.isMainThread {
-                loginUrlUnderlyingCallsCount = newValue
-            } else {
-                DispatchQueue.main.sync {
-                    loginUrlUnderlyingCallsCount = newValue
-                }
-            }
-        }
-    }
-    open var loginUrlCalled: Bool {
-        return loginUrlCallsCount > 0
-    }
-
-    var loginUrlUnderlyingReturnValue: String!
-    open var loginUrlReturnValue: String! {
-        get {
-            if Thread.isMainThread {
-                return loginUrlUnderlyingReturnValue
-            } else {
-                var returnValue: String? = nil
-                DispatchQueue.main.sync {
-                    returnValue = loginUrlUnderlyingReturnValue
-                }
-
-                return returnValue!
-            }
-        }
-        set {
-            if Thread.isMainThread {
-                loginUrlUnderlyingReturnValue = newValue
-            } else {
-                DispatchQueue.main.sync {
-                    loginUrlUnderlyingReturnValue = newValue
-                }
-            }
-        }
-    }
-    open var loginUrlClosure: (() -> String)?
-
-    open override func loginUrl() -> String {
-        loginUrlCallsCount += 1
-        if let loginUrlClosure = loginUrlClosure {
-            return loginUrlClosure()
-        } else {
-            return loginUrlReturnValue
-        }
     }
 }
 open class QrCodeDataSDKMock: MatrixRustSDK.QrCodeData {

--- a/ElementX/Sources/Other/Extensions/ClientBuilder.swift
+++ b/ElementX/Sources/Other/Extensions/ClientBuilder.swift
@@ -1,0 +1,42 @@
+//
+// Copyright 2024 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import MatrixRustSDK
+
+extension ClientBuilder {
+    /// A helper method that applies the common builder modifiers needed for the app.
+    static func baseBuilder(setupEncryption: Bool = true, httpProxy: String? = nil, slidingSyncProxy: URL? = nil, sessionDelegate: ClientSessionDelegate) -> ClientBuilder {
+        var builder = ClientBuilder()
+            .slidingSyncProxy(slidingSyncProxy: slidingSyncProxy?.absoluteString)
+            .enableCrossProcessRefreshLock(processId: InfoPlistReader.main.bundleIdentifier, sessionDelegate: sessionDelegate)
+            .userAgent(userAgent: UserAgentBuilder.makeASCIIUserAgent())
+            .serverVersions(versions: ["v1.0", "v1.1", "v1.2", "v1.3", "v1.4", "v1.5"]) // FIXME: Quick and dirty fix for stopping version requests on startup https://github.com/matrix-org/matrix-rust-sdk/pull/1376
+        
+        if setupEncryption {
+            builder = builder
+                .autoEnableCrossSigning(autoEnableCrossSigning: true)
+                .backupDownloadStrategy(backupDownloadStrategy: .afterDecryptionFailure)
+                .autoEnableBackups(autoEnableBackups: true)
+        }
+        
+        if let httpProxy {
+            builder = builder.proxy(url: httpProxy)
+        }
+        
+        return builder
+    }
+}

--- a/ElementX/Sources/Screens/Authentication/LoginScreen/LoginScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Authentication/LoginScreen/LoginScreenCoordinator.swift
@@ -19,7 +19,7 @@ import SwiftUI
 
 struct LoginScreenCoordinatorParameters {
     /// The service used to authenticate the user.
-    let authenticationService: AuthenticationServiceProxyProtocol
+    let authenticationService: AuthenticationServiceProtocol
     
     let analytics: AnalyticsService
     let userIndicatorController: UserIndicatorControllerProtocol
@@ -38,7 +38,7 @@ final class LoginScreenCoordinator: CoordinatorProtocol {
     private let parameters: LoginScreenCoordinatorParameters
     private var viewModel: LoginScreenViewModelProtocol
         
-    private var authenticationService: AuthenticationServiceProxyProtocol { parameters.authenticationService }
+    private var authenticationService: AuthenticationServiceProtocol { parameters.authenticationService }
 
     private let actionsSubject: PassthroughSubject<LoginScreenCoordinatorAction, Never> = .init()
     private var cancellables = Set<AnyCancellable>()

--- a/ElementX/Sources/Screens/Authentication/OIDCAuthenticationPresenter.swift
+++ b/ElementX/Sources/Screens/Authentication/OIDCAuthenticationPresenter.swift
@@ -19,7 +19,7 @@ import AuthenticationServices
 /// Presents a web authentication session for an OIDC request.
 @MainActor
 class OIDCAuthenticationPresenter: NSObject {
-    private let authenticationService: AuthenticationServiceProxyProtocol
+    private let authenticationService: AuthenticationServiceProtocol
     private let oidcRedirectURL: URL
     private let presentationAnchor: UIWindow
     
@@ -33,7 +33,7 @@ class OIDCAuthenticationPresenter: NSObject {
     /// The current request in progress. This is a single use value and will be moved on access.
     @Consumable private var request: Request?
     
-    init(authenticationService: AuthenticationServiceProxyProtocol, oidcRedirectURL: URL, presentationAnchor: UIWindow) {
+    init(authenticationService: AuthenticationServiceProtocol, oidcRedirectURL: URL, presentationAnchor: UIWindow) {
         self.authenticationService = authenticationService
         self.oidcRedirectURL = oidcRedirectURL
         self.presentationAnchor = presentationAnchor

--- a/ElementX/Sources/Screens/Authentication/OIDCAuthenticationPresenter.swift
+++ b/ElementX/Sources/Screens/Authentication/OIDCAuthenticationPresenter.swift
@@ -26,7 +26,7 @@ class OIDCAuthenticationPresenter: NSObject {
     /// The data required to complete a request.
     struct Request {
         let session: ASWebAuthenticationSession
-        let oidcData: OIDCAuthenticationDataProxy
+        let oidcData: OIDCAuthorizationDataProxy
         let continuation: CheckedContinuation<Result<UserSessionProtocol, AuthenticationServiceError>, Never>
     }
     
@@ -41,7 +41,7 @@ class OIDCAuthenticationPresenter: NSObject {
     }
     
     /// Presents a web authentication session for the supplied data.
-    func authenticate(using oidcData: OIDCAuthenticationDataProxy) async -> Result<UserSessionProtocol, AuthenticationServiceError> {
+    func authenticate(using oidcData: OIDCAuthorizationDataProxy) async -> Result<UserSessionProtocol, AuthenticationServiceError> {
         await withCheckedContinuation { continuation in
             let session = ASWebAuthenticationSession(url: oidcData.url,
                                                      callbackURLScheme: oidcRedirectURL.scheme) { [weak self] url, error in

--- a/ElementX/Sources/Screens/Authentication/OIDCAuthenticationPresenter.swift
+++ b/ElementX/Sources/Screens/Authentication/OIDCAuthenticationPresenter.swift
@@ -107,7 +107,10 @@ class OIDCAuthenticationPresenter: NSObject {
             return
         }
         
-        request.continuation.resume(returning: .failure(error))
+        Task {
+            await authenticationService.abortOIDCLogin(data: request.oidcData)
+            request.continuation.resume(returning: .failure(error))
+        }
     }
 }
 

--- a/ElementX/Sources/Screens/Authentication/ServerConfirmationScreen/ServerConfirmationScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerConfirmationScreen/ServerConfirmationScreenCoordinator.swift
@@ -18,7 +18,7 @@ import Combine
 import SwiftUI
 
 struct ServerConfirmationScreenCoordinatorParameters {
-    let authenticationService: AuthenticationServiceProxyProtocol
+    let authenticationService: AuthenticationServiceProtocol
     let authenticationFlow: AuthenticationFlow
 }
 

--- a/ElementX/Sources/Screens/Authentication/ServerConfirmationScreen/ServerConfirmationScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerConfirmationScreen/ServerConfirmationScreenViewModel.swift
@@ -26,7 +26,7 @@ class ServerConfirmationScreenViewModel: ServerConfirmationScreenViewModelType, 
         actionsSubject.eraseToAnyPublisher()
     }
 
-    init(authenticationService: AuthenticationServiceProxyProtocol, authenticationFlow: AuthenticationFlow) {
+    init(authenticationService: AuthenticationServiceProtocol, authenticationFlow: AuthenticationFlow) {
         super.init(initialViewState: ServerConfirmationScreenViewState(homeserverAddress: authenticationService.homeserver.value.address,
                                                                        authenticationFlow: authenticationFlow))
         

--- a/ElementX/Sources/Screens/Authentication/ServerSelectionScreen/ServerSelectionScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerSelectionScreen/ServerSelectionScreenCoordinator.swift
@@ -19,7 +19,7 @@ import SwiftUI
 
 struct ServerSelectionScreenCoordinatorParameters {
     /// The service used to authenticate the user.
-    let authenticationService: AuthenticationServiceProxyProtocol
+    let authenticationService: AuthenticationServiceProtocol
     let userIndicatorController: UserIndicatorControllerProtocol
     /// Whether the screen is presented modally or within a navigation stack.
     let isModallyPresented: Bool
@@ -34,7 +34,7 @@ final class ServerSelectionScreenCoordinator: CoordinatorProtocol {
     private let parameters: ServerSelectionScreenCoordinatorParameters
     private let userIndicatorController: UserIndicatorControllerProtocol
     private var viewModel: ServerSelectionScreenViewModelProtocol
-    private var authenticationService: AuthenticationServiceProxyProtocol { parameters.authenticationService }
+    private var authenticationService: AuthenticationServiceProtocol { parameters.authenticationService }
 
     private let actionsSubject: PassthroughSubject<ServerSelectionScreenCoordinatorAction, Never> = .init()
     private var cancellables = Set<AnyCancellable>()

--- a/ElementX/Sources/Screens/Authentication/SoftLogoutScreen/SoftLogoutScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Authentication/SoftLogoutScreen/SoftLogoutScreenCoordinator.swift
@@ -18,7 +18,7 @@ import Combine
 import SwiftUI
 
 struct SoftLogoutScreenCoordinatorParameters {
-    let authenticationService: AuthenticationServiceProxyProtocol
+    let authenticationService: AuthenticationServiceProtocol
     let credentials: SoftLogoutScreenCredentials
     let keyBackupNeeded: Bool
     let userIndicatorController: UserIndicatorControllerProtocol
@@ -47,7 +47,7 @@ final class SoftLogoutScreenCoordinator: CoordinatorProtocol {
     private let actionsSubject: PassthroughSubject<SoftLogoutScreenCoordinatorResult, Never> = .init()
     private var cancellables = Set<AnyCancellable>()
     
-    private var authenticationService: AuthenticationServiceProxyProtocol { parameters.authenticationService }
+    private var authenticationService: AuthenticationServiceProtocol { parameters.authenticationService }
     private var oidcPresenter: OIDCAuthenticationPresenter?
     
     var actions: AnyPublisher<SoftLogoutScreenCoordinatorResult, Never> {

--- a/ElementX/Sources/Screens/Authentication/WaitlistScreen/WaitlistScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Authentication/WaitlistScreen/WaitlistScreenCoordinator.swift
@@ -21,7 +21,7 @@ struct WaitlistScreenCoordinatorParameters {
     /// The credentials for the login.
     let credentials: WaitlistScreenCredentials
     /// The service used to authenticate the user.
-    let authenticationService: AuthenticationServiceProxyProtocol
+    let authenticationService: AuthenticationServiceProtocol
     /// The service locator for the screen.
     var userIndicatorController: UserIndicatorControllerProtocol = ServiceLocator.shared.userIndicatorController
 }

--- a/ElementX/Sources/Services/Authentication/AuthenticationService.swift
+++ b/ElementX/Sources/Services/Authentication/AuthenticationService.swift
@@ -137,22 +137,13 @@ class AuthenticationService: AuthenticationServiceProtocol {
     // MARK: - Private
     
     private func makeClientBuilder() -> ClientBuilder {
-        var builder = ClientBuilder()
+        ClientBuilder
+            .baseBuilder(httpProxy: appSettings.websiteURL.globalProxy,
+                         slidingSyncProxy: appSettings.slidingSyncProxyURL,
+                         sessionDelegate: userSessionStore.clientSessionDelegate)
             .sessionPath(path: sessionDirectory.path(percentEncoded: false))
             .passphrase(passphrase: passphrase)
             .requiresSlidingSync()
-            .slidingSyncProxy(slidingSyncProxy: appSettings.slidingSyncProxyURL?.absoluteString)
-            .enableCrossProcessRefreshLock(processId: InfoPlistReader.main.bundleIdentifier, sessionDelegate: userSessionStore.clientSessionDelegate)
-            .userAgent(userAgent: UserAgentBuilder.makeASCIIUserAgent())
-            .autoEnableCrossSigning(autoEnableCrossSigning: true) // TODO: Maybe we should remove these or change the defaults?
-            .backupDownloadStrategy(backupDownloadStrategy: .afterDecryptionFailure)
-            .autoEnableBackups(autoEnableBackups: true)
-
-        if let httpProxy = appSettings.websiteURL.globalProxy {
-            builder = builder.proxy(url: httpProxy)
-        }
-        
-        return builder
     }
     
     private func userSession(for client: Client) async -> Result<UserSessionProtocol, AuthenticationServiceError> {

--- a/ElementX/Sources/Services/Authentication/AuthenticationService.swift
+++ b/ElementX/Sources/Services/Authentication/AuthenticationService.swift
@@ -82,9 +82,9 @@ class AuthenticationService: AuthenticationServiceProtocol {
         }
     }
     
-    // TODO: Call me 🤙
     func abortOIDCLogin(data: OIDCAuthorizationDataProxy) async {
         guard let client else { return }
+        MXLog.info("Aborting OIDC login.")
         await client.abortOidcLogin(authorizationData: data.underlyingData)
     }
     

--- a/ElementX/Sources/Services/Authentication/AuthenticationService.swift
+++ b/ElementX/Sources/Services/Authentication/AuthenticationService.swift
@@ -18,8 +18,7 @@ import Combine
 import Foundation
 import MatrixRustSDK
 
-// FIXME: This (and the protocol) is no longer a Proxy.
-class AuthenticationServiceProxy: AuthenticationServiceProxyProtocol {
+class AuthenticationService: AuthenticationServiceProtocol {
     private var client: Client?
     private let sessionDirectory: URL
     private let passphrase: String

--- a/ElementX/Sources/Services/Authentication/AuthenticationServiceProtocol.swift
+++ b/ElementX/Sources/Services/Authentication/AuthenticationServiceProtocol.swift
@@ -39,7 +39,7 @@ enum AuthenticationServiceError: Error {
     case sessionTokenRefreshNotSupported
 }
 
-protocol AuthenticationServiceProxyProtocol {
+protocol AuthenticationServiceProtocol {
     /// The currently configured homeserver.
     var homeserver: CurrentValuePublisher<LoginHomeserver, Never> { get }
         

--- a/ElementX/Sources/Services/Authentication/AuthenticationServiceProtocol.swift
+++ b/ElementX/Sources/Services/Authentication/AuthenticationServiceProtocol.swift
@@ -47,7 +47,9 @@ protocol AuthenticationServiceProtocol {
     func configure(for homeserverAddress: String) async -> Result<Void, AuthenticationServiceError>
     /// Performs login using OIDC for the current homeserver.
     func urlForOIDCLogin() async -> Result<OIDCAuthorizationDataProxy, AuthenticationServiceError>
-    /// Add docs.
+    /// Asks the SDK to abort an ongoing OIDC login if we didn't get a callback to complete the request with.
+    func abortOIDCLogin(data: OIDCAuthorizationDataProxy) async
+    /// Completes an OIDC login that was started using ``urlForOIDCLogin``.
     func loginWithOIDCCallback(_ callbackURL: URL, data: OIDCAuthorizationDataProxy) async -> Result<UserSessionProtocol, AuthenticationServiceError>
     /// Performs a password login using the current homeserver.
     func login(username: String, password: String, initialDeviceName: String?, deviceID: String?) async -> Result<UserSessionProtocol, AuthenticationServiceError>

--- a/ElementX/Sources/Services/Authentication/AuthenticationServiceProxyProtocol.swift
+++ b/ElementX/Sources/Services/Authentication/AuthenticationServiceProxyProtocol.swift
@@ -46,9 +46,9 @@ protocol AuthenticationServiceProxyProtocol {
     /// Sets up the service for login on the specified homeserver address.
     func configure(for homeserverAddress: String) async -> Result<Void, AuthenticationServiceError>
     /// Performs login using OIDC for the current homeserver.
-    func urlForOIDCLogin() async -> Result<OIDCAuthenticationDataProxy, AuthenticationServiceError>
+    func urlForOIDCLogin() async -> Result<OIDCAuthorizationDataProxy, AuthenticationServiceError>
     /// Add docs.
-    func loginWithOIDCCallback(_ callbackURL: URL, data: OIDCAuthenticationDataProxy) async -> Result<UserSessionProtocol, AuthenticationServiceError>
+    func loginWithOIDCCallback(_ callbackURL: URL, data: OIDCAuthorizationDataProxy) async -> Result<UserSessionProtocol, AuthenticationServiceError>
     /// Performs a password login using the current homeserver.
     func login(username: String, password: String, initialDeviceName: String?, deviceID: String?) async -> Result<UserSessionProtocol, AuthenticationServiceError>
 }
@@ -66,8 +66,8 @@ enum OIDCError: Error {
     case unknown
 }
 
-struct OIDCAuthenticationDataProxy: Equatable {
-    let underlyingData: OidcAuthenticationData
+struct OIDCAuthorizationDataProxy: Equatable {
+    let underlyingData: OidcAuthorizationData
     
     var url: URL {
         guard let url = URL(string: underlyingData.loginUrl()) else {
@@ -77,8 +77,8 @@ struct OIDCAuthenticationDataProxy: Equatable {
     }
 }
 
-extension OidcAuthenticationData: Equatable {
-    public static func == (lhs: MatrixRustSDK.OidcAuthenticationData, rhs: MatrixRustSDK.OidcAuthenticationData) -> Bool {
+extension OidcAuthorizationData: Equatable {
+    public static func == (lhs: MatrixRustSDK.OidcAuthorizationData, rhs: MatrixRustSDK.OidcAuthorizationData) -> Bool {
         lhs.loginUrl() == rhs.loginUrl()
     }
 }

--- a/ElementX/Sources/Services/Authentication/MockAuthenticationServiceProxy.swift
+++ b/ElementX/Sources/Services/Authentication/MockAuthenticationServiceProxy.swift
@@ -48,11 +48,11 @@ class MockAuthenticationServiceProxy: AuthenticationServiceProxyProtocol {
         }
     }
     
-    func urlForOIDCLogin() async -> Result<OIDCAuthenticationDataProxy, AuthenticationServiceError> {
+    func urlForOIDCLogin() async -> Result<OIDCAuthorizationDataProxy, AuthenticationServiceError> {
         .failure(.oidcError(.notSupported))
     }
     
-    func loginWithOIDCCallback(_ callbackURL: URL, data: OIDCAuthenticationDataProxy) async -> Result<UserSessionProtocol, AuthenticationServiceError> {
+    func loginWithOIDCCallback(_ callbackURL: URL, data: OIDCAuthorizationDataProxy) async -> Result<UserSessionProtocol, AuthenticationServiceError> {
         .failure(.oidcError(.notSupported))
     }
     

--- a/ElementX/Sources/Services/Authentication/MockAuthenticationServiceProxy.swift
+++ b/ElementX/Sources/Services/Authentication/MockAuthenticationServiceProxy.swift
@@ -52,6 +52,8 @@ class MockAuthenticationServiceProxy: AuthenticationServiceProtocol {
         .failure(.oidcError(.notSupported))
     }
     
+    func abortOIDCLogin(data: OIDCAuthorizationDataProxy) async { }
+    
     func loginWithOIDCCallback(_ callbackURL: URL, data: OIDCAuthorizationDataProxy) async -> Result<UserSessionProtocol, AuthenticationServiceError> {
         .failure(.oidcError(.notSupported))
     }

--- a/ElementX/Sources/Services/Authentication/MockAuthenticationServiceProxy.swift
+++ b/ElementX/Sources/Services/Authentication/MockAuthenticationServiceProxy.swift
@@ -18,7 +18,7 @@ import Combine
 import Foundation
 import MatrixRustSDK
 
-class MockAuthenticationServiceProxy: AuthenticationServiceProxyProtocol {
+class MockAuthenticationServiceProxy: AuthenticationServiceProtocol {
     let validCredentials = (username: "alice", password: "12345678")
     
     private let homeserverSubject: CurrentValueSubject<LoginHomeserver, Never>

--- a/ElementX/Sources/Services/Client/ClientError.swift
+++ b/ElementX/Sources/Services/Client/ClientError.swift
@@ -34,18 +34,6 @@ extension ClientError {
 
         return first
     }
-}
-
-extension AuthenticationError {
-    var code: MatrixErrorCode {
-        guard case let .Generic(message) = self else { return .unknown }
-        
-        guard let first = MatrixErrorCode.allCases.first(where: { message.contains($0.rawValue) }) else {
-            return .unknown
-        }
-
-        return first
-    }
     
     /// Whether or not the error is related to the sliding sync proxy being full.
     ///

--- a/ElementX/Sources/Services/QRCode/QRCodeLoginService.swift
+++ b/ElementX/Sources/Services/QRCode/QRCodeLoginService.swift
@@ -59,7 +59,7 @@ final class QRCodeLoginService: QRCodeLoginServiceProtocol {
                              sessionDelegate: userSessionStore.clientSessionDelegate)
                 .sessionPath(path: sessionDirectory.path(percentEncoded: false))
                 .passphrase(passphrase: passphrase)
-                .requiresSlidingSync() // TODO: Check me?
+                .requiresSlidingSync()
                 .buildWithQrCode(qrCodeData: qrData, oidcConfiguration: appSettings.oidcConfiguration.rustValue, progressListener: listener)
             return await login(client: client)
         } catch let error as HumanQrLoginError {

--- a/ElementX/Sources/Services/QRCode/QRCodeLoginService.swift
+++ b/ElementX/Sources/Services/QRCode/QRCodeLoginService.swift
@@ -20,21 +20,21 @@ import Foundation
 import MatrixRustSDK
 
 final class QRCodeLoginService: QRCodeLoginServiceProtocol {
-    private let oidcConfiguration: OidcConfiguration
     private let sessionDirectory: URL
     private let passphrase: String
     private let userSessionStore: UserSessionStoreProtocol
+    private let appSettings: AppSettings
     
     private let qrLoginProgressSubject = PassthroughSubject<QrLoginProgress, Never>()
     var qrLoginProgressPublisher: AnyPublisher<QrLoginProgress, Never> {
         qrLoginProgressSubject.eraseToAnyPublisher()
     }
     
-    init(oidcConfiguration: OidcConfiguration,
-         encryptionKeyProvider: EncryptionKeyProviderProtocol,
-         userSessionStore: UserSessionStoreProtocol) {
-        self.oidcConfiguration = oidcConfiguration
+    init(encryptionKeyProvider: EncryptionKeyProviderProtocol,
+         userSessionStore: UserSessionStoreProtocol,
+         appSettings: AppSettings) {
         self.userSessionStore = userSessionStore
+        self.appSettings = appSettings
         sessionDirectory = .sessionsBaseDirectory.appending(component: UUID().uuidString)
         passphrase = encryptionKeyProvider.generateKey().base64EncodedString()
     }
@@ -53,14 +53,14 @@ final class QRCodeLoginService: QRCodeLoginServiceProtocol {
         }
         
         do {
-            let client = try await ClientBuilder()
+            let client = try await ClientBuilder
+                .baseBuilder(httpProxy: appSettings.websiteURL.globalProxy,
+                             slidingSyncProxy: appSettings.slidingSyncProxyURL,
+                             sessionDelegate: userSessionStore.clientSessionDelegate)
                 .sessionPath(path: sessionDirectory.path(percentEncoded: false))
                 .passphrase(passphrase: passphrase)
-                .userAgent(userAgent: UserAgentBuilder.makeASCIIUserAgent())
-                .enableCrossProcessRefreshLock(processId: InfoPlistReader.main.bundleIdentifier,
-                                               sessionDelegate: userSessionStore.clientSessionDelegate)
-                .serverVersions(versions: ["v1.0", "v1.1", "v1.2", "v1.3", "v1.4", "v1.5"]) // FIXME: Quick and dirty fix for stopping version requests on startup https://github.com/matrix-org/matrix-rust-sdk/pull/1376
-                .buildWithQrCode(qrCodeData: qrData, oidcConfiguration: oidcConfiguration, progressListener: listener)
+                .requiresSlidingSync() // TODO: Check me?
+                .buildWithQrCode(qrCodeData: qrData, oidcConfiguration: appSettings.oidcConfiguration.rustValue, progressListener: listener)
             return await login(client: client)
         } catch let error as HumanQrLoginError {
             MXLog.error("QRCode login error: \(error)")

--- a/ElementX/Sources/Services/UserSession/UserSessionStore.swift
+++ b/ElementX/Sources/Services/UserSession/UserSessionStore.swift
@@ -118,24 +118,16 @@ class UserSessionStore: UserSessionStoreProtocol {
         
         let homeserverURL = credentials.restorationToken.session.homeserverUrl
         
-        var builder = ClientBuilder()
+        let builder = ClientBuilder
+            .baseBuilder(httpProxy: URL(string: homeserverURL)?.globalProxy,
+                         sessionDelegate: keychainController)
             .sessionPath(path: credentials.restorationToken.sessionDirectory.path(percentEncoded: false))
             .username(username: credentials.userID)
             .homeserverUrl(url: homeserverURL)
             .passphrase(passphrase: credentials.restorationToken.passphrase)
-            .userAgent(userAgent: UserAgentBuilder.makeASCIIUserAgent())
-            .enableCrossProcessRefreshLock(processId: InfoPlistReader.main.bundleIdentifier,
-                                           sessionDelegate: keychainController)
-            .serverVersions(versions: ["v1.0", "v1.1", "v1.2", "v1.3", "v1.4", "v1.5"]) // FIXME: Quick and dirty fix for stopping version requests on startup https://github.com/matrix-org/matrix-rust-sdk/pull/1376
-        
-        if let homeserverURL = URL(string: homeserverURL),
-           let proxy = homeserverURL.globalProxy {
-            builder = builder.proxy(url: proxy)
-        }
-        let completeBuilder = builder
         
         do {
-            let client = try await completeBuilder.build()
+            let client = try await builder.build()
             
             try await client.restoreSession(session: credentials.restorationToken.session)
             

--- a/NSE/Sources/Other/NSEUserSession.swift
+++ b/NSE/Sources/Other/NSEUserSession.swift
@@ -32,19 +32,14 @@ final class NSEUserSession {
         }
         
         let homeserverURL = credentials.restorationToken.session.homeserverUrl
-        var clientBuilder = ClientBuilder()
+        let clientBuilder = ClientBuilder
+            .baseBuilder(setupEncryption: false,
+                         httpProxy: URL(string: homeserverURL)?.globalProxy,
+                         sessionDelegate: clientSessionDelegate)
             .sessionPath(path: credentials.restorationToken.sessionDirectory.path(percentEncoded: false))
             .username(username: credentials.userID)
             .homeserverUrl(url: homeserverURL)
             .passphrase(passphrase: credentials.restorationToken.passphrase)
-            .userAgent(userAgent: UserAgentBuilder.makeASCIIUserAgent())
-            .enableCrossProcessRefreshLock(processId: InfoPlistReader.main.bundleIdentifier,
-                                           sessionDelegate: clientSessionDelegate)
-        
-        if let homeserverURL = URL(string: homeserverURL),
-           let proxy = homeserverURL.globalProxy {
-            clientBuilder = clientBuilder.proxy(url: proxy)
-        }
         
         baseClient = try await clientBuilder.build()
         delegateHandle = baseClient.setDelegate(delegate: ClientDelegateWrapper())

--- a/NSE/SupportingFiles/target.yml
+++ b/NSE/SupportingFiles/target.yml
@@ -77,6 +77,7 @@ targets:
     - path: ../../ElementX/Sources/Other/AvatarSize.swift
     - path: ../../ElementX/Sources/Other/Extensions/AttributedString.swift
     - path: ../../ElementX/Sources/Other/Extensions/Bundle.swift
+    - path: ../../ElementX/Sources/Other/Extensions/ClientBuilder.swift
     - path: ../../ElementX/Sources/Other/Extensions/Date.swift
     - path: ../../ElementX/Sources/Other/Extensions/FileManager.swift
     - path: ../../ElementX/Sources/Other/Extensions/ImageCache.swift

--- a/changelog.d/pr-2954.change
+++ b/changelog.d/pr-2954.change
@@ -1,0 +1,1 @@
+Adopt the new authentication methods exposed on Rust's Client.

--- a/project.yml
+++ b/project.yml
@@ -49,7 +49,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/element-hq/matrix-rust-components-swift
-    exactVersion: 1.0.17
+    exactVersion: 1.0.18
     # path: ../matrix-rust-sdk
   Compound:
     url: https://github.com/element-hq/compound-ios


### PR DESCRIPTION
Rust's AuthenticationService has been removed in https://github.com/matrix-org/matrix-rust-sdk/pull/3594. This PR moves what was very simple logic that called into a `Client` directly into our app-side AuthenticationService.

Can be reviewed commit-by-commit.