### PR TITLE
FIX: saving draft did not save the pill markdown content

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarViewModel.swift
@@ -310,7 +310,7 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
                 }
                 return
             }
-            plainText = getPlainComposerContent().text
+            plainText = plainComposerContent.text
             htmlText = nil
         }
         
@@ -349,7 +349,7 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
         }
     }
     
-    private func getPlainComposerContent() -> PlainComposerContent {
+    private var plainComposerContent: PlainComposerContent {
         let attributedString = NSMutableAttributedString(attributedString: context.plainComposerText)
 
         var shouldMakeAnotherPass = false
@@ -400,7 +400,7 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
     }
     
     private func sendPlainComposerText() {
-        let plainComposerContent = getPlainComposerContent()
+        let plainComposerContent = plainComposerContent
         actionsSubject.send(.sendMessage(plain: plainComposerContent.text, html: nil,
                                          mode: state.composerMode,
                                          intentionalMentions: .init(userIDs: plainComposerContent.mentionedUserIDs, atRoom: plainComposerContent.containsAtRoomMention)))


### PR DESCRIPTION
This fix will allow the saved draft to contain the markdown content of a pill... however when restored we will still display the markdown only since the plain text composer still has no way to directly interpret and convert a markdown into a pill before its sent.