### PR TITLE
Use native video call picture in picture!

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -665,6 +665,7 @@
 		95690DDD9D547D3D842ACBE3 /* AnalyticsSettingsScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BD371B60E07A5324B9507EF /* AnalyticsSettingsScreenCoordinator.swift */; };
 		9586E90A447C4896C0CA3A8E /* TimelineItemReplyDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE89A8BD65CCE3FCC925CA14 /* TimelineItemReplyDetails.swift */; };
 		95E7B236F7116CACE05A6BC9 /* BlockedUsersScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A16D0F226B1819D017531647 /* BlockedUsersScreenCoordinator.swift */; };
+		9603EEF6DE980BB1D15D4707 /* UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05A3E8741D199CD1A37F4CBF /* UIView.swift */; };
 		962A4F8AD6312804E2C6BB6E /* PhotoLibraryPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A232D9156D225BD9FD1D0C43 /* PhotoLibraryPicker.swift */; };
 		964B9D2EC38C488C360CE0C9 /* HomeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B902EA6CD3296B0E10EE432B /* HomeScreen.swift */; };
 		968A5B890004526AB58A217C /* AvatarSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24B88AD3D1599E8CB1376E0 /* AvatarSize.swift */; };
@@ -1203,6 +1204,7 @@
 		054F469E433864CC6FE6EE8E /* ServerSelectionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSelectionUITests.swift; sourceTree = "<group>"; };
 		05512FB13987D221B7205DE0 /* HomeScreenRecoveryKeyConfirmationBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenRecoveryKeyConfirmationBanner.swift; sourceTree = "<group>"; };
 		05596E4A11A8C9346E9E54AE /* SoftLogoutScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoftLogoutScreenCoordinator.swift; sourceTree = "<group>"; };
+		05A3E8741D199CD1A37F4CBF /* UIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIView.swift; sourceTree = "<group>"; };
 		05AF58372CA884A789EB9C5A /* AppMediatorProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppMediatorProtocol.swift; sourceTree = "<group>"; };
 		05F598B1B346DAF223651C91 /* LoginScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginScreenCoordinator.swift; sourceTree = "<group>"; };
 		0685156EB62D7E243F097CFC /* ServerSelectionScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSelectionScreenViewModelProtocol.swift; sourceTree = "<group>"; };
@@ -3194,6 +3196,7 @@
 				40B21E611DADDEF00307E7AC /* String.swift */,
 				A40C19719687984FD9478FBE /* Task.swift */,
 				287FC98AF2664EAD79C0D902 /* UIDevice.swift */,
+				05A3E8741D199CD1A37F4CBF /* UIView.swift */,
 				BE148A4FFEE853C5A281500C /* UNNotificationContent.swift */,
 				227AC5D71A4CE43512062243 /* URL.swift */,
 				2BFDCA5A09EE70BC17F2EFA7 /* URLComponents.swift */,
@@ -6809,6 +6812,7 @@
 				384D6B9A7DFD7260139D6852 /* UITestsNotificationCenter.swift in Sources */,
 				22882C710BC99EC34A5024A0 /* UITestsScreenIdentifier.swift in Sources */,
 				706289B086B0A6B0C211763F /* UITestsSignalling.swift in Sources */,
+				9603EEF6DE980BB1D15D4707 /* UIView.swift in Sources */,
 				D02AA6208C7ACB9BE6332394 /* UNNotificationContent.swift in Sources */,
 				071A017E415AD378F2961B11 /* URL.swift in Sources */,
 				6FD8053301C5FEFA82D2F246 /* URLComponents.swift in Sources */,

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -47,6 +47,7 @@ final class AppSettings {
         case publicSearchEnabled
         case fuzzyRoomListSearchEnabled
         case pinningEnabled
+        case elementCallPictureInPictureEnabled
     }
     
     private static var suiteName: String = InfoPlistReader.main.appGroupIdentifier
