### PR TITLE
Navigation support for upcoming Element Call Picture in Picture mode.

### DIFF
--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -252,7 +252,8 @@ final class AppSettings {
 
     // MARK: - Element Call
     
-    let elementCallBaseURL: URL = "https://call.element.io"
+    #warning("Temporary base URL whilst PiP support is being added.")
+    let elementCallBaseURL: URL = "https://pr2563--element-call.netlify.app/"
     
     @UserPreference(key: UserDefaultsKeys.elementCallBaseURLOverride, defaultValue: nil, storageType: .userDefaults(store))
     var elementCallBaseURLOverride: URL?

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -252,8 +252,7 @@ final class AppSettings {
 
     // MARK: - Element Call
     
-    #warning("Temporary base URL whilst PiP support is being added.")
-    let elementCallBaseURL: URL = "https://pr2563--element-call.netlify.app/"
+    let elementCallBaseURL: URL = "https://call.element.io"
     
     @UserPreference(key: UserDefaultsKeys.elementCallBaseURLOverride, defaultValue: nil, storageType: .userDefaults(store))
     var elementCallBaseURLOverride: URL?
@@ -289,6 +288,9 @@ final class AppSettings {
     
     @UserPreference(key: UserDefaultsKeys.timelineItemAuthenticityEnabled, defaultValue: false, storageType: .userDefaults(store))
     var timelineItemAuthenticityEnabled
+    
+    // Not user configurable as it depends on work in EC too.
+    let elementCallPictureInPictureEnabled = false
         
     #endif
     

--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+import AVKit
 import Combine
 import SwiftUI
 
@@ -557,7 +558,14 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
         
     // MARK: Calls
     
+    private var callScreenPictureInPictureController: AVPictureInPictureController?
     private func presentCallScreen(roomProxy: RoomProxyProtocol) {
+        guard elementCallService.ongoingCallRoomID != roomProxy.id else {
+            MXLog.info("Returning to existing call.")
+            callScreenPictureInPictureController?.stopPictureInPicture()
+            return
+        }
+        
         let colorScheme: ColorScheme = appMediator.windowManager.mainWindow.traitCollection.userInterfaceStyle == .light ? .light : .dark
         let callScreenCoordinator = CallScreenCoordinator(parameters: .init(elementCallService: elementCallService,
                                                                             clientProxy: userSession.clientProxy,
@@ -570,13 +578,18 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
         
         callScreenCoordinator.actions
             .sink { [weak self] action in
+                guard let self else { return }
                 switch action {
-                case .hide:
-                    self?.navigationSplitCoordinator.setOverlayPresentationMode(.minimized)
-                case .show:
-                    self?.navigationSplitCoordinator.setOverlayPresentationMode(.fullScreen)
+                case .pictureInPictureStarted(let controller):
+                    MXLog.info("Hiding call for PiP presentation.")
+                    callScreenPictureInPictureController = controller
+                    navigationSplitCoordinator.setOverlayPresentationMode(.minimized)
+                case .pictureInPictureStopped:
+                    MXLog.info("Restoring call after PiP presentation.")
+                    navigationSplitCoordinator.setOverlayPresentationMode(.fullScreen)
+                    callScreenPictureInPictureController = nil
                 case .dismiss:
-                    self?.navigationSplitCoordinator.setOverlayCoordinator(nil)
+                    navigationSplitCoordinator.setOverlayCoordinator(nil)
                 }
             }
             .store(in: &cancellables)

--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -573,6 +573,7 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
                                                                             clientID: InfoPlistReader.main.bundleIdentifier,
                                                                             elementCallBaseURL: appSettings.elementCallBaseURL,
                                                                             elementCallBaseURLOverride: appSettings.elementCallBaseURLOverride,
+                                                                            elementCallPictureInPictureEnabled: appSettings.elementCallPictureInPictureEnabled,
                                                                             colorScheme: colorScheme,
                                                                             appHooks: appHooks))
         

--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -571,13 +571,17 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
         callScreenCoordinator.actions
             .sink { [weak self] action in
                 switch action {
+                case .hide:
+                    self?.navigationSplitCoordinator.setOverlayPresentationMode(.minimized)
+                case .show:
+                    self?.navigationSplitCoordinator.setOverlayPresentationMode(.fullScreen)
                 case .dismiss:
-                    self?.navigationSplitCoordinator.setSheetCoordinator(nil)
+                    self?.navigationSplitCoordinator.setOverlayCoordinator(nil)
                 }
             }
             .store(in: &cancellables)
         
-        navigationSplitCoordinator.setSheetCoordinator(callScreenCoordinator, animated: true)
+        navigationSplitCoordinator.setOverlayCoordinator(callScreenCoordinator, animated: true)
         
         analytics.track(screen: .RoomCall)
     }

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -4894,6 +4894,7 @@ class ElementCallServiceMock: ElementCallServiceProtocol {
         set(value) { underlyingActions = value }
     }
     var underlyingActions: AnyPublisher<ElementCallServiceAction, Never>!
+    var ongoingCallRoomID: String?
 
     //MARK: - setClientProxy
 

--- a/ElementX/Sources/Screens/CallScreen/CallScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenCoordinator.swift
@@ -25,6 +25,7 @@ struct CallScreenCoordinatorParameters {
     let clientID: String
     let elementCallBaseURL: URL
     let elementCallBaseURLOverride: URL?
+    let elementCallPictureInPictureEnabled: Bool
     let colorScheme: ColorScheme
     let appHooks: AppHooks
 }
@@ -54,6 +55,7 @@ final class CallScreenCoordinator: CoordinatorProtocol {
                                         clientID: parameters.clientID,
                                         elementCallBaseURL: parameters.elementCallBaseURL,
                                         elementCallBaseURLOverride: parameters.elementCallBaseURLOverride,
+                                        elementCallPictureInPictureEnabled: parameters.elementCallPictureInPictureEnabled,
                                         colorScheme: parameters.colorScheme,
                                         appHooks: parameters.appHooks)
     }

--- a/ElementX/Sources/Screens/CallScreen/CallScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenCoordinator.swift
@@ -29,6 +29,11 @@ struct CallScreenCoordinatorParameters {
 }
 
 enum CallScreenCoordinatorAction {
+    /// The call is still ongoing but the user wishes to navigate around the app.
+    case hide
+    /// The call is hidden and the user wishes to return to it.
+    case show
+    /// The call is finished and the screen is done with.
     case dismiss
 }
 
@@ -62,6 +67,18 @@ final class CallScreenCoordinator: CoordinatorProtocol {
             }
         }
         .store(in: &cancellables)
+        
+        NotificationCenter.default.publisher(for: .init("AVPictureInPictureControllerWillStartNotification"))
+            .sink { [weak self] _ in
+                self?.actionsSubject.send(.hide)
+            }
+            .store(in: &cancellables)
+        
+        NotificationCenter.default.publisher(for: .init("AVPictureInPictureControllerWillStopNotification"))
+            .sink { [weak self] _ in
+                self?.actionsSubject.send(.show)
+            }
+            .store(in: &cancellables)
     }
     
     func stop() {

--- a/ElementX/Sources/Screens/CallScreen/CallScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenCoordinator.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+import AVKit
 import Combine
 import SwiftUI
 
@@ -30,9 +31,9 @@ struct CallScreenCoordinatorParameters {
 
 enum CallScreenCoordinatorAction {
     /// The call is still ongoing but the user wishes to navigate around the app.
-    case hide
+    case pictureInPictureStarted(AVPictureInPictureController?)
     /// The call is hidden and the user wishes to return to it.
-    case show
+    case pictureInPictureStopped
     /// The call is finished and the screen is done with.
     case dismiss
 }
@@ -62,23 +63,15 @@ final class CallScreenCoordinator: CoordinatorProtocol {
             guard let self else { return }
             
             switch action {
+            case .pictureInPictureStarted(let controller):
+                actionsSubject.send(.pictureInPictureStarted(controller))
+            case .pictureInPictureStopped:
+                actionsSubject.send(.pictureInPictureStopped)
             case .dismiss:
                 actionsSubject.send(.dismiss)
             }
         }
         .store(in: &cancellables)
-        
-        NotificationCenter.default.publisher(for: .init("AVPictureInPictureControllerWillStartNotification"))
-            .sink { [weak self] _ in
-                self?.actionsSubject.send(.hide)
-            }
-            .store(in: &cancellables)
-        
-        NotificationCenter.default.publisher(for: .init("AVPictureInPictureControllerWillStopNotification"))
-            .sink { [weak self] _ in
-                self?.actionsSubject.send(.show)
-            }
-            .store(in: &cancellables)
     }
     
     func stop() {

--- a/ElementX/Sources/Screens/CallScreen/CallScreenModels.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenModels.swift
@@ -14,9 +14,12 @@
 // limitations under the License.
 //
 
+import AVKit
 import Foundation
 
 enum CallScreenViewModelAction {
+    case pictureInPictureStarted(AVPictureInPictureController?)
+    case pictureInPictureStopped
     case dismiss
 }
 
@@ -39,4 +42,5 @@ struct Bindings {
 
 enum CallScreenViewAction {
     case urlChanged(URL?)
+    case navigateBack
 }

--- a/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
@@ -24,6 +24,7 @@ typealias CallScreenViewModelType = StateStoreViewModel<CallScreenViewState, Cal
 class CallScreenViewModel: CallScreenViewModelType, CallScreenViewModelProtocol {
     private let elementCallService: ElementCallServiceProtocol
     private let roomProxy: RoomProxyProtocol
+    private let isPictureInPictureEnabled: Bool
     
     private let widgetDriver: ElementCallWidgetDriverProtocol
     
@@ -46,12 +47,14 @@ class CallScreenViewModel: CallScreenViewModelType, CallScreenViewModelProtocol 
          clientID: String,
          elementCallBaseURL: URL,
          elementCallBaseURLOverride: URL?,
+         elementCallPictureInPictureEnabled: Bool,
          colorScheme: ColorScheme,
          appHooks: AppHooks) {
         guard let deviceID = clientProxy.deviceID else { fatalError("Missing device ID for the call.") }
         
         self.elementCallService = elementCallService
         self.roomProxy = roomProxy
+        isPictureInPictureEnabled = elementCallPictureInPictureEnabled
         
         widgetDriver = roomProxy.elementCallWidgetDriver(deviceID: deviceID)
         
@@ -200,14 +203,14 @@ class CallScreenViewModel: CallScreenViewModelType, CallScreenViewModelProtocol 
         }
         #endif
         
-        guard state.url != nil else {
+        guard isPictureInPictureEnabled, state.url != nil else {
             actionsSubject.send(.dismiss)
             return
         }
         
         Task {
             try await state.bindings.javaScriptEvaluator?("controls.enableCompatPip()")
-            // TODO: Enable this check when implemented on web.
+            // Enable this check when implemented on web.
             // if result as? Bool != true {
             //    actionsSubject.send(.dismiss)
             // }

--- a/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+import AVKit
 import CallKit
 import Combine
 import SwiftUI
@@ -151,6 +152,23 @@ class CallScreenViewModel: CallScreenViewModelType, CallScreenViewModelProtocol 
                     syncUpdateCancellable = nil
                 }
             }, receiveValue: { _ in })
+        
+        // Use did start otherwise there's a black box left on the screen during the pip controller animation.
+        NotificationCenter.default.publisher(for: .init("AVPictureInPictureControllerDidStartNotification"))
+            .sink { [weak self] notification in
+                guard let self else { return }
+                let controller = notification.object as? AVPictureInPictureController
+                actionsSubject.send(.pictureInPictureStarted(controller))
+            }
+            .store(in: &cancellables)
+        
+        NotificationCenter.default.publisher(for: .init("AVPictureInPictureControllerWillStopNotification"))
+            .sink { [weak self] _ in
+                guard let self else { return }
+                actionsSubject.send(.pictureInPictureStopped)
+                Task { try await self.state.bindings.javaScriptEvaluator?("controls.disableCompatPip()") }
+            }
+            .store(in: &cancellables)
     }
     
     override func process(viewAction: CallScreenViewAction) {
@@ -158,6 +176,8 @@ class CallScreenViewModel: CallScreenViewModelType, CallScreenViewModelProtocol 
         case .urlChanged(let url):
             guard let url else { return }
             MXLog.info("URL changed to: \(url)")
+        case .navigateBack:
+            handleBackwardsNavigation()
         }
     }
     
