### PR TITLE
Fix RTE framework signature error when building DEBUG builds for a device.

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -5701,7 +5701,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# The RTE XCFramework contains .frameworks instead of static libs. For some reason Xcode embeds the binary, but also\n# an empty framework containing a stub binary. This stub binary is generated for our app and so its version mismatches\n# the one declared by the XCFramework's Info.plist file (and we can't match it because of Element iOS).\n/usr/libexec/PlistBuddy -c \"Set :MinimumOSVersion ${IPHONEOS_DEPLOYMENT_TARGET}\" ${BUILT_PRODUCTS_DIR}/ElementX.app/Frameworks/WysiwygComposerFFI.framework/Info.plist\n";
+			shellScript = "# The RTE XCFramework contains .frameworks instead of static libs. For some reason Xcode embeds the binary, but also\n# an empty framework containing a stub binary. This stub binary is generated for our app and so its version mismatches\n# the one declared by the XCFramework's Info.plist file (and we can't match it because of Element iOS). ASC doesn't like this.\nif [ \"$CONFIGURATION\" == \"Release\" ]; then\n    # On the other hand local device builds detect a signature change, so only do this when in Release mode.\n    # Not ideal but helps us most of the time and we can remove this run phase locally if needed.\n    /usr/libexec/PlistBuddy -c \"Set :MinimumOSVersion ${IPHONEOS_DEPLOYMENT_TARGET}\" ${BUILT_PRODUCTS_DIR}/ElementX.app/Frameworks/WysiwygComposerFFI.framework/Info.plist\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -181,8 +181,12 @@ targets:
       script: |
         # The RTE XCFramework contains .frameworks instead of static libs. For some reason Xcode embeds the binary, but also
         # an empty framework containing a stub binary. This stub binary is generated for our app and so its version mismatches
-        # the one declared by the XCFramework's Info.plist file (and we can't match it because of Element iOS).
-        /usr/libexec/PlistBuddy -c "Set :MinimumOSVersion ${IPHONEOS_DEPLOYMENT_TARGET}" ${BUILT_PRODUCTS_DIR}/ElementX.app/Frameworks/WysiwygComposerFFI.framework/Info.plist
+        # the one declared by the XCFramework's Info.plist file (and we can't match it because of Element iOS). ASC doesn't like this.
+        if [ "$CONFIGURATION" == "Release" ]; then
+            # On the other hand local device builds detect a signature change, so only do this when in Release mode.
+            # Not ideal but helps us most of the time and we can remove this run phase locally if needed.
+            /usr/libexec/PlistBuddy -c "Set :MinimumOSVersion ${IPHONEOS_DEPLOYMENT_TARGET}" ${BUILT_PRODUCTS_DIR}/ElementX.app/Frameworks/WysiwygComposerFFI.framework/Info.plist
+        fi
 
     dependencies:
     - target: NSE


### PR DESCRIPTION
Follow on from #3029 there is now a bug when trying to build locally for a device:

![Screenshot 2024-07-15 at 3 12 32 PM](https://github.com/user-attachments/assets/70d8e41c-a177-4401-8cb7-51ee023f22fc)

I tried using the condition of `"$ACTION" == "archive"` but that didn't work so for now just setting it to only run for release builds.