### PR TITLE
Fix a potential crash when logging out.

### DIFF
--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -288,11 +288,14 @@ class ClientProxy: ClientProxyProtocol {
             restartTask = nil
         }
         
-        Task {
+        // Capture the sync service strongly as this method is called on deinit and so the
+        // existence of self when the Task executes is questionable and would sometimes crash.
+        Task { [syncService] in
             do {
                 defer {
                     completion?()
                 }
+                
                 try await syncService?.stop()
             } catch {
                 MXLog.error("Failed stopping the sync service with error: \(error)")


### PR DESCRIPTION
There was something like a 30% chance that a logout would crash, we tracked it down to the use of `self` in the stopSync task.