### PR TITLE
Fixes #2840 - Use both the room list room and the room preview details to populate the join room screen

### DIFF
--- a/ElementX/Sources/Screens/JoinRoomScreen/JoinRoomScreenModels.swift
+++ b/ElementX/Sources/Screens/JoinRoomScreen/JoinRoomScreenModels.swift
@@ -29,11 +29,19 @@ enum JoinRoomScreenInteractionMode {
     case knock
 }
 
+struct JoinRoomScreenRoomDetails {
+    let name: String?
+    let topic: String?
+    let canonicalAlias: String?
+    let avatar: RoomAvatar
+    let memberCount: UInt
+}
+
 struct JoinRoomScreenViewState: BindableState {
     // Maybe use room summary details or similar here??
     let roomID: String
     
-    var roomDetails: RoomPreviewDetails?
+    var roomDetails: JoinRoomScreenRoomDetails?
     
     var mode: JoinRoomScreenInteractionMode = .loading
     
@@ -52,7 +60,7 @@ struct JoinRoomScreenViewState: BindableState {
     }
     
     var avatar: RoomAvatar {
-        .room(id: roomID, name: title, avatarURL: roomDetails?.avatarURL)
+        roomDetails?.avatar ?? .room(id: roomID, name: title, avatarURL: nil)
     }
 }
 

--- a/PreviewTests/__Snapshots__/PreviewTests/test_joinRoomScreen-iPad-en-GB.Unknown.png
+++ b/PreviewTests/__Snapshots__/PreviewTests/test_joinRoomScreen-iPad-en-GB.Unknown.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a0b850d16e626197c8ce12f6b6467284adefaf19295b2c75deb13599bda4796f
-size 1963867
+oid sha256:d101e405e058e332a699eb6c2db1ab38b15966e06b185b2241be78608dd1939e
+size 1959342

--- a/PreviewTests/__Snapshots__/PreviewTests/test_joinRoomScreen-iPad-pseudo.Unknown.png
+++ b/PreviewTests/__Snapshots__/PreviewTests/test_joinRoomScreen-iPad-pseudo.Unknown.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b3cb6c41cb549203b7bae407d7dd9bc11381a1f15087d148dd067dbaab819e75
-size 1977775
+oid sha256:d101e405e058e332a699eb6c2db1ab38b15966e06b185b2241be78608dd1939e
+size 1959342


### PR DESCRIPTION
- the room summary API is indeed enabled on matrix.org and working fine for most rooms
- it is not however capable of giving us data about non-joined + private rooms
- the SDK addresses that by first trying to use known rooms before resorting to the preview endpoint
- that fails if it's a brand new room that the client doesn't know about yet i.e. a sync hasn't ran, which is exactly what's happening here
- the ClientProxy instead does wait for the room list to go into the first loaded before returning the room

