### PR TITLE
Fix a crash when 2 present room events are sent in quick succession.

### DIFF
--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -214,6 +214,7 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
                 fatalError("Trying to create different room proxies for the same flow coordinator")
             }
             
+            MXLog.warning("Found an existing proxy, returning.")
             return
         }
         
@@ -221,9 +222,12 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
             fatalError("Requesting room details for an unjoined room")
         }
         
-        self.roomProxy = roomProxy
-        
         await roomProxy.subscribeForUpdates()
+        
+        // Make sure not to set this until after the subscription has succeeded, otherwise the
+        // early return above could result in trying to access the room's timeline provider
+        // before it has been set which triggers a fatal error.
+        self.roomProxy = roomProxy
     }
     
     // swiftlint:disable:next function_body_length


### PR DESCRIPTION
I'm not exactly sure what the trigger for the double events are but I can see how a crash accessing [`TimelineProxy.timelineProvider`](https://github.com/element-hq/element-x-ios/blob/7a09be192ec5c58662176f835f04e9e0908f69ff/ElementX/Sources/Services/Timeline/TimelineProxy.swift#L34) would happen given an early return being hit whilst a previous call to this method is still awaiting the subscription.