### PR TITLE
Fix a bug on iOS 18 where the timeline background would use the wrong colour scheme when using the app switcher.

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -60,6 +60,12 @@ custom_rules:
     message: "Please use explicit spacing in HStacks."
     severity: warning
 
+  compound_color_conversion:
+    regex: "UIColor\\(\\.compound"
+    match_kinds: identifier
+    message: "Please use the UIColor token directly to ensure the colour scheme is honoured."
+    severity: warning
+
   print_deprecation:
     regex: "\\b(print)\\b"
     match_kinds: identifier

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -7887,7 +7887,7 @@
 			repositoryURL = "https://github.com/element-hq/compound-ios";
 			requirement = {
 				kind = revision;
-				revision = 0d6248492aa577b3747a34c50104cc738b628478;
+				revision = 92110afc158ac6ee7c68d5e975144bafa6c58396;
 			};
 		};
 		F76A08D0EA29A07A54F4EB4D /* XCRemoteSwiftPackageReference "swift-collections" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/compound-ios",
       "state" : {
-        "revision" : "0d6248492aa577b3747a34c50104cc738b628478"
+        "revision" : "92110afc158ac6ee7c68d5e975144bafa6c58396"
       }
     },
     {

--- a/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilder.swift
+++ b/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilder.swift
@@ -5,6 +5,7 @@
 // Please see LICENSE in the repository root for full details.
 //
 
+import Compound
 import DTCoreText
 import Foundation
 import LRUCache
@@ -267,7 +268,7 @@ struct AttributedStringBuilder: AttributedStringBuilderProtocol {
         attributedString.enumerateAttribute(.backgroundColor, in: .init(location: 0, length: attributedString.length), options: []) { value, range, _ in
             if let value = value as? UIColor,
                value == temporaryCodeBlockMarkingColor {
-                attributedString.addAttribute(.backgroundColor, value: UIColor(.compound._bgCodeBlock) as Any, range: range)
+                attributedString.addAttribute(.backgroundColor, value: UIColor.compound._bgCodeBlock as Any, range: range)
                 attributedString.removeAttribute(.link, range: range)
             }
         }

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/MessageComposerTextField.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/MessageComposerTextField.swift
@@ -4,6 +4,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Please see LICENSE in the repository root for full details.
 //
+
+import Compound
 import SwiftUI
 
 struct MessageComposerTextField: View {
@@ -96,7 +98,7 @@ private struct UITextViewWrapper: UIViewRepresentable {
     func updateUIView(_ textView: UITextView, context: UIViewRepresentableContext<UITextViewWrapper>) {
         // Prevent the textView from inheriting attributes from mention pills
         textView.typingAttributes = [.font: font,
-                                     .foregroundColor: UIColor(.compound.textPrimary)]
+                                     .foregroundColor: UIColor.compound.textPrimary]
         
         if textView.attributedText != text {
             // Remember the selection if only the attributes have changed.
@@ -311,7 +313,7 @@ struct MessageComposerTextField_Previews: PreviewProvider, TestablePreview {
 
         init(text: String) {
             _text = .init(initialValue: .init(string: text, attributes: [.font: UIFont.preferredFont(forTextStyle: .body),
-                                                                         .foregroundColor: UIColor(.compound.textPrimary)]))
+                                                                         .foregroundColor: UIColor.compound.textPrimary]))
         }
 
         var body: some View {

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
@@ -6,6 +6,7 @@
 //
 
 import Combine
+import Compound
 import HTMLParser
 import SwiftUI
 import WysiwygComposer
@@ -207,14 +208,14 @@ enum ComposerConstant {
 private extension HTMLParserStyle {
     static let elementX = HTMLParserStyle(textColor: UIColor.label,
                                           linkColor: UIColor.link,
-                                          codeBlockStyle: BlockStyle(backgroundColor: UIColor(.compound._bgCodeBlock),
-                                                                     borderColor: UIColor(.compound.borderInteractiveSecondary),
+                                          codeBlockStyle: BlockStyle(backgroundColor: UIColor.compound._bgCodeBlock,
+                                                                     borderColor: UIColor.compound.borderInteractiveSecondary,
                                                                      borderWidth: 1.0,
                                                                      cornerRadius: 2.0,
                                                                      padding: BlockStyle.Padding(horizontal: 10, vertical: 12),
                                                                      type: .background),
-                                          quoteBlockStyle: BlockStyle(backgroundColor: UIColor(.compound.iconTertiary),
-                                                                      borderColor: UIColor(.compound.borderInteractiveSecondary),
+                                          quoteBlockStyle: BlockStyle(backgroundColor: UIColor.compound.iconTertiary,
+                                                                      borderColor: UIColor.compound.borderInteractiveSecondary,
                                                                       borderWidth: 0.0,
                                                                       cornerRadius: 0.0,
                                                                       padding: BlockStyle.Padding(horizontal: 25, vertical: 12),

--- a/ElementX/Sources/Screens/Timeline/TimelineTableViewController.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineTableViewController.swift
@@ -173,7 +173,7 @@ class TimelineTableViewController: UIViewController {
         tableView.separatorStyle = .none
         tableView.allowsSelection = false
         tableView.keyboardDismissMode = .onDrag
-        tableView.backgroundColor = UIColor(.compound.bgCanvasDefault)
+        tableView.backgroundColor = .compound.bgCanvasDefault
         tableView.transform = CGAffineTransform(scaleX: 1, y: -1)
         view.addSubview(tableView)
         

--- a/project.yml
+++ b/project.yml
@@ -64,7 +64,7 @@ packages:
     # path: ../matrix-rust-sdk
   Compound:
     url: https://github.com/element-hq/compound-ios
-    revision: 0d6248492aa577b3747a34c50104cc738b628478
+    revision: 92110afc158ac6ee7c68d5e975144bafa6c58396
     # path: ../compound-ios
   AnalyticsEvents:
     url: https://github.com/matrix-org/matrix-analytics-events


### PR DESCRIPTION
Use the UIColors directly instead of wrapping the SwiftUI Colors.
| Before | After |
| - | - |
| ![before](https://github.com/user-attachments/assets/019e6c3c-f194-4415-8c64-c50883d3a420) | ![after](https://github.com/user-attachments/assets/02f84e25-af36-4820-a816-2ae0e2b5cd81) |
