### PR TITLE
Fix wrong durations for uploaded media

### DIFF
--- a/ElementX/Sources/Services/Media/MediaUploadingPreprocessor.swift
+++ b/ElementX/Sources/Services/Media/MediaUploadingPreprocessor.swift
@@ -77,7 +77,7 @@ private struct VideoProcessingInfo {
     let url: URL
     let height: Double
     let width: Double
-    let duration: Double
+    let duration: Double // seconds
     let mimeType: String
 }
 
@@ -213,7 +213,7 @@ struct MediaUploadingPreprocessor {
             return .failure(.failedProcessingAudio)
         }
         
-        let audioInfo = AudioInfo(duration: durationInSeconds * 1000, size: fileSize, mimetype: mimeType)
+        let audioInfo = AudioInfo(duration: durationInSeconds, size: fileSize, mimetype: mimeType)
         return .success(.audio(audioURL: url, audioInfo: audioInfo))
     }
     
@@ -413,7 +413,7 @@ struct MediaUploadingPreprocessor {
                 return .success(.init(url: newOutputURL,
                                       height: adjustedNaturalSize.height,
                                       width: adjustedNaturalSize.width,
-                                      duration: durationInSeconds * 1000,
+                                      duration: durationInSeconds,
                                       mimeType: "video/mp4"))
             } catch {
                 return .failure(.failedConvertingVideo)

--- a/UnitTests/Sources/MediaUploadingPreprocessorTests.swift
+++ b/UnitTests/Sources/MediaUploadingPreprocessorTests.swift
@@ -28,7 +28,7 @@ final class MediaUploadingPreprocessorTests: XCTestCase {
         XCTAssertEqual(audioURL.lastPathComponent, "test_audio.mp3")
         
         XCTAssertEqual(audioInfo.mimetype, "audio/mpeg")
-        XCTAssertEqual(audioInfo.duration ?? 0, 27252, accuracy: 100)
+        XCTAssertEqual(audioInfo.duration ?? 0, 27, accuracy: 100)
         XCTAssertEqual(audioInfo.size ?? 0, 764_176, accuracy: 100)
     }
     
@@ -63,7 +63,7 @@ final class MediaUploadingPreprocessorTests: XCTestCase {
         XCTAssertEqual(videoInfo.size ?? 0, 1_431_959, accuracy: 100)
         XCTAssertEqual(videoInfo.width, 1280)
         XCTAssertEqual(videoInfo.height, 720)
-        XCTAssertEqual(videoInfo.duration ?? 0, 30483, accuracy: 100)
+        XCTAssertEqual(videoInfo.duration ?? 0, 30, accuracy: 100)
         
         XCTAssertNotNil(videoInfo.thumbnailInfo)
         XCTAssertEqual(videoInfo.thumbnailInfo?.mimetype, "image/jpeg")
@@ -103,7 +103,7 @@ final class MediaUploadingPreprocessorTests: XCTestCase {
         XCTAssertEqual(videoInfo.size ?? 0, 9_775_822, accuracy: 100)
         XCTAssertEqual(videoInfo.width, 1080)
         XCTAssertEqual(videoInfo.height, 1920)
-        XCTAssertEqual(videoInfo.duration ?? 0, 21000, accuracy: 100)
+        XCTAssertEqual(videoInfo.duration ?? 0, 21, accuracy: 100)
         
         XCTAssertNotNil(videoInfo.thumbnailInfo)
         XCTAssertEqual(videoInfo.thumbnailInfo?.mimetype, "image/jpeg")


### PR DESCRIPTION
At some point Uniffi introduced [automatic conversions](https://github.com/mozilla/uniffi-rs/blob/35140607dce7092f04d619a5d0b07f9ffe98b4ff/uniffi_bindgen/src/bindings/swift/templates/DurationHelper.swift#L19) from Rust's `Duration` to `TimeInterval`s but the original implementation for media uploading was using milliseconds. When the conversion happened there were no breaking changes and iOS kept sending millis instead of seconds, resulting in **very** wrong values.

Android seems fine as it's using [java.time.Duration](https://github.com/mozilla/uniffi-rs/blob/35140607dce7092f04d619a5d0b07f9ffe98b4ff/uniffi_bindgen/src/bindings/kotlin/templates/DurationHelper.kt#L32)