### PR TITLE
Update RTE with inline prediction working

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -7404,7 +7404,7 @@
 			repositoryURL = "https://github.com/matrix-org/matrix-rich-text-editor-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 2.37.5;
+				version = 2.37.6;
 			};
 		};
 		4BDA7F6042968E8422470F3F /* XCRemoteSwiftPackageReference "LoremSwiftum" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-rich-text-editor-swift",
       "state" : {
-        "revision" : "acf0821a87ded426afe59647e578464f840eff43",
-        "version" : "2.37.5"
+        "revision" : "3f45e8e04d6998fc02fee4212f214a90687f42d7",
+        "version" : "2.37.6"
       }
     },
     {

--- a/project.yml
+++ b/project.yml
@@ -79,7 +79,7 @@ packages:
     # path: ../swift-ogg
   WysiwygComposer:
     url: https://github.com/matrix-org/matrix-rich-text-editor-swift
-    exactVersion: 2.37.5
+    exactVersion: 2.37.6
     # path: ../matrix-rich-text-editor/platforms/ios/lib/WysiwygComposer
   
   # External dependencies


### PR DESCRIPTION
This new version of RTE re-enables inline predictive text and fixes a bunch of issues with it.