### PR TITLE
Force the room list search text field to always be displayed

### DIFF
--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreenContent.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreenContent.swift
@@ -65,7 +65,7 @@ struct HomeScreenContent: View {
                         }
                     }
                     .isSearching($context.isSearchFieldFocused)
-                    .searchable(text: $context.searchQuery)
+                    .searchable(text: $context.searchQuery, placement: .navigationBarDrawer(displayMode: .always))
                     .compoundSearchField()
                     .disableAutocorrection(true)
                 case .migration:

--- a/PreviewTests/__Snapshots__/PreviewTests/test_homeScreen-iPad-en-GB.Loaded.png
+++ b/PreviewTests/__Snapshots__/PreviewTests/test_homeScreen-iPad-en-GB.Loaded.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4e367b0c42e5fc7912bbb2e8d8d2761b4698ec7d7ebf769e8bc0f901f7e199e8
-size 252596
+oid sha256:686f15681b9b6c0dc437f5fa2832ee83272f0dfb6a81d1429c8e629a7bceefab
+size 249090

--- a/PreviewTests/__Snapshots__/PreviewTests/test_homeScreen-iPad-pseudo.Loaded.png
+++ b/PreviewTests/__Snapshots__/PreviewTests/test_homeScreen-iPad-pseudo.Loaded.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0e53d73c473a9a87103a62cbf0d8151f30716171232de6345b5f7f9ecb8fdd1f
-size 258906
+oid sha256:289e097c870f4feb95855c4895211585b364647b8b92a2f83da609a7ee49fca0
+size 256877

--- a/PreviewTests/__Snapshots__/PreviewTests/test_homeScreen-iPhone-15-en-GB.Loaded.png
+++ b/PreviewTests/__Snapshots__/PreviewTests/test_homeScreen-iPhone-15-en-GB.Loaded.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fafa765065540bb81542b6358de759c269a9dc810b72ee1460f69a09cc1b35c5
-size 178100
+oid sha256:38344dcbf240f85d2210b1edbd5f9b840122a0b79b3bfdf136306105c5085f44
+size 178099

--- a/PreviewTests/__Snapshots__/PreviewTests/test_homeScreen-iPhone-15-pseudo.Loaded.png
+++ b/PreviewTests/__Snapshots__/PreviewTests/test_homeScreen-iPhone-15-pseudo.Loaded.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f1fb8fbf4d90d9ffb578432ddf08256fb2854431751c91dc7dfde90b17c1fa5e
-size 180705
+oid sha256:6629655cd250a07ee2a0ddcbf29517c1972c715dfdf4874e7d9e015f575138b5
+size 180703


### PR DESCRIPTION
- while looking into fixes we noticed that we can more easily break the layout when the search field is automatically hidden