### PR TITLE
Replace old visible rooms range with subscriptions in the room list.

### DIFF
--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -680,7 +680,7 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
             navigationStackCoordinator.setRootCoordinator(nil, animated: false)
         }
         
-        roomProxy?.unsubscribeFromUpdates()
+        Task { await roomProxy?.unsubscribeFromUpdates() }
         
         timelineController = nil
         

--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -680,8 +680,6 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
             navigationStackCoordinator.setRootCoordinator(nil, animated: false)
         }
         
-        Task { await roomProxy?.unsubscribeFromUpdates() }
-        
         timelineController = nil
         
         actionsSubject.send(.finished)

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -8259,41 +8259,6 @@ class RoomProxyMock: RoomProxyProtocol {
         subscribeForUpdatesCallsCount += 1
         await subscribeForUpdatesClosure?()
     }
-    //MARK: - unsubscribeFromUpdates
-
-    var unsubscribeFromUpdatesUnderlyingCallsCount = 0
-    var unsubscribeFromUpdatesCallsCount: Int {
-        get {
-            if Thread.isMainThread {
-                return unsubscribeFromUpdatesUnderlyingCallsCount
-            } else {
-                var returnValue: Int? = nil
-                DispatchQueue.main.sync {
-                    returnValue = unsubscribeFromUpdatesUnderlyingCallsCount
-                }
-
-                return returnValue!
-            }
-        }
-        set {
-            if Thread.isMainThread {
-                unsubscribeFromUpdatesUnderlyingCallsCount = newValue
-            } else {
-                DispatchQueue.main.sync {
-                    unsubscribeFromUpdatesUnderlyingCallsCount = newValue
-                }
-            }
-        }
-    }
-    var unsubscribeFromUpdatesCalled: Bool {
-        return unsubscribeFromUpdatesCallsCount > 0
-    }
-    var unsubscribeFromUpdatesClosure: (() async -> Void)?
-
-    func unsubscribeFromUpdates() async {
-        unsubscribeFromUpdatesCallsCount += 1
-        await unsubscribeFromUpdatesClosure?()
-    }
     //MARK: - timelineFocusedOnEvent
 
     var timelineFocusedOnEventEventIDNumberOfEventsUnderlyingCallsCount = 0

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -8288,11 +8288,11 @@ class RoomProxyMock: RoomProxyProtocol {
     var unsubscribeFromUpdatesCalled: Bool {
         return unsubscribeFromUpdatesCallsCount > 0
     }
-    var unsubscribeFromUpdatesClosure: (() -> Void)?
+    var unsubscribeFromUpdatesClosure: (() async -> Void)?
 
-    func unsubscribeFromUpdates() {
+    func unsubscribeFromUpdates() async {
         unsubscribeFromUpdatesCallsCount += 1
-        unsubscribeFromUpdatesClosure?()
+        await unsubscribeFromUpdatesClosure?()
     }
     //MARK: - timelineFocusedOnEvent
 

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -46,7 +46,15 @@ enum ClientProxyError: Error {
 }
 
 enum SlidingSyncConstants {
-    static let defaultTimelineLimit: UInt = 20
+    static let defaultTimelineLimit: UInt32 = 20
+    static let maximumVisibleRangeSize = 30
+    static let defaultRequiredState = [
+        RequiredState(key: "m.room.name", value: ""),
+        RequiredState(key: "m.room.topic", value: ""),
+        RequiredState(key: "m.room.avatar", value: ""),
+        RequiredState(key: "m.room.canonical_alias", value: ""),
+        RequiredState(key: "m.room.join_rules", value: "")
+    ]
 }
 
 /// This struct represents the configuration that we are using to register the application through Pusher to Sygnal

--- a/ElementX/Sources/Services/Room/RoomProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomProxy.swift
@@ -145,12 +145,8 @@ class RoomProxy: RoomProxyProtocol {
         }
         
         subscribedForUpdates = true
-        let settings = RoomSubscription(requiredState: [RequiredState(key: "m.room.name", value: ""),
-                                                        RequiredState(key: "m.room.topic", value: ""),
-                                                        RequiredState(key: "m.room.avatar", value: ""),
-                                                        RequiredState(key: "m.room.canonical_alias", value: ""),
-                                                        RequiredState(key: "m.room.join_rules", value: "")],
-                                        timelineLimit: UInt32(SlidingSyncConstants.defaultTimelineLimit),
+        let settings = RoomSubscription(requiredState: SlidingSyncConstants.defaultRequiredState,
+                                        timelineLimit: SlidingSyncConstants.defaultTimelineLimit,
                                         includeHeroes: false) // We don't need heroes here as they're already included in the `all_rooms` list
         await Self.subscriptionTracker.subscribe(to: roomListItem, with: settings)
         

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -66,8 +66,6 @@ protocol RoomProxyProtocol {
     
     func subscribeForUpdates() async
     
-    func unsubscribeFromUpdates() async
-    
     func timelineFocusedOnEvent(eventID: String, numberOfEvents: UInt16) async -> Result<TimelineProxyProtocol, RoomProxyError>
     
     func redact(_ eventID: String) async -> Result<Void, RoomProxyError>

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -66,7 +66,7 @@ protocol RoomProxyProtocol {
     
     func subscribeForUpdates() async
     
-    func unsubscribeFromUpdates()
+    func unsubscribeFromUpdates() async
     
     func timelineFocusedOnEvent(eventID: String, numberOfEvents: UInt16) async -> Result<TimelineProxyProtocol, RoomProxyError>
     


### PR DESCRIPTION
This PR does 2 things:
- Use the visible range publisher once again, this time to add subscriptions to the rooms so we get back the `timeline_limit: 20` behaviour.
- Removes the use of `roomListItem.unsubscribe()` (and tracking the subscription count) as this won't be part of Simplified Sliding Sync.

Closes #3007.