### PR TITLE
Fixes #3126 - Prevent identity confirmation from blocking the user's progress after registering through OIDC

### DIFF
--- a/ElementX/Sources/FlowCoordinators/OnboardingFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/OnboardingFlowCoordinator.swift
@@ -231,7 +231,7 @@ class OnboardingFlowCoordinator: FlowCoordinatorProtocol {
                 presentRecoveryKeyScreen()
             case .skip:
                 appSettings.hasRunIdentityConfirmationOnboarding = true
-                stateMachine.tryEvent(.next)
+                stateMachine.tryEvent(.nextSkippingIdentityConfimed)
             case .reset:
                 presentEncryptionResetScreen()
             }
@@ -246,10 +246,14 @@ class OnboardingFlowCoordinator: FlowCoordinatorProtocol {
                 .map(\.verificationState)
                 .removeDuplicates()
                 .sink { [weak self] value in
+                    guard let self else { return }
+                    
                     if value == .verified {
-                        self?.stateMachine.tryEvent(.nextSkippingIdentityConfimed)
+                        appSettings.hasRunIdentityConfirmationOnboarding = true
+                        stateMachine.tryEvent(.nextSkippingIdentityConfimed)
                     } else {
-                        verificationStateCancellable = nil
+                        // Captured by the block below, nil-ing it wouldn't work
+                        verificationStateCancellable?.cancel()
                     }
                 }
         }


### PR DESCRIPTION
- happened because `hasRunIdentityConfirmationOnboarding` is false while the verification state is still `.unknown`
- verification eventually changes to `.verified` but the flow coordinator doesn't catch up on it and blocks the flow