### PR TITLE
Don't use the new iPad modal presentation mode for the timeline item menu

### DIFF
--- a/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenu.swift
+++ b/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenu.swift
@@ -51,6 +51,7 @@ struct TimelineItemMenu: View {
             }
         }
         .accessibilityIdentifier(A11yIdentifiers.roomScreen.timelineItemActionMenu)
+        .presentationPage()
         .presentationDetents([.medium, .large])
         .presentationBackground(Color.compound.bgCanvasDefault)
         .presentationDragIndicator(.visible)
@@ -229,6 +230,17 @@ private extension EncryptionAuthenticity {
         switch color {
         case .red: .compound.textCriticalPrimary
         case .gray: .compound.textSecondary
+        }
+    }
+}
+
+private extension View {
+    /// Uses the old page style modal so that on iPadOS 18 the presentation detents have no effect.
+    @ViewBuilder func presentationPage() -> some View {
+        if #available(iOS 18.0, *) {
+            presentationSizing(.page)
+        } else {
+            self
         }
     }
 }


### PR DESCRIPTION
There are other sheets that have been shrunk with Xcode 16, but this one looks really bad with the new size and is the one people will see most of the time, so fixing this before making the RC.