### PR TITLE
Bring back default controls for QuickLook based media viewers

### DIFF
--- a/ElementX/Sources/Screens/FilePreviewScreen/InteractiveQuickLook.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/InteractiveQuickLook.swift
@@ -12,22 +12,19 @@ import SwiftUI
 extension View {
     /// Preview a media file using a QuickLook Preview Controller. The preview is interactive with
     /// the dismiss gesture working as expected if it was presented from UIKit.
-    func interactiveQuickLook(item: Binding<MediaPreviewItem?>, shouldHideControls: Bool = false) -> some View {
-        modifier(InteractiveQuickLookModifier(item: item, shouldHideControls: shouldHideControls))
+    func interactiveQuickLook(item: Binding<MediaPreviewItem?>) -> some View {
+        modifier(InteractiveQuickLookModifier(item: item))
     }
 }
 
 private struct InteractiveQuickLookModifier: ViewModifier {
     @Binding var item: MediaPreviewItem?
-    let shouldHideControls: Bool
-    
     @State private var dismissalPublisher = PassthroughSubject<Void, Never>()
     
     func body(content: Content) -> some View {
         content.background {
             if let item {
                 MediaPreviewViewController(previewItem: item,
-                                           shouldHideControls: shouldHideControls,
                                            dismissalPublisher: dismissalPublisher) { self.item = nil }
             } else {
                 // Work around QLPreviewController dismissal issues, see below.
@@ -39,13 +36,11 @@ private struct InteractiveQuickLookModifier: ViewModifier {
 
 private struct MediaPreviewViewController: UIViewControllerRepresentable {
     let previewItem: MediaPreviewItem
-    let shouldHideControls: Bool
     let dismissalPublisher: PassthroughSubject<Void, Never>
     let onDismiss: () -> Void
 
     func makeUIViewController(context: Context) -> PreviewHostingController {
         PreviewHostingController(previewItem: previewItem,
-                                 shouldHideControls: shouldHideControls,
                                  dismissalPublisher: dismissalPublisher,
                                  onDismiss: onDismiss)
     }
@@ -58,7 +53,6 @@ private struct MediaPreviewViewController: UIViewControllerRepresentable {
     /// animations and interactions which don't work if you represent it directly to SwiftUI 🤷‍♂️
     class PreviewHostingController: UIViewController, QLPreviewControllerDataSource, QLPreviewControllerDelegate {
         let previewItem: MediaPreviewItem
-        let shouldHideControls: Bool
         let onDismiss: () -> Void
         
         private var dismissalObserver: AnyCancellable?
@@ -66,11 +60,9 @@ private struct MediaPreviewViewController: UIViewControllerRepresentable {
         var previewController: QLPreviewController?
 
         init(previewItem: MediaPreviewItem,
-             shouldHideControls: Bool,
              dismissalPublisher: PassthroughSubject<Void, Never>,
              onDismiss: @escaping () -> Void) {
             self.previewItem = previewItem
-            self.shouldHideControls = shouldHideControls
             self.onDismiss = onDismiss
 
             super.init(nibName: nil, bundle: nil)
@@ -100,7 +92,7 @@ private struct MediaPreviewViewController: UIViewControllerRepresentable {
             
             guard self.previewController == nil else { return }
             
-            let previewController = (shouldHideControls ? NoControlsPreviewController() : QLPreviewController())
+            let previewController = QLPreviewController()
             previewController.dataSource = self
             previewController.delegate = self
             present(previewController, animated: true)
@@ -119,6 +111,10 @@ private struct MediaPreviewViewController: UIViewControllerRepresentable {
         }
         
         // MARK: QLPreviewControllerDelegate
+        
+        func previewController(_ controller: QLPreviewController, editingModeFor previewItem: QLPreviewItem) -> QLPreviewItemEditingMode {
+            .disabled
+        }
         
         func previewControllerDidDismiss(_ controller: QLPreviewController) {
             onDismiss()
@@ -139,28 +135,6 @@ class MediaPreviewItem: NSObject, QLPreviewItem {
     }
 }
 
-private class NoControlsPreviewController: QLPreviewController {
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        
-        guard let navigationController = children.first as? UINavigationController else {
-            return
-        }
-        
-        // Remove top file details bar
-        navigationController.navigationBar.isHidden = true
-        
-        // Remove the toolbars and their buttons
-        navigationController.view.subviews.compactMap { $0 as? UIToolbar }.forEach { toolbar in
-            toolbar.subviews.forEach { item in
-                item.isHidden = true
-            }
-            
-            toolbar.isHidden = true
-        }
-    }
-}
-
 // MARK: - Previews
 
 struct PreviewView_Previews: PreviewProvider {
@@ -170,7 +144,6 @@ struct PreviewView_Previews: PreviewProvider {
     
     static var previews: some View {
         MediaPreviewViewController(previewItem: previewItem,
-                                   shouldHideControls: false,
                                    dismissalPublisher: .init()) { }
     }
 }

--- a/ElementX/Sources/Screens/RoomDetailsScreen/View/RoomDetailsScreen.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/View/RoomDetailsScreen.swift
@@ -57,7 +57,7 @@ struct RoomDetailsScreen: View {
         .navigationTitle(L10n.screenRoomDetailsTitle)
         .navigationBarTitleDisplayMode(.inline)
         .track(screen: .RoomDetails)
-        .interactiveQuickLook(item: $context.mediaPreviewItem)
+        .interactiveQuickLook(item: $context.mediaPreviewItem, allowEditing: false)
     }
     
     // MARK: - Private

--- a/ElementX/Sources/Screens/RoomDetailsScreen/View/RoomDetailsScreen.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/View/RoomDetailsScreen.swift
@@ -57,7 +57,7 @@ struct RoomDetailsScreen: View {
         .navigationTitle(L10n.screenRoomDetailsTitle)
         .navigationBarTitleDisplayMode(.inline)
         .track(screen: .RoomDetails)
-        .interactiveQuickLook(item: $context.mediaPreviewItem, shouldHideControls: true)
+        .interactiveQuickLook(item: $context.mediaPreviewItem)
     }
     
     // MARK: - Private

--- a/ElementX/Sources/Screens/RoomMemberDetailsScreen/View/RoomMemberDetailsScreen.swift
+++ b/ElementX/Sources/Screens/RoomMemberDetailsScreen/View/RoomMemberDetailsScreen.swift
@@ -24,7 +24,7 @@ struct RoomMemberDetailsScreen: View {
         .alert(item: $context.ignoreUserAlert, actions: blockUserAlertActions, message: blockUserAlertMessage)
         .alert(item: $context.alertInfo)
         .track(screen: .User)
-        .interactiveQuickLook(item: $context.mediaPreviewItem)
+        .interactiveQuickLook(item: $context.mediaPreviewItem, allowEditing: false)
     }
     
     // MARK: - Private

--- a/ElementX/Sources/Screens/RoomMemberDetailsScreen/View/RoomMemberDetailsScreen.swift
+++ b/ElementX/Sources/Screens/RoomMemberDetailsScreen/View/RoomMemberDetailsScreen.swift
@@ -24,7 +24,7 @@ struct RoomMemberDetailsScreen: View {
         .alert(item: $context.ignoreUserAlert, actions: blockUserAlertActions, message: blockUserAlertMessage)
         .alert(item: $context.alertInfo)
         .track(screen: .User)
-        .interactiveQuickLook(item: $context.mediaPreviewItem, shouldHideControls: true)
+        .interactiveQuickLook(item: $context.mediaPreviewItem)
     }
     
     // MARK: - Private

--- a/ElementX/Sources/Screens/UserProfileScreen/View/UserProfileScreen.swift
+++ b/ElementX/Sources/Screens/UserProfileScreen/View/UserProfileScreen.swift
@@ -21,7 +21,7 @@ struct UserProfileScreen: View {
         .toolbar { toolbar }
         .alert(item: $context.alertInfo)
         .track(screen: .User)
-        .interactiveQuickLook(item: $context.mediaPreviewItem, shouldHideControls: true)
+        .interactiveQuickLook(item: $context.mediaPreviewItem)
     }
     
     // MARK: - Private

--- a/ElementX/Sources/Screens/UserProfileScreen/View/UserProfileScreen.swift
+++ b/ElementX/Sources/Screens/UserProfileScreen/View/UserProfileScreen.swift
@@ -21,7 +21,7 @@ struct UserProfileScreen: View {
         .toolbar { toolbar }
         .alert(item: $context.alertInfo)
         .track(screen: .User)
-        .interactiveQuickLook(item: $context.mediaPreviewItem)
+        .interactiveQuickLook(item: $context.mediaPreviewItem, allowEditing: false)
     }
     
     // MARK: - Private


### PR DESCRIPTION
Not a lot else to say:


https://github.com/user-attachments/assets/8ac72a2d-564a-4a28-b150-21be0424081d

