### PR TITLE
Improve UX when answering EL-Call through the notification

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -145,15 +145,17 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
         
         registerBackgroundAppRefresh()
         
-        elementCallService.actions.sink { [weak self] action in
-            switch action {
-            case .answerCall(let roomID):
-                self?.handleAppRoute(.call(roomID: roomID))
-            case .declineCall:
-                break
+        elementCallService.actions
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] action in
+                switch action {
+                case .answerCall(let roomID):
+                    self?.handleAppRoute(.call(roomID: roomID))
+                case .declineCall:
+                    break
+                }
             }
-        }
-        .store(in: &cancellables)
+            .store(in: &cancellables)
     }
     
     func start() {


### PR DESCRIPTION
- The navigation is now received on DispatchQueue.main since it was triggerd by background threads, and creating a possible deadlock.
- When a call is answered the 15 seconds timeout is cancelled.

This will also solve the issue that makes the call screen when the device is locked disappear after some seconds (which as of right now only works when answering the call with the push notification)