### PR TITLE
Fix a bug where moving a new line in the composer could move the caret.

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/MessageComposerTextField.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/MessageComposerTextField.swift
@@ -105,6 +105,9 @@ private struct UITextViewWrapper: UIViewRepresentable {
                                      .foregroundColor: UIColor(.compound.textPrimary)]
         
         if textView.attributedText != text {
+            // Remember the selection if only the attributes have changed.
+            let selection = textView.attributedText.string == text.string ? textView.selectedTextRange : nil
+            
             textView.attributedText = text
             
             // Re-apply the default font when setting text for e.g. edits.
@@ -120,6 +123,11 @@ private struct UITextViewWrapper: UIViewRepresentable {
                     textView.keyboardType = .default
                     textView.reloadInputViews()
                 }
+            } else if let selection {
+                // Fixes a bug where pressing Return in the middle of two paragraphs
+                // moves the caret back to the bottom of the composer.
+                // https://github.com/element-hq/element-x-ios/issues/3104
+                textView.selectedTextRange = selection
             }
         }
     }


### PR DESCRIPTION
Fixes #3104.

The diffs revealed some missing attributes on the new line so I'm only restoring the selection when the plain string is unchanged.