### PR TITLE
Fix interactive dismissal of our QLPreviewController iOS 18 (when built with Xcode 16).

### DIFF
--- a/ElementX/Sources/Screens/FilePreviewScreen/InteractiveQuickLook.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/InteractiveQuickLook.swift
@@ -60,6 +60,7 @@ private struct MediaPreviewViewController: UIViewControllerRepresentable {
         let previewItem: MediaPreviewItem
         let allowEditing: Bool
         let onDismiss: () -> Void
+        let sourceView = UIView()
         
         private var dismissalObserver: AnyCancellable?
         
@@ -93,10 +94,23 @@ private struct MediaPreviewViewController: UIViewControllerRepresentable {
         
         override func viewDidLoad() {
             view.backgroundColor = .clear
+            view.addSubview(sourceView)
+            
+            sourceView.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                sourceView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+                sourceView.centerYAnchor.constraint(equalTo: view.bottomAnchor),
+                sourceView.widthAnchor.constraint(equalToConstant: 200),
+                sourceView.heightAnchor.constraint(equalToConstant: 200)
+            ])
         }
         
-        override func viewWillAppear(_ animated: Bool) {
-            super.viewWillAppear(animated)
+        // Don't use viewWillAppear due to the following warning:
+        // Presenting view controller <QLPreviewController> from detached view controller <HostingController> is not supported,
+        // and may result in incorrect safe area insets and a corrupt root presentation. Make sure <HostingController> is in
+        // the view controller hierarchy before presenting from it. Will become a hard exception in a future release.
+        override func viewDidAppear(_ animated: Bool) {
+            super.viewDidAppear(animated)
             
             guard self.previewController == nil else { return }
             
@@ -122,6 +136,10 @@ private struct MediaPreviewViewController: UIViewControllerRepresentable {
         
         func previewController(_ controller: QLPreviewController, editingModeFor previewItem: QLPreviewItem) -> QLPreviewItemEditingMode {
             allowEditing ? .createCopy : .disabled
+        }
+        
+        func previewController(_ controller: QLPreviewController, transitionViewFor item: any QLPreviewItem) -> UIView? {
+            sourceView
         }
         
         func previewControllerDidDismiss(_ controller: QLPreviewController) {


### PR DESCRIPTION
This PR is the second part of #3243 which (when built with Xcode 16) will allow the view to be interactively dismissed again. This is what it looks like the the source view as set up in the PR (it should be pretty similar to the current behaviour):

| Xcode 15, iOS 17 | Xcode 15, iOS 18 | Xcode 16, iOS 17 | Xcode 16, iOS 18 |
| - | - | - | - |
| ![Xcode 15 iOS 17](https://github.com/user-attachments/assets/164c500d-d07c-4c83-9d12-4227cef5011b) | ![Xcode 15 iOS 18](https://github.com/user-attachments/assets/3795c9e3-ce19-4582-aea7-0689169880f4) | ![Xcode 16 iOS 17](https://github.com/user-attachments/assets/0d8636a8-b2fd-44be-bdf9-653680c4b55f) | ![Xcode 16 iOS 18](https://github.com/user-attachments/assets/9ebfc07a-e283-4cec-8d38-09a7010ee815) |
