### PR TITLE
Fix a regression where you can't scroll the timeline on iOS 17

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/View/SwipeRightAction.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/SwipeRightAction.swift
@@ -31,7 +31,7 @@ struct SwipeRightAction<Label: View>: ViewModifier {
         content
             .offset(x: xOffset, y: 0.0)
             .animation(.interactiveSpring().speed(0.5), value: xOffset)
-            .simultaneousGesture(gesture)
+            .timelineGesture(gesture)
             .onChange(of: dragGestureActive) { value in
                 if value == true {
                     if shouldStartAction() {
@@ -112,6 +112,18 @@ extension View {
                           shouldStartAction: @escaping () -> Bool,
                           action: @escaping () -> Void) -> some View {
         modifier(SwipeRightAction(label: label, shouldStartAction: shouldStartAction, action: action))
+    }
+    
+    @ViewBuilder
+    fileprivate func timelineGesture(_ gesture: some Gesture) -> some View {
+        if #available(iOS 18.0, *) {
+            // iOS 18 has a bug https://forums.developer.apple.com/forums/thread/760035 and you
+            // can't scroll the timeline when `gesture` is used.
+            simultaneousGesture(gesture)
+        } else {
+            // Equally on iOS 17 you can't scroll the timeline when `simultaneousGesture` is used.
+            self.gesture(gesture)
+        }
     }
 }
 


### PR DESCRIPTION
It was caused by a fix for the same bug on iOS 18 🤦‍♂️

Seems we need to use separate paths for configuring these gestures. Might be worth exploring the use of UIGestureRecognizer within SwiftUI on iOS 18 at this point, but I'll leave that for a future PR.