### PR TITLE
Fix an App Store upload error due to an RTE version mismatch.

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -5316,6 +5316,7 @@
 				8E3CD0D0BB6697512E867C1D /* Embed Foundation Extensions */,
 				98CA896D84BFD53B2554E891 /* ⚠️ SwiftLint */,
 				B35AB66424BB30087EEE408C /* 🧹 SwiftFormat */,
+				C3B6A7500AE6E2A21B1DF527 /* 🔧 Fix the Rich Text Editor */,
 			);
 			buildRules = (
 			);
@@ -5682,6 +5683,25 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftformat >/dev/null; then\n    swiftformat --lint --lenient \"$PROJECT_DIR\"\nelse\n    echo \"warning: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\nfi\n";
+		};
+		C3B6A7500AE6E2A21B1DF527 /* 🔧 Fix the Rich Text Editor */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "🔧 Fix the Rich Text Editor";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# The RTE XCFramework contains .frameworks instead of static libs. For some reason Xcode embeds the binary, but also\n# an empty framework containing a stub binary. This stub binary is generated for our app and so its version mismatches\n# the one declared by the XCFramework's Info.plist file (and we can't match it because of Element iOS).\n/usr/libexec/PlistBuddy -c \"Set :MinimumOSVersion ${IPHONEOS_DEPLOYMENT_TARGET}\" ${BUILT_PRODUCTS_DIR}/ElementX.app/Frameworks/WysiwygComposerFFI.framework/Info.plist\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "f365b5beb40745f208e5ec7cd4891301b38101ddbeae52296261f3d4a25436c7",
   "pins" : [
     {
       "identity" : "compound-design-tokens",
@@ -288,5 +289,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -174,6 +174,15 @@ targets:
         else
             echo "warning: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat"
         fi
+    - name: 🔧 Fix the Rich Text Editor
+      runOnlyWhenInstalling: false
+      basedOnDependencyAnalysis: false
+      shell: /bin/sh
+      script: |
+        # The RTE XCFramework contains .frameworks instead of static libs. For some reason Xcode embeds the binary, but also
+        # an empty framework containing a stub binary. This stub binary is generated for our app and so its version mismatches
+        # the one declared by the XCFramework's Info.plist file (and we can't match it because of Element iOS).
+        /usr/libexec/PlistBuddy -c "Set :MinimumOSVersion ${IPHONEOS_DEPLOYMENT_TARGET}" ${BUILT_PRODUCTS_DIR}/ElementX.app/Frameworks/WysiwygComposerFFI.framework/Info.plist
 
     dependencies:
     - target: NSE


### PR DESCRIPTION
ElementX.app/Frameworks/WysiwygComposerFFI.framework contains a `WysiwygComposerFFI` stub binary that's autogenerated by Xcode. Its minimum OS version (as described by `otool`) matches the project instead of the framework's Info.plist, so this PR fixes the Info.plist to match our project.