### PR TITLE
Pin Tweaks

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/View/PinnedItemsBanner/PinnedItemsBannerView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/PinnedItemsBanner/PinnedItemsBannerView.swift
@@ -63,10 +63,13 @@ struct PinnedItemsBannerView: View {
     
     private var content: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text(state.bannerIndicatorDescription)
-                .font(.compound.bodySM)
-                .foregroundColor(.compound.textActionAccent)
-                .lineLimit(1)
+            // Only the display the indicator description for more than 1 pinned item
+            if state.count > 1 {
+                Text(state.bannerIndicatorDescription)
+                    .font(.compound.bodySM)
+                    .foregroundColor(.compound.textActionAccent)
+                    .lineLimit(1)
+            }
             Text(state.displayedMessage)
                 .font(.compound.bodyMD)
                 .foregroundColor(.compound.textPrimary)

--- a/ElementX/Sources/Screens/Timeline/TimelineTableViewController.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineTableViewController.swift
@@ -308,8 +308,12 @@ class TimelineTableViewController: UIViewController {
         guard let dataSource else { return }
 
         var snapshot = NSDiffableDataSourceSnapshot<TimelineSection, String>()
-        snapshot.appendSections([.typingIndicator])
-        snapshot.appendItems([TimelineTypingIndicatorCell.reuseIdentifier])
+        
+        // We don't want to display the typing notification in this timeline
+        if !coordinator.context.viewState.isPinnedEventsTimeline {
+            snapshot.appendSections([.typingIndicator])
+            snapshot.appendItems([TimelineTypingIndicatorCell.reuseIdentifier])
+        }
         snapshot.appendSections([.main])
         snapshot.appendItems(timelineItemsIDs)
         

--- a/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenuAction.swift
+++ b/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenuAction.swift
@@ -100,7 +100,7 @@ enum TimelineItemMenuAction: Identifiable, Hashable {
     
     var canAppearInPinnedEventsTimeline: Bool {
         switch self {
-        case .viewInRoomTimeline, .pin, .unpin, .forward, .redact:
+        case .viewInRoomTimeline, .pin, .unpin, .forward:
             return true
         default:
             return false

--- a/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenuActionProvider.swift
+++ b/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenuActionProvider.swift
@@ -58,13 +58,13 @@ struct TimelineItemMenuActionProvider {
         if item.isForwardable {
             actions.append(.forward(itemID: item.id))
         }
-        
-        if canCurrentUserPin, let eventID = item.id.eventID {
-            actions.append(pinnedEventIDs.contains(eventID) ? .unpin : .pin)
-        }
 
         if item.isEditable {
             actions.append(.edit)
+        }
+        
+        if canCurrentUserPin, let eventID = item.id.eventID {
+            actions.append(pinnedEventIDs.contains(eventID) ? .unpin : .pin)
         }
 
         if item.isCopyable {

--- a/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemBubbledStylerView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemBubbledStylerView.swift
@@ -102,7 +102,9 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
                     context.send(viewAction: .displayTimelineItemMenu(itemID: timelineItem.id))
                 }
             
-            if !timelineItem.properties.reactions.isEmpty {
+            // Do not display reactions in the pinned events timeline
+            if !context.viewState.isPinnedEventsTimeline,
+               !timelineItem.properties.reactions.isEmpty {
                 TimelineReactionsView(context: context,
                                       itemID: timelineItem.id,
                                       reactions: timelineItem.properties.reactions,

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_pinnedItemsBannerView-iPad-en-GB.1.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_pinnedItemsBannerView-iPad-en-GB.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:52a543349c38a46a7abf42d9f5b83aed47b40621e358fe63b98487acff03b461
-size 147075
+oid sha256:f1c0f5c4908a4846f72c3842054a072b28a403c4e0a58094ce2ec2197da3c3c5
+size 140801

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_pinnedItemsBannerView-iPad-pseudo.1.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_pinnedItemsBannerView-iPad-pseudo.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:131dadbb128453abb744bd49c2cd592bbd9f0f5bdee5ba6ea71f541a10ee70ee
-size 182373
+oid sha256:faa4dade1cd81194b56c82bb90c95b7cd933db10735baf6718037593f90c21ab
+size 168534

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_pinnedItemsBannerView-iPhone-15-en-GB.1.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_pinnedItemsBannerView-iPhone-15-en-GB.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ade81f08af5344aab81fdebbffe27a4b04976ce8e3cc8f397d5328c51998ad09
-size 91413
+oid sha256:675bac92ca94414ae552689d0dfe2d4eacbb756ab065a859a954c0e392917933
+size 85919

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_pinnedItemsBannerView-iPhone-15-pseudo.1.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_pinnedItemsBannerView-iPhone-15-pseudo.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6ada9407d2f6c9da3cedb750353ffcf6e4cc6493177b3e2796d66b8245982042
-size 107677
+oid sha256:515384fc8cabd0e83238b2205d2df61be08d32a42027dedf6099c36e60c6bbdb
+size 100273


### PR DESCRIPTION
Pun intended

- [x] Remove delete action from the pinned context menu
- [x] Move Pin/Unpin action below Edit
- [x] Timeline in pinned modes should NOT display the typing notifications
- [x] Remove the 1 of 1 copy when there is only 1 message in the banner
- [x] Filter reactions in the pinned timeline client side
