### PR TITLE
Picture in Picture support for Calls (requires a supported widget deployment).

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -659,7 +659,7 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
         
         let callScreenCoordinator = CallScreenCoordinator(parameters: .init(elementCallService: elementCallService,
                                                                             configuration: configuration,
-                                                                            elementCallPictureInPictureEnabled: false,
+                                                                            allowPictureInPicture: false,
                                                                             appHooks: appHooks))
         
         callScreenCoordinator.actions

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -47,7 +47,6 @@ final class AppSettings {
         case publicSearchEnabled
         case fuzzyRoomListSearchEnabled
         case pinningEnabled
-        case elementCallPictureInPictureEnabled
     }
     
     private static var suiteName: String = InfoPlistReader.main.appGroupIdentifier
@@ -285,9 +284,6 @@ final class AppSettings {
     
     @UserPreference(key: UserDefaultsKeys.pinningEnabled, defaultValue: false, storageType: .userDefaults(store))
     var pinningEnabled
-    
-    @UserPreference(key: UserDefaultsKeys.elementCallPictureInPictureEnabled, defaultValue: false, storageType: .userDefaults(store))
-    var elementCallPictureInPictureEnabled
         
     #endif
     

--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -589,7 +589,7 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
         
         let callScreenCoordinator = CallScreenCoordinator(parameters: .init(elementCallService: elementCallService,
                                                                             configuration: configuration,
-                                                                            elementCallPictureInPictureEnabled: appSettings.elementCallPictureInPictureEnabled,
+                                                                            allowPictureInPicture: true,
                                                                             appHooks: appHooks))
         
         callScreenCoordinator.actions

--- a/ElementX/Sources/Screens/CallScreen/CallScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenCoordinator.swift
@@ -21,7 +21,7 @@ import SwiftUI
 struct CallScreenCoordinatorParameters {
     let elementCallService: ElementCallServiceProtocol
     let configuration: ElementCallConfiguration
-    let elementCallPictureInPictureEnabled: Bool
+    let allowPictureInPicture: Bool
     let appHooks: AppHooks
 }
 
@@ -46,7 +46,7 @@ final class CallScreenCoordinator: CoordinatorProtocol {
     init(parameters: CallScreenCoordinatorParameters) {
         viewModel = CallScreenViewModel(elementCallService: parameters.elementCallService,
                                         configuration: parameters.configuration,
-                                        elementCallPictureInPictureEnabled: parameters.elementCallPictureInPictureEnabled,
+                                        allowPictureInPicture: parameters.allowPictureInPicture,
                                         appHooks: parameters.appHooks)
     }
     

--- a/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
@@ -24,7 +24,7 @@ typealias CallScreenViewModelType = StateStoreViewModel<CallScreenViewState, Cal
 class CallScreenViewModel: CallScreenViewModelType, CallScreenViewModelProtocol {
     private let elementCallService: ElementCallServiceProtocol
     private let configuration: ElementCallConfiguration
-    private let isPictureInPictureEnabled: Bool
+    private let isPictureInPictureAllowed: Bool
     
     private let widgetDriver: ElementCallWidgetDriverProtocol
     
@@ -43,11 +43,11 @@ class CallScreenViewModel: CallScreenViewModelType, CallScreenViewModelProtocol 
     ///   - clientID: Something to identify the current client on the Element Call side
     init(elementCallService: ElementCallServiceProtocol,
          configuration: ElementCallConfiguration,
-         elementCallPictureInPictureEnabled: Bool,
+         allowPictureInPicture: Bool,
          appHooks: AppHooks) {
         self.elementCallService = elementCallService
         self.configuration = configuration
-        isPictureInPictureEnabled = elementCallPictureInPictureEnabled
+        isPictureInPictureAllowed = allowPictureInPicture
         
         switch configuration.kind {
         case .genericCallLink(let url):
@@ -189,7 +189,7 @@ class CallScreenViewModel: CallScreenViewModelType, CallScreenViewModelProtocol 
     
     private func handleBackwardsNavigation() async {
         guard state.url != nil,
-              isPictureInPictureEnabled,
+              isPictureInPictureAllowed,
               let requestPictureInPictureHandler = state.bindings.requestPictureInPictureHandler else {
             actionsSubject.send(.dismiss)
             return

--- a/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
+++ b/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
@@ -300,7 +300,7 @@ struct CallScreen_Previews: PreviewProvider {
                                                         elementCallBaseURL: "https://call.element.io",
                                                         elementCallBaseURLOverride: nil,
                                                         colorScheme: .light),
-                                   elementCallPictureInPictureEnabled: false,
+                                   allowPictureInPicture: false,
                                    appHooks: AppHooks())
     }()
     

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
@@ -53,7 +53,6 @@ protocol DeveloperOptionsProtocol: AnyObject {
     var elementCallBaseURLOverride: URL? { get set }
     var fuzzyRoomListSearchEnabled: Bool { get set }
     var pinningEnabled: Bool { get set }
-    var elementCallPictureInPictureEnabled: Bool { get set }
 }
 
 extension AppSettings: DeveloperOptionsProtocol { }

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
@@ -69,11 +69,6 @@ struct DeveloperOptionsScreen: View {
                             context.elementCallBaseURLOverride = url
                         }
                     }
-                
-                Toggle(isOn: $context.elementCallPictureInPictureEnabled) {
-                    Text("Picture in Picture support")
-                    Text("Requires an Element Call deployment with support for signalling PiP availability.")
-                }
             } header: {
                 Text("Element Call")
             } footer: {


### PR DESCRIPTION
Remove the feature flag on EC PiP support - this will now be driven by the web view `canEnablePip` API.