### PR TITLE
Trigger a Danger CI run when labelling a PR too.

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,6 +1,8 @@
 name: Danger CI
 
-on: [pull_request]
+on:
+  pull_request:
+    types: [ labeled, synchronize, opened, reopened ]
 
 jobs:
   build:


### PR DESCRIPTION
Copies the same triggers as we have on the PR Build workflow.

Will test by adding the label to this PR after it fails ✅