### PR TITLE
Fix for the left room event using member instead of the sender

### DIFF
--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomStateEventStringBuilder.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomStateEventStringBuilder.swift
@@ -44,7 +44,7 @@ struct RoomStateEventStringBuilder {
         case .joined:
             return memberIsYou ? L10n.stateEventRoomJoinByYou : L10n.stateEventRoomJoin(senderDisplayName)
         case .left:
-            return memberIsYou ? L10n.stateEventRoomLeaveByYou : L10n.stateEventRoomLeave(senderDisplayName)
+            return memberIsYou ? L10n.stateEventRoomLeaveByYou : L10n.stateEventRoomLeave(member)
         case .banned, .kickedAndBanned:
             return senderIsYou ? L10n.stateEventRoomBanByYou(member) : L10n.stateEventRoomBan(senderDisplayName, member)
         case .unbanned:


### PR DESCRIPTION
Member always contains the display name which is not always available for the sender display name sometimes.

This fix however will only be seen if the current SDK version includes: https://github.com/matrix-org/matrix-rust-sdk/pull/3648