### PR TITLE
Make sure the whole room header is tappable.

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
@@ -163,6 +163,7 @@ struct RoomScreen: View {
                            roomAvatar: context.viewState.roomAvatar,
                            imageProvider: context.imageProvider)
                 // Using a button stops it from getting truncated in the navigation bar
+                .contentShape(.rect)
                 .onTapGesture {
                     context.send(viewAction: .displayRoomDetails)
                 }


### PR DESCRIPTION
The space between the avatar and the label wasn't which is probably fine on iOS but definitely noticeable on macOS.