### PR TITLE
Fix the restoration of a Simplified Sliding Sync session.

### DIFF
--- a/ElementX/Sources/Services/UserSession/RestorationToken.swift
+++ b/ElementX/Sources/Services/UserSession/RestorationToken.swift
@@ -47,7 +47,8 @@ extension MatrixRustSDK.Session: Codable {
                          deviceId: container.decode(String.self, forKey: .deviceId),
                          homeserverUrl: container.decode(String.self, forKey: .homeserverUrl),
                          oidcData: container.decodeIfPresent(String.self, forKey: .oidcData),
-                         slidingSyncProxy: container.decode(String.self, forKey: .slidingSyncProxy))
+                         // Note: the proxy is optional now that we support Simplified Sliding Sync.
+                         slidingSyncProxy: container.decodeIfPresent(String.self, forKey: .slidingSyncProxy))
     }
     
     public func encode(to encoder: Encoder) throws {

--- a/UnitTests/Sources/KeychainControllerTests.swift
+++ b/UnitTests/Sources/KeychainControllerTests.swift
@@ -127,6 +127,28 @@ class KeychainControllerTests: XCTestCase {
         XCTAssertNotNil(keychain.restorationTokenForUsername("@test4:example.com"), "The restoration token should not have been deleted.")
     }
     
+    func testSimplifiedSlidingSyncRestorationToken() {
+        // Given an empty keychain.
+        XCTAssertTrue(keychain.restorationTokens().isEmpty, "The keychain should be empty to begin with.")
+        
+        // When adding an restoration token that doesn't contain a sliding sync proxy (e.g. for SSS).
+        let username = "@test:example.com"
+        let restorationToken = RestorationToken(session: .init(accessToken: "accessToken",
+                                                               refreshToken: "refreshToken",
+                                                               userId: "userId",
+                                                               deviceId: "deviceId",
+                                                               homeserverUrl: "homeserverUrl",
+                                                               oidcData: "oidcData",
+                                                               slidingSyncProxy: nil),
+                                                sessionDirectory: .homeDirectory.appending(component: UUID().uuidString),
+                                                passphrase: "passphrase",
+                                                pusherNotificationClientIdentifier: "pusherClientID")
+        keychain.setRestorationToken(restorationToken, forUsername: username)
+        
+        // Then decoding the restoration token from the keychain should still work.
+        XCTAssertEqual(keychain.restorationTokenForUsername(username), restorationToken, "The retrieved restoration token should match the value that was stored.")
+    }
+    
     func testAddPINCode() throws {
         // Given a keychain without a PIN code set.
         try XCTAssertFalse(keychain.containsPINCode(), "A new keychain shouldn't contain a PIN code.")


### PR DESCRIPTION
This fixes the following bugs:

- Force closing the app signs you out.
- Clearing the cache in Developer Options signs you out.
- Missing verification/restoration prompts.