@@ -285,8 +286,8 @@ final class AppSettings {
     @UserPreference(key: UserDefaultsKeys.pinningEnabled, defaultValue: false, storageType: .userDefaults(store))
     var pinningEnabled
     
-    // Not user configurable as it depends on work in EC too.
-    let elementCallPictureInPictureEnabled = false
+    @UserPreference(key: UserDefaultsKeys.elementCallPictureInPictureEnabled, defaultValue: false, storageType: .userDefaults(store))
+    var elementCallPictureInPictureEnabled
         
     #endif
     

--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -58,6 +58,7 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
     private let roomTimelineControllerFactory: RoomTimelineControllerFactoryProtocol
     private let navigationStackCoordinator: NavigationStackCoordinator
     private let emojiProvider: EmojiProviderProtocol
+    private let ongoingCallRoomIDPublisher: CurrentValuePublisher<String?, Never>
     private let appMediator: AppMediatorProtocol
     private let appSettings: AppSettings
     private let analytics: AnalyticsService
@@ -90,6 +91,7 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
          roomTimelineControllerFactory: RoomTimelineControllerFactoryProtocol,
          navigationStackCoordinator: NavigationStackCoordinator,
          emojiProvider: EmojiProviderProtocol,
+         ongoingCallRoomIDPublisher: CurrentValuePublisher<String?, Never>,
          appMediator: AppMediatorProtocol,
          appSettings: AppSettings,
          analytics: AnalyticsService,
@@ -100,6 +102,7 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
         self.roomTimelineControllerFactory = roomTimelineControllerFactory
         self.navigationStackCoordinator = navigationStackCoordinator
         self.emojiProvider = emojiProvider
+        self.ongoingCallRoomIDPublisher = ongoingCallRoomIDPublisher
         self.appMediator = appMediator
         self.appSettings = appSettings
         self.analytics = analytics
@@ -580,6 +583,7 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
                                                          voiceMessageMediaManager: userSession.voiceMessageMediaManager,
                                                          emojiProvider: emojiProvider,
                                                          completionSuggestionService: completionSuggestionService,
+                                                         ongoingCallRoomIDPublisher: ongoingCallRoomIDPublisher,
                                                          appMediator: appMediator,
                                                          appSettings: appSettings,
                                                          composerDraftService: composerDraftService)
@@ -1350,6 +1354,7 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
                                                     roomTimelineControllerFactory: roomTimelineControllerFactory,
                                                     navigationStackCoordinator: navigationStackCoordinator,
                                                     emojiProvider: emojiProvider,
+                                                    ongoingCallRoomIDPublisher: ongoingCallRoomIDPublisher,
                                                     appMediator: appMediator,
                                                     appSettings: appSettings,
                                                     analytics: analytics,

