### PR TITLE
Stop delaying subscriptions until after startup

### DIFF
--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -83,8 +83,6 @@ class ClientProxy: ClientProxyProtocol {
             .asCurrentValuePublisher()
     }
     
-    private let roomListServiceStateSubject = CurrentValueSubject<RoomListServiceState, Never>(.initial)
-    
     private var cancellables = Set<AnyCancellable>()
     
     /// Will be `true` whilst the app cleans up and forces a logout. Prevents the sync service from restarting
@@ -735,7 +733,6 @@ class ClientProxy: ClientProxyProtocol {
                                                             shouldPrefixSenderName: true)
             
             roomSummaryProvider = RoomSummaryProvider(roomListService: roomListService,
-                                                      roomListServiceStatePublisher: roomListServiceStateSubject.asCurrentValuePublisher(),
                                                       eventStringBuilder: eventStringBuilder,
                                                       name: "AllRooms",
                                                       shouldUpdateVisibleRange: true,
@@ -744,7 +741,6 @@ class ClientProxy: ClientProxyProtocol {
             try await roomSummaryProvider?.setRoomList(roomListService.allRooms())
             
             alternateRoomSummaryProvider = RoomSummaryProvider(roomListService: roomListService,
-                                                               roomListServiceStatePublisher: roomListServiceStateSubject.asCurrentValuePublisher(),
                                                                eventStringBuilder: eventStringBuilder,
                                                                name: "MessageForwarding",
                                                                notificationSettings: notificationSettings,
@@ -783,8 +779,6 @@ class ClientProxy: ClientProxyProtocol {
             guard let self else { return }
             
             MXLog.info("Received room list update: \(state)")
-            
-            roomListServiceStateSubject.send(state)
             
             guard state != .error,
                   state != .terminated else {

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
@@ -11,7 +11,6 @@ import MatrixRustSDK
 
 class RoomSummaryProvider: RoomSummaryProviderProtocol {
     private let roomListService: RoomListServiceProtocol
-    private let roomListServiceStatePublisher: CurrentValuePublisher<RoomListServiceState, Never>
     private let eventStringBuilder: RoomEventStringBuilder
     private let name: String
     private let shouldUpdateVisibleRange: Bool
@@ -57,14 +56,12 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
     ///   to the room list service through the `applyInput(input: .viewport(ranges` api. Only useful for
     ///   lists that need to update the visible range on Sliding Sync
     init(roomListService: RoomListServiceProtocol,
-         roomListServiceStatePublisher: CurrentValuePublisher<RoomListServiceState, Never>,
          eventStringBuilder: RoomEventStringBuilder,
          name: String,
          shouldUpdateVisibleRange: Bool = false,
          notificationSettings: NotificationSettingsProxyProtocol,
          appSettings: AppSettings) {
         self.roomListService = roomListService
-        self.roomListServiceStatePublisher = roomListServiceStatePublisher
         serialDispatchQueue = DispatchQueue(label: "io.element.elementx.roomsummaryprovider", qos: .default)
         self.eventStringBuilder = eventStringBuilder
         self.name = name
@@ -77,16 +74,7 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
             .sink { [weak self] in self?.updateRoomsWithDiffs($0) }
             .store(in: &cancellables)
         
-        roomListServiceStateCancellable = roomListServiceStatePublisher
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] state in
-                guard let self else { return }
-                
-                if state == .running {
-                    setupVisibleRangeObservers()
-                    roomListServiceStateCancellable = nil
-                }
-            }
+        setupVisibleRangeObservers()
         
         setupNotificationSettingsSubscription()
     }


### PR DESCRIPTION
Stop delaying subscriptions until after the room list service goes into running, that's not handled internally by the SDK
- reverts b43797f4bf0a7c20f44ae488ad47da333a7963a5
- relies on https://github.com/matrix-org/matrix-rust-sdk/pull/3981