### PR TITLE
Fix a crash experienced when trying to report a crash.

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -112,10 +112,10 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
         notificationManager = NotificationManager(notificationCenter: UNUserNotificationCenter.current(),
                                                   appSettings: appSettings)
         
+        Self.setupServiceLocator(appSettings: appSettings, appHooks: appHooks)
         Self.setupSentry(appSettings: appSettings)
         
-        Self.setupServiceLocator(appSettings: appSettings, appHooks: appHooks)
-        
+        ServiceLocator.shared.analytics.signpost.start()
         ServiceLocator.shared.analytics.startIfEnabled()
         
         windowManager.delegate = self


### PR DESCRIPTION
Sentry needs to be created after the ServiceLocator because of the onLastCrash closure. Additionally, out `Signpost` (which lives in the `AnalyticsService` inside the locator) shouldn't start talking to Sentry until it has been configured.