--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -580,7 +580,7 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
     
     private var callScreenPictureInPictureController: AVPictureInPictureController?
     private func presentCallScreen(configuration: ElementCallConfiguration) {
-        guard elementCallService.ongoingCallRoomID != configuration.callID else {
+        guard elementCallService.ongoingCallRoomID != configuration.callRoomID else {
             MXLog.info("Returning to existing call.")
             callScreenPictureInPictureController?.stopPictureInPicture()
             return

--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -477,6 +477,7 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
                                                     roomTimelineControllerFactory: roomTimelineControllerFactory,
                                                     navigationStackCoordinator: detailNavigationStackCoordinator,
                                                     emojiProvider: EmojiProvider(),
+                                                    ongoingCallRoomIDPublisher: elementCallService.ongoingCallRoomIDPublisher,
                                                     appMediator: appMediator,
                                                     appSettings: appSettings,
                                                     analytics: analytics,
@@ -580,7 +581,7 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
     
     private var callScreenPictureInPictureController: AVPictureInPictureController?
     private func presentCallScreen(configuration: ElementCallConfiguration) {
-        guard elementCallService.ongoingCallRoomID != configuration.callRoomID else {
+        guard elementCallService.ongoingCallRoomIDPublisher.value != configuration.callRoomID else {
             MXLog.info("Returning to existing call.")
             callScreenPictureInPictureController?.stopPictureInPicture()
             return

--- a/ElementX/Sources/Mocks/ElementCallServiceMock.swift
+++ b/ElementX/Sources/Mocks/ElementCallServiceMock.swift
@@ -17,12 +17,15 @@
 import Combine
 import Foundation
 
-struct ElementCallServiceMockConfiguration { }
+struct ElementCallServiceMockConfiguration {
+    var ongoingCallRoomID: String?
+}
 
 extension ElementCallServiceMock {
     convenience init(_ configuration: ElementCallServiceMockConfiguration) {
         self.init()
         
         underlyingActions = PassthroughSubject().eraseToAnyPublisher()
+        underlyingOngoingCallRoomIDPublisher = .init(.init(configuration.ongoingCallRoomID))
     }
 }

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -4894,7 +4894,11 @@ class ElementCallServiceMock: ElementCallServiceProtocol {
         set(value) { underlyingActions = value }
     }
     var underlyingActions: AnyPublisher<ElementCallServiceAction, Never>!
-    var ongoingCallRoomID: String?
+    var ongoingCallRoomIDPublisher: CurrentValuePublisher<String?, Never> {
+        get { return underlyingOngoingCallRoomIDPublisher }
+        set(value) { underlyingOngoingCallRoomIDPublisher = value }
+    }
+    var underlyingOngoingCallRoomIDPublisher: CurrentValuePublisher<String?, Never>!
 
     //MARK: - setClientProxy
 

--- a/ElementX/Sources/Other/Extensions/UIView.swift
+++ b/ElementX/Sources/Other/Extensions/UIView.swift
@@ -1,0 +1,30 @@
+//
+// Copyright 2024 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import SwiftUI
+
+extension UIView {
+    func addMatchedSubview(_ subview: UIView) {
+        addSubview(subview)
+        subview.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            subview.topAnchor.constraint(equalTo: topAnchor),
+            subview.leadingAnchor.constraint(equalTo: leadingAnchor),
+            subview.trailingAnchor.constraint(equalTo: trailingAnchor),
+            subview.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+}

--- a/ElementX/Sources/Screens/CallScreen/CallScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenCoordinator.swift
@@ -27,7 +27,7 @@ struct CallScreenCoordinatorParameters {
 
 enum CallScreenCoordinatorAction {
     /// The call is still ongoing but the user wishes to navigate around the app.
-    case pictureInPictureStarted(AVPictureInPictureController?)
+    case pictureInPictureStarted(AVPictureInPictureController)
     /// The call is hidden and the user wishes to return to it.
     case pictureInPictureStopped
     /// The call is finished and the screen is done with.

--- a/ElementX/Sources/Screens/CallScreen/CallScreenModels.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenModels.swift
@@ -36,7 +36,7 @@ struct CallScreenViewState: BindableState {
 struct Bindings {
     var javaScriptMessageHandler: ((Any) -> Void)?
     var javaScriptEvaluator: ((String) async throws -> Any)?
-    var requestPictureInPictureHandler: (() -> AVPictureInPictureController)?
+    var requestPictureInPictureHandler: (() async -> Result<AVPictureInPictureController, CallScreenError>)?
     
     var alertInfo: AlertInfo<UUID>?
 }
@@ -45,4 +45,10 @@ enum CallScreenViewAction {
     case urlChanged(URL?)
     case navigateBack
     case pictureInPictureWillStop
+    case endCall
+}
+
+enum CallScreenError: Error {
+    case webViewError(Error)
+    case pictureInPictureNotSupported
 }

--- a/ElementX/Sources/Screens/CallScreen/CallScreenModels.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenModels.swift
@@ -18,7 +18,7 @@ import AVKit
 import Foundation
 
 enum CallScreenViewModelAction {
-    case pictureInPictureStarted(AVPictureInPictureController?)
+    case pictureInPictureStarted(AVPictureInPictureController)
     case pictureInPictureStopped
     case dismiss
 }
@@ -36,6 +36,7 @@ struct CallScreenViewState: BindableState {
 struct Bindings {
     var javaScriptMessageHandler: ((Any) -> Void)?
     var javaScriptEvaluator: ((String) async throws -> Any)?
+    var requestPictureInPictureHandler: (() -> AVPictureInPictureController)?
     
     var alertInfo: AlertInfo<UUID>?
 }
@@ -43,4 +44,5 @@ struct Bindings {
 enum CallScreenViewAction {
     case urlChanged(URL?)
     case navigateBack
+    case pictureInPictureWillStop
 }

--- a/ElementX/Sources/Screens/CallScreen/CallScreenModels.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenModels.swift
@@ -49,6 +49,5 @@ enum CallScreenViewAction {
 }
 
 enum CallScreenError: Error {
-    case webViewError(Error)
-    case pictureInPictureNotSupported
+    case pictureInPictureNotAvailable
 }

--- a/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
+++ b/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
@@ -57,7 +57,7 @@ struct CallScreen: View {
 
 private struct CallView: UIViewRepresentable {
     /// The top-level view this representable displays. It wraps the web view when picture in picture isn't running.
-    class WebViewWrapper: UIView { }
+    typealias WebViewWrapper = UIView
     
     let url: URL?
     let viewModelContext: CallScreenViewModel.Context

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
@@ -28,6 +28,7 @@ struct RoomScreenCoordinatorParameters {
     let voiceMessageMediaManager: VoiceMessageMediaManagerProtocol
     let emojiProvider: EmojiProviderProtocol
     let completionSuggestionService: CompletionSuggestionServiceProtocol
+    let ongoingCallRoomIDPublisher: CurrentValuePublisher<String?, Never>
     let appMediator: AppMediatorProtocol
     let appSettings: AppSettings
     let composerDraftService: ComposerDraftServiceProtocol
@@ -64,6 +65,7 @@ final class RoomScreenCoordinator: CoordinatorProtocol {
     init(parameters: RoomScreenCoordinatorParameters) {
         roomViewModel = RoomScreenViewModel(roomProxy: parameters.roomProxy,
                                             mediaProvider: parameters.mediaProvider,
+                                            ongoingCallRoomIDPublisher: parameters.ongoingCallRoomIDPublisher,
                                             appMediator: parameters.appMediator,
                                             appSettings: ServiceLocator.shared.settings,
                                             analyticsService: ServiceLocator.shared.analytics)

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
@@ -46,6 +46,7 @@ struct RoomScreenViewState: BindableState {
     
     var canJoinCall = false
     var hasOngoingCall: Bool
+    var shouldShowCallButton = true
     
     var bindings: RoomScreenViewStateBindings
 }

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
@@ -175,8 +175,10 @@ struct RoomScreen: View {
         
         if !ProcessInfo.processInfo.isiOSAppOnMac {
             ToolbarItem(placement: .primaryAction) {
-                callButton
-                    .disabled(roomContext.viewState.canJoinCall == false)
+                if roomContext.viewState.shouldShowCallButton {
+                    callButton
+                        .disabled(roomContext.viewState.canJoinCall == false)
+                }
             }
         }
     }

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
@@ -177,7 +177,7 @@ struct RoomScreen: View {
             ToolbarItem(placement: .primaryAction) {
                 if roomContext.viewState.shouldShowCallButton {
                     callButton
-                        .disabled(roomContext.viewState.canJoinCall == false)
+                        .disabled(!roomContext.viewState.canJoinCall)
                 }
             }
         }

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
@@ -53,6 +53,7 @@ protocol DeveloperOptionsProtocol: AnyObject {
     var elementCallBaseURLOverride: URL? { get set }
     var fuzzyRoomListSearchEnabled: Bool { get set }
     var pinningEnabled: Bool { get set }
+    var elementCallPictureInPictureEnabled: Bool { get set }
 }
 
 extension AppSettings: DeveloperOptionsProtocol { }

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
@@ -64,7 +64,7 @@ struct DeveloperOptionsScreen: View {
                 
                 Toggle(isOn: $context.elementCallPictureInPictureEnabled) {
                     Text("Picture in Picture support")
-                    Text("You may get stuck in the call until some backend updates have been deployed.")
+                    Text("Requires an Element Call deployment with support for signalling PiP availability.")
                 }
             }
             

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
@@ -61,6 +61,11 @@ struct DeveloperOptionsScreen: View {
                     .autocorrectionDisabled(true)
                     .autocapitalization(.none)
                     .foregroundColor(URL(string: elementCallBaseURLString) == nil ? .red : .primary)
+                
+                Toggle(isOn: $context.elementCallPictureInPictureEnabled) {
+                    Text("Picture in Picture support")
+                    Text("You may get stuck in the call until some backend updates have been deployed.")
+                }
             }
             
             Section {

--- a/ElementX/Sources/Services/ElementCall/ElementCallConfiguration.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallConfiguration.swift
@@ -77,7 +77,7 @@ struct ElementCallConfiguration {
     }
     
     /// A string representing the call being configured.
-    var callID: String {
+    var callRoomID: String {
         switch kind {
         case .genericCallLink(let url):
             url.absoluteString

--- a/ElementX/Sources/Services/ElementCall/ElementCallService.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallService.swift
@@ -57,9 +57,14 @@ class ElementCallService: NSObject, ElementCallServiceProtocol, PKPushRegistryDe
     
     private var endUnansweredCallTask: Task<Void, Never>?
     
-    private var ongoingCallID: CallID?
+    private var ongoingCallID: CallID? {
+        didSet { ongoingCallRoomIDSubject.send(ongoingCallID?.roomID) }
+    }
     
-    var ongoingCallRoomID: String? { ongoingCallID?.roomID }
+    let ongoingCallRoomIDSubject = CurrentValueSubject<String?, Never>(nil)
+    var ongoingCallRoomIDPublisher: CurrentValuePublisher<String?, Never> {
+        ongoingCallRoomIDSubject.asCurrentValuePublisher()
+    }
     
     private let actionsSubject: PassthroughSubject<ElementCallServiceAction, Never> = .init()
     var actions: AnyPublisher<ElementCallServiceAction, Never> {

--- a/ElementX/Sources/Services/ElementCall/ElementCallServiceProtocol.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallServiceProtocol.swift
@@ -26,7 +26,7 @@ enum ElementCallServiceAction {
 protocol ElementCallServiceProtocol {
     var actions: AnyPublisher<ElementCallServiceAction, Never> { get }
     
-    var ongoingCallRoomID: String? { get }
+    var ongoingCallRoomIDPublisher: CurrentValuePublisher<String?, Never> { get }
     
     func setClientProxy(_ clientProxy: ClientProxyProtocol)
     

--- a/ElementX/Sources/UITests/UITestsAppCoordinator.swift
+++ b/ElementX/Sources/UITests/UITestsAppCoordinator.swift
@@ -255,6 +255,7 @@ class MockScreen: Identifiable {
                                                              voiceMessageMediaManager: VoiceMessageMediaManagerMock(),
                                                              emojiProvider: EmojiProvider(),
                                                              completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
+                                                             ongoingCallRoomIDPublisher: .init(.init(nil)),
                                                              appMediator: AppMediatorMock.default,
                                                              appSettings: ServiceLocator.shared.settings,
                                                              composerDraftService: ComposerDraftServiceMock(.init()))
@@ -272,6 +273,7 @@ class MockScreen: Identifiable {
                                                              voiceMessageMediaManager: VoiceMessageMediaManagerMock(),
                                                              emojiProvider: EmojiProvider(),
                                                              completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
+                                                             ongoingCallRoomIDPublisher: .init(.init(nil)),
                                                              appMediator: AppMediatorMock.default,
                                                              appSettings: ServiceLocator.shared.settings,
                                                              composerDraftService: ComposerDraftServiceMock(.init()))
@@ -289,6 +291,7 @@ class MockScreen: Identifiable {
                                                              voiceMessageMediaManager: VoiceMessageMediaManagerMock(),
                                                              emojiProvider: EmojiProvider(),
                                                              completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
+                                                             ongoingCallRoomIDPublisher: .init(.init(nil)),
                                                              appMediator: AppMediatorMock.default,
                                                              appSettings: ServiceLocator.shared.settings,
                                                              composerDraftService: ComposerDraftServiceMock(.init()))
@@ -306,6 +309,7 @@ class MockScreen: Identifiable {
                                                              voiceMessageMediaManager: VoiceMessageMediaManagerMock(),
                                                              emojiProvider: EmojiProvider(),
                                                              completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
+                                                             ongoingCallRoomIDPublisher: .init(.init(nil)),
                                                              appMediator: AppMediatorMock.default,
                                                              appSettings: ServiceLocator.shared.settings,
                                                              composerDraftService: ComposerDraftServiceMock(.init()))
@@ -326,6 +330,7 @@ class MockScreen: Identifiable {
                                                              voiceMessageMediaManager: VoiceMessageMediaManagerMock(),
                                                              emojiProvider: EmojiProvider(),
                                                              completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
+                                                             ongoingCallRoomIDPublisher: .init(.init(nil)),
                                                              appMediator: AppMediatorMock.default,
                                                              appSettings: ServiceLocator.shared.settings,
                                                              composerDraftService: ComposerDraftServiceMock(.init()))
@@ -346,6 +351,7 @@ class MockScreen: Identifiable {
                                                              voiceMessageMediaManager: VoiceMessageMediaManagerMock(),
                                                              emojiProvider: EmojiProvider(),
                                                              completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
+                                                             ongoingCallRoomIDPublisher: .init(.init(nil)),
                                                              appMediator: AppMediatorMock.default,
                                                              appSettings: ServiceLocator.shared.settings,
                                                              composerDraftService: ComposerDraftServiceMock(.init()))
@@ -366,6 +372,7 @@ class MockScreen: Identifiable {
                                                              voiceMessageMediaManager: VoiceMessageMediaManagerMock(),
                                                              emojiProvider: EmojiProvider(),
                                                              completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
+                                                             ongoingCallRoomIDPublisher: .init(.init(nil)),
                                                              appMediator: AppMediatorMock.default,
                                                              appSettings: ServiceLocator.shared.settings,
                                                              composerDraftService: ComposerDraftServiceMock(.init()))
@@ -387,6 +394,7 @@ class MockScreen: Identifiable {
                                                              voiceMessageMediaManager: VoiceMessageMediaManagerMock(),
                                                              emojiProvider: EmojiProvider(),
                                                              completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
+                                                             ongoingCallRoomIDPublisher: .init(.init(nil)),
                                                              appMediator: AppMediatorMock.default,
                                                              appSettings: ServiceLocator.shared.settings,
                                                              composerDraftService: ComposerDraftServiceMock(.init()))
@@ -407,6 +415,7 @@ class MockScreen: Identifiable {
                                                              voiceMessageMediaManager: VoiceMessageMediaManagerMock(),
                                                              emojiProvider: EmojiProvider(),
                                                              completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
+                                                             ongoingCallRoomIDPublisher: .init(.init(nil)),
                                                              appMediator: AppMediatorMock.default,
                                                              appSettings: ServiceLocator.shared.settings,
                                                              composerDraftService: ComposerDraftServiceMock(.init()))
@@ -426,6 +435,7 @@ class MockScreen: Identifiable {
                                                              voiceMessageMediaManager: VoiceMessageMediaManagerMock(),
                                                              emojiProvider: EmojiProvider(),
                                                              completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
+                                                             ongoingCallRoomIDPublisher: .init(.init(nil)),
                                                              appMediator: AppMediatorMock.default,
                                                              appSettings: ServiceLocator.shared.settings,
                                                              composerDraftService: ComposerDraftServiceMock(.init()))
@@ -459,6 +469,7 @@ class MockScreen: Identifiable {
                                                              voiceMessageMediaManager: VoiceMessageMediaManagerMock(),
                                                              emojiProvider: EmojiProvider(),
                                                              completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
+                                                             ongoingCallRoomIDPublisher: .init(.init(nil)),
                                                              appMediator: AppMediatorMock.default,
                                                              appSettings: ServiceLocator.shared.settings,
                                                              composerDraftService: ComposerDraftServiceMock(.init()))
@@ -479,6 +490,7 @@ class MockScreen: Identifiable {
                                                              voiceMessageMediaManager: VoiceMessageMediaManagerMock(),
                                                              emojiProvider: EmojiProvider(),
                                                              completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
+                                                             ongoingCallRoomIDPublisher: .init(.init(nil)),
                                                              appMediator: AppMediatorMock.default,
                                                              appSettings: ServiceLocator.shared.settings,
                                                              composerDraftService: ComposerDraftServiceMock(.init()))
@@ -499,6 +511,7 @@ class MockScreen: Identifiable {
                                                              voiceMessageMediaManager: VoiceMessageMediaManagerMock(),
                                                              emojiProvider: EmojiProvider(),
                                                              completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
+                                                             ongoingCallRoomIDPublisher: .init(.init(nil)),
                                                              appMediator: AppMediatorMock.default,
                                                              appSettings: ServiceLocator.shared.settings,
                                                              composerDraftService: ComposerDraftServiceMock(.init()))

--- a/UnitTests/Sources/RoomFlowCoordinatorTests.swift
+++ b/UnitTests/Sources/RoomFlowCoordinatorTests.swift
@@ -308,6 +308,7 @@ class RoomFlowCoordinatorTests: XCTestCase {
                                                         roomTimelineControllerFactory: timelineControllerFactory,
                                                         navigationStackCoordinator: navigationStackCoordinator,
                                                         emojiProvider: EmojiProvider(),
+                                                        ongoingCallRoomIDPublisher: .init(.init(nil)),
                                                         appMediator: AppMediatorMock.default,
                                                         appSettings: ServiceLocator.shared.settings,
                                                         analytics: ServiceLocator.shared.analytics,


### PR DESCRIPTION
This PR uses an `AVPictureInPictureVideoCallController` to PiP the whole EC web view instead of the previous solution where EC would request the web view to PiP the speaker's video. I've made the feature flag user configurable now as it no longer requires a specific EC deployment*.

This PR doesn't handle responses from the web view about whether PiP is possible so it is possible to get stuck in a call when an error occurs.

The second and third commits improves the handling of whether or not the we should start the PiP or dismiss the screen.

The fourth commit hides the call button when you're already joined to the call in that room.

\* It subsequently does now, however when using an unsupported deployment it will simply navigate back which isn't the case with the old implementation on `develop`. The user can enter https://pr2573--element-call.netlify.app/ as the base URL above the flag for testing purposes.