### PR TITLE
Free up CI runner disk space before running UI tests.

### DIFF
--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -30,6 +30,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gems-
 
+      - name: Free disk space
+        run: ci_scripts/free_space.sh
+
       - name: Setup environment
         run: source ci_scripts/ci_common.sh && setup_github_actions_environment
 

--- a/ci_scripts/free_space.sh
+++ b/ci_scripts/free_space.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+#
+# Taken from 
+# https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
+#
+
+set -ux
+
+df -h
+sudo rm -rf /usr/share/dotnet
+sudo rm -rf /opt/ghc
+sudo rm -rf "/usr/local/share/boost"
+sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+df -h


### PR DESCRIPTION
Fixes `System.IO.IOException: No space left on device` errors when running UI tests