### PR TITLE
Make sure we reset the feature flag when upgrading to SSS.

### DIFF
--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -143,6 +143,7 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
         case .skipRecoveryKeyConfirmation:
             state.securityBannerMode = .dismissed
         case .confirmSlidingSyncUpgrade:
+            appSettings.slidingSyncDiscovery = .native
             actionsSubject.send(.logout)
         case .skipSlidingSyncUpgrade:
             state.slidingSyncMigrationBannerMode = .dismissed
@@ -326,6 +327,7 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
                                                               title: L10n.bannerMigrateToNativeSlidingSyncForceLogoutTitle,
                                                               primaryButton: .init(title: L10n.bannerMigrateToNativeSlidingSyncAction,
                                                                                    action: { [weak self] in
+                                                                                       self?.appSettings.slidingSyncDiscovery = .native
                                                                                        self?.actionsSubject.send(.logoutWithoutConfirmation)
                                                                                    }))
                 }


### PR DESCRIPTION
Currently if you tap the banner to Logout & Upgrade, if you have changed the discovery to Proxy only, you will be logged back in using SS and not SSS and will be presented with the banner again.

Same for the alert I would imagine too.