### PR TITLE
Update subscriptions if visible range rooms change without the range itself changing

### DIFF
--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
@@ -40,7 +40,7 @@ enum HomeScreenViewAction {
     case startChat
     case confirmRecoveryKey
     case skipRecoveryKeyConfirmation
-    case updateVisibleItemRange(range: Range<Int>, isScrolling: Bool)
+    case updateVisibleItemRange(Range<Int>)
     case globalSearch
     case markRoomAsUnread(roomIdentifier: String)
     case markRoomAsRead(roomIdentifier: String)

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -324,7 +324,6 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
         visibleItemRangeObservationToken = visibleItemRangePublisher
             .filter { $0.isScrolling == false }
             .throttle(for: 0.5, scheduler: DispatchQueue.main, latest: true)
-            .removeDuplicates(by: { $0.isScrolling == $1.isScrolling && $0.range == $1.range })
             .sink { [weak self] value in
                 guard let self else { return }
                 

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -30,9 +30,6 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
     
     private var migrationCancellable: AnyCancellable?
     
-    private var visibleItemRangeObservationToken: AnyCancellable?
-    private let visibleItemRangePublisher = CurrentValueSubject<(range: Range<Int>, isScrolling: Bool), Never>((0..<0, false))
-    
     private var actionsSubject: PassthroughSubject<HomeScreenViewModelAction, Never> = .init()
     var actions: AnyPublisher<HomeScreenViewModelAction, Never> {
         actionsSubject.eraseToAnyPublisher()
@@ -151,8 +148,8 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
             actionsSubject.send(.presentSecureBackupSettings)
         case .skipRecoveryKeyConfirmation:
             state.securityBannerMode = .dismissed
-        case .updateVisibleItemRange(let range, let isScrolling):
-            visibleItemRangePublisher.send((range, isScrolling))
+        case .updateVisibleItemRange(let range):
+            roomSummaryProvider?.updateVisibleRange(range)
         case .startChat:
             actionsSubject.send(.presentStartChatScreen)
         case .globalSearch:
@@ -266,14 +263,9 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
             .store(in: &cancellables)
         
         roomSummaryProvider.roomListPublisher
-            .dropFirst(1) // We don't care about its initial value
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.updateRooms()
-                
-                // Wait for the all rooms view to receive its first update before installing
-                // dynamic timeline modifiers
-                self?.installListRangeModifiers()
             }
             .store(in: &cancellables)
     }
@@ -315,26 +307,6 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
             }
         }
     }
-    
-    private func installListRangeModifiers() {
-        guard visibleItemRangeObservationToken == nil else {
-            return
-        }
-        
-        visibleItemRangeObservationToken = visibleItemRangePublisher
-            .filter { $0.isScrolling == false }
-            .throttle(for: 0.5, scheduler: DispatchQueue.main, latest: true)
-            .sink { [weak self] value in
-                guard let self else { return }
-                
-                // Ignore scrolling while filtering rooms
-                guard self.state.bindings.searchQuery.isEmpty else {
-                    return
-                }
-                
-                self.updateVisibleRange(value.range)
-            }
-    }
         
     private func updateRooms() {
         guard let roomSummaryProvider else {
@@ -351,20 +323,7 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
         
         state.rooms = rooms
     }
-    
-    private func updateVisibleRange(_ range: Range<Int>) {
-        guard !range.isEmpty else {
-            return
-        }
         
-        guard let roomSummaryProvider else {
-            MXLog.error("Visible rooms summary provider unavailable")
-            return
-        }
-        
-        roomSummaryProvider.updateVisibleRange(range)
-    }
-    
     private func markRoomAsFavourite(_ roomID: String, isFavourite: Bool) async {
         guard case let .joined(roomProxy) = await userSession.clientProxy.roomForIdentifier(roomID) else {
             MXLog.error("Failed retrieving room for identifier: \(roomID)")

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreenContent.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreenContent.swift
@@ -200,6 +200,8 @@ struct HomeScreenContent: View {
     
     private func delayedUpdateVisibleRange() {
         guard let scrollView = scrollViewAdapter.scrollView,
+              scrollViewAdapter.isScrolling.value == false, // Ignore while scrolling
+              context.searchQuery.isEmpty == true, // Ignore while filtering
               context.viewState.visibleRooms.count > 0 else {
             return
         }
@@ -215,6 +217,6 @@ struct HomeScreenContent: View {
         let lastIndex = Int(max(0.0, scrollView.contentOffset.y + scrollView.bounds.height) / cellHeight)
         
         // This will be deduped and throttled on the view model layer
-        context.send(viewAction: .updateVisibleItemRange(range: firstIndex..<lastIndex, isScrolling: scrollViewAdapter.isScrolling.value))
+        context.send(viewAction: .updateVisibleItemRange(firstIndex..<lastIndex))
     }
 }


### PR DESCRIPTION
- we switched from range based subscribing with duplicate suppression to id based, but ids can change without ranges changing
- the all rooms list fetches at least 1 event per rooms and can cause rooms to come in and out of the visible range without user interaction
- this PR rewrites how we handle visible ranges and moves processing of both the range (for pagination) and the room identifiers (for subscriptions) within the `RoomSummaryProvider`