### PR TITLE
crypto: Configure decryption trustRequirement based on config flag

### DIFF
--- a/ElementX/Sources/Other/Extensions/ClientBuilder.swift
+++ b/ElementX/Sources/Other/Extensions/ClientBuilder.swift
@@ -35,9 +35,13 @@ extension ClientBuilder {
                 .autoEnableBackups(autoEnableBackups: true)
                 
             if enableOnlySignedDeviceIsolationMode {
-                builder = builder.roomKeyRecipientStrategy(strategy: CollectStrategy.identityBasedStrategy)
+                builder = builder
+                    .roomKeyRecipientStrategy(strategy: CollectStrategy.identityBasedStrategy)
+                    .roomDecryptionTrustRequirement(trustRequirement: TrustRequirement.crossSignedOrLegacy)
             } else {
-                builder = builder.roomKeyRecipientStrategy(strategy: .deviceBasedStrategy(onlyAllowTrustedDevices: false, errorOnVerifiedUserProblem: true))
+                builder = builder
+                    .roomKeyRecipientStrategy(strategy: .deviceBasedStrategy(onlyAllowTrustedDevices: false, errorOnVerifiedUserProblem: true))
+                    .roomDecryptionTrustRequirement(trustRequirement: TrustRequirement.untrusted)
             }
         }
         

--- a/ElementX/Sources/Other/Extensions/ClientBuilder.swift
+++ b/ElementX/Sources/Other/Extensions/ClientBuilder.swift
@@ -36,12 +36,12 @@ extension ClientBuilder {
                 
             if enableOnlySignedDeviceIsolationMode {
                 builder = builder
-                    .roomKeyRecipientStrategy(strategy: CollectStrategy.identityBasedStrategy)
-                    .roomDecryptionTrustRequirement(trustRequirement: TrustRequirement.crossSignedOrLegacy)
+                    .roomKeyRecipientStrategy(strategy: .identityBasedStrategy)
+                    .roomDecryptionTrustRequirement(trustRequirement: .crossSignedOrLegacy)
             } else {
                 builder = builder
                     .roomKeyRecipientStrategy(strategy: .deviceBasedStrategy(onlyAllowTrustedDevices: false, errorOnVerifiedUserProblem: true))
-                    .roomDecryptionTrustRequirement(trustRequirement: TrustRequirement.untrusted)
+                    .roomDecryptionTrustRequirement(trustRequirement: .untrusted)
             }
         }
         

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
@@ -53,7 +53,7 @@ struct DeveloperOptionsScreen: View {
             
             Section {
                 Toggle(isOn: $context.enableOnlySignedDeviceIsolationMode) {
-                    Text("Exclude not secure devices when sending/receiving messages")
+                    Text("Exclude insecure devices when sending/receiving messages")
                     Text("Requires app reboot")
                 }
             } header: {


### PR DESCRIPTION
### Pull Request Checklist
Depends on https://github.com/matrix-org/matrix-rust-sdk/pull/4046

Part of https://github.com/element-hq/crypto-internal/issues/354

For now the new decryption errors will show as regular ones (waiting for this message), a following PR will fix that once the sdk has support for different UTD errors

- [ ] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off).

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
