### PR TITLE
`TimelineKind` refactor

### DIFF
--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -12590,11 +12590,6 @@ class SessionVerificationControllerProxyMock: SessionVerificationControllerProxy
     }
 }
 class TimelineProxyMock: TimelineProxyProtocol {
-    var kind: TimelineKind {
-        get { return underlyingKind }
-        set(value) { underlyingKind = value }
-    }
-    var underlyingKind: TimelineKind!
     var timelineProvider: RoomTimelineProviderProtocol {
         get { return underlyingTimelineProvider }
         set(value) { underlyingTimelineProvider = value }

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -11910,11 +11910,11 @@ class RoomTimelineProviderMock: RoomTimelineProviderProtocol {
         set(value) { underlyingPaginationState = value }
     }
     var underlyingPaginationState: PaginationState!
-    var isLive: Bool {
-        get { return underlyingIsLive }
-        set(value) { underlyingIsLive = value }
+    var kind: TimelineKind {
+        get { return underlyingKind }
+        set(value) { underlyingKind = value }
     }
-    var underlyingIsLive: Bool!
+    var underlyingKind: TimelineKind!
     var membershipChangePublisher: AnyPublisher<Void, Never> {
         get { return underlyingMembershipChangePublisher }
         set(value) { underlyingMembershipChangePublisher = value }
@@ -12590,6 +12590,11 @@ class SessionVerificationControllerProxyMock: SessionVerificationControllerProxy
     }
 }
 class TimelineProxyMock: TimelineProxyProtocol {
+    var kind: TimelineKind {
+        get { return underlyingKind }
+        set(value) { underlyingKind = value }
+    }
+    var underlyingKind: TimelineKind!
     var timelineProvider: RoomTimelineProviderProtocol {
         get { return underlyingTimelineProvider }
         set(value) { underlyingTimelineProvider = value }

--- a/ElementX/Sources/Mocks/RoomTimelineProviderMock.swift
+++ b/ElementX/Sources/Mocks/RoomTimelineProviderMock.swift
@@ -35,7 +35,7 @@ class AutoUpdatingRoomTimelineProviderMock: RoomTimelineProvider {
         }
         
         super.init(timeline: timelineMock,
-                   isLive: true,
+                   kind: .live,
                    paginationStatePublisher: innerPaginationStatePublisher.eraseToAnyPublisher())
         
         Task.detached {

--- a/ElementX/Sources/Screens/PinnedEventsTimelineScreen/PinnedEventsTimelineScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/PinnedEventsTimelineScreen/PinnedEventsTimelineScreenCoordinator.swift
@@ -52,7 +52,6 @@ final class PinnedEventsTimelineScreenCoordinator: CoordinatorProtocol {
         viewModel = PinnedEventsTimelineScreenViewModel()
         timelineViewModel = TimelineViewModel(roomProxy: parameters.roomProxy,
                                               timelineController: parameters.timelineController,
-                                              isPinnedEventsTimeline: true,
                                               mediaProvider: parameters.mediaProvider,
                                               mediaPlayerProvider: parameters.mediaPlayerProvider,
                                               voiceMessageMediaManager: parameters.voiceMessageMediaManager,

--- a/ElementX/Sources/Screens/PinnedEventsTimelineScreen/View/PinnedEventsTimelineScreen.swift
+++ b/ElementX/Sources/Screens/PinnedEventsTimelineScreen/View/PinnedEventsTimelineScreen.swift
@@ -95,11 +95,10 @@ struct PinnedEventsTimelineScreen: View {
 struct PinnedEventsTimelineScreen_Previews: PreviewProvider, TestablePreview {
     static let viewModel = PinnedEventsTimelineScreenViewModel()
     static let emptyTimelineViewModel: TimelineViewModel = {
-        let timelineController = MockRoomTimelineController()
+        let timelineController = MockRoomTimelineController(timelineKind: .pinned)
         timelineController.timelineItems = []
         return TimelineViewModel(roomProxy: JoinedRoomProxyMock(.init(name: "Preview room")),
                                  timelineController: timelineController,
-                                 isPinnedEventsTimeline: true,
                                  mediaProvider: MockMediaProvider(),
                                  mediaPlayerProvider: MediaPlayerProviderMock(),
                                  voiceMessageMediaManager: VoiceMessageMediaManagerMock(),

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
@@ -79,7 +79,6 @@ final class RoomScreenCoordinator: CoordinatorProtocol {
         timelineViewModel = TimelineViewModel(roomProxy: parameters.roomProxy,
                                               focussedEventID: parameters.focussedEvent?.eventID,
                                               timelineController: parameters.timelineController,
-                                              isPinnedEventsTimeline: false,
                                               mediaProvider: parameters.mediaProvider,
                                               mediaPlayerProvider: parameters.mediaPlayerProvider,
                                               voiceMessageMediaManager: parameters.voiceMessageMediaManager,

--- a/ElementX/Sources/Screens/RoomScreen/View/PinnedItemsBanner/PinnedItemsBannerView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/PinnedItemsBanner/PinnedItemsBannerView.swift
@@ -55,7 +55,7 @@ struct PinnedItemsBannerView: View {
     @ViewBuilder
     private var viewAllButton: some View {
         Button { onViewAllButtonTap() } label: {
-            Text(L10n.screenRoomPinnedBannerViewAllButtonTitle)
+            Text(state.isLoading ? "" : L10n.screenRoomPinnedBannerViewAllButtonTitle)
                 .font(.compound.bodyMDSemibold)
                 .foregroundStyle(Color.compound.textPrimary)
                 .opacity(state.isLoading ? 0 : 1)

--- a/ElementX/Sources/Screens/RoomScreen/View/PinnedItemsBanner/PinnedItemsBannerView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/PinnedItemsBanner/PinnedItemsBannerView.swift
@@ -31,6 +31,7 @@ struct PinnedItemsBannerView: View {
         .padding(.vertical, 16)
         .padding(.leading, 16)
         .background(Color.compound.bgCanvasDefault)
+        .drawingGroup()
         .shadow(color: Color(red: 0.11, green: 0.11, blue: 0.13).opacity(0.1), radius: 12, x: 0, y: 4)
     }
     

--- a/ElementX/Sources/Screens/RoomScreen/View/PinnedItemsBanner/PinnedItemsBannerView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/PinnedItemsBanner/PinnedItemsBannerView.swift
@@ -31,7 +31,6 @@ struct PinnedItemsBannerView: View {
         .padding(.vertical, 16)
         .padding(.leading, 16)
         .background(Color.compound.bgCanvasDefault)
-        .drawingGroup()
         .shadow(color: Color(red: 0.11, green: 0.11, blue: 0.13).opacity(0.1), radius: 12, x: 0, y: 4)
     }
     
@@ -55,19 +54,20 @@ struct PinnedItemsBannerView: View {
     
     @ViewBuilder
     private var viewAllButton: some View {
-        switch state {
-        case .loaded:
-            Button { onViewAllButtonTap() } label: {
-                Text(L10n.screenRoomPinnedBannerViewAllButtonTitle)
-                    .font(.compound.bodyMDSemibold)
-                    .foregroundStyle(Color.compound.textPrimary)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 5)
-            }
-        case .loading:
-            ProgressView()
+        Button { onViewAllButtonTap() } label: {
+            Text(L10n.screenRoomPinnedBannerViewAllButtonTitle)
+                .font(.compound.bodyMDSemibold)
+                .foregroundStyle(Color.compound.textPrimary)
+                .opacity(state.isLoading ? 0 : 1)
+                // Use overlay instead otherwise the sliding animation would not work
+                .overlay(alignment: .trailing) {
+                    ProgressView()
+                        .opacity(state.isLoading ? 1 : 0)
+                }
                 .padding(.horizontal, 16)
+                .padding(.vertical, 5)
         }
+        .disabled(state.isLoading)
     }
     
     private var content: some View {

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
@@ -220,7 +220,6 @@ struct RoomScreen_Previews: PreviewProvider, TestablePreview {
     static let roomViewModel = RoomScreenViewModel.mock(roomProxyMock: roomProxyMock)
     static let timelineViewModel = TimelineViewModel(roomProxy: roomProxyMock,
                                                      timelineController: MockRoomTimelineController(),
-                                                     isPinnedEventsTimeline: false,
                                                      mediaProvider: MockMediaProvider(),
                                                      mediaPlayerProvider: MediaPlayerProviderMock(),
                                                      voiceMessageMediaManager: VoiceMessageMediaManagerMock(),

--- a/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
@@ -52,7 +52,6 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
     init(roomProxy: JoinedRoomProxyProtocol,
          focussedEventID: String? = nil,
          timelineController: RoomTimelineControllerProtocol,
-         isPinnedEventsTimeline: Bool,
          mediaProvider: MediaProviderProtocol,
          mediaPlayerProvider: MediaPlayerProviderProtocol,
          voiceMessageMediaManager: VoiceMessageMediaManagerProtocol,
@@ -81,7 +80,7 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
                                                                 appSettings: appSettings,
                                                                 analyticsService: analyticsService)
         
-        super.init(initialViewState: TimelineViewState(isPinnedEventsTimeline: isPinnedEventsTimeline,
+        super.init(initialViewState: TimelineViewState(isPinnedEventsTimeline: timelineController.timelineKind == .pinned,
                                                        roomID: roomProxy.id,
                                                        isEncryptedOneToOneRoom: roomProxy.isEncryptedOneToOneRoom,
                                                        timelineViewState: TimelineState(focussedEvent: focussedEventID.map { .init(eventID: $0, appearance: .immediate) }),
@@ -827,7 +826,6 @@ extension TimelineViewModel {
     static let mock = TimelineViewModel(roomProxy: JoinedRoomProxyMock(.init(name: "Preview room")),
                                         focussedEventID: nil,
                                         timelineController: MockRoomTimelineController(),
-                                        isPinnedEventsTimeline: false,
                                         mediaProvider: MockMediaProvider(),
                                         mediaPlayerProvider: MediaPlayerProviderMock(),
                                         voiceMessageMediaManager: VoiceMessageMediaManagerMock(),
@@ -838,8 +836,7 @@ extension TimelineViewModel {
     
     static let pinnedEventsTimelineMock = TimelineViewModel(roomProxy: JoinedRoomProxyMock(.init(name: "Preview room")),
                                                             focussedEventID: nil,
-                                                            timelineController: MockRoomTimelineController(),
-                                                            isPinnedEventsTimeline: true,
+                                                            timelineController: MockRoomTimelineController(timelineKind: .pinned),
                                                             mediaProvider: MockMediaProvider(),
                                                             mediaPlayerProvider: MediaPlayerProviderMock(),
                                                             voiceMessageMediaManager: VoiceMessageMediaManagerMock(),

--- a/ElementX/Sources/Screens/Timeline/View/ReadReceipts/ReadReceiptsSummaryView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/ReadReceipts/ReadReceiptsSummaryView.swift
@@ -54,7 +54,6 @@ struct ReadReceiptsSummaryView_Previews: PreviewProvider, TestablePreview {
         let roomProxyMock = JoinedRoomProxyMock(.init(name: "Room", members: members))
         let mock = TimelineViewModel(roomProxy: roomProxyMock,
                                      timelineController: MockRoomTimelineController(),
-                                     isPinnedEventsTimeline: false,
                                      mediaProvider: MockMediaProvider(),
                                      mediaPlayerProvider: MediaPlayerProviderMock(),
                                      voiceMessageMediaManager: VoiceMessageMediaManagerMock(),

--- a/ElementX/Sources/Screens/Timeline/View/Supplementary/TimelineReadReceiptsView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Supplementary/TimelineReadReceiptsView.swift
@@ -92,7 +92,6 @@ struct TimelineReadReceiptsView_Previews: PreviewProvider, TestablePreview {
 
     static let viewModel = TimelineViewModel(roomProxy: JoinedRoomProxyMock(.init(name: "Test", members: members)),
                                              timelineController: MockRoomTimelineController(),
-                                             isPinnedEventsTimeline: false,
                                              mediaProvider: MockMediaProvider(),
                                              mediaPlayerProvider: MediaPlayerProviderMock(),
                                              voiceMessageMediaManager: VoiceMessageMediaManagerMock(),

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/HighlightedTimelineItemModifier.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/HighlightedTimelineItemModifier.swift
@@ -99,7 +99,6 @@ struct HighlightedTimelineItemTimeline_Previews: PreviewProvider {
     static let timelineViewModel = TimelineViewModel(roomProxy: roomProxyMock,
                                                      focussedEventID: focussedEventID,
                                                      timelineController: MockRoomTimelineController(),
-                                                     isPinnedEventsTimeline: false,
                                                      mediaProvider: MockMediaProvider(),
                                                      mediaPlayerProvider: MediaPlayerProviderMock(),
                                                      voiceMessageMediaManager: VoiceMessageMediaManagerMock(),

--- a/ElementX/Sources/Screens/Timeline/View/TimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineView.swift
@@ -84,7 +84,6 @@ struct TimelineView_Previews: PreviewProvider, TestablePreview {
     static let roomViewModel = RoomScreenViewModel.mock(roomProxyMock: roomProxyMock)
     static let timelineViewModel = TimelineViewModel(roomProxy: roomProxyMock,
                                                      timelineController: MockRoomTimelineController(),
-                                                     isPinnedEventsTimeline: false,
                                                      mediaProvider: MockMediaProvider(),
                                                      mediaPlayerProvider: MediaPlayerProviderMock(),
                                                      voiceMessageMediaManager: VoiceMessageMediaManagerMock(),

--- a/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
@@ -44,7 +44,7 @@ class JoinedRoomProxy: JoinedRoomProxyProtocol {
                     }
                     
                     do {
-                        let timeline = try await TimelineProxy(timeline: room.pinnedEventsTimeline(internalIdPrefix: nil, maxEventsToLoad: 100), isLive: true)
+                        let timeline = try await TimelineProxy(timeline: room.pinnedEventsTimeline(internalIdPrefix: nil, maxEventsToLoad: 100), kind: .pinned)
                         await timeline.subscribeForUpdates()
                         innerPinnedEventsTimeline = timeline
                         return timeline
@@ -172,7 +172,7 @@ class JoinedRoomProxy: JoinedRoomProxyProtocol {
         self.roomListItem = roomListItem
         self.room = room
         
-        timeline = try await TimelineProxy(timeline: room.timeline(), isLive: true)
+        timeline = try await TimelineProxy(timeline: room.timeline(), kind: .live)
         
         Task {
             await updateMembers()
@@ -216,7 +216,7 @@ class JoinedRoomProxy: JoinedRoomProxyProtocol {
     func timelineFocusedOnEvent(eventID: String, numberOfEvents: UInt16) async -> Result<TimelineProxyProtocol, RoomProxyError> {
         do {
             let timeline = try await room.timelineFocusedOnEvent(eventId: eventID, numContextEvents: numberOfEvents, internalIdPrefix: UUID().uuidString)
-            return .success(TimelineProxy(timeline: timeline, isLive: false))
+            return .success(TimelineProxy(timeline: timeline, kind: .detached))
         } catch let error as FocusEventError {
             switch error {
             case .InvalidEventId(_, let error):

--- a/ElementX/Sources/Services/Timeline/RoomTimelineProvider.swift
+++ b/ElementX/Sources/Services/Timeline/RoomTimelineProvider.swift
@@ -42,7 +42,7 @@ class RoomTimelineProvider: RoomTimelineProviderProtocol {
             .eraseToAnyPublisher()
     }
     
-    private(set) var isLive: Bool
+    let kind: TimelineKind
     
     private let membershipChangeSubject = PassthroughSubject<Void, Never>()
     var membershipChangePublisher: AnyPublisher<Void, Never> {
@@ -54,10 +54,10 @@ class RoomTimelineProvider: RoomTimelineProviderProtocol {
         roomTimelineObservationToken?.cancel()
     }
 
-    init(timeline: Timeline, isLive: Bool, paginationStatePublisher: AnyPublisher<PaginationState, Never>) {
+    init(timeline: Timeline, kind: TimelineKind, paginationStatePublisher: AnyPublisher<PaginationState, Never>) {
         serialDispatchQueue = DispatchQueue(label: "io.element.elementx.roomtimelineprovider", qos: .utility)
         itemProxiesSubject = CurrentValueSubject<[TimelineItemProxy], Never>([])
-        self.isLive = isLive
+        self.kind = kind
         
         paginationStatePublisher
             .sink { [weak self] in

--- a/ElementX/Sources/Services/Timeline/RoomTimelineProviderProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/RoomTimelineProviderProtocol.swift
@@ -45,8 +45,8 @@ protocol RoomTimelineProviderProtocol {
     var itemProxies: [TimelineItemProxy] { get }
     /// Whether the timeline is back/forward paginating or not (or has reached the start/end of the room).
     var paginationState: PaginationState { get }
-    /// Whether or not the provider is for a live timeline.
-    var isLive: Bool { get }
+    /// The kind of the timeline
+    var kind: TimelineKind { get }
     /// A publisher that signals when changes to the room's membership have occurred through `/sync`.
     ///
     /// This is temporary and will be replace by a subscription on the room itself.

--- a/ElementX/Sources/Services/Timeline/TimelineController/MockRoomTimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/MockRoomTimelineController.swift
@@ -28,6 +28,7 @@ class MockRoomTimelineController: RoomTimelineControllerProtocol {
     
     var roomProxy: JoinedRoomProxyProtocol?
     var roomID: String { roomProxy?.id ?? "MockRoomIdentifier" }
+    var timelineKind: TimelineKind
     
     let callbacks = PassthroughSubject<RoomTimelineControllerCallback, Never>()
     
@@ -36,7 +37,8 @@ class MockRoomTimelineController: RoomTimelineControllerProtocol {
     
     private var client: UITestsSignalling.Client?
     
-    init(listenForSignals: Bool = false) {
+    init(timelineKind: TimelineKind = .live, listenForSignals: Bool = false) {
+        self.timelineKind = timelineKind
         callbacks.send(.paginationState(PaginationState(backward: .idle, forward: .timelineEndReached)))
         callbacks.send(.isLive(true))
         

--- a/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineControllerFactory.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineControllerFactory.swift
@@ -23,7 +23,6 @@ struct RoomTimelineControllerFactory: RoomTimelineControllerFactoryProtocol {
         RoomTimelineController(roomProxy: roomProxy,
                                timelineProxy: roomProxy.timeline,
                                initialFocussedEventID: initialFocussedEventID,
-                               shouldHideStart: false,
                                timelineItemFactory: timelineItemFactory,
                                appSettings: ServiceLocator.shared.settings)
     }
@@ -36,7 +35,6 @@ struct RoomTimelineControllerFactory: RoomTimelineControllerFactoryProtocol {
         return RoomTimelineController(roomProxy: roomProxy,
                                       timelineProxy: pinnedEventsTimeline,
                                       initialFocussedEventID: nil,
-                                      shouldHideStart: true,
                                       timelineItemFactory: timelineItemFactory,
                                       appSettings: ServiceLocator.shared.settings)
     }

--- a/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineControllerProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineControllerProtocol.swift
@@ -38,6 +38,7 @@ enum RoomTimelineControllerError: Error {
 @MainActor
 protocol RoomTimelineControllerProtocol {
     var roomID: String { get }
+    var timelineKind: TimelineKind { get }
     
     var timelineItems: [RoomTimelineItemProtocol] { get }
     var callbacks: PassthroughSubject<RoomTimelineControllerCallback, Never> { get }

--- a/ElementX/Sources/Services/Timeline/TimelineProxy.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineProxy.swift
@@ -95,7 +95,10 @@ final class TimelineProxy: TimelineProxyProtocol {
     }
     
     func paginateForwards(requestSize: UInt16) async -> Result<Void, TimelineProxyError> {
-        await focussedPaginate(.forwards, requestSize: requestSize)
+        guard kind != .pinned else {
+            return .success(())
+        }
+        return await focussedPaginate(.forwards, requestSize: requestSize)
     }
     
     /// Paginate backwards using the subscription from Rust to drive the pagination state.
@@ -561,6 +564,7 @@ final class TimelineProxy: TimelineProxyProtocol {
             } catch {
                 MXLog.error("Failed to subscribe to back pagination status with error: \(error)")
             }
+            forwardPaginationStatusSubject.send(.timelineEndReached)
         case .detached:
             // Detached timelines don't support observation, set the initial state ourself.
             backPaginationStatusSubject.send(.idle)

--- a/ElementX/Sources/Services/Timeline/TimelineProxy.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineProxy.swift
@@ -27,7 +27,7 @@ final class TimelineProxy: TimelineProxyProtocol {
     private let backPaginationStatusSubject = CurrentValueSubject<PaginationStatus, Never>(.timelineEndReached)
     private let forwardPaginationStatusSubject = CurrentValueSubject<PaginationStatus, Never>(.timelineEndReached)
     
-    let kind: TimelineKind
+    private let kind: TimelineKind
    
     private var innerTimelineProvider: RoomTimelineProviderProtocol!
     var timelineProvider: RoomTimelineProviderProtocol {

--- a/ElementX/Sources/Services/Timeline/TimelineProxyProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineProxyProtocol.swift
@@ -34,8 +34,6 @@ enum TimelineProxyError: Error {
 
 // sourcery: AutoMockable
 protocol TimelineProxyProtocol {
-    var kind: TimelineKind { get }
-    
     var timelineProvider: RoomTimelineProviderProtocol { get }
     
     func subscribeForUpdates() async

--- a/ElementX/Sources/Services/Timeline/TimelineProxyProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineProxyProtocol.swift
@@ -18,6 +18,12 @@ import Combine
 import Foundation
 import MatrixRustSDK
 
+enum TimelineKind {
+    case live
+    case detached
+    case pinned
+}
+
 enum TimelineProxyError: Error {
     case sdkError(Error)
     
@@ -28,6 +34,8 @@ enum TimelineProxyError: Error {
 
 // sourcery: AutoMockable
 protocol TimelineProxyProtocol {
+    var kind: TimelineKind { get }
+    
     var timelineProvider: RoomTimelineProviderProtocol { get }
     
     func subscribeForUpdates() async

--- a/ElementX/Sources/UITests/UITestsAppCoordinator.swift
+++ b/ElementX/Sources/UITests/UITestsAppCoordinator.swift
@@ -649,7 +649,6 @@ class MockScreen: Identifiable {
             let timelineController = RoomTimelineController(roomProxy: roomProxy,
                                                             timelineProxy: roomProxy.timeline,
                                                             initialFocussedEventID: nil,
-                                                            shouldHideStart: false,
                                                             timelineItemFactory: RoomTimelineItemFactory(userID: "@alice:matrix.org",
                                                                                                          attributedStringBuilder: AttributedStringBuilder(mentionBuilder: MentionBuilder()),
                                                                                                          stateEventStringBuilder: RoomStateEventStringBuilder(userID: "@alice:matrix.org")),

--- a/PreviewTests/__Snapshots__/PreviewTests/test_pinnedItemsBannerView-iPhone-15-pseudo.1.png
+++ b/PreviewTests/__Snapshots__/PreviewTests/test_pinnedItemsBannerView-iPhone-15-pseudo.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:919e3df86ce263d06f479c701b6981a66b0d6217e13cf3cff12445b9c6a24d77
-size 106938
+oid sha256:6ada9407d2f6c9da3cedb750353ffcf6e4cc6493177b3e2796d66b8245982042
+size 107677

--- a/UnitTests/Sources/PillContextTests.swift
+++ b/UnitTests/Sources/PillContextTests.swift
@@ -28,7 +28,6 @@ class PillContextTests: XCTestCase {
         proxyMock.membersPublisher = subject.asCurrentValuePublisher()
         let mock = TimelineViewModel(roomProxy: proxyMock,
                                      timelineController: MockRoomTimelineController(),
-                                     isPinnedEventsTimeline: false,
                                      mediaProvider: MockMediaProvider(),
                                      mediaPlayerProvider: MediaPlayerProviderMock(),
                                      voiceMessageMediaManager: VoiceMessageMediaManagerMock(),
@@ -57,7 +56,6 @@ class PillContextTests: XCTestCase {
         proxyMock.membersPublisher = subject.asCurrentValuePublisher()
         let mock = TimelineViewModel(roomProxy: proxyMock,
                                      timelineController: MockRoomTimelineController(),
-                                     isPinnedEventsTimeline: false,
                                      mediaProvider: MockMediaProvider(),
                                      mediaPlayerProvider: MediaPlayerProviderMock(),
                                      voiceMessageMediaManager: VoiceMessageMediaManagerMock(),
@@ -79,7 +77,6 @@ class PillContextTests: XCTestCase {
         mockController.roomProxy = proxyMock
         let mock = TimelineViewModel(roomProxy: proxyMock,
                                      timelineController: mockController,
-                                     isPinnedEventsTimeline: false,
                                      mediaProvider: MockMediaProvider(),
                                      mediaPlayerProvider: MediaPlayerProviderMock(),
                                      voiceMessageMediaManager: VoiceMessageMediaManagerMock(),

--- a/UnitTests/Sources/TimelineViewModelTests.swift
+++ b/UnitTests/Sources/TimelineViewModelTests.swift
@@ -345,7 +345,6 @@ class TimelineViewModelTests: XCTestCase {
 
         let viewModel = TimelineViewModel(roomProxy: roomProxy,
                                           timelineController: timelineController,
-                                          isPinnedEventsTimeline: false,
                                           mediaProvider: MockMediaProvider(),
                                           mediaPlayerProvider: MediaPlayerProviderMock(),
                                           voiceMessageMediaManager: VoiceMessageMediaManagerMock(),
@@ -370,7 +369,6 @@ class TimelineViewModelTests: XCTestCase {
         timelineController.timelineItems = [message]
         let viewModel = TimelineViewModel(roomProxy: JoinedRoomProxyMock(.init(name: "", members: [RoomMemberProxyMock.mockAlice, RoomMemberProxyMock.mockCharlie])),
                                           timelineController: timelineController,
-                                          isPinnedEventsTimeline: false,
                                           mediaProvider: MockMediaProvider(),
                                           mediaPlayerProvider: MediaPlayerProviderMock(),
                                           voiceMessageMediaManager: VoiceMessageMediaManagerMock(),
@@ -396,7 +394,6 @@ class TimelineViewModelTests: XCTestCase {
         roomProxyMock.underlyingActionsPublisher = actionsSubject.eraseToAnyPublisher()
         let viewModel = TimelineViewModel(roomProxy: roomProxyMock,
                                           timelineController: MockRoomTimelineController(),
-                                          isPinnedEventsTimeline: false,
                                           mediaProvider: MockMediaProvider(),
                                           mediaPlayerProvider: MediaPlayerProviderMock(),
                                           voiceMessageMediaManager: VoiceMessageMediaManagerMock(),
@@ -425,7 +422,6 @@ class TimelineViewModelTests: XCTestCase {
         roomProxyMock.underlyingActionsPublisher = actionsSubject.eraseToAnyPublisher()
         let viewModel = TimelineViewModel(roomProxy: roomProxyMock,
                                           timelineController: MockRoomTimelineController(),
-                                          isPinnedEventsTimeline: false,
                                           mediaProvider: MockMediaProvider(),
                                           mediaPlayerProvider: MediaPlayerProviderMock(),
                                           voiceMessageMediaManager: VoiceMessageMediaManagerMock(),
@@ -455,7 +451,6 @@ class TimelineViewModelTests: XCTestCase {
         TimelineViewModel(roomProxy: roomProxy ?? JoinedRoomProxyMock(.init(name: "")),
                           focussedEventID: focussedEventID,
                           timelineController: timelineController,
-                          isPinnedEventsTimeline: false,
                           mediaProvider: MockMediaProvider(),
                           mediaPlayerProvider: MediaPlayerProviderMock(),
                           voiceMessageMediaManager: VoiceMessageMediaManagerMock(),


### PR DESCRIPTION
`isLive` has been replaced with a `TimelineKind enum` to allow a better handling of the pinned timeline