@@ -170,6 +190,29 @@ class CallScreenViewModel: CallScreenViewModelType, CallScreenViewModelProtocol 
     }
     
     // MARK: - Private
+    
+    private func handleBackwardsNavigation() {
+        #if targetEnvironment(simulator)
+        if UIDevice.current.isPhone {
+            MXLog.warning("The iPhone simulator doesn't support PiP.")
+            actionsSubject.send(.dismiss)
+            return
+        }
+        #endif
+        
+        guard state.url != nil else {
+            actionsSubject.send(.dismiss)
+            return
+        }
+        
+        Task {
+            try await state.bindings.javaScriptEvaluator?("controls.enableCompatPip()")
+            // TODO: Enable this check when implemented on web.
+            // if result as? Bool != true {
+            //    actionsSubject.send(.dismiss)
+            // }
+        }
+    }
     
     private func setAudioEnabled(_ enabled: Bool) async {
         let message = ElementCallWidgetMessage(direction: .toWidget,

--- a/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
+++ b/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
@@ -22,6 +22,13 @@ struct CallScreen: View {
     @ObservedObject var context: CallScreenViewModel.Context
     
     var body: some View {
+        content
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color.compound.bgCanvasDefault.ignoresSafeArea())
+    }
+    
+    @ViewBuilder
+    var content: some View {
         if context.viewState.url == nil {
             ProgressView()
         } else {

--- a/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
+++ b/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
@@ -15,6 +15,7 @@
 //
 
 import Combine
+import SFSafeSymbols
 import SwiftUI
 import WebKit
 
@@ -22,9 +23,22 @@ struct CallScreen: View {
     @ObservedObject var context: CallScreenViewModel.Context
     
     var body: some View {
-        content
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color.compound.bgCanvasDefault.ignoresSafeArea())
+        NavigationStack {
+            content
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Color.compound.bgCanvasDefault.ignoresSafeArea())
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button { context.send(viewAction: .navigateBack) } label: {
+                            Image(systemSymbol: .chevronBackward)
+                                .fontWeight(.semibold)
+                        }
+                        .offset(y: -8)
+                        // .padding(.leading, -8) // Fixes the button alignment, but harder to tap.
+                    }
+                }
+        }
     }
     
     @ViewBuilder
@@ -194,6 +208,7 @@ struct CallScreen_Previews: PreviewProvider {
     static let viewModel = {
         let clientProxy = ClientProxyMock()
         clientProxy.getElementWellKnownReturnValue = .success(nil)
+        clientProxy.deviceID = "call-device-id"
         
         let roomProxy = RoomProxyMock()
         roomProxy.sendCallNotificationIfNeeededReturnValue = .success(())

--- a/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
+++ b/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
@@ -226,6 +226,7 @@ struct CallScreen_Previews: PreviewProvider {
                                    clientID: "io.element.elementx",
                                    elementCallBaseURL: "https://call.element.io",
                                    elementCallBaseURLOverride: nil,
+                                   elementCallPictureInPictureEnabled: false,
                                    colorScheme: .light,
                                    appHooks: AppHooks())
     }()

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
@@ -156,6 +156,8 @@ final class RoomScreenCoordinator: CoordinatorProtocol {
                     actionsSubject.send(.presentRoomDetails)
                 case .displayCall:
                     actionsSubject.send(.presentCallScreen)
+                case .removeComposerFocus:
+                    composerViewModel.process(timelineAction: .removeFocus)
                 }
             }
             .store(in: &cancellables)

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
@@ -22,6 +22,7 @@ enum RoomScreenViewModelAction {
     case displayPinnedEventsTimeline
     case displayRoomDetails
     case displayCall
+    case removeComposerFocus
 }
 
 enum RoomScreenViewAction {

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -84,6 +84,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
             actionsSubject.send(.displayRoomDetails)
         case .displayCall:
             actionsSubject.send(.displayCall)
+            actionsSubject.send(.removeComposerFocus)
             analyticsService.trackInteraction(name: .MobileRoomCallButton)
         }
     }

