### PR TITLE
Make pinned events required state in SlidingSync

### DIFF
--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -54,7 +54,8 @@ enum SlidingSyncConstants {
         RequiredState(key: "m.room.topic", value: ""),
         RequiredState(key: "m.room.avatar", value: ""),
         RequiredState(key: "m.room.canonical_alias", value: ""),
-        RequiredState(key: "m.room.join_rules", value: "")
+        RequiredState(key: "m.room.join_rules", value: ""),
+        RequiredState(key: "m.room.pinned_events", value: "")
     ]
 }
 


### PR DESCRIPTION
*Look Ma, I'm an iOS dev now!*

## Changes

Make pinned events required state in SlidingSync. This is needed to always have the pinned events of a room as soon as we open it.

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off).

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
