### PR TITLE
Make sure we don't reuse an old NSEUserSession after logging out and back in.

### DIFF
--- a/NSE/Sources/NotificationServiceExtension.swift
+++ b/NSE/Sources/NotificationServiceExtension.swift
@@ -72,7 +72,9 @@ class NotificationServiceExtension: UNNotificationServiceExtension {
         MXLog.info("\(tag) Payload came: \(request.content.userInfo)")
         
         Self.serialQueue.sync {
-            if Self.userSession == nil {
+            // If the session directories have changed, the user has logged out and back in (even if they entered the same user ID).
+            // We can't do this comparison with the access token of the existing session here due to token refresh when using OIDC.
+            if Self.userSession == nil || Self.userSession?.sessionDirectories != credentials.restorationToken.sessionDirectories {
                 // This function might be run concurrently and from different processes
                 // It's imperative that we create **at most** one UserSession/Client per process
                 Task.synchronous { [appHooks] in

--- a/NSE/Sources/Other/NSEUserSession.swift
+++ b/NSE/Sources/Other/NSEUserSession.swift
@@ -9,6 +9,8 @@ import Foundation
 import MatrixRustSDK
 
 final class NSEUserSession {
+    let sessionDirectories: SessionDirectories
+    
     private let baseClient: Client
     private let notificationClient: NotificationClient
     private let userID: String
@@ -18,6 +20,8 @@ final class NSEUserSession {
     private let delegateHandle: TaskHandle?
 
     init(credentials: KeychainCredentials, clientSessionDelegate: ClientSessionDelegate, appHooks: AppHooks) async throws {
+        sessionDirectories = credentials.restorationToken.sessionDirectories
+        
         userID = credentials.userID
         if credentials.restorationToken.passphrase != nil {
             MXLog.info("Restoring client with encrypted store.")


### PR DESCRIPTION
There have been reports of users receiving blank notifications after upgrading to SSS. Turns out when the user logs out, the NSE isn't aware of this so attempts to re-use the same UserSession/Client from the old session.

This PR fixes it with an additional comparison at the start of the flow.