### PR TITLE
Add detection for latest devices.

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -28,6 +28,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gems-
 
+      - name: Available simulators
+        run: xcrun simctl list
+
       - name: Setup environment
         run:
           source ci_scripts/ci_common.sh && setup_github_actions_environment

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -28,9 +28,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gems-
 
-      - name: Available simulators
-        run: xcrun simctl list
-
       - name: Setup environment
         run:
           source ci_scripts/ci_common.sh && setup_github_actions_environment

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -7726,8 +7726,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/krzysztofzablocki/KZFileWatchers";
 			requirement = {
-				branch = master;
-				kind = branch;
+				kind = upToNextMinorVersion;
+				minimumVersion = 1.2.0;
 			};
 		};
 		44FA555384AD79668D886043 /* XCRemoteSwiftPackageReference "matrix-rich-text-editor-swift" */ = {
@@ -7783,7 +7783,7 @@
 			repositoryURL = "https://github.com/nicklockwood/GZIP";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 1.3.0;
+				minimumVersion = 1.3.2;
 			};
 		};
 		821C67C9A7F8CC3FD41B28B4 /* XCRemoteSwiftPackageReference "emojibase-bindings" */ = {
@@ -7847,7 +7847,7 @@
 			repositoryURL = "https://github.com/devicekit/DeviceKit";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 5.2.2;
+				minimumVersion = 5.5.0;
 			};
 		};
 		E025F19D013D9BA6C58B37F4 /* XCRemoteSwiftPackageReference "swift-algorithms" */ = {
@@ -7879,7 +7879,7 @@
 			repositoryURL = "https://github.com/mxcl/Version";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.0.0;
+				minimumVersion = 2.1.0;
 			};
 		};
 		F71C70A4404CC6D9C4AF35F2 /* XCRemoteSwiftPackageReference "compound-ios" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/devicekit/DeviceKit",
       "state" : {
-        "revision" : "fe41d18eccd92a115cffaa35dfff03018c67e635",
-        "version" : "5.2.2"
+        "revision" : "7ff5331960151aec74fb422e1d45f54ef6cc086d",
+        "version" : "5.5.0"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nicklockwood/GZIP",
       "state" : {
-        "revision" : "bd55f1d89e71ae3f481da74cd4adeadbb849620c",
-        "version" : "1.3.1"
+        "revision" : "f710a37aa978a93b815a4f64bd504dc4c3256312",
+        "version" : "1.3.2"
       }
     },
     {
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/krzysztofzablocki/KZFileWatchers",
       "state" : {
-        "branch" : "master",
-        "revision" : "d27a9557427d261adccdf4b566acc9d9c0fec6f4"
+        "revision" : "d27a9557427d261adccdf4b566acc9d9c0fec6f4",
+        "version" : "1.2.0"
       }
     },
     {
@@ -284,8 +284,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mxcl/Version",
       "state" : {
-        "revision" : "1fe824b80d89201652e7eca7c9252269a1d85e25",
-        "version" : "2.0.1"
+        "revision" : "303a0f916772545e1e8667d3104f83be708a723c",
+        "version" : "2.1.0"
       }
     }
   ],

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -80,9 +80,21 @@ lane :alpha do
 end
 
 lane :unit_tests do |options|
+  create_simulator_if_necessary(
+    name: "iPhone 16 (Element X)",
+    type: "com.apple.CoreSimulator.SimDeviceType.iPhone-16",
+    runtime: "com.apple.CoreSimulator.SimRuntime.iOS-18-0"
+  )
+  
+  create_simulator_if_necessary(
+    name: "iPhone SE (Element X)",
+    type: "com.apple.CoreSimulator.SimDeviceType.iPhone-SE-3rd-generation",
+    runtime: "com.apple.CoreSimulator.SimRuntime.iOS-18-0"
+  )
+  
   run_tests(
     scheme: "UnitTests",
-    device: 'iPhone 16',
+    device: "iPhone 16 (Element X)",
     ensure_devices_found: true,
     result_bundle: true,
     number_of_retries: 3,
@@ -91,7 +103,7 @@ lane :unit_tests do |options|
   if !options[:skip_previews]
     run_tests(
       scheme: "PreviewTests",
-      device: 'iPhone SE (3rd generation)',
+      device: "iPhone SE (Element X)",
       ensure_devices_found: true,
       result_bundle: true,
       number_of_retries: 3,
@@ -107,13 +119,13 @@ lane :ui_tests do |options|
   # reset_simulator_contents()
   
   create_simulator_if_necessary(
-    name: "iPhone 16",
+    name: "iPhone 16 (Element X)",
     type: "com.apple.CoreSimulator.SimDeviceType.iPhone-16",
     runtime: "com.apple.CoreSimulator.SimRuntime.iOS-18-0"
   )
   
   create_simulator_if_necessary(
-    name: "iPad (10th generation)",
+    name: "iPad (Element X)",
     type: "com.apple.CoreSimulator.SimDeviceType.iPad-10th-generation",
     runtime: "com.apple.CoreSimulator.SimRuntime.iOS-18-0"
   )
@@ -126,7 +138,7 @@ lane :ui_tests do |options|
 
   run_tests(
     scheme: "UITests",
-    devices: ["iPhone 16", "iPad (10th generation)"],
+    devices: ["iPhone 16 (Element X)", "iPad (Element X)"],
     ensure_devices_found: true,
     prelaunch_simulator: true,
     result_bundle: true,
@@ -140,14 +152,14 @@ lane :integration_tests do
   clear_derived_data()
   
   create_simulator_if_necessary(
-    name: "iPhone 16 Pro",
+    name: "iPhone 16 Pro (Element X)",
     type: "com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro",
     runtime: "com.apple.CoreSimulator.SimRuntime.iOS-18-0"
   )
 
   run_tests(
     scheme: "IntegrationTests",
-    devices: ["iPhone 16 Pro"],
+    devices: ["iPhone 16 Pro (Element X)"],
     ensure_devices_found: true,
     result_bundle: true,
     reset_simulator: true

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -80,21 +80,9 @@ lane :alpha do
 end
 
 lane :unit_tests do |options|
-  create_simulator_if_necessary(
-    name: "iPhone 16 (Element X)",
-    type: "com.apple.CoreSimulator.SimDeviceType.iPhone-16",
-    runtime: "com.apple.CoreSimulator.SimRuntime.iOS-18-0"
-  )
-  
-  create_simulator_if_necessary(
-    name: "iPhone SE (Element X)",
-    type: "com.apple.CoreSimulator.SimDeviceType.iPhone-SE-3rd-generation",
-    runtime: "com.apple.CoreSimulator.SimRuntime.iOS-18-0"
-  )
-  
   run_tests(
     scheme: "UnitTests",
-    device: "iPhone 16 (Element X)",
+    destination: "platform=iOS Simulator,name=iPhone 16,OS=18.0",
     ensure_devices_found: true,
     result_bundle: true,
     number_of_retries: 3,
@@ -103,7 +91,7 @@ lane :unit_tests do |options|
   if !options[:skip_previews]
     run_tests(
       scheme: "PreviewTests",
-      device: "iPhone SE (Element X)",
+      destination: "platform=iOS Simulator,name=iPhone SE (3rd generation),OS=18.0",
       ensure_devices_found: true,
       result_bundle: true,
       number_of_retries: 3,
@@ -119,13 +107,13 @@ lane :ui_tests do |options|
   # reset_simulator_contents()
   
   create_simulator_if_necessary(
-    name: "iPhone 16 (Element X)",
+    name: "iPhone 16",
     type: "com.apple.CoreSimulator.SimDeviceType.iPhone-16",
     runtime: "com.apple.CoreSimulator.SimRuntime.iOS-18-0"
   )
   
   create_simulator_if_necessary(
-    name: "iPad (Element X)",
+    name: "iPad (10th generation)",
     type: "com.apple.CoreSimulator.SimDeviceType.iPad-10th-generation",
     runtime: "com.apple.CoreSimulator.SimRuntime.iOS-18-0"
   )
@@ -138,7 +126,7 @@ lane :ui_tests do |options|
 
   run_tests(
     scheme: "UITests",
-    devices: ["iPhone 16 (Element X)", "iPad (Element X)"],
+    devices: ["iPhone 16", "iPad (10th generation)"],
     ensure_devices_found: true,
     prelaunch_simulator: true,
     result_bundle: true,
@@ -152,14 +140,14 @@ lane :integration_tests do
   clear_derived_data()
   
   create_simulator_if_necessary(
-    name: "iPhone 16 Pro (Element X)",
+    name: "iPhone 16 Pro",
     type: "com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro",
     runtime: "com.apple.CoreSimulator.SimRuntime.iOS-18-0"
   )
 
   run_tests(
     scheme: "IntegrationTests",
-    devices: ["iPhone 16 Pro (Element X)"],
+    destination: "platform=iOS Simulator,name=iPhone 16 Pro,OS=18.0",
     ensure_devices_found: true,
     result_bundle: true,
     reset_simulator: true

--- a/project.yml
+++ b/project.yml
@@ -91,7 +91,7 @@ packages:
     minorVersion: 1.0.0
   DeviceKit:
     url: https://github.com/devicekit/DeviceKit
-    minorVersion: 5.2.2
+    minorVersion: 5.5.0
   DSWaveformImage:
     url: https://github.com/dmrschmidt/DSWaveformImage
     exactVersion: 14.1.1
@@ -100,7 +100,7 @@ packages:
     exactVersion: 1.6.26
   GZIP:
     url: https://github.com/nicklockwood/GZIP
-    minorVersion: 1.3.0
+    minorVersion: 1.3.2
   KeychainAccess:
     url: https://github.com/kishikawakatsumi/KeychainAccess
     minorVersion: 4.2.0
@@ -109,7 +109,7 @@ packages:
     minorVersion: 7.6.0
   KZFileWatchers:
     url: https://github.com/krzysztofzablocki/KZFileWatchers
-    branch: master
+    minorVersion: 1.2.0
   LoremSwiftum:
     url: https://github.com/lukaskubanek/LoremSwiftum
     minorVersion: 2.2.1
@@ -133,7 +133,7 @@ packages:
     minorVersion: 6.0.0
   Version:
     url: https://github.com/mxcl/Version
-    minorVersion: 2.0.0
+    minorVersion: 2.1.0
 
 aggregateTargets:
   Periphery:


### PR DESCRIPTION
The main update is for DeviceKit which now detects iPad Pro (M4), iPad Air (M2) and iPhones 16.

Additionally updates other packages including changing KZFileWatchers to use a release now that there's a [tag](https://github.com/krzysztofzablocki/KZFileWatchers/issues/28) against the commit we needed to use.