### PR TITLE
Remove a notification if its event has been redacted.

### DIFF
--- a/ElementX/Sources/Other/Extensions/UNNotificationContent.swift
+++ b/ElementX/Sources/Other/Extensions/UNNotificationContent.swift
@@ -44,6 +44,10 @@ extension UNNotificationContent {
     @objc var roomID: String? {
         userInfo[NotificationConstants.UserInfoKey.roomIdentifier] as? String
     }
+    
+    @objc var eventID: String? {
+        userInfo[NotificationConstants.UserInfoKey.eventIdentifier] as? String
+    }
 }
 
 extension UNMutableNotificationContent {
@@ -62,6 +66,15 @@ extension UNMutableNotificationContent {
         }
         set {
             userInfo[NotificationConstants.UserInfoKey.roomIdentifier] = newValue
+        }
+    }
+    
+    override var eventID: String? {
+        get {
+            userInfo[NotificationConstants.UserInfoKey.eventIdentifier] as? String
+        }
+        set {
+            userInfo[NotificationConstants.UserInfoKey.eventIdentifier] = newValue
         }
     }
 

--- a/NSE/Sources/NotificationContentBuilder.swift
+++ b/NSE/Sources/NotificationContentBuilder.swift
@@ -63,6 +63,10 @@ struct NotificationContentBuilder {
         let notification = UNMutableNotificationContent()
         notification.receiverID = notificationItem.receiverID
         notification.roomID = notificationItem.roomID
+        notification.eventID = switch notificationItem.event {
+        case .timeline(let event): event.eventId()
+        case .invite, .none: nil
+        }
         notification.sound = notificationItem.isNoisy ? UNNotificationSound(named: UNNotificationSoundName(rawValue: "message.caf")) : nil
         // So that the UI groups notification that are received for the same room but also for the same user
         // Removing the @ fixes an iOS bug where the notification crashes if the mute button is tapped

--- a/NSE/Sources/Other/UNNotificationRequest.swift
+++ b/NSE/Sources/Other/UNNotificationRequest.swift
@@ -18,11 +18,11 @@ import Foundation
 import UserNotifications
 
 extension UNNotificationRequest {
-    var roomId: String? {
+    var roomID: String? {
         content.userInfo[NotificationConstants.UserInfoKey.roomIdentifier] as? String
     }
 
-    var eventId: String? {
+    var eventID: String? {
         content.userInfo[NotificationConstants.UserInfoKey.eventIdentifier] as? String
     }
 


### PR DESCRIPTION
iOS equivalent of https://github.com/element-hq/element-x-android/pull/3320

We can't mutate existing notifications on iOS so we simply remove it instead.