### PR TITLE
Fixes #3050 - Sync mute state between ElementCall and CallKit

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -838,8 +838,7 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
     private func startSync() {
         guard let userSession else { return }
         
-        // FIXME: replace this with `user_id_server_name` from https://github.com/matrix-org/matrix-rust-sdk/pull/3617
-        let serverName = String(userSession.clientProxy.userID.split(separator: ":").last ?? "Unknown")
+        let serverName = String(userSession.clientProxy.userIDServerName ?? "Unknown")
         
         ServiceLocator.shared.analytics.signpost.beginFirstSync(serverName: serverName)
         userSession.clientProxy.startSync()

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -5007,17 +5007,17 @@ class ElementCallServiceMock: ElementCallServiceProtocol {
         tearDownCallSessionCallsCount += 1
         tearDownCallSessionClosure?()
     }
-    //MARK: - setCallMuted
+    //MARK: - setAudioEnabled
 
-    var setCallMutedRoomIDUnderlyingCallsCount = 0
-    var setCallMutedRoomIDCallsCount: Int {
+    var setAudioEnabledRoomIDUnderlyingCallsCount = 0
+    var setAudioEnabledRoomIDCallsCount: Int {
         get {
             if Thread.isMainThread {
-                return setCallMutedRoomIDUnderlyingCallsCount
+                return setAudioEnabledRoomIDUnderlyingCallsCount
             } else {
                 var returnValue: Int? = nil
                 DispatchQueue.main.sync {
-                    returnValue = setCallMutedRoomIDUnderlyingCallsCount
+                    returnValue = setAudioEnabledRoomIDUnderlyingCallsCount
                 }
 
                 return returnValue!
@@ -5025,28 +5025,28 @@ class ElementCallServiceMock: ElementCallServiceProtocol {
         }
         set {
             if Thread.isMainThread {
-                setCallMutedRoomIDUnderlyingCallsCount = newValue
+                setAudioEnabledRoomIDUnderlyingCallsCount = newValue
             } else {
                 DispatchQueue.main.sync {
-                    setCallMutedRoomIDUnderlyingCallsCount = newValue
+                    setAudioEnabledRoomIDUnderlyingCallsCount = newValue
                 }
             }
         }
     }
-    var setCallMutedRoomIDCalled: Bool {
-        return setCallMutedRoomIDCallsCount > 0
+    var setAudioEnabledRoomIDCalled: Bool {
+        return setAudioEnabledRoomIDCallsCount > 0
     }
-    var setCallMutedRoomIDReceivedArguments: (muted: Bool, roomID: String)?
-    var setCallMutedRoomIDReceivedInvocations: [(muted: Bool, roomID: String)] = []
-    var setCallMutedRoomIDClosure: ((Bool, String) -> Void)?
+    var setAudioEnabledRoomIDReceivedArguments: (enabled: Bool, roomID: String)?
+    var setAudioEnabledRoomIDReceivedInvocations: [(enabled: Bool, roomID: String)] = []
+    var setAudioEnabledRoomIDClosure: ((Bool, String) -> Void)?
 
-    func setCallMuted(_ muted: Bool, roomID: String) {
-        setCallMutedRoomIDCallsCount += 1
-        setCallMutedRoomIDReceivedArguments = (muted: muted, roomID: roomID)
+    func setAudioEnabled(_ enabled: Bool, roomID: String) {
+        setAudioEnabledRoomIDCallsCount += 1
+        setAudioEnabledRoomIDReceivedArguments = (enabled: enabled, roomID: roomID)
         DispatchQueue.main.async {
-            self.setCallMutedRoomIDReceivedInvocations.append((muted: muted, roomID: roomID))
+            self.setAudioEnabledRoomIDReceivedInvocations.append((enabled: enabled, roomID: roomID))
         }
-        setCallMutedRoomIDClosure?(muted, roomID)
+        setAudioEnabledRoomIDClosure?(enabled, roomID)
     }
 }
 class ElementCallWidgetDriverMock: ElementCallWidgetDriverProtocol {

--- a/ElementX/Sources/Services/ElementCall/ElementCallService.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallService.swift
@@ -118,7 +118,7 @@ class ElementCallService: NSObject, ElementCallServiceProtocol, PKPushRegistryDe
         tearDownCallSession(sendEndCallAction: true)
     }
     
-    func setCallMuted(_ muted: Bool, roomID: String) {
+    func setAudioEnabled(_ enabled: Bool, roomID: String) {
         guard let ongoingCallID else {
             MXLog.error("Failed toggling call microphone, no calls running")
             return
@@ -129,7 +129,7 @@ class ElementCallService: NSObject, ElementCallServiceProtocol, PKPushRegistryDe
             return
         }
         
-        let transaction = CXTransaction(action: CXSetMutedCallAction(call: ongoingCallID.callKitID, muted: muted))
+        let transaction = CXTransaction(action: CXSetMutedCallAction(call: ongoingCallID.callKitID, muted: !enabled))
         callController.request(transaction) { error in
             if let error {
                 MXLog.error("Failed toggling call microphone with error: \(error)")
@@ -211,16 +211,13 @@ class ElementCallService: NSObject, ElementCallServiceProtocol, PKPushRegistryDe
     }
     
     func provider(_ provider: CXProvider, perform action: CXSetMutedCallAction) {
-        // if let ongoingCallID {
-        //    actionsSubject.send(.setCallMuted(action.isMuted, roomID: ongoingCallID.roomID))
-        // } else {
-        //     MXLog.error("Failed muting/unmuting call, missing ongoingCallID")
-        // }
-        //
-        // action.fulfill()
+        if let ongoingCallID {
+            actionsSubject.send(.setAudioEnabled(!action.isMuted, roomID: ongoingCallID.roomID))
+        } else {
+            MXLog.error("Failed muting/unmuting call, missing ongoingCallID")
+        }
         
-        // TODO: EC doesn't expose controls for this yet. Fail the action for now.
-        action.fail()
+        action.fulfill()
     }
     
     func provider(_ provider: CXProvider, perform action: CXEndCallAction) {

--- a/ElementX/Sources/Services/ElementCall/ElementCallServiceProtocol.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallServiceProtocol.swift
@@ -19,7 +19,7 @@ import Combine
 enum ElementCallServiceAction {
     case startCall(roomID: String)
     case endCall(roomID: String)
-    case setCallMuted(_ muted: Bool, roomID: String)
+    case setAudioEnabled(_ enabled: Bool, roomID: String)
 }
 
 // sourcery: AutoMockable
@@ -32,5 +32,5 @@ protocol ElementCallServiceProtocol {
     
     func tearDownCallSession()
     
-    func setCallMuted(_ muted: Bool, roomID: String)
+    func setAudioEnabled(_ enabled: Bool, roomID: String)
 }

--- a/ElementX/Sources/Services/ElementCall/ElementCallWidgetDriverProtocol.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallWidgetDriverProtocol.swift
@@ -28,6 +28,7 @@ enum ElementCallWidgetDriverError: Error {
 
 enum ElementCallWidgetDriverAction {
     case callEnded
+    case mediaStateChanged(audioEnabled: Bool, videoEnabled: Bool)
 }
 
 // sourcery: AutoMockable


### PR DESCRIPTION
* listen to changes in the mute state and sync up the CallKit controls with ElementCall and back
* rewrite how we construct and pass custom messages between the ElementCall widget and the widget driver


https://github.com/user-attachments/assets/6c84d9c7-c5f2-4846-9db7-40422c31220b

