### PR TITLE
crypto: rename invisible crypto flag to deviceIsolationMode

### DIFF
--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -11,7 +11,7 @@ import SwiftUI
 // Common settings between app and NSE
 protocol CommonSettingsProtocol {
     var logLevel: TracingConfiguration.LogLevel { get }
-    var invisibleCryptoEnabled: Bool { get }
+    var enableOnlySignedDeviceIsolationMode: Bool { get }
 }
 
 /// Store Element specific app settings.
@@ -43,7 +43,7 @@ final class AppSettings {
         case publicSearchEnabled
         case fuzzyRoomListSearchEnabled
         case pinningEnabled
-        case invisibleCryptoEnabled
+        case enableOnlySignedDeviceIsolationMode
     }
     
     private static var suiteName: String = InfoPlistReader.main.appGroupIdentifier
@@ -285,9 +285,9 @@ final class AppSettings {
     @UserPreference(key: UserDefaultsKeys.logLevel, defaultValue: TracingConfiguration.LogLevel.info, storageType: .userDefaults(store))
     var logLevel
     
-    /// Configuration to enable invisible crypto. In this mode only devices signed by their owner will be considered in e2ee rooms.
-    @UserPreference(key: UserDefaultsKeys.invisibleCryptoEnabled, defaultValue: false, storageType: .userDefaults(store))
-    var invisibleCryptoEnabled
+    /// Configuration to enable only signed device isolation mode for  crypto. In this mode only devices signed by their owner will be considered in e2ee rooms.
+    @UserPreference(key: UserDefaultsKeys.enableOnlySignedDeviceIsolationMode, defaultValue: false, storageType: .userDefaults(store))
+    var enableOnlySignedDeviceIsolationMode
 }
 
 extension AppSettings: CommonSettingsProtocol { }

--- a/ElementX/Sources/Other/Extensions/ClientBuilder.swift
+++ b/ElementX/Sources/Other/Extensions/ClientBuilder.swift
@@ -15,7 +15,7 @@ extension ClientBuilder {
                             slidingSync: ClientBuilderSlidingSync,
                             sessionDelegate: ClientSessionDelegate,
                             appHooks: AppHooks,
-                            invisibleCryptoEnabled: Bool) -> ClientBuilder {
+                            enableOnlySignedDeviceIsolationMode: Bool) -> ClientBuilder {
         var builder = ClientBuilder()
             .enableCrossProcessRefreshLock(processId: InfoPlistReader.main.bundleIdentifier, sessionDelegate: sessionDelegate)
             .userAgent(userAgent: UserAgentBuilder.makeASCIIUserAgent())
@@ -34,7 +34,7 @@ extension ClientBuilder {
                 .backupDownloadStrategy(backupDownloadStrategy: .afterDecryptionFailure)
                 .autoEnableBackups(autoEnableBackups: true)
                 
-            if invisibleCryptoEnabled {
+            if enableOnlySignedDeviceIsolationMode {
                 builder = builder.roomKeyRecipientStrategy(strategy: CollectStrategy.identityBasedStrategy)
             } else {
                 builder = builder.roomKeyRecipientStrategy(strategy: .deviceBasedStrategy(onlyAllowTrustedDevices: false, errorOnVerifiedUserProblem: true))

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
@@ -47,7 +47,7 @@ protocol DeveloperOptionsProtocol: AnyObject {
     var elementCallBaseURLOverride: URL? { get set }
     var fuzzyRoomListSearchEnabled: Bool { get set }
     var pinningEnabled: Bool { get set }
-    var invisibleCryptoEnabled: Bool { get set }
+    var enableOnlySignedDeviceIsolationMode: Bool { get set }
 }
 
 extension AppSettings: DeveloperOptionsProtocol { }

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
@@ -53,14 +53,14 @@ struct DeveloperOptionsScreen: View {
             }
             
             Section {
-                Toggle(isOn: $context.invisibleCryptoEnabled) {
-                    Text("Enabled Invisible Crypto")
+                Toggle(isOn: $context.enableOnlySignedDeviceIsolationMode) {
+                    Text("Exclude not secure devices when sending/receiving messages")
                     Text("Requires app reboot")
                 }
             } header: {
                 Text("Trust and Decoration")
             } footer: {
-                Text("This setting controls how end-to-end encryption (E2EE) keys are shared. Enabling it will prevent the inclusion of devices that have not been explicitly verified by their owners.")
+                Text("This setting controls how end-to-end encryption (E2EE) keys are exchanged. Enabling it will prevent the inclusion of devices that have not been explicitly verified by their owners.")
             }
 
             Section {

--- a/ElementX/Sources/Services/Authentication/AuthenticationClientBuilder.swift
+++ b/ElementX/Sources/Services/Authentication/AuthenticationClientBuilder.swift
@@ -78,7 +78,7 @@ struct AuthenticationClientBuilder: AuthenticationClientBuilderProtocol {
                          slidingSync: slidingSync,
                          sessionDelegate: clientSessionDelegate,
                          appHooks: appHooks,
-                         invisibleCryptoEnabled: appSettings.invisibleCryptoEnabled)
+                         enableOnlySignedDeviceIsolationMode: appSettings.enableOnlySignedDeviceIsolationMode)
             .sessionPaths(dataPath: sessionDirectories.dataPath,
                           cachePath: sessionDirectories.cachePath)
             .passphrase(passphrase: passphrase)

--- a/ElementX/Sources/Services/UserSession/UserSessionStore.swift
+++ b/ElementX/Sources/Services/UserSession/UserSessionStore.swift
@@ -125,7 +125,7 @@ class UserSessionStore: UserSessionStoreProtocol {
                          slidingSync: .restored,
                          sessionDelegate: keychainController,
                          appHooks: appHooks,
-                         invisibleCryptoEnabled: appSettings.invisibleCryptoEnabled)
+                         enableOnlySignedDeviceIsolationMode: appSettings.enableOnlySignedDeviceIsolationMode)
             .sessionPaths(dataPath: credentials.restorationToken.sessionDirectories.dataPath,
                           cachePath: credentials.restorationToken.sessionDirectories.cachePath)
             .username(username: credentials.userID)

--- a/NSE/Sources/Other/NSEUserSession.swift
+++ b/NSE/Sources/Other/NSEUserSession.swift
@@ -34,7 +34,7 @@ final class NSEUserSession {
                          slidingSync: .restored,
                          sessionDelegate: clientSessionDelegate,
                          appHooks: appHooks,
-                         invisibleCryptoEnabled: appSettings.invisibleCryptoEnabled)
+                         enableOnlySignedDeviceIsolationMode: appSettings.enableOnlySignedDeviceIsolationMode)
             .sessionPaths(dataPath: credentials.restorationToken.sessionDirectories.dataPath,
                           cachePath: credentials.restorationToken.sessionDirectories.cachePath)
             .username(username: credentials.userID)


### PR DESCRIPTION
### Pull Request Checklist

Fixes https://github.com/element-hq/element-x-ios/issues/3322

Rename the config flag, and dev tool lab flag as per discussions.

<img width="382" alt="image" src="https://github.com/user-attachments/assets/7b600673-cbff-47a8-937b-058072bf8cdf">


- [ ] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off).

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
