### PR TITLE
Make sure reactions always go through the timeline controller.

### DIFF
--- a/ElementX/Sources/Screens/Timeline/TimelineInteractionHandler.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineInteractionHandler.swift
@@ -168,8 +168,7 @@ class TimelineInteractionHandler {
         case .react:
             displayEmojiPicker(for: itemID)
         case .toggleReaction(let key):
-            guard let eventID = itemID.eventID else { return }
-            Task { await roomProxy.timeline.toggleReaction(key, to: eventID) }
+            Task { await timelineController.toggleReaction(key, to: itemID) }
         case .endPoll(let pollStartID):
             endPoll(pollStartID: pollStartID)
         case .pin:


### PR DESCRIPTION
There was one use of the live timeline (the 5 default emojis in the action menu) but we should always do this on the `activeTimeline`.