### PR TITLE
Use the new strings for send failures when the unsigned devices are your own.

### DIFF
--- a/ElementX/Sources/Screens/ResolveVerifiedUserSendFailureScreen/ResolveVerifiedUserSendFailureScreenModels.swift
+++ b/ElementX/Sources/Screens/ResolveVerifiedUserSendFailureScreen/ResolveVerifiedUserSendFailureScreenModels.swift
@@ -23,18 +23,23 @@ enum ResolveVerifiedUserSendFailureScreenViewModelAction {
 struct ResolveVerifiedUserSendFailureScreenViewState: BindableState {
     var currentFailure: TimelineItemSendFailure.VerifiedUser
     var currentMemberDisplayName: String
+    var isYou: Bool
     
     var title: String {
         switch currentFailure {
-        case .hasUnsignedDevice: L10n.screenResolveSendFailureUnsignedDeviceTitle(currentMemberDisplayName)
-        case .changedIdentity: L10n.screenResolveSendFailureChangedIdentityTitle(currentMemberDisplayName)
+        case .hasUnsignedDevice:
+            isYou ? L10n.screenResolveSendFailureYouUnsignedDeviceTitle : L10n.screenResolveSendFailureUnsignedDeviceTitle(currentMemberDisplayName)
+        case .changedIdentity:
+            L10n.screenResolveSendFailureChangedIdentityTitle(currentMemberDisplayName)
         }
     }
     
     var subtitle: String {
         switch currentFailure {
-        case .hasUnsignedDevice: L10n.screenResolveSendFailureUnsignedDeviceSubtitle(currentMemberDisplayName, currentMemberDisplayName)
-        case .changedIdentity: L10n.screenResolveSendFailureChangedIdentitySubtitle(currentMemberDisplayName)
+        case .hasUnsignedDevice:
+            isYou ? L10n.screenResolveSendFailureYouUnsignedDeviceSubtitle : L10n.screenResolveSendFailureUnsignedDeviceSubtitle(currentMemberDisplayName, currentMemberDisplayName)
+        case .changedIdentity:
+            L10n.screenResolveSendFailureChangedIdentitySubtitle(currentMemberDisplayName)
         }
     }
     

--- a/ElementX/Sources/Screens/ResolveVerifiedUserSendFailureScreen/ResolveVerifiedUserSendFailureScreenViewModel.swift
+++ b/ElementX/Sources/Screens/ResolveVerifiedUserSendFailureScreen/ResolveVerifiedUserSendFailureScreenViewModel.swift
@@ -49,7 +49,8 @@ class ResolveVerifiedUserSendFailureScreenViewModel: ResolveVerifiedUserSendFail
         }
         
         super.init(initialViewState: ResolveVerifiedUserSendFailureScreenViewState(currentFailure: failure,
-                                                                                   currentMemberDisplayName: members[userID]?.displayName ?? userID))
+                                                                                   currentMemberDisplayName: members[userID]?.displayName ?? userID,
+                                                                                   isYou: userID == roomProxy.ownUserID))
     }
     
     // MARK: Public
@@ -83,6 +84,7 @@ class ResolveVerifiedUserSendFailureScreenViewModel: ResolveVerifiedUserSendFail
         if let (userID, failure) = iterator.next() {
             state.currentMemberDisplayName = members[userID]?.displayName ?? userID
             state.currentFailure = failure
+            state.isYou = userID == roomProxy.ownUserID
         } else {
             actionsSubject.send(.dismiss)
         }

