### PR TITLE
Show message encryption authenticity warnings in the timeline.

### DIFF
--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -47,7 +47,6 @@ final class AppSettings {
         case publicSearchEnabled
         case fuzzyRoomListSearchEnabled
         case pinningEnabled
-        case timelineItemAuthenticityEnabled
     }
     
     private static var suiteName: String = InfoPlistReader.main.appGroupIdentifier
@@ -285,9 +284,6 @@ final class AppSettings {
     
     @UserPreference(key: UserDefaultsKeys.pinningEnabled, defaultValue: false, storageType: .userDefaults(store))
     var pinningEnabled
-    
-    @UserPreference(key: UserDefaultsKeys.timelineItemAuthenticityEnabled, defaultValue: false, storageType: .userDefaults(store))
-    var timelineItemAuthenticityEnabled
     
     // Not user configurable as it depends on work in EC too.
     let elementCallPictureInPictureEnabled = false

--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -562,7 +562,6 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
         let userID = userSession.clientProxy.userID
         
         let timelineItemFactory = RoomTimelineItemFactory(userID: userID,
-                                                          encryptionAuthenticityEnabled: appSettings.timelineItemAuthenticityEnabled,
                                                           attributedStringBuilder: AttributedStringBuilder(mentionBuilder: MentionBuilder()),
                                                           stateEventStringBuilder: RoomStateEventStringBuilder(userID: userID))
                 
@@ -968,7 +967,6 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
     private func presentPinnedEventsTimeline() async {
         let userID = userSession.clientProxy.userID
         let timelineItemFactory = RoomTimelineItemFactory(userID: userID,
-                                                          encryptionAuthenticityEnabled: appSettings.timelineItemAuthenticityEnabled,
                                                           attributedStringBuilder: AttributedStringBuilder(mentionBuilder: MentionBuilder()),
                                                           stateEventStringBuilder: RoomStateEventStringBuilder(userID: userID))
                 
@@ -1098,7 +1096,6 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
         let userID = userSession.clientProxy.userID
         
         let timelineItemFactory = RoomTimelineItemFactory(userID: userID,
-                                                          encryptionAuthenticityEnabled: appSettings.timelineItemAuthenticityEnabled,
                                                           attributedStringBuilder: AttributedStringBuilder(mentionBuilder: MentionBuilder()),
                                                           stateEventStringBuilder: RoomStateEventStringBuilder(userID: userID))
                 

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
@@ -53,7 +53,6 @@ protocol DeveloperOptionsProtocol: AnyObject {
     var elementCallBaseURLOverride: URL? { get set }
     var fuzzyRoomListSearchEnabled: Bool { get set }
     var pinningEnabled: Bool { get set }
-    var timelineItemAuthenticityEnabled: Bool { get set }
 }
 
 extension AppSettings: DeveloperOptionsProtocol { }

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
@@ -50,13 +50,6 @@ struct DeveloperOptionsScreen: View {
                     Text("Fuzzy searching")
                 }
             }
-            
-            Section("Encryption") {
-                Toggle(isOn: $context.timelineItemAuthenticityEnabled) {
-                    Text("Message authenticity warnings")
-                    Text("Requires app reboot")
-                }
-            }
                                     
             Section("Element Call") {
                 TextField(context.viewState.elementCallBaseURL.absoluteString, text: $elementCallBaseURLString)

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
@@ -24,14 +24,11 @@ struct RoomTimelineItemFactory: RoomTimelineItemFactoryProtocol {
     
     /// The Matrix ID of the current user.
     private let userID: String
-    private let encryptionAuthenticityEnabled: Bool
     
     init(userID: String,
-         encryptionAuthenticityEnabled: Bool,
          attributedStringBuilder: AttributedStringBuilderProtocol,
          stateEventStringBuilder: RoomStateEventStringBuilder) {
         self.userID = userID
-        self.encryptionAuthenticityEnabled = encryptionAuthenticityEnabled
         self.attributedStringBuilder = attributedStringBuilder
         self.stateEventStringBuilder = stateEventStringBuilder
     }
@@ -503,8 +500,7 @@ struct RoomTimelineItemFactory: RoomTimelineItemFactoryProtocol {
     }
     
     private func authenticity(_ shieldState: ShieldState?) -> EncryptionAuthenticity? {
-        guard encryptionAuthenticityEnabled else { return nil }
-        return shieldState.flatMap(EncryptionAuthenticity.init)
+        shieldState.flatMap(EncryptionAuthenticity.init)
     }
     
     // MARK: - Message events content

--- a/ElementX/Sources/UITests/UITestsAppCoordinator.swift
+++ b/ElementX/Sources/UITests/UITestsAppCoordinator.swift
@@ -637,7 +637,6 @@ class MockScreen: Identifiable {
                                                             timelineProxy: roomProxy.timeline,
                                                             initialFocussedEventID: nil,
                                                             timelineItemFactory: RoomTimelineItemFactory(userID: "@alice:matrix.org",
-                                                                                                         encryptionAuthenticityEnabled: true,
                                                                                                          attributedStringBuilder: AttributedStringBuilder(mentionBuilder: MentionBuilder()),
                                                                                                          stateEventStringBuilder: RoomStateEventStringBuilder(userID: "@alice:matrix.org")),
                                                             appSettings: ServiceLocator.shared.settings)

--- a/UnitTests/Sources/TimelineItemFactoryTests.swift
+++ b/UnitTests/Sources/TimelineItemFactoryTests.swift
@@ -24,7 +24,6 @@ class TimelineItemFactoryTests: XCTestCase {
         let senderUserID = "@bob:matrix.org"
 
         let factory = RoomTimelineItemFactory(userID: ownUserID,
-                                              encryptionAuthenticityEnabled: true,
                                               attributedStringBuilder: AttributedStringBuilder(mentionBuilder: MentionBuilder()),
                                               stateEventStringBuilder: RoomStateEventStringBuilder(userID: ownUserID))
         


### PR DESCRIPTION
Now that the feature is available on [Android](https://github.com/element-hq/element-x-android/pull/3240), we can remove the feature flag on iOS.