### PR TITLE
Hide timeline style selection

### DIFF
--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -236,9 +236,6 @@ final class AppSettings {
     
     // MARK: - Room Screen
     
-    @UserPreference(key: UserDefaultsKeys.timelineStyle, defaultValue: TimelineStyle.bubbles, storageType: .volatile)
-    var timelineStyle
-    
     @UserPreference(key: UserDefaultsKeys.viewSourceEnabled, defaultValue: isDevelopmentBuild, storageType: .userDefaults(store))
     var viewSourceEnabled
 

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
@@ -149,7 +149,7 @@ struct RoomScreenViewState: BindableState {
     var typingMembers: [String] = []
     var showLoading = false
     var showReadReceipts = false
-    var timelineStyle: TimelineStyle
+    let timelineStyle = TimelineStyle.bubbles
     var isEncryptedOneToOneRoom = false
     var timelineViewState: TimelineViewState // check the doc before changing this
 

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -83,7 +83,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
         super.init(initialViewState: RoomScreenViewState(roomID: roomProxy.id,
                                                          roomTitle: roomProxy.roomTitle,
                                                          roomAvatar: roomProxy.avatar,
-                                                         timelineStyle: appSettings.timelineStyle,
+                                                         timelineStyle: .bubbles,
                                                          isEncryptedOneToOneRoom: roomProxy.isEncryptedOneToOneRoom,
                                                          timelineViewState: TimelineViewState(focussedEvent: focussedEventID.map { .init(eventID: $0, appearance: .immediate) }),
                                                          ownUserID: roomProxy.ownUserID,
@@ -390,10 +390,6 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
                 state.roomAvatar = roomProxy.avatar
                 state.hasOngoingCall = roomProxy.hasOngoingCall
             }
-            .store(in: &cancellables)
-        
-        appSettings.$timelineStyle
-            .weakAssign(to: \.state.timelineStyle, on: self)
             .store(in: &cancellables)
         
         appSettings.$sharePresence

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -83,7 +83,6 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
         super.init(initialViewState: RoomScreenViewState(roomID: roomProxy.id,
                                                          roomTitle: roomProxy.roomTitle,
                                                          roomAvatar: roomProxy.avatar,
-                                                         timelineStyle: .bubbles,
                                                          isEncryptedOneToOneRoom: roomProxy.isEncryptedOneToOneRoom,
                                                          timelineViewState: TimelineViewState(focussedEvent: focussedEventID.map { .init(eventID: $0, appearance: .immediate) }),
                                                          ownUserID: roomProxy.ownUserID,

--- a/ElementX/Sources/Screens/Settings/AvancedOptionsScreen/AdvancedSettingsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/AvancedOptionsScreen/AdvancedSettingsScreenModels.swift
@@ -38,7 +38,6 @@ struct AdvancedSettingsScreenViewStateBindings {
 enum AdvancedSettingsScreenViewAction { }
 
 protocol AdvancedSettingsProtocol: AnyObject {
-    var timelineStyle: TimelineStyle { get set }
     var viewSourceEnabled: Bool { get set }
     var appAppearance: AppAppearance { get set }
     var sharePresence: Bool { get set }

--- a/ElementX/Sources/Screens/Settings/AvancedOptionsScreen/View/AdvancedSettingsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/AvancedOptionsScreen/View/AdvancedSettingsScreen.swift
@@ -27,10 +27,6 @@ struct AdvancedSettingsScreen: View {
                         kind: .picker(selection: $context.appAppearance,
                                       items: AppAppearance.allCases.map { (title: $0.name, tag: $0) }))
                 
-                ListRow(label: .plain(title: L10n.commonMessageLayout),
-                        kind: .picker(selection: $context.timelineStyle,
-                                      items: TimelineStyle.allCases.map { (title: $0.name, tag: $0) }))
-                
                 ListRow(label: .plain(title: L10n.actionViewSource),
                         kind: .toggle($context.viewSourceEnabled))
                 

--- a/PreviewTests/__Snapshots__/PreviewTests/test_advancedSettingsScreen-iPad-en-GB.1.png
+++ b/PreviewTests/__Snapshots__/PreviewTests/test_advancedSettingsScreen-iPad-en-GB.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f85f8897cd79b5d4d2df216679ffcdc45da409e9fc1bce42cbb434512e7d5053
-size 156848
+oid sha256:6986a441d9719d8c2a5254ed06c51cb845ef940ba5a70eae3e7fec464a8dec88
+size 143354

--- a/PreviewTests/__Snapshots__/PreviewTests/test_advancedSettingsScreen-iPad-pseudo.1.png
+++ b/PreviewTests/__Snapshots__/PreviewTests/test_advancedSettingsScreen-iPad-pseudo.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:af072c34f22fa7757d3a7f48e318c20f78bfc0b6dda2ca976edea2985d8e4706
-size 218093
+oid sha256:61ba569506684af18eefc8e06d01c1c337659e452db9bb226118bd0609e4c51f
+size 193251

--- a/PreviewTests/__Snapshots__/PreviewTests/test_advancedSettingsScreen-iPhone-15-en-GB.1.png
+++ b/PreviewTests/__Snapshots__/PreviewTests/test_advancedSettingsScreen-iPhone-15-en-GB.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4c88a64b71907671ad6ba30275a58efb4c8131533d983c4ad3c341dd1d6d9a74
-size 104849
+oid sha256:a51e193e49f96c000fc42881316d42d81a6f5f8bd0babad557d587f1ae6f22bc
+size 93116

--- a/PreviewTests/__Snapshots__/PreviewTests/test_advancedSettingsScreen-iPhone-15-pseudo.1.png
+++ b/PreviewTests/__Snapshots__/PreviewTests/test_advancedSettingsScreen-iPhone-15-pseudo.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dcdf67bedffc6d677cbb292986dfe3270ce04afeb51611fc62bc1d8d77b1c936
-size 166288
+oid sha256:1a5404c61f662f6bb93316f2d917fefef7e486f526b22b985253322c5a9bd2cb
+size 138400


### PR DESCRIPTION
First part of https://github.com/element-hq/element-x-ios/issues/2964

This will default the timeline style to always be bubble, and will hide to the user the possibility of switching to plain mode.
This PR won't fully remove the plain text code since doing so is a delicate process, which we will do in a follow up PR.