--- a/ElementX/Sources/Services/ElementCall/ElementCallService.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallService.swift
@@ -59,6 +59,8 @@ class ElementCallService: NSObject, ElementCallServiceProtocol, PKPushRegistryDe
     
     private var ongoingCallID: CallID?
     
+    var ongoingCallRoomID: String? { ongoingCallID?.roomID }
+    
     private let actionsSubject: PassthroughSubject<ElementCallServiceAction, Never> = .init()
     var actions: AnyPublisher<ElementCallServiceAction, Never> {
         actionsSubject.eraseToAnyPublisher()

--- a/ElementX/Sources/Services/ElementCall/ElementCallServiceProtocol.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallServiceProtocol.swift
@@ -26,6 +26,8 @@ enum ElementCallServiceAction {
 protocol ElementCallServiceProtocol {
     var actions: AnyPublisher<ElementCallServiceAction, Never> { get }
     
+    var ongoingCallRoomID: String? { get }
+    
     func setClientProxy(_ clientProxy: ClientProxyProtocol)
     
     func setupCallSession(roomID: String, roomDisplayName: String) async

--- a/UnitTests/Sources/NavigationSplitCoordinatorTests.swift
+++ b/UnitTests/Sources/NavigationSplitCoordinatorTests.swift
@@ -99,6 +99,52 @@ class NavigationSplitCoordinatorTests: XCTestCase {
         assertCoordinatorsEqual(someOtherSheetCoordinator, navigationSplitCoordinator.sheetCoordinator)
     }
     
+    func testFullScreenCover() {
+        let sidebarCoordinator = SomeTestCoordinator()
+        navigationSplitCoordinator.setSidebarCoordinator(sidebarCoordinator)
+        let detailCoordinator = SomeTestCoordinator()
+        navigationSplitCoordinator.setDetailCoordinator(detailCoordinator)
+        
+        let fullScreenCoordinator = SomeTestCoordinator()
+        navigationSplitCoordinator.setFullScreenCoverCoordinator(fullScreenCoordinator)
+        
+        assertCoordinatorsEqual(sidebarCoordinator, navigationSplitCoordinator.sidebarCoordinator)
+        assertCoordinatorsEqual(detailCoordinator, navigationSplitCoordinator.detailCoordinator)
+        assertCoordinatorsEqual(fullScreenCoordinator, navigationSplitCoordinator.fullScreenCoverCoordinator)
+        
+        navigationSplitCoordinator.setFullScreenCoverCoordinator(nil)
+        
+        assertCoordinatorsEqual(sidebarCoordinator, navigationSplitCoordinator.sidebarCoordinator)
+        assertCoordinatorsEqual(detailCoordinator, navigationSplitCoordinator.detailCoordinator)
+        XCTAssertNil(navigationSplitCoordinator.fullScreenCoverCoordinator)
+    }
+    
+    func testOverlay() {
+        let sidebarCoordinator = SomeTestCoordinator()
+        navigationSplitCoordinator.setSidebarCoordinator(sidebarCoordinator)
+        let detailCoordinator = SomeTestCoordinator()
+        navigationSplitCoordinator.setDetailCoordinator(detailCoordinator)
+        
+        let overlayCoordinator = SomeTestCoordinator()
+        navigationSplitCoordinator.setOverlayCoordinator(overlayCoordinator)
+        
+        assertCoordinatorsEqual(sidebarCoordinator, navigationSplitCoordinator.sidebarCoordinator)
+        assertCoordinatorsEqual(detailCoordinator, navigationSplitCoordinator.detailCoordinator)
+        assertCoordinatorsEqual(overlayCoordinator, navigationSplitCoordinator.overlayCoordinator)
+        
+        // The coordinator should still be retained when changing the presentation mode.
+        navigationSplitCoordinator.setOverlayPresentationMode(.minimized)
+        assertCoordinatorsEqual(overlayCoordinator, navigationSplitCoordinator.overlayCoordinator)
+        navigationSplitCoordinator.setOverlayPresentationMode(.fullScreen)
+        assertCoordinatorsEqual(overlayCoordinator, navigationSplitCoordinator.overlayCoordinator)
+        
+        navigationSplitCoordinator.setOverlayCoordinator(nil)
+        
+        assertCoordinatorsEqual(sidebarCoordinator, navigationSplitCoordinator.sidebarCoordinator)
+        assertCoordinatorsEqual(detailCoordinator, navigationSplitCoordinator.detailCoordinator)
+        XCTAssertNil(navigationSplitCoordinator.overlayCoordinator)
+    }
+    
     func testSidebarReplacementCallbacks() {
         let sidebarCoordinator = SomeTestCoordinator()
         
@@ -132,6 +178,43 @@ class NavigationSplitCoordinatorTests: XCTestCase {
         }
         
         navigationSplitCoordinator.setSheetCoordinator(nil)
+        waitForExpectations(timeout: 1.0)
+    }
+    
+    func testFullScreenCoverDismissalCallback() {
+        let fullScreenCoordinator = SomeTestCoordinator()
+        
+        let expectation = expectation(description: "Wait for callback")
+        navigationSplitCoordinator.setFullScreenCoverCoordinator(fullScreenCoordinator) {
+            expectation.fulfill()
+        }
+        
+        navigationSplitCoordinator.setFullScreenCoverCoordinator(nil)
+        waitForExpectations(timeout: 1.0)
+    }
+    
+    func testOverlayDismissalCallback() {
+        let overlayCoordinator = SomeTestCoordinator()
+        
+        let expectation = expectation(description: "Wait for callback")
+        navigationSplitCoordinator.setOverlayCoordinator(overlayCoordinator) {
+            expectation.fulfill()
+        }
+        
+        navigationSplitCoordinator.setOverlayCoordinator(nil)
+        waitForExpectations(timeout: 1.0)
+    }
+    
+    func testOverlayDismissalCallbackWhenChangingMode() {
+        let overlayCoordinator = SomeTestCoordinator()
+        
+        let expectation = expectation(description: "Wait for callback")
+        expectation.isInverted = true
+        navigationSplitCoordinator.setOverlayCoordinator(overlayCoordinator) {
+            expectation.fulfill()
+        }
+        
+        navigationSplitCoordinator.setOverlayPresentationMode(.minimized)
         waitForExpectations(timeout: 1.0)
     }
     


### PR DESCRIPTION
This PR adds the initial support for EC PiP with the following changes:
- Replace the sheet with a SwiftUI fullscreen overlay (so we can hide the web view without removing it from the view hierarchy).
- Listen for AVPictureInPictureController notifications and use these to show/hide the call overlay.
- Make sure that joining the same call that's running in PiP, dismisses the PiP instead of creates a new call.
- Dismiss the composer before starting a call (as there's no longer a sheet to take the focus away).