--- a/ElementX/Sources/Screens/ResolveVerifiedUserSendFailureScreen/View/ResolveVerifiedUserSendFailureScreen.swift
+++ b/ElementX/Sources/Screens/ResolveVerifiedUserSendFailureScreen/View/ResolveVerifiedUserSendFailureScreen.swift
@@ -78,11 +78,15 @@ struct ResolveVerifiedUserSendFailureScreen: View {
 
 struct ResolveVerifiedUserSendFailureScreen_Previews: PreviewProvider, TestablePreview {
     static let unsignedDeviceViewModel = makeViewModel(failure: .hasUnsignedDevice(devices: ["@alice:matrix.org": []]))
+    static let ownUnsignedDeviceViewModel = makeViewModel(failure: .hasUnsignedDevice(devices: [RoomMemberProxyMock.mockMe.userID: []]))
     static let changedIdentityViewModel = makeViewModel(failure: .changedIdentity(users: ["@alice:matrix.org"]))
     
     static var previews: some View {
         ResolveVerifiedUserSendFailureScreen(context: unsignedDeviceViewModel.context)
             .previewDisplayName("Unsigned Device")
+        
+        ResolveVerifiedUserSendFailureScreen(context: ownUnsignedDeviceViewModel.context)
+            .previewDisplayName("Own Unsigned Device")
         
         ResolveVerifiedUserSendFailureScreen(context: changedIdentityViewModel.context)
             .previewDisplayName("Identity Changed")

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_resolveVerifiedUserSendFailureScreen-iPad-en-GB.Own-Unsigned-Device.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_resolveVerifiedUserSendFailureScreen-iPad-en-GB.Own-Unsigned-Device.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4753c2858ee5ecec25a29b399e7ea80182f687c6a2f841a92a414e8e920b5924
+size 125882

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_resolveVerifiedUserSendFailureScreen-iPad-pseudo.Own-Unsigned-Device.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_resolveVerifiedUserSendFailureScreen-iPad-pseudo.Own-Unsigned-Device.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2d8fb744f1ae503247c5da24b629808edef82b99478834a31f4116d7d5db992
+size 160093

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_resolveVerifiedUserSendFailureScreen-iPhone-15-en-GB.Own-Unsigned-Device.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_resolveVerifiedUserSendFailureScreen-iPhone-15-en-GB.Own-Unsigned-Device.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5145981b3a4ec6e66341f81fd7dac4c6229f361c22f2ceb9a2f3b442cecaec76
+size 90320

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_resolveVerifiedUserSendFailureScreen-iPhone-15-pseudo.Own-Unsigned-Device.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_resolveVerifiedUserSendFailureScreen-iPhone-15-pseudo.Own-Unsigned-Device.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88602e805a91c4857f0f8101d1dd0856d92b8d3ba1335d2057e1e3cec727ec6b
+size 137841

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_timelineItemMenu-iPad-en-GB.Own-Unsigned-Devices.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_timelineItemMenu-iPad-en-GB.Own-Unsigned-Devices.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ddc2888bc4e11319006b54091b3a1b48fb2da6973ffb350210a2b17e5aa86b9e
+size 138532

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_timelineItemMenu-iPad-pseudo.Own-Unsigned-Devices.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_timelineItemMenu-iPad-pseudo.Own-Unsigned-Devices.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3160ad5abc34d80f146b47abb9b6f7e4b194824b0043a0e1c70ee443f41ca1e
+size 144600

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_timelineItemMenu-iPhone-15-en-GB.Own-Unsigned-Devices.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_timelineItemMenu-iPhone-15-en-GB.Own-Unsigned-Devices.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:172fe16471b58c45a4f34cc2c2064cc6f7d2667447773d760254b49a354f0f48
+size 91682

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_timelineItemMenu-iPhone-15-pseudo.Own-Unsigned-Devices.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_timelineItemMenu-iPhone-15-pseudo.Own-Unsigned-Devices.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8a4f3dbb2a4cd191f31f48a95ecf20a082a7f1e7d28755979ec3ca8ef536972
+size 108127


### PR DESCRIPTION
iOS equivalent to https://github.com/element-hq/element-x-android/pull/3485

| Item Menu | Resolve failure sheet |
| - | - |
| <img width="375" alt="test_timelineItemMenu-iPhone-15-en-GB Own-Unsigned-Devices" src="https://github.com/user-attachments/assets/7323ff47-fa13-4053-8289-779112d37a9d"> | <img width="375" alt="test_resolveVerifiedUserSendFailureScreen-iPhone-15-en-GB Own-Unsigned-Device" src="https://github.com/user-attachments/assets/60e15d0d-0b46-487b-ba1f-f079facc4be1"> |
