### PR TITLE
Refactor the`TimelineItemIdentifier` handling

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -611,6 +611,7 @@
 		86F9D3028A1F4AE819D75560 /* RoomChangePermissionsScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D879FC4E881E748BB9B34DC /* RoomChangePermissionsScreenCoordinator.swift */; };
 		872A6457DF573AF8CEAE927A /* LoginHomeserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9349F590E35CE514A71E6764 /* LoginHomeserver.swift */; };
 		874FEFB9D4A4AF447E0E086E /* AuthenticationStartScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0F7CCC4A9D1927223F559D5 /* AuthenticationStartScreenViewModelProtocol.swift */; };
+		877D3CE8680536DB430DE6A2 /* TimelineItemIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48C91C8BE55CAE1A3DBC3BC /* TimelineItemIdentifier.swift */; };
 		878070573C7BF19E735707B4 /* RoomTimelineItemProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DE8D25D6A91030175D52A20 /* RoomTimelineItemProperties.swift */; };
 		87B4E59A4467F8EC75F82372 /* VoiceMessageRoomTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B70A50C41C5871B4DB905E7E /* VoiceMessageRoomTimelineView.swift */; };
 		87CEA3E07B602705BC2D2A20 /* ClientBuilderHook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AC0CD1CAFD3F8B057F9AEA5 /* ClientBuilderHook.swift */; };
@@ -2189,6 +2190,7 @@
 		E44E35AA87F49503E7B3BF6E /* AudioConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioConverter.swift; sourceTree = "<group>"; };
 		E45EBAFF1A83538D54ABDF92 /* ServerSelectionScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSelectionScreenViewModelTests.swift; sourceTree = "<group>"; };
 		E461B3C8BBBFCA400B268D14 /* AppRouteURLParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRouteURLParserTests.swift; sourceTree = "<group>"; };
+		E48C91C8BE55CAE1A3DBC3BC /* TimelineItemIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineItemIdentifier.swift; sourceTree = "<group>"; };
 		E5272BC4A60B6AD7553BACA1 /* BlurHashDecode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurHashDecode.swift; sourceTree = "<group>"; };
 		E53BFB7E4F329621C844E8C3 /* AnalyticsPromptScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsPromptScreen.swift; sourceTree = "<group>"; };
 		E55B5EA766E89FF1F87C3ACB /* RoomNotificationSettingsProxyProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomNotificationSettingsProxyProtocol.swift; sourceTree = "<group>"; };
@@ -5473,6 +5475,7 @@
 				0DF5CBAF69BDF5DF31C661E1 /* IntentionalMentions.swift */,
 				66F2402D738694F98729A441 /* RoomTimelineProvider.swift */,
 				095AED4CF56DFF3EB7BB84C8 /* RoomTimelineProviderProtocol.swift */,
+				E48C91C8BE55CAE1A3DBC3BC /* TimelineItemIdentifier.swift */,
 				2D505843AB66822EB91F0DF0 /* TimelineItemProxy.swift */,
 				55AEEF8142DF1B59DB40FB93 /* TimelineItemSender.swift */,
 				F9E543072DE58E751F028998 /* TimelineProxy.swift */,
@@ -6931,6 +6934,7 @@
 				E6FA87F773424B27614B23E9 /* TimelineItemAccessibilityModifier.swift in Sources */,
 				79959F8E45C3749997482A7F /* TimelineItemBubbledStylerView.swift in Sources */,
 				A808DC3F72D15C6C5A52317E /* TimelineItemDebugView.swift in Sources */,
+				877D3CE8680536DB430DE6A2 /* TimelineItemIdentifier.swift in Sources */,
 				C0B97FFEC0083F3A36609E61 /* TimelineItemMacContextMenu.swift in Sources */,
 				6C98153D60FF9B648C166C27 /* TimelineItemMenu.swift in Sources */,
 				AE07F215EBC2B9CBF17AA54B /* TimelineItemMenuAction.swift in Sources */,

--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -334,6 +334,7 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
         
         switch await roomProxy.timeline.sendMessage(replyText,
                                                     html: nil,
+                                                    inReplyToEventID: nil,
                                                     intentionalMentions: .empty) {
         case .success:
             break

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -13987,8 +13987,8 @@ class TimelineProxyMock: TimelineProxyProtocol {
     var editNewContentCalled: Bool {
         return editNewContentCallsCount > 0
     }
-    var editNewContentReceivedArguments: (timelineItem: EventTimelineItem, newContent: RoomMessageEventContentWithoutRelation)?
-    var editNewContentReceivedInvocations: [(timelineItem: EventTimelineItem, newContent: RoomMessageEventContentWithoutRelation)] = []
+    var editNewContentReceivedArguments: (eventOrTransactionID: EventOrTransactionId, newContent: RoomMessageEventContentWithoutRelation)?
+    var editNewContentReceivedInvocations: [(eventOrTransactionID: EventOrTransactionId, newContent: RoomMessageEventContentWithoutRelation)] = []
 
     var editNewContentUnderlyingReturnValue: Result<Void, TimelineProxyError>!
     var editNewContentReturnValue: Result<Void, TimelineProxyError>! {
@@ -14014,16 +14014,16 @@ class TimelineProxyMock: TimelineProxyProtocol {
             }
         }
     }
-    var editNewContentClosure: ((EventTimelineItem, RoomMessageEventContentWithoutRelation) async -> Result<Void, TimelineProxyError>)?
+    var editNewContentClosure: ((EventOrTransactionId, RoomMessageEventContentWithoutRelation) async -> Result<Void, TimelineProxyError>)?
 
-    func edit(_ timelineItem: EventTimelineItem, newContent: RoomMessageEventContentWithoutRelation) async -> Result<Void, TimelineProxyError> {
+    func edit(_ eventOrTransactionID: EventOrTransactionId, newContent: RoomMessageEventContentWithoutRelation) async -> Result<Void, TimelineProxyError> {
         editNewContentCallsCount += 1
-        editNewContentReceivedArguments = (timelineItem: timelineItem, newContent: newContent)
+        editNewContentReceivedArguments = (eventOrTransactionID: eventOrTransactionID, newContent: newContent)
         DispatchQueue.main.async {
-            self.editNewContentReceivedInvocations.append((timelineItem: timelineItem, newContent: newContent))
+            self.editNewContentReceivedInvocations.append((eventOrTransactionID: eventOrTransactionID, newContent: newContent))
         }
         if let editNewContentClosure = editNewContentClosure {
-            return await editNewContentClosure(timelineItem, newContent)
+            return await editNewContentClosure(eventOrTransactionID, newContent)
         } else {
             return editNewContentReturnValue
         }
@@ -14770,15 +14770,15 @@ class TimelineProxyMock: TimelineProxyProtocol {
     }
     //MARK: - sendMessage
 
-    var sendMessageHtmlInReplyToIntentionalMentionsUnderlyingCallsCount = 0
-    var sendMessageHtmlInReplyToIntentionalMentionsCallsCount: Int {
+    var sendMessageHtmlInReplyToEventIDIntentionalMentionsUnderlyingCallsCount = 0
+    var sendMessageHtmlInReplyToEventIDIntentionalMentionsCallsCount: Int {
         get {
             if Thread.isMainThread {
-                return sendMessageHtmlInReplyToIntentionalMentionsUnderlyingCallsCount
+                return sendMessageHtmlInReplyToEventIDIntentionalMentionsUnderlyingCallsCount
             } else {
                 var returnValue: Int? = nil
                 DispatchQueue.main.sync {
-                    returnValue = sendMessageHtmlInReplyToIntentionalMentionsUnderlyingCallsCount
+                    returnValue = sendMessageHtmlInReplyToEventIDIntentionalMentionsUnderlyingCallsCount
                 }
 
                 return returnValue!
@@ -14786,29 +14786,29 @@ class TimelineProxyMock: TimelineProxyProtocol {
         }
         set {
             if Thread.isMainThread {
-                sendMessageHtmlInReplyToIntentionalMentionsUnderlyingCallsCount = newValue
+                sendMessageHtmlInReplyToEventIDIntentionalMentionsUnderlyingCallsCount = newValue
             } else {
                 DispatchQueue.main.sync {
-                    sendMessageHtmlInReplyToIntentionalMentionsUnderlyingCallsCount = newValue
+                    sendMessageHtmlInReplyToEventIDIntentionalMentionsUnderlyingCallsCount = newValue
                 }
             }
         }
     }
-    var sendMessageHtmlInReplyToIntentionalMentionsCalled: Bool {
-        return sendMessageHtmlInReplyToIntentionalMentionsCallsCount > 0
+    var sendMessageHtmlInReplyToEventIDIntentionalMentionsCalled: Bool {
+        return sendMessageHtmlInReplyToEventIDIntentionalMentionsCallsCount > 0
     }
-    var sendMessageHtmlInReplyToIntentionalMentionsReceivedArguments: (message: String, html: String?, eventID: String?, intentionalMentions: IntentionalMentions)?
-    var sendMessageHtmlInReplyToIntentionalMentionsReceivedInvocations: [(message: String, html: String?, eventID: String?, intentionalMentions: IntentionalMentions)] = []
+    var sendMessageHtmlInReplyToEventIDIntentionalMentionsReceivedArguments: (message: String, html: String?, inReplyToEventID: String?, intentionalMentions: IntentionalMentions)?
+    var sendMessageHtmlInReplyToEventIDIntentionalMentionsReceivedInvocations: [(message: String, html: String?, inReplyToEventID: String?, intentionalMentions: IntentionalMentions)] = []
 
-    var sendMessageHtmlInReplyToIntentionalMentionsUnderlyingReturnValue: Result<Void, TimelineProxyError>!
-    var sendMessageHtmlInReplyToIntentionalMentionsReturnValue: Result<Void, TimelineProxyError>! {
+    var sendMessageHtmlInReplyToEventIDIntentionalMentionsUnderlyingReturnValue: Result<Void, TimelineProxyError>!
+    var sendMessageHtmlInReplyToEventIDIntentionalMentionsReturnValue: Result<Void, TimelineProxyError>! {
         get {
             if Thread.isMainThread {
-                return sendMessageHtmlInReplyToIntentionalMentionsUnderlyingReturnValue
+                return sendMessageHtmlInReplyToEventIDIntentionalMentionsUnderlyingReturnValue
             } else {
                 var returnValue: Result<Void, TimelineProxyError>? = nil
                 DispatchQueue.main.sync {
-                    returnValue = sendMessageHtmlInReplyToIntentionalMentionsUnderlyingReturnValue
+                    returnValue = sendMessageHtmlInReplyToEventIDIntentionalMentionsUnderlyingReturnValue
                 }
 
                 return returnValue!
@@ -14816,26 +14816,26 @@ class TimelineProxyMock: TimelineProxyProtocol {
         }
         set {
             if Thread.isMainThread {
-                sendMessageHtmlInReplyToIntentionalMentionsUnderlyingReturnValue = newValue
+                sendMessageHtmlInReplyToEventIDIntentionalMentionsUnderlyingReturnValue = newValue
             } else {
                 DispatchQueue.main.sync {
-                    sendMessageHtmlInReplyToIntentionalMentionsUnderlyingReturnValue = newValue
+                    sendMessageHtmlInReplyToEventIDIntentionalMentionsUnderlyingReturnValue = newValue
                 }
             }
         }
     }
-    var sendMessageHtmlInReplyToIntentionalMentionsClosure: ((String, String?, String?, IntentionalMentions) async -> Result<Void, TimelineProxyError>)?
+    var sendMessageHtmlInReplyToEventIDIntentionalMentionsClosure: ((String, String?, String?, IntentionalMentions) async -> Result<Void, TimelineProxyError>)?
 
-    func sendMessage(_ message: String, html: String?, inReplyTo eventID: String?, intentionalMentions: IntentionalMentions) async -> Result<Void, TimelineProxyError> {
-        sendMessageHtmlInReplyToIntentionalMentionsCallsCount += 1
-        sendMessageHtmlInReplyToIntentionalMentionsReceivedArguments = (message: message, html: html, eventID: eventID, intentionalMentions: intentionalMentions)
+    func sendMessage(_ message: String, html: String?, inReplyToEventID: String?, intentionalMentions: IntentionalMentions) async -> Result<Void, TimelineProxyError> {
+        sendMessageHtmlInReplyToEventIDIntentionalMentionsCallsCount += 1
+        sendMessageHtmlInReplyToEventIDIntentionalMentionsReceivedArguments = (message: message, html: html, inReplyToEventID: inReplyToEventID, intentionalMentions: intentionalMentions)
         DispatchQueue.main.async {
-            self.sendMessageHtmlInReplyToIntentionalMentionsReceivedInvocations.append((message: message, html: html, eventID: eventID, intentionalMentions: intentionalMentions))
+            self.sendMessageHtmlInReplyToEventIDIntentionalMentionsReceivedInvocations.append((message: message, html: html, inReplyToEventID: inReplyToEventID, intentionalMentions: intentionalMentions))
         }
-        if let sendMessageHtmlInReplyToIntentionalMentionsClosure = sendMessageHtmlInReplyToIntentionalMentionsClosure {
-            return await sendMessageHtmlInReplyToIntentionalMentionsClosure(message, html, eventID, intentionalMentions)
+        if let sendMessageHtmlInReplyToEventIDIntentionalMentionsClosure = sendMessageHtmlInReplyToEventIDIntentionalMentionsClosure {
+            return await sendMessageHtmlInReplyToEventIDIntentionalMentionsClosure(message, html, inReplyToEventID, intentionalMentions)
         } else {
-            return sendMessageHtmlInReplyToIntentionalMentionsReturnValue
+            return sendMessageHtmlInReplyToEventIDIntentionalMentionsReturnValue
         }
     }
     //MARK: - toggleReaction

--- a/ElementX/Sources/Mocks/PollMock.swift
+++ b/ElementX/Sources/Mocks/PollMock.swift
@@ -82,7 +82,7 @@ extension Poll.Option {
 
 extension PollRoomTimelineItem {
     static func mock(poll: Poll, isOutgoing: Bool = true, isEditable: Bool = false) -> Self {
-        .init(id: .random,
+        .init(id: .randomEvent,
               poll: poll,
               body: "poll",
               timestamp: "Now",

--- a/ElementX/Sources/Screens/MessageForwardingScreen/View/MessageForwardingScreen.swift
+++ b/ElementX/Sources/Screens/MessageForwardingScreen/View/MessageForwardingScreen.swift
@@ -93,7 +93,7 @@ private struct MessageForwardingListRow: View {
 struct MessageForwardingScreen_Previews: PreviewProvider, TestablePreview {
     static var previews: some View {
         let summaryProvider = RoomSummaryProviderMock(.init(state: .loaded(.mockRooms)))
-        let viewModel = MessageForwardingScreenViewModel(forwardingItem: .init(id: .init(uniqueID: ""),
+        let viewModel = MessageForwardingScreenViewModel(forwardingItem: .init(id: .randomEvent,
                                                                                roomID: "",
                                                                                content: .init(noPointer: .init())),
                                                          clientProxy: ClientProxyMock(.init()),

--- a/ElementX/Sources/Screens/ResolveVerifiedUserSendFailureScreen/View/ResolveVerifiedUserSendFailureScreen.swift
+++ b/ElementX/Sources/Screens/ResolveVerifiedUserSendFailureScreen/View/ResolveVerifiedUserSendFailureScreen.swift
@@ -94,7 +94,7 @@ struct ResolveVerifiedUserSendFailureScreen_Previews: PreviewProvider, TestableP
     
     static func makeViewModel(failure: TimelineItemSendFailure.VerifiedUser) -> ResolveVerifiedUserSendFailureScreenViewModel {
         ResolveVerifiedUserSendFailureScreenViewModel(failure: failure,
-                                                      itemID: .random,
+                                                      itemID: .randomEvent,
                                                       roomProxy: JoinedRoomProxyMock(.init()),
                                                       userIndicatorController: UserIndicatorControllerMock())
     }
@@ -102,7 +102,7 @@ struct ResolveVerifiedUserSendFailureScreen_Previews: PreviewProvider, TestableP
 
 struct ResolveVerifiedUserSendFailureScreenSheet_Previews: PreviewProvider {
     static let viewModel = ResolveVerifiedUserSendFailureScreenViewModel(failure: .changedIdentity(users: ["@alice:matrix.org"]),
-                                                                         itemID: .random,
+                                                                         itemID: .randomEvent,
                                                                          roomProxy: JoinedRoomProxyMock(.init()),
                                                                          userIndicatorController: UserIndicatorControllerMock())
     

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarModels.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarModels.swift
@@ -6,6 +6,7 @@
 //
 
 import Compound
+import MatrixRustSDK
 import SwiftUI
 import WysiwygComposer
 
@@ -283,9 +284,14 @@ extension FormatType {
 }
 
 enum ComposerMode: Equatable {
+    enum EditSource {
+        case timeline
+        case draftService
+    }
+    
     case `default`
-    case reply(itemID: TimelineItemIdentifier, replyDetails: TimelineItemReplyDetails, isThread: Bool)
-    case edit(originalItemId: TimelineItemIdentifier)
+    case reply(eventID: String, replyDetails: TimelineItemReplyDetails, isThread: Bool)
+    case edit(originalEventOrTransactionID: EventOrTransactionId, source: EditSource)
     case recordVoiceMessage(state: AudioRecorderState)
     case previewVoiceMessage(state: AudioPlayerState, waveform: WaveformSource, isUploading: Bool)
 
@@ -323,8 +329,8 @@ enum ComposerMode: Equatable {
     
     var replyEventID: String? {
         switch self {
-        case .reply(let itemID, _, _):
-            return itemID.eventID
+        case .reply(let eventID, _, _):
+            return eventID
         default:
             return nil
         }

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/ComposerToolbar.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/ComposerToolbar.swift
@@ -415,10 +415,10 @@ extension ComposerToolbar {
                                                  mentionDisplayHelper: ComposerMentionDisplayHelper.mock,
                                                  analyticsService: ServiceLocator.shared.analytics,
                                                  composerDraftService: ComposerDraftServiceMock())
-            model.state.composerMode = isLoading ? .reply(itemID: .init(uniqueID: ""),
+            model.state.composerMode = isLoading ? .reply(eventID: UUID().uuidString,
                                                           replyDetails: .loading(eventID: ""),
                                                           isThread: false) :
-                .reply(itemID: .init(uniqueID: ""),
+                .reply(eventID: UUID().uuidString,
                        replyDetails: .loaded(sender: .init(id: "",
                                                            displayName: "Test"),
                                              eventID: "", eventContent: .message(.text(.init(body: "Hello World!")))), isThread: false)

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/MessageComposer.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/MessageComposer.swift
@@ -275,9 +275,9 @@ struct MessageComposer_Previews: PreviewProvider, TestablePreview {
             messageComposer()
             
             messageComposer(.init(string: "Some message"),
-                            mode: .edit(originalItemId: .random))
+                            mode: .edit(originalEventOrTransactionID: .eventId(eventId: UUID().uuidString), source: .timeline))
             
-            messageComposer(mode: .reply(itemID: .random,
+            messageComposer(mode: .reply(eventID: UUID().uuidString,
                                          replyDetails: .loaded(sender: .init(id: "Kirk"),
                                                                eventID: "123",
                                                                eventContent: .message(.text(.init(body: "Text: Where the wild things are")))),
@@ -288,7 +288,7 @@ struct MessageComposer_Previews: PreviewProvider, TestablePreview {
         ScrollView {
             VStack(spacing: 8) {
                 ForEach(replyTypes, id: \.self) { replyDetails in
-                    messageComposer(mode: .reply(itemID: .random,
+                    messageComposer(mode: .reply(eventID: UUID().uuidString,
                                                  replyDetails: replyDetails, isThread: false))
                 }
             }
@@ -300,7 +300,7 @@ struct MessageComposer_Previews: PreviewProvider, TestablePreview {
         ScrollView {
             VStack(spacing: 8) {
                 ForEach(replyTypes, id: \.self) { replyDetails in
-                    messageComposer(mode: .reply(itemID: .random,
+                    messageComposer(mode: .reply(eventID: UUID().uuidString,
                                                  replyDetails: replyDetails, isThread: true))
                 }
             }

--- a/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
@@ -593,13 +593,14 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
         actionsSubject.send(.composer(action: .clear))
 
         switch mode {
-        case .reply(let itemId, _, _):
+        case .reply(let eventID, _, _):
             await timelineController.sendMessage(message,
                                                  html: html,
-                                                 inReplyTo: itemId,
+                                                 inReplyToEventID: eventID,
                                                  intentionalMentions: intentionalMentions)
-        case .edit(let originalItemId):
-            await timelineController.edit(originalItemId,
+        case .edit(let originalEventOrTransactionID, let source):
+            await timelineController.edit(originalEventOrTransactionID,
+                                          useTimeline: source == .timeline,
                                           message: message,
                                           html: html,
                                           intentionalMentions: intentionalMentions)
@@ -610,6 +611,7 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
             case .none:
                 await timelineController.sendMessage(message,
                                                      html: html,
+                                                     inReplyToEventID: nil,
                                                      intentionalMentions: intentionalMentions)
             }
         case .recordVoiceMessage, .previewVoiceMessage:

--- a/ElementX/Sources/Screens/Timeline/View/Style/SwipeToReplyView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Style/SwipeToReplyView.swift
@@ -19,7 +19,7 @@ struct SwipeToReplyView: View {
 }
 
 struct SwipeToReplyView_Previews: PreviewProvider, TestablePreview {
-    static let timelineItem = TextRoomTimelineItem(id: .init(uniqueID: ""),
+    static let timelineItem = TextRoomTimelineItem(id: .randomEvent,
                                                    timestamp: "",
                                                    isOutgoing: true,
                                                    isEditable: true,

--- a/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemBubbledStylerView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemBubbledStylerView.swift
@@ -398,7 +398,7 @@ struct TimelineItemBubbledStylerView_Previews: PreviewProvider, TestablePreview 
     
     static var replies: some View {
         VStack(spacing: 0) {
-            RoomTimelineItemView(viewState: .init(item: TextRoomTimelineItem(id: .init(uniqueID: ""),
+            RoomTimelineItemView(viewState: .init(item: TextRoomTimelineItem(id: .randomEvent,
                                                                              timestamp: "10:42",
                                                                              isOutgoing: true,
                                                                              isEditable: false,
@@ -411,7 +411,7 @@ struct TimelineItemBubbledStylerView_Previews: PreviewProvider, TestablePreview 
                                                                                                    eventContent: .message(.text(.init(body: "Short"))))),
                                                   groupStyle: .single))
 
-            RoomTimelineItemView(viewState: .init(item: TextRoomTimelineItem(id: .init(uniqueID: ""),
+            RoomTimelineItemView(viewState: .init(item: TextRoomTimelineItem(id: .randomEvent,
                                                                              timestamp: "10:42",
                                                                              isOutgoing: true,
                                                                              isEditable: false,
@@ -443,7 +443,7 @@ struct TimelineItemBubbledStylerView_Previews: PreviewProvider, TestablePreview 
     
     static var encryptionAuthenticity: some View {
         VStack(spacing: 0) {
-            RoomTimelineItemView(viewState: .init(item: TextRoomTimelineItem(id: .init(uniqueID: ""),
+            RoomTimelineItemView(viewState: .init(item: TextRoomTimelineItem(id: .randomEvent,
                                                                              timestamp: "10:42",
                                                                              isOutgoing: true,
                                                                              isEditable: false,
@@ -454,7 +454,7 @@ struct TimelineItemBubbledStylerView_Previews: PreviewProvider, TestablePreview 
                                                                              properties: RoomTimelineItemProperties(encryptionAuthenticity: .unsignedDevice(color: .red))),
                                                   groupStyle: .single))
             
-            RoomTimelineItemView(viewState: .init(item: TextRoomTimelineItem(id: .init(uniqueID: ""),
+            RoomTimelineItemView(viewState: .init(item: TextRoomTimelineItem(id: .randomEvent,
                                                                              timestamp: "10:42",
                                                                              isOutgoing: true,
                                                                              isEditable: false,
@@ -466,7 +466,7 @@ struct TimelineItemBubbledStylerView_Previews: PreviewProvider, TestablePreview 
                                                                                                                     encryptionAuthenticity: .unsignedDevice(color: .red))),
                                                   groupStyle: .single))
             
-            RoomTimelineItemView(viewState: .init(item: TextRoomTimelineItem(id: .init(uniqueID: ""),
+            RoomTimelineItemView(viewState: .init(item: TextRoomTimelineItem(id: .randomEvent,
                                                                              timestamp: "10:42",
                                                                              isOutgoing: false,
                                                                              isEditable: false,
@@ -477,7 +477,7 @@ struct TimelineItemBubbledStylerView_Previews: PreviewProvider, TestablePreview 
                                                                              properties: RoomTimelineItemProperties(encryptionAuthenticity: .unknownDevice(color: .red))),
                                                   groupStyle: .first))
             
-            RoomTimelineItemView(viewState: .init(item: TextRoomTimelineItem(id: .init(uniqueID: ""),
+            RoomTimelineItemView(viewState: .init(item: TextRoomTimelineItem(id: .randomEvent,
                                                                              timestamp: "10:42",
                                                                              isOutgoing: false,
                                                                              isEditable: false,
@@ -488,7 +488,7 @@ struct TimelineItemBubbledStylerView_Previews: PreviewProvider, TestablePreview 
                                                                              properties: RoomTimelineItemProperties(encryptionAuthenticity: .notGuaranteed(color: .gray))),
                                                   groupStyle: .last))
             
-            ImageRoomTimelineView(timelineItem: ImageRoomTimelineItem(id: .random,
+            ImageRoomTimelineView(timelineItem: ImageRoomTimelineItem(id: .randomEvent,
                                                                       timestamp: "Now",
                                                                       isOutgoing: false,
                                                                       isEditable: false,
@@ -501,7 +501,7 @@ struct TimelineItemBubbledStylerView_Previews: PreviewProvider, TestablePreview 
                                                                       
                                                                       properties: RoomTimelineItemProperties(encryptionAuthenticity: .notGuaranteed(color: .gray))))
             
-            VoiceMessageRoomTimelineView(timelineItem: .init(id: .init(uniqueID: ""),
+            VoiceMessageRoomTimelineView(timelineItem: .init(id: .randomEvent,
                                                              timestamp: "10:42",
                                                              isOutgoing: true,
                                                              isEditable: false,
@@ -514,7 +514,7 @@ struct TimelineItemBubbledStylerView_Previews: PreviewProvider, TestablePreview 
                                                                             source: nil,
                                                                             contentType: nil),
                                                              properties: RoomTimelineItemProperties(encryptionAuthenticity: .notGuaranteed(color: .gray))),
-                                         playerState: AudioPlayerState(id: .timelineItemIdentifier(.random),
+                                         playerState: AudioPlayerState(id: .timelineItemIdentifier(.randomEvent),
                                                                        title: L10n.commonVoiceMessage,
                                                                        duration: 10,
                                                                        waveform: EstimatedWaveform.mockWaveform))
@@ -616,14 +616,14 @@ private struct MockTimelineContent: View {
                                                                         source: nil,
                                                                         contentType: nil),
                                                          replyDetails: replyDetails),
-                                     playerState: AudioPlayerState(id: .timelineItemIdentifier(.random),
+                                     playerState: AudioPlayerState(id: .timelineItemIdentifier(.randomEvent),
                                                                    title: L10n.commonVoiceMessage,
                                                                    duration: 10,
                                                                    waveform: EstimatedWaveform.mockWaveform))
     }
     
     func makeItemIdentifier() -> TimelineItemIdentifier {
-        isPinned ? .init(uniqueID: "", eventOrTransactionID: .eventId(eventId: "pinned")) : .random
+        isPinned ? .event(uniqueID: "", eventOrTransactionID: .eventId(eventId: "pinned")) : .randomEvent
     }
     
     var replyDetails: TimelineItemReplyDetails? {

--- a/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemSendInfoLabel.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemSendInfoLabel.swift
@@ -180,22 +180,22 @@ private extension EncryptionAuthenticity {
 struct TimelineItemSendInfoLabel_Previews: PreviewProvider, TestablePreview {
     static var previews: some View {
         VStack(spacing: 16) {
-            TimelineItemSendInfoLabel(sendInfo: .init(itemID: .random,
+            TimelineItemSendInfoLabel(sendInfo: .init(itemID: .randomEvent,
                                                       localizedString: "09:47 AM",
                                                       layoutType: .horizontal()))
-            TimelineItemSendInfoLabel(sendInfo: .init(itemID: .random,
+            TimelineItemSendInfoLabel(sendInfo: .init(itemID: .randomEvent,
                                                       localizedString: "09:47 AM",
                                                       status: .sendingFailed,
                                                       layoutType: .horizontal()))
-            TimelineItemSendInfoLabel(sendInfo: .init(itemID: .random,
+            TimelineItemSendInfoLabel(sendInfo: .init(itemID: .randomEvent,
                                                       localizedString: "09:47 AM",
                                                       status: .encryptionAuthenticity(.unsignedDevice(color: .red)),
                                                       layoutType: .horizontal()))
-            TimelineItemSendInfoLabel(sendInfo: .init(itemID: .random,
+            TimelineItemSendInfoLabel(sendInfo: .init(itemID: .randomEvent,
                                                       localizedString: "09:47 AM",
                                                       status: .encryptionAuthenticity(.notGuaranteed(color: .gray)),
                                                       layoutType: .horizontal()))
-            TimelineItemSendInfoLabel(sendInfo: .init(itemID: .random,
+            TimelineItemSendInfoLabel(sendInfo: .init(itemID: .randomEvent,
                                                       localizedString: "09:47 AM",
                                                       status: .encryptionAuthenticity(.sentInClear(color: .red)),
                                                       layoutType: .horizontal()))

--- a/ElementX/Sources/Screens/Timeline/View/Style/TimelineStyler.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Style/TimelineStyler.swift
@@ -57,7 +57,7 @@ struct TimelineStyler<Content: View>: View {
 struct TimelineItemStyler_Previews: PreviewProvider, TestablePreview {
     static let viewModel = TimelineViewModel.mock
 
-    static let base = TextRoomTimelineItem(id: .random,
+    static let base = TextRoomTimelineItem(id: .randomEvent,
                                            timestamp: "Now",
                                            isOutgoing: true,
                                            isEditable: false,
@@ -80,7 +80,7 @@ struct TimelineItemStyler_Previews: PreviewProvider, TestablePreview {
 
     static let sendingLast: TextRoomTimelineItem = {
         let id = viewModel.state.timelineViewState.uniqueIDs.last ?? UUID().uuidString
-        var result = TextRoomTimelineItem(id: .init(uniqueID: id),
+        var result = TextRoomTimelineItem(id: .event(uniqueID: id, eventOrTransactionID: .eventId(eventId: UUID().uuidString)),
                                           timestamp: "Now",
                                           isOutgoing: true,
                                           isEditable: false,
@@ -100,7 +100,7 @@ struct TimelineItemStyler_Previews: PreviewProvider, TestablePreview {
 
     static let sentLast: TextRoomTimelineItem = {
         let id = viewModel.state.timelineViewState.uniqueIDs.last ?? UUID().uuidString
-        let result = TextRoomTimelineItem(id: .init(uniqueID: id),
+        let result = TextRoomTimelineItem(id: .event(uniqueID: id, eventOrTransactionID: .eventId(eventId: UUID().uuidString)),
                                           timestamp: "Now",
                                           isOutgoing: true,
                                           isEditable: false,
@@ -111,7 +111,7 @@ struct TimelineItemStyler_Previews: PreviewProvider, TestablePreview {
         return result
     }()
 
-    static let ltrString = TextRoomTimelineItem(id: .random,
+    static let ltrString = TextRoomTimelineItem(id: .randomEvent,
                                                 timestamp: "Now",
                                                 isOutgoing: true,
                                                 isEditable: false,
@@ -119,7 +119,7 @@ struct TimelineItemStyler_Previews: PreviewProvider, TestablePreview {
                                                 isThreaded: false,
                                                 sender: .test, content: .init(body: "house!"))
 
-    static let rtlString = TextRoomTimelineItem(id: .random,
+    static let rtlString = TextRoomTimelineItem(id: .randomEvent,
                                                 timestamp: "Now",
                                                 isOutgoing: true,
                                                 isEditable: false,
@@ -127,7 +127,7 @@ struct TimelineItemStyler_Previews: PreviewProvider, TestablePreview {
                                                 isThreaded: false,
                                                 sender: .test, content: .init(body: "באמת!"))
 
-    static let ltrStringThatContainsRtl = TextRoomTimelineItem(id: .random,
+    static let ltrStringThatContainsRtl = TextRoomTimelineItem(id: .randomEvent,
                                                                timestamp: "Now",
                                                                isOutgoing: true,
                                                                isEditable: false,
@@ -136,7 +136,7 @@ struct TimelineItemStyler_Previews: PreviewProvider, TestablePreview {
                                                                sender: .test,
                                                                content: .init(body: "house! -- באמת‏! -- house!"))
 
-    static let rtlStringThatContainsLtr = TextRoomTimelineItem(id: .random,
+    static let rtlStringThatContainsLtr = TextRoomTimelineItem(id: .randomEvent,
                                                                timestamp: "Now",
                                                                isOutgoing: true,
                                                                isEditable: false,
@@ -145,7 +145,7 @@ struct TimelineItemStyler_Previews: PreviewProvider, TestablePreview {
                                                                sender: .test,
                                                                content: .init(body: "באמת‏! -- house! -- באמת!"))
 
-    static let ltrStringThatFinishesInRtl = TextRoomTimelineItem(id: .random,
+    static let ltrStringThatFinishesInRtl = TextRoomTimelineItem(id: .randomEvent,
                                                                  timestamp: "Now",
                                                                  isOutgoing: true,
                                                                  isEditable: false,
@@ -154,7 +154,7 @@ struct TimelineItemStyler_Previews: PreviewProvider, TestablePreview {
                                                                  sender: .test,
                                                                  content: .init(body: "house! -- באמת!"))
 
-    static let rtlStringThatFinishesInLtr = TextRoomTimelineItem(id: .random,
+    static let rtlStringThatFinishesInLtr = TextRoomTimelineItem(id: .randomEvent,
                                                                  timestamp: "Now",
                                                                  isOutgoing: true,
                                                                  isEditable: false,

--- a/ElementX/Sources/Screens/Timeline/View/Supplementary/TimelineReactionsView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Supplementary/TimelineReactionsView.swift
@@ -196,20 +196,20 @@ struct TimelineReactionViewPreviewsContainer: View {
     var body: some View {
         VStack(spacing: 8) {
             TimelineReactionsView(context: TimelineViewModel.mock.context,
-                                  itemID: .init(uniqueID: "1"),
+                                  itemID: .randomEvent,
                                   reactions: [AggregatedReaction.mockReactionWithLongText,
                                               AggregatedReaction.mockReactionWithLongTextRTL])
             Divider()
             TimelineReactionsView(context: TimelineViewModel.mock.context,
-                                  itemID: .init(uniqueID: "2"),
+                                  itemID: .randomEvent,
                                   reactions: Array(AggregatedReaction.mockReactions.prefix(3)))
             Divider()
             TimelineReactionsView(context: TimelineViewModel.mock.context,
-                                  itemID: .init(uniqueID: "3"),
+                                  itemID: .randomEvent,
                                   reactions: AggregatedReaction.mockReactions)
             Divider()
             TimelineReactionsView(context: TimelineViewModel.mock.context,
-                                  itemID: .init(uniqueID: "4"),
+                                  itemID: .randomEvent,
                                   reactions: AggregatedReaction.mockReactions,
                                   isLayoutRTL: true)
         }

--- a/ElementX/Sources/Screens/Timeline/View/Supplementary/TimelineReadReceiptsView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Supplementary/TimelineReadReceiptsView.swift
@@ -103,7 +103,7 @@ struct TimelineReadReceiptsView_Previews: PreviewProvider, TestablePreview {
                                    ReadReceipt(userID: RoomMemberProxyMock.mockDan.userID, formattedTimestamp: "Way, way before")]
 
     static func mockTimelineItem(with receipts: [ReadReceipt]) -> TextRoomTimelineItem {
-        TextRoomTimelineItem(id: .random,
+        TextRoomTimelineItem(id: .randomEvent,
                              timestamp: "Now",
                              isOutgoing: true,
                              isEditable: false,

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/AudioRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/AudioRoomTimelineView.swift
@@ -34,7 +34,7 @@ struct AudioRoomTimelineView_Previews: PreviewProvider, TestablePreview {
     }
     
     static var body: some View {
-        AudioRoomTimelineView(timelineItem: AudioRoomTimelineItem(id: .random,
+        AudioRoomTimelineView(timelineItem: AudioRoomTimelineItem(id: .randomEvent,
                                                                   timestamp: "Now",
                                                                   isOutgoing: false,
                                                                   isEditable: false,

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/CallInviteRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/CallInviteRoomTimelineView.swift
@@ -30,7 +30,7 @@ struct CallInviteRoomTimelineView_Previews: PreviewProvider, TestablePreview {
     }
     
     static var body: some View {
-        CallInviteRoomTimelineView(timelineItem: .init(id: .random,
+        CallInviteRoomTimelineView(timelineItem: .init(id: .randomEvent,
                                                        timestamp: "Now",
                                                        isEditable: false,
                                                        canBeRepliedTo: false,

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/CallNotificationRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/CallNotificationRoomTimelineView.swift
@@ -60,7 +60,7 @@ struct CallNotificationRoomTimelineView_Previews: PreviewProvider, TestablePrevi
     }
     
     static var body: some View {
-        CallNotificationRoomTimelineView(timelineItem: .init(id: .random,
+        CallNotificationRoomTimelineView(timelineItem: .init(id: .randomEvent,
                                                              timestamp: "Now",
                                                              isEditable: false,
                                                              canBeRepliedTo: false,

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/CollapsibleRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/CollapsibleRoomTimelineView.swift
@@ -52,8 +52,8 @@ struct CollapsibleRoomTimelineView: View {
 
 struct CollapsibleRoomTimelineView_Previews: PreviewProvider, TestablePreview {
     static let item = CollapsibleTimelineItem(items: [
-        SeparatorRoomTimelineItem(id: .init(uniqueID: "First separator"), text: "This is a separator"),
-        SeparatorRoomTimelineItem(id: .init(uniqueID: "Second separator"), text: "This is another separator")
+        SeparatorRoomTimelineItem(id: .virtual(uniqueID: "First separator"), text: "This is a separator"),
+        SeparatorRoomTimelineItem(id: .virtual(uniqueID: "Second separator"), text: "This is another separator")
     ])
     
     static var previews: some View {

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/EmoteRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/EmoteRoomTimelineView.swift
@@ -42,7 +42,7 @@ struct EmoteRoomTimelineView_Previews: PreviewProvider, TestablePreview {
     }
     
     private static func itemWith(text: String, timestamp: String, senderId: String) -> EmoteRoomTimelineItem {
-        EmoteRoomTimelineItem(id: .random,
+        EmoteRoomTimelineItem(id: .randomEvent,
                               timestamp: timestamp,
                               isOutgoing: false,
                               isEditable: false,

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/EncryptedRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/EncryptedRoomTimelineView.swift
@@ -77,7 +77,7 @@ struct EncryptedRoomTimelineView_Previews: PreviewProvider, TestablePreview {
     }
     
     private static func itemWith(text: String, timestamp: String, isOutgoing: Bool, senderId: String) -> EncryptedRoomTimelineItem {
-        EncryptedRoomTimelineItem(id: .random,
+        EncryptedRoomTimelineItem(id: .randomEvent,
                                   body: text,
                                   encryptionType: .unknown,
                                   timestamp: timestamp,
@@ -88,7 +88,7 @@ struct EncryptedRoomTimelineView_Previews: PreviewProvider, TestablePreview {
     }
     
     private static func expectedItemWith(timestamp: String, isOutgoing: Bool, senderId: String) -> EncryptedRoomTimelineItem {
-        EncryptedRoomTimelineItem(id: .random,
+        EncryptedRoomTimelineItem(id: .randomEvent,
                                   body: L10n.commonUnableToDecryptNoAccess,
                                   encryptionType: .megolmV1AesSha2(sessionID: "foo", cause: .membership),
                                   timestamp: timestamp,

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/FileRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/FileRoomTimelineView.swift
@@ -35,7 +35,7 @@ struct FileRoomTimelineView_Previews: PreviewProvider, TestablePreview {
     
     static var body: some View {
         VStack(spacing: 20.0) {
-            FileRoomTimelineView(timelineItem: FileRoomTimelineItem(id: .random,
+            FileRoomTimelineView(timelineItem: FileRoomTimelineItem(id: .randomEvent,
                                                                     timestamp: "Now",
                                                                     isOutgoing: false,
                                                                     isEditable: false,
@@ -47,7 +47,7 @@ struct FileRoomTimelineView_Previews: PreviewProvider, TestablePreview {
                                                                                    thumbnailSource: nil,
                                                                                    contentType: nil)))
 
-            FileRoomTimelineView(timelineItem: FileRoomTimelineItem(id: .random,
+            FileRoomTimelineView(timelineItem: FileRoomTimelineItem(id: .randomEvent,
                                                                     timestamp: "Now",
                                                                     isOutgoing: false,
                                                                     isEditable: false,
@@ -59,7 +59,7 @@ struct FileRoomTimelineView_Previews: PreviewProvider, TestablePreview {
                                                                                    thumbnailSource: nil,
                                                                                    contentType: nil)))
             
-            FileRoomTimelineView(timelineItem: FileRoomTimelineItem(id: .random,
+            FileRoomTimelineView(timelineItem: FileRoomTimelineItem(id: .randomEvent,
                                                                     timestamp: "Now",
                                                                     isOutgoing: false,
                                                                     isEditable: false,

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/ImageRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/ImageRoomTimelineView.swift
@@ -52,7 +52,7 @@ struct ImageRoomTimelineView_Previews: PreviewProvider, TestablePreview {
     
     static var body: some View {
         VStack(spacing: 20.0) {
-            ImageRoomTimelineView(timelineItem: ImageRoomTimelineItem(id: .random,
+            ImageRoomTimelineView(timelineItem: ImageRoomTimelineItem(id: .randomEvent,
                                                                       timestamp: "Now",
                                                                       isOutgoing: false,
                                                                       isEditable: false,
@@ -63,7 +63,7 @@ struct ImageRoomTimelineView_Previews: PreviewProvider, TestablePreview {
                                                                                      source: MediaSourceProxy(url: .picturesDirectory, mimeType: "image/jpg"),
                                                                                      thumbnailSource: nil)))
             
-            ImageRoomTimelineView(timelineItem: ImageRoomTimelineItem(id: .random,
+            ImageRoomTimelineView(timelineItem: ImageRoomTimelineItem(id: .randomEvent,
                                                                       timestamp: "Now",
                                                                       isOutgoing: false,
                                                                       isEditable: false,
@@ -74,7 +74,7 @@ struct ImageRoomTimelineView_Previews: PreviewProvider, TestablePreview {
                                                                                      source: MediaSourceProxy(url: .picturesDirectory, mimeType: "image/png"),
                                                                                      thumbnailSource: nil)))
             
-            ImageRoomTimelineView(timelineItem: ImageRoomTimelineItem(id: .random,
+            ImageRoomTimelineView(timelineItem: ImageRoomTimelineItem(id: .randomEvent,
                                                                       timestamp: "Now",
                                                                       isOutgoing: false,
                                                                       isEditable: false,

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/LocationRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/LocationRoomTimelineView.swift
@@ -86,7 +86,7 @@ struct LocationRoomTimelineView_Previews: PreviewProvider, TestablePreview {
 
     @ViewBuilder
     static var states: some View {
-        LocationRoomTimelineView(timelineItem: .init(id: .random,
+        LocationRoomTimelineView(timelineItem: .init(id: .randomEvent,
                                                      timestamp: "Now",
                                                      isOutgoing: false,
                                                      isEditable: false,
@@ -95,7 +95,7 @@ struct LocationRoomTimelineView_Previews: PreviewProvider, TestablePreview {
                                                      sender: .init(id: "Bob"),
                                                      content: .init(body: "Fallback geo uri description")))
 
-        LocationRoomTimelineView(timelineItem: .init(id: .random,
+        LocationRoomTimelineView(timelineItem: .init(id: .randomEvent,
                                                      timestamp: "Now",
                                                      isOutgoing: false,
                                                      isEditable: false,
@@ -104,7 +104,7 @@ struct LocationRoomTimelineView_Previews: PreviewProvider, TestablePreview {
                                                      sender: .init(id: "Bob"),
                                                      content: .init(body: "Fallback geo uri description",
                                                                     geoURI: .init(latitude: 41.902782, longitude: 12.496366), description: "Location description description description description description description description description")))
-        LocationRoomTimelineView(timelineItem: .init(id: .random,
+        LocationRoomTimelineView(timelineItem: .init(id: .randomEvent,
                                                      timestamp: "Now",
                                                      isOutgoing: false,
                                                      isEditable: false,

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/NoticeRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/NoticeRoomTimelineView.swift
@@ -54,7 +54,7 @@ struct NoticeRoomTimelineView_Previews: PreviewProvider, TestablePreview {
     }
     
     private static func itemWith(text: String, timestamp: String, senderId: String) -> NoticeRoomTimelineItem {
-        NoticeRoomTimelineItem(id: .random,
+        NoticeRoomTimelineItem(id: .randomEvent,
                                timestamp: timestamp,
                                isOutgoing: false,
                                isEditable: false,

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/ReadMarkerRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/ReadMarkerRoomTimelineView.swift
@@ -29,12 +29,12 @@ struct ReadMarkerRoomTimelineView: View {
 struct ReadMarkerRoomTimelineView_Previews: PreviewProvider, TestablePreview {
     static let viewModel = TimelineViewModel.mock
 
-    static let item = ReadMarkerRoomTimelineItem(id: .init(uniqueID: .init(UUID().uuidString)))
+    static let item = ReadMarkerRoomTimelineItem(id: .randomVirtual)
 
     static var previews: some View {
         VStack(alignment: .leading, spacing: 0) {
-            RoomTimelineItemView(viewState: .init(type: .separator(.init(id: .init(uniqueID: "Separator"), text: "Today")), groupStyle: .single))
-            RoomTimelineItemView(viewState: .init(type: .text(.init(id: .random,
+            RoomTimelineItemView(viewState: .init(type: .separator(.init(id: .virtual(uniqueID: "Separator"), text: "Today")), groupStyle: .single))
+            RoomTimelineItemView(viewState: .init(type: .text(.init(id: .randomEvent,
                                                                     timestamp: "",
                                                                     isOutgoing: true,
                                                                     isEditable: false,
@@ -45,8 +45,8 @@ struct ReadMarkerRoomTimelineView_Previews: PreviewProvider, TestablePreview {
 
             ReadMarkerRoomTimelineView(timelineItem: item)
 
-            RoomTimelineItemView(viewState: .init(type: .separator(.init(id: .init(uniqueID: "Separator"), text: "Today")), groupStyle: .single))
-            RoomTimelineItemView(viewState: .init(type: .text(.init(id: .random,
+            RoomTimelineItemView(viewState: .init(type: .separator(.init(id: .virtual(uniqueID: "Separator"), text: "Today")), groupStyle: .single))
+            RoomTimelineItemView(viewState: .init(type: .text(.init(id: .randomEvent,
                                                                     timestamp: "",
                                                                     isOutgoing: false,
                                                                     isEditable: false,

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/RedactedRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/RedactedRoomTimelineView.swift
@@ -33,7 +33,7 @@ struct RedactedRoomTimelineView_Previews: PreviewProvider, TestablePreview {
     }
     
     private static func itemWith(text: String, timestamp: String, senderId: String) -> RedactedRoomTimelineItem {
-        RedactedRoomTimelineItem(id: .random,
+        RedactedRoomTimelineItem(id: .randomEvent,
                                  body: text,
                                  timestamp: timestamp,
                                  isOutgoing: false,

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/SeparatorRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/SeparatorRoomTimelineView.swift
@@ -23,7 +23,8 @@ struct SeparatorRoomTimelineView: View {
 
 struct SeparatorRoomTimelineView_Previews: PreviewProvider, TestablePreview {
     static var previews: some View {
-        let item = SeparatorRoomTimelineItem(id: .init(uniqueID: "Separator"), text: "This is a separator")
+        let item = SeparatorRoomTimelineItem(id: .virtual(uniqueID: "Separator"),
+                                             text: "This is a separator")
         SeparatorRoomTimelineView(timelineItem: item)
     }
 }

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/StateRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/StateRoomTimelineView.swift
@@ -30,7 +30,7 @@ struct StateRoomTimelineView_Previews: PreviewProvider, TestablePreview {
         StateRoomTimelineView(timelineItem: item)
     }
     
-    static let item = StateRoomTimelineItem(id: .random,
+    static let item = StateRoomTimelineItem(id: .randomVirtual,
                                             body: "Alice joined",
                                             timestamp: "Now",
                                             isOutgoing: false,

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/StickerRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/StickerRoomTimelineView.swift
@@ -43,7 +43,7 @@ struct StickerRoomTimelineView_Previews: PreviewProvider, TestablePreview {
     
     static var body: some View {
         VStack(spacing: 20.0) {
-            StickerRoomTimelineView(timelineItem: StickerRoomTimelineItem(id: .random,
+            StickerRoomTimelineView(timelineItem: StickerRoomTimelineItem(id: .randomEvent,
                                                                           body: "Some image",
                                                                           timestamp: "Now",
                                                                           isOutgoing: false,
@@ -52,7 +52,7 @@ struct StickerRoomTimelineView_Previews: PreviewProvider, TestablePreview {
                                                                           sender: .init(id: "Bob"),
                                                                           imageURL: URL.picturesDirectory))
             
-            StickerRoomTimelineView(timelineItem: StickerRoomTimelineItem(id: .random,
+            StickerRoomTimelineView(timelineItem: StickerRoomTimelineItem(id: .randomEvent,
                                                                           body: "Some other image",
                                                                           timestamp: "Now",
                                                                           isOutgoing: false,
@@ -61,7 +61,7 @@ struct StickerRoomTimelineView_Previews: PreviewProvider, TestablePreview {
                                                                           sender: .init(id: "Bob"),
                                                                           imageURL: URL.picturesDirectory))
             
-            StickerRoomTimelineView(timelineItem: StickerRoomTimelineItem(id: .random,
+            StickerRoomTimelineView(timelineItem: StickerRoomTimelineItem(id: .randomEvent,
                                                                           body: "Blurhashed image",
                                                                           timestamp: "Now",
                                                                           isOutgoing: false,

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/TextRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/TextRoomTimelineView.swift
@@ -80,7 +80,7 @@ struct TextRoomTimelineView_Previews: PreviewProvider, TestablePreview {
     }
     
     private static func itemWith(text: String, timestamp: String, isOutgoing: Bool, senderId: String) -> TextRoomTimelineItem {
-        TextRoomTimelineItem(id: .random,
+        TextRoomTimelineItem(id: .randomEvent,
                              timestamp: timestamp,
                              isOutgoing: isOutgoing,
                              isEditable: isOutgoing,
@@ -94,7 +94,7 @@ struct TextRoomTimelineView_Previews: PreviewProvider, TestablePreview {
         let builder = AttributedStringBuilder(cacheKey: "preview", mentionBuilder: MentionBuilder())
         let attributedString = builder.fromHTML(html)
         
-        return TextRoomTimelineItem(id: .random,
+        return TextRoomTimelineItem(id: .randomEvent,
                                     timestamp: timestamp,
                                     isOutgoing: isOutgoing,
                                     isEditable: isOutgoing,

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/UnsupportedRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/UnsupportedRoomTimelineView.swift
@@ -52,7 +52,7 @@ struct UnsupportedRoomTimelineView_Previews: PreviewProvider, TestablePreview {
     }
     
     private static func itemWith(text: String, timestamp: String, isOutgoing: Bool, senderId: String) -> UnsupportedRoomTimelineItem {
-        UnsupportedRoomTimelineItem(id: .random,
+        UnsupportedRoomTimelineItem(id: .randomEvent,
                                     body: text,
                                     eventType: "Some Event Type",
                                     error: "Something went wrong",

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/VideoRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/VideoRoomTimelineView.swift
@@ -63,7 +63,7 @@ struct VideoRoomTimelineView_Previews: PreviewProvider, TestablePreview {
     
     static var body: some View {
         VStack(spacing: 20.0) {
-            VideoRoomTimelineView(timelineItem: VideoRoomTimelineItem(id: .random,
+            VideoRoomTimelineView(timelineItem: VideoRoomTimelineItem(id: .randomEvent,
                                                                       timestamp: "Now",
                                                                       isOutgoing: false,
                                                                       isEditable: false,
@@ -75,7 +75,7 @@ struct VideoRoomTimelineView_Previews: PreviewProvider, TestablePreview {
                                                                                      source: nil,
                                                                                      thumbnailSource: nil)))
 
-            VideoRoomTimelineView(timelineItem: VideoRoomTimelineItem(id: .random,
+            VideoRoomTimelineView(timelineItem: VideoRoomTimelineItem(id: .randomEvent,
                                                                       timestamp: "Now",
                                                                       isOutgoing: false,
                                                                       isEditable: false,
@@ -87,7 +87,7 @@ struct VideoRoomTimelineView_Previews: PreviewProvider, TestablePreview {
                                                                                      source: nil,
                                                                                      thumbnailSource: nil)))
             
-            VideoRoomTimelineView(timelineItem: VideoRoomTimelineItem(id: .random,
+            VideoRoomTimelineView(timelineItem: VideoRoomTimelineItem(id: .randomEvent,
                                                                       timestamp: "Now",
                                                                       isOutgoing: false,
                                                                       isEditable: false,

--- a/ElementX/Sources/Services/Timeline/Fixtures/RoomTimelineItemFixtures.swift
+++ b/ElementX/Sources/Services/Timeline/Fixtures/RoomTimelineItemFixtures.swift
@@ -10,9 +10,9 @@ import Foundation
 enum RoomTimelineItemFixtures {
     /// The default timeline items used in Xcode previews etc.
     static var `default`: [RoomTimelineItemProtocol] = [
-        SeparatorRoomTimelineItem(id: .init(uniqueID: "Yesterday"), text: "Yesterday"),
-        TextRoomTimelineItem(id: .init(uniqueID: ".RoomTimelineItemFixtures.default.0",
-                                       eventOrTransactionID: .eventId(eventId: "RoomTimelineItemFixtures.default.0")),
+        SeparatorRoomTimelineItem(id: .virtual(uniqueID: "Yesterday"), text: "Yesterday"),
+        TextRoomTimelineItem(id: .event(uniqueID: ".RoomTimelineItemFixtures.default.0",
+                                        eventOrTransactionID: .eventId(eventId: "RoomTimelineItemFixtures.default.0")),
                              timestamp: "10:10 AM",
                              isOutgoing: false,
                              isEditable: false,
@@ -21,8 +21,8 @@ enum RoomTimelineItemFixtures {
                              sender: .init(id: "", displayName: "Jacob"),
                              content: .init(body: "That looks so good!"),
                              properties: RoomTimelineItemProperties(isEdited: true)),
-        TextRoomTimelineItem(id: .init(uniqueID: "RoomTimelineItemFixtures.default.1",
-                                       eventOrTransactionID: .eventId(eventId: "RoomTimelineItemFixtures.default.1")),
+        TextRoomTimelineItem(id: .event(uniqueID: "RoomTimelineItemFixtures.default.1",
+                                        eventOrTransactionID: .eventId(eventId: "RoomTimelineItemFixtures.default.1")),
                              timestamp: "10:11 AM",
                              isOutgoing: false,
                              isEditable: false,
@@ -33,8 +33,8 @@ enum RoomTimelineItemFixtures {
                              properties: RoomTimelineItemProperties(reactions: [
                                  AggregatedReaction(accountOwnerID: "me", key: "🙌", senders: [ReactionSender(id: "me", timestamp: Date())])
                              ])),
-        TextRoomTimelineItem(id: .init(uniqueID: "RoomTimelineItemFixtures.default.2",
-                                       eventOrTransactionID: .eventId(eventId: "RoomTimelineItemFixtures.default.2")),
+        TextRoomTimelineItem(id: .event(uniqueID: "RoomTimelineItemFixtures.default.2",
+                                        eventOrTransactionID: .eventId(eventId: "RoomTimelineItemFixtures.default.2")),
                              timestamp: "10:11 AM",
                              isOutgoing: false,
                              isEditable: false,
@@ -52,9 +52,9 @@ enum RoomTimelineItemFixtures {
                                                         ReactionSender(id: "jacob", timestamp: Date())
                                                     ])
                              ])),
-        SeparatorRoomTimelineItem(id: .init(uniqueID: "Today"), text: "Today"),
-        TextRoomTimelineItem(id: .init(uniqueID: "RoomTimelineItemFixtures.default.3",
-                                       eventOrTransactionID: .eventId(eventId: "RoomTimelineItemFixtures.default.3")),
+        SeparatorRoomTimelineItem(id: .virtual(uniqueID: "Today"), text: "Today"),
+        TextRoomTimelineItem(id: .event(uniqueID: "RoomTimelineItemFixtures.default.3",
+                                        eventOrTransactionID: .eventId(eventId: "RoomTimelineItemFixtures.default.3")),
                              timestamp: "5 PM",
                              isOutgoing: false,
                              isEditable: false,
@@ -63,8 +63,8 @@ enum RoomTimelineItemFixtures {
                              sender: .init(id: "", displayName: "Helena"),
                              content: .init(body: "Wow, cool. Ok, lets go the usual place tomorrow?! Is that too soon?  Here’s the menu, let me know what you want it’s on me!"),
                              properties: RoomTimelineItemProperties(orderedReadReceipts: [ReadReceipt(userID: "alice", formattedTimestamp: nil)])),
-        TextRoomTimelineItem(id: .init(uniqueID: "RoomTimelineItemFixtures.default.4",
-                                       eventOrTransactionID: .eventId(eventId: "RoomTimelineItemFixtures.default.4")),
+        TextRoomTimelineItem(id: .event(uniqueID: "RoomTimelineItemFixtures.default.4",
+                                        eventOrTransactionID: .eventId(eventId: "RoomTimelineItemFixtures.default.4")),
                              timestamp: "5 PM",
                              isOutgoing: true,
                              isEditable: true,
@@ -72,8 +72,8 @@ enum RoomTimelineItemFixtures {
                              isThreaded: false,
                              sender: .init(id: "", displayName: "Bob"),
                              content: .init(body: "And John's speech was amazing!")),
-        TextRoomTimelineItem(id: .init(uniqueID: "RoomTimelineItemFixtures.default.5",
-                                       eventOrTransactionID: .eventId(eventId: "RoomTimelineItemFixtures.default.5")),
+        TextRoomTimelineItem(id: .event(uniqueID: "RoomTimelineItemFixtures.default.5",
+                                        eventOrTransactionID: .eventId(eventId: "RoomTimelineItemFixtures.default.5")),
                              timestamp: "5 PM",
                              isOutgoing: true,
                              isEditable: true,
@@ -86,8 +86,8 @@ enum RoomTimelineItemFixtures {
                                                                                           ReadReceipt(userID: "bob", formattedTimestamp: nil),
                                                                                           ReadReceipt(userID: "charlie", formattedTimestamp: nil),
                                                                                           ReadReceipt(userID: "dan", formattedTimestamp: nil)])),
-        TextRoomTimelineItem(id: .init(uniqueID: "RoomTimelineItemFixtures.default.6",
-                                       eventOrTransactionID: .eventId(eventId: "RoomTimelineItemFixtures.default.6")),
+        TextRoomTimelineItem(id: .event(uniqueID: "RoomTimelineItemFixtures.default.6",
+                                        eventOrTransactionID: .eventId(eventId: "RoomTimelineItemFixtures.default.6")),
                              timestamp: "5 PM",
                              isOutgoing: false,
                              isEditable: false,
@@ -242,7 +242,7 @@ enum RoomTimelineItemFixtures {
     
     static var permalinkChunk: [RoomTimelineItemProtocol] {
         (1...20).map { index in
-            TextRoomTimelineItem(id: .init(uniqueID: "\(index)", eventOrTransactionID: .eventId(eventId: "$\(index)")),
+            TextRoomTimelineItem(id: .event(uniqueID: "\(index)", eventOrTransactionID: .eventId(eventId: "$\(index)")),
                                  text: "Message ID \(index)",
                                  senderDisplayName: index > 10 ? "Alice" : "Bob")
         }
@@ -250,7 +250,7 @@ enum RoomTimelineItemFixtures {
     
     static var mediaChunk: [RoomTimelineItemProtocol] {
         [
-            VideoRoomTimelineItem(id: .random,
+            VideoRoomTimelineItem(id: .randomEvent,
                                   timestamp: "10:47 am",
                                   isOutgoing: false,
                                   isEditable: false,
@@ -265,7 +265,7 @@ enum RoomTimelineItemFixtures {
                                                  height: 1080,
                                                  aspectRatio: 1.78,
                                                  blurhash: "KtI~70X5V?yss9oyrYs:t6")),
-            ImageRoomTimelineItem(id: .random,
+            ImageRoomTimelineItem(id: .randomEvent,
                                   timestamp: "10:47 am",
                                   isOutgoing: false,
                                   isEditable: false,
@@ -285,7 +285,7 @@ enum RoomTimelineItemFixtures {
 
 private extension TextRoomTimelineItem {
     init(id: TimelineItemIdentifier? = nil, text: String, senderDisplayName: String) {
-        self.init(id: id ?? .random,
+        self.init(id: id ?? .randomEvent,
                   timestamp: "10:47 am",
                   isOutgoing: senderDisplayName == "Alice",
                   isEditable: false,

--- a/ElementX/Sources/Services/Timeline/TimelineController/MockRoomTimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/MockRoomTimelineController.swift
@@ -81,12 +81,13 @@ class MockRoomTimelineController: RoomTimelineControllerProtocol {
     
     func sendMessage(_ message: String,
                      html: String?,
-                     inReplyTo itemID: TimelineItemIdentifier?,
+                     inReplyToEventID: String?,
                      intentionalMentions: IntentionalMentions) async { }
         
     func toggleReaction(_ reaction: String, to itemID: TimelineItemIdentifier) async { }
     
-    func edit(_ timelineItemID: TimelineItemIdentifier,
+    func edit(_ eventOrTransactionID: EventOrTransactionId,
+              useTimeline: Bool,
               message: String,
               html: String?,
               intentionalMentions: IntentionalMentions) async { }

--- a/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineControllerProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineControllerProtocol.swift
@@ -48,10 +48,11 @@ protocol RoomTimelineControllerProtocol {
     
     func sendMessage(_ message: String,
                      html: String?,
-                     inReplyTo itemID: TimelineItemIdentifier?,
+                     inReplyToEventID: String?,
                      intentionalMentions: IntentionalMentions) async
     
-    func edit(_ timelineItemID: TimelineItemIdentifier,
+    func edit(_ eventOrTransactionID: EventOrTransactionId,
+              useTimeline: Bool,
               message: String,
               html: String?,
               intentionalMentions: IntentionalMentions) async
@@ -71,15 +72,4 @@ protocol RoomTimelineControllerProtocol {
     func retryDecryption(for sessionID: String) async
     
     func eventTimestamp(for itemID: TimelineItemIdentifier) -> Date?
-}
-
-extension RoomTimelineControllerProtocol {
-    func sendMessage(_ message: String,
-                     html: String?,
-                     intentionalMentions: IntentionalMentions) async {
-        await sendMessage(message,
-                          html: html,
-                          inReplyTo: nil,
-                          intentionalMentions: intentionalMentions)
-    }
 }

--- a/ElementX/Sources/Services/Timeline/TimelineItemIdentifier.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItemIdentifier.swift
@@ -1,0 +1,66 @@
+//
+// Copyright 2024 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+// Please see LICENSE in the repository root for full details.
+//
+
+import Foundation
+import MatrixRustSDK
+
+/// A timeline item identifier
+/// - uniqueID: Stable id across state changes of the timeline item, it uniquely identifies an item in a timeline.
+/// Its value is consistent only per timeline instance, it should **not** be used to identify an item across timeline instances.
+/// - eventOrTransactionID: Contains the 2 possible identifiers of an event, either it has a remote event id or
+/// a local transaction id, never both or none.
+enum TimelineItemIdentifier: Hashable {
+    case event(uniqueID: String, eventOrTransactionID: EventOrTransactionId)
+    case virtual(uniqueID: String)
+    
+    var uniqueID: String {
+        switch self {
+        case .event(let uniqueID, _):
+            return uniqueID
+        case .virtual(let uniqueID):
+            return uniqueID
+        }
+    }
+    
+    var eventID: String? {
+        guard case let .event(_, eventOrTransactionID) = self else {
+            return nil
+        }
+        
+        switch eventOrTransactionID {
+        case .eventId(let eventID):
+            return eventID
+        default:
+            return nil
+        }
+    }
+    
+    var transactionID: String? {
+        guard case let .event(_, eventOrTransactionID) = self else {
+            return nil
+        }
+        
+        switch eventOrTransactionID {
+        case .transactionId(let transactionID):
+            return transactionID
+        default:
+            return nil
+        }
+    }
+}
+
+// MARK: - Mocks
+
+extension TimelineItemIdentifier {
+    static var randomEvent: Self {
+        .event(uniqueID: UUID().uuidString, eventOrTransactionID: .eventId(eventId: UUID().uuidString))
+    }
+    
+    static var randomVirtual: Self {
+        .virtual(uniqueID: UUID().uuidString)
+    }
+}

--- a/ElementX/Sources/Services/Timeline/TimelineItemProxy.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItemProxy.swift
@@ -8,40 +8,6 @@
 import Foundation
 import MatrixRustSDK
 
-struct TimelineItemIdentifier: Hashable {
-    /// Stable id across state changes of the timeline item, it uniquely identifies an item in a timeline.
-    /// It's value is consistent only per timeline instance, it should **not** be used to identify an item across timeline instances.
-    let uniqueID: String
-    
-    /// Contains the 2 possible identifiers of an event, either it has a remote event id or a local transaction id, never both or none.
-    var eventOrTransactionID: EventOrTransactionId?
-    
-    var eventID: String? {
-        switch eventOrTransactionID {
-        case .eventId(let eventId):
-            return eventId
-        default:
-            return nil
-        }
-    }
-    
-    var transactionID: String? {
-        switch eventOrTransactionID {
-        case .transactionId(let transactionId):
-            return transactionId
-        default:
-            return nil
-        }
-    }
-}
-
-extension TimelineItemIdentifier {
-    /// Use only for mocks/tests
-    static var random: Self {
-        .init(uniqueID: UUID().uuidString, eventOrTransactionID: .eventId(eventId: UUID().uuidString))
-    }
-}
-
 /// A light wrapper around timeline items returned from Rust.
 enum TimelineItemProxy {
     case event(EventTimelineItemProxy)
@@ -108,7 +74,7 @@ class EventTimelineItemProxy {
     init(item: MatrixRustSDK.EventTimelineItem, uniqueID: String) {
         self.item = item
         
-        id = TimelineItemIdentifier(uniqueID: uniqueID, eventOrTransactionID: item.eventOrTransactionId)
+        id = .event(uniqueID: uniqueID, eventOrTransactionID: item.eventOrTransactionId)
     }
     
     lazy var deliveryStatus: TimelineItemDeliveryStatus? = {

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/VoiceMessages/VoiceMessageRoomPlaybackView.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/VoiceMessages/VoiceMessageRoomPlaybackView.swift
@@ -97,7 +97,7 @@ struct VoiceMessageRoomPlaybackView_Previews: PreviewProvider, TestablePreview {
                                                    294, 131, 19, 2, 3, 3, 1, 2, 0, 0,
                                                    0, 0, 0, 0, 0, 3])
     
-    static var playerState = AudioPlayerState(id: .timelineItemIdentifier(.random),
+    static var playerState = AudioPlayerState(id: .timelineItemIdentifier(.randomEvent),
                                               title: L10n.commonVoiceMessage,
                                               duration: 10.0,
                                               waveform: waveform,

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/VoiceMessages/VoiceMessageRoomTimelineView.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/VoiceMessages/VoiceMessageRoomTimelineView.swift
@@ -55,7 +55,7 @@ struct VoiceMessageRoomTimelineView: View {
 
 struct VoiceMessageRoomTimelineView_Previews: PreviewProvider, TestablePreview {
     static let viewModel = TimelineViewModel.mock
-    static let timelineItemIdentifier = TimelineItemIdentifier.random
+    static let timelineItemIdentifier = TimelineItemIdentifier.randomEvent
     static let voiceRoomTimelineItem = VoiceMessageRoomTimelineItem(id: timelineItemIdentifier,
                                                                     timestamp: "Now",
                                                                     isOutgoing: false,

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/Virtual/PaginationIndicatorRoomTimelineItem.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/Virtual/PaginationIndicatorRoomTimelineItem.swift
@@ -22,6 +22,6 @@ struct PaginationIndicatorRoomTimelineItem: DecorationTimelineItemProtocol, Equa
     }
     
     init(position: Position) {
-        id = TimelineItemIdentifier(uniqueID: position.id)
+        id = .virtual(uniqueID: position.id)
     }
 }

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/Virtual/TimelineStartRoomTimelineItem.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/Virtual/TimelineStartRoomTimelineItem.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 struct TimelineStartRoomTimelineItem: DecorationTimelineItemProtocol, Equatable {
-    let id = TimelineItemIdentifier(uniqueID: UUID().uuidString)
+    let id: TimelineItemIdentifier = .virtual(uniqueID: UUID().uuidString)
     let name: String?
 }

--- a/ElementX/Sources/Services/Timeline/TimelineProxyProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineProxyProtocol.swift
@@ -38,7 +38,8 @@ protocol TimelineProxyProtocol {
     func paginateBackwards(requestSize: UInt16) async -> Result<Void, TimelineProxyError>
     func paginateForwards(requestSize: UInt16) async -> Result<Void, TimelineProxyError>
     
-    func edit(_ timelineItem: EventTimelineItem, newContent: RoomMessageEventContentWithoutRelation) async -> Result<Void, TimelineProxyError>
+    func edit(_ eventOrTransactionID: EventOrTransactionId,
+              newContent: RoomMessageEventContentWithoutRelation) async -> Result<Void, TimelineProxyError>
     
     func redact(_ timelineItemID: TimelineItemIdentifier,
                 reason: String?) async -> Result<Void, TimelineProxyError>
@@ -89,12 +90,11 @@ protocol TimelineProxyProtocol {
     
     func sendMessage(_ message: String,
                      html: String?,
-                     inReplyTo eventID: String?,
+                     inReplyToEventID: String?,
                      intentionalMentions: IntentionalMentions) async -> Result<Void, TimelineProxyError>
     
     func toggleReaction(_ reaction: String, to itemID: TimelineItemIdentifier) async -> Result<Void, TimelineProxyError>
     
-    // Polls
     func createPoll(question: String, answers: [String], pollKind: Poll.Kind) async -> Result<Void, TimelineProxyError>
     
     func editPoll(original eventID: String,
@@ -111,15 +111,4 @@ protocol TimelineProxyProtocol {
     func buildMessageContentFor(_ message: String,
                                 html: String?,
                                 intentionalMentions: Mentions) -> RoomMessageEventContentWithoutRelation
-}
-
-extension TimelineProxyProtocol {
-    func sendMessage(_ message: String,
-                     html: String?,
-                     intentionalMentions: IntentionalMentions) async -> Result<Void, TimelineProxyError> {
-        await sendMessage(message,
-                          html: html,
-                          inReplyTo: nil,
-                          intentionalMentions: intentionalMentions)
-    }
 }

--- a/UnitTests/Sources/AudioPlayerStateTests.swift
+++ b/UnitTests/Sources/AudioPlayerStateTests.swift
@@ -38,7 +38,7 @@ class AudioPlayerStateTests: XCTestCase {
     override func setUp() async throws {
         audioPlayerActionsSubject = .init()
         audioPlayerSeekCallsSubject = .init()
-        audioPlayerState = AudioPlayerState(id: .timelineItemIdentifier(.random), title: "", duration: Self.audioDuration)
+        audioPlayerState = AudioPlayerState(id: .timelineItemIdentifier(.randomEvent), title: "", duration: Self.audioDuration)
         audioPlayerMock = buildAudioPlayerMock()
         audioPlayerMock.seekToClosure = { [weak self] progress in
             self?.audioPlayerMock.currentTime = Self.audioDuration * progress
@@ -162,7 +162,7 @@ class AudioPlayerStateTests: XCTestCase {
     func testHandlingAudioPlayerActionDidFinishLoading() async throws {
         audioPlayerMock.duration = 10.0
         
-        audioPlayerState = AudioPlayerState(id: .timelineItemIdentifier(.random), title: "", duration: 0)
+        audioPlayerState = AudioPlayerState(id: .timelineItemIdentifier(.randomEvent), title: "", duration: 0)
         audioPlayerState.attachAudioPlayer(audioPlayerMock)
 
         let deferred = deferFulfillment(audioPlayerState.$playbackState) { action in

--- a/UnitTests/Sources/ComposerToolbarViewModelTests.swift
+++ b/UnitTests/Sources/ComposerToolbarViewModelTests.swift
@@ -41,14 +41,14 @@ class ComposerToolbarViewModelTests: XCTestCase {
     }
 
     func testComposerFocus() {
-        viewModel.process(timelineAction: .setMode(mode: .edit(originalItemId: TimelineItemIdentifier(uniqueID: "mock"))))
+        viewModel.process(timelineAction: .setMode(mode: .edit(originalEventOrTransactionID: .eventId(eventId: "mock"), source: .timeline)))
         XCTAssertTrue(viewModel.state.bindings.composerFocused)
         viewModel.process(timelineAction: .removeFocus)
         XCTAssertFalse(viewModel.state.bindings.composerFocused)
     }
 
     func testComposerMode() {
-        let mode: ComposerMode = .edit(originalItemId: TimelineItemIdentifier(uniqueID: "mock"))
+        let mode: ComposerMode = .edit(originalEventOrTransactionID: .eventId(eventId: "mock"), source: .timeline)
         viewModel.process(timelineAction: .setMode(mode: mode))
         XCTAssertEqual(viewModel.state.composerMode, mode)
         viewModel.process(timelineAction: .clear)
@@ -56,7 +56,7 @@ class ComposerToolbarViewModelTests: XCTestCase {
     }
 
     func testComposerModeIsPublished() {
-        let mode: ComposerMode = .edit(originalItemId: TimelineItemIdentifier(uniqueID: "mock"))
+        let mode: ComposerMode = .edit(originalEventOrTransactionID: .eventId(eventId: "mock"), source: .timeline)
         let expectation = expectation(description: "Composer mode is published")
         let cancellable = viewModel
             .context
@@ -236,7 +236,7 @@ class ComposerToolbarViewModelTests: XCTestCase {
         }
         
         viewModel.context.composerFormattingEnabled = false
-        viewModel.process(timelineAction: .setMode(mode: .edit(originalItemId: .init(uniqueID: "", eventOrTransactionID: .eventId(eventId: "testID")))))
+        viewModel.process(timelineAction: .setMode(mode: .edit(originalEventOrTransactionID: .eventId(eventId: "testID"), source: .timeline)))
         viewModel.context.plainComposerText = .init(string: "Hello world!")
         viewModel.saveDraft()
         
@@ -257,7 +257,7 @@ class ComposerToolbarViewModelTests: XCTestCase {
         }
         
         viewModel.context.composerFormattingEnabled = false
-        viewModel.process(timelineAction: .setMode(mode: .reply(itemID: .init(uniqueID: "", eventOrTransactionID: .eventId(eventId: "testID")),
+        viewModel.process(timelineAction: .setMode(mode: .reply(eventID: "testID",
                                                                 replyDetails: .loaded(sender: .init(id: ""),
                                                                                       eventID: "testID",
                                                                                       eventContent: .message(.text(.init(body: "reply text")))),
@@ -282,7 +282,7 @@ class ComposerToolbarViewModelTests: XCTestCase {
         }
         
         viewModel.context.composerFormattingEnabled = false
-        viewModel.process(timelineAction: .setMode(mode: .reply(itemID: .init(uniqueID: "", eventOrTransactionID: .eventId(eventId: "testID")),
+        viewModel.process(timelineAction: .setMode(mode: .reply(eventID: "testID",
                                                                 replyDetails: .loaded(sender: .init(id: ""),
                                                                                       eventID: "testID",
                                                                                       eventContent: .message(.text(.init(body: "reply text")))),
@@ -395,7 +395,7 @@ class ComposerToolbarViewModelTests: XCTestCase {
         
         await fulfillment(of: [expectation], timeout: 10)
         XCTAssertFalse(viewModel.context.composerFormattingEnabled)
-        XCTAssertEqual(viewModel.state.composerMode, .edit(originalItemId: .init(uniqueID: "", eventOrTransactionID: .eventId(eventId: "testID"))))
+        XCTAssertEqual(viewModel.state.composerMode, .edit(originalEventOrTransactionID: .eventId(eventId: "testID"), source: .draftService))
         XCTAssertEqual(viewModel.context.plainComposerText, NSAttributedString(string: "Hello world!"))
     }
     
@@ -429,13 +429,13 @@ class ComposerToolbarViewModelTests: XCTestCase {
         await fulfillment(of: [draftExpectation], timeout: 10)
         XCTAssertFalse(viewModel.context.composerFormattingEnabled)
         // Testing the loading state first
-        XCTAssertEqual(viewModel.state.composerMode, .reply(itemID: .init(uniqueID: "", eventOrTransactionID: .eventId(eventId: testEventID)),
+        XCTAssertEqual(viewModel.state.composerMode, .reply(eventID: testEventID,
                                                             replyDetails: .loading(eventID: testEventID),
                                                             isThread: false))
         XCTAssertEqual(viewModel.context.plainComposerText, NSAttributedString(string: text))
         
         await fulfillment(of: [loadReplyExpectation], timeout: 10)
-        XCTAssertEqual(viewModel.state.composerMode, .reply(itemID: .init(uniqueID: "", eventOrTransactionID: .eventId(eventId: testEventID)),
+        XCTAssertEqual(viewModel.state.composerMode, .reply(eventID: testEventID,
                                                             replyDetails: loadedReply,
                                                             isThread: true))
     }
@@ -469,7 +469,7 @@ class ComposerToolbarViewModelTests: XCTestCase {
         await fulfillment(of: [draftExpectation], timeout: 10)
         XCTAssertFalse(viewModel.context.composerFormattingEnabled)
         // Testing the loading state first
-        XCTAssertEqual(viewModel.state.composerMode, .reply(itemID: .init(uniqueID: "", eventOrTransactionID: .eventId(eventId: testEventID)),
+        XCTAssertEqual(viewModel.state.composerMode, .reply(eventID: testEventID,
                                                             replyDetails: .loading(eventID: testEventID),
                                                             isThread: false))
         XCTAssertEqual(viewModel.context.plainComposerText, NSAttributedString(string: text))
@@ -483,7 +483,7 @@ class ComposerToolbarViewModelTests: XCTestCase {
     func testSaveVolatileDraftWhenEditing() {
         viewModel.context.composerFormattingEnabled = false
         viewModel.context.plainComposerText = .init(string: "Hello world!")
-        viewModel.process(timelineAction: .setMode(mode: .edit(originalItemId: .random)))
+        viewModel.process(timelineAction: .setMode(mode: .edit(originalEventOrTransactionID: .eventId(eventId: UUID().uuidString), source: .timeline)))
         
         let draft = draftServiceMock.saveVolatileDraftReceivedDraft
         XCTAssertNotNil(draft)

--- a/UnitTests/Sources/LoggingTests.swift
+++ b/UnitTests/Sources/LoggingTests.swift
@@ -116,7 +116,7 @@ class LoggingTests: XCTestCase {
     func validateTimelineContentIsRedacted() throws {
         // Given timeline items that contain text
         let textAttributedString = "TextAttributed"
-        let textMessage = TextRoomTimelineItem(id: .random,
+        let textMessage = TextRoomTimelineItem(id: .randomEvent,
                                                timestamp: "",
                                                isOutgoing: false,
                                                isEditable: false,
@@ -125,7 +125,7 @@ class LoggingTests: XCTestCase {
                                                sender: .init(id: "sender"),
                                                content: .init(body: "TextString", formattedBody: AttributedString(textAttributedString)))
         let noticeAttributedString = "NoticeAttributed"
-        let noticeMessage = NoticeRoomTimelineItem(id: .random,
+        let noticeMessage = NoticeRoomTimelineItem(id: .randomEvent,
                                                    timestamp: "",
                                                    isOutgoing: false,
                                                    isEditable: false,
@@ -134,7 +134,7 @@ class LoggingTests: XCTestCase {
                                                    sender: .init(id: "sender"),
                                                    content: .init(body: "NoticeString", formattedBody: AttributedString(noticeAttributedString)))
         let emoteAttributedString = "EmoteAttributed"
-        let emoteMessage = EmoteRoomTimelineItem(id: .random,
+        let emoteMessage = EmoteRoomTimelineItem(id: .randomEvent,
                                                  timestamp: "",
                                                  isOutgoing: false,
                                                  isEditable: false,
@@ -142,7 +142,7 @@ class LoggingTests: XCTestCase {
                                                  isThreaded: false,
                                                  sender: .init(id: "sender"),
                                                  content: .init(body: "EmoteString", formattedBody: AttributedString(emoteAttributedString)))
-        let imageMessage = ImageRoomTimelineItem(id: .init(uniqueID: "myimagemessage"),
+        let imageMessage = ImageRoomTimelineItem(id: .randomEvent,
                                                  timestamp: "",
                                                  isOutgoing: false,
                                                  isEditable: false,
@@ -153,7 +153,7 @@ class LoggingTests: XCTestCase {
                                                                 caption: "ImageString",
                                                                 source: MediaSourceProxy(url: .picturesDirectory, mimeType: "image/gif"),
                                                                 thumbnailSource: nil))
-        let videoMessage = VideoRoomTimelineItem(id: .random,
+        let videoMessage = VideoRoomTimelineItem(id: .randomEvent,
                                                  timestamp: "",
                                                  isOutgoing: false,
                                                  isEditable: false,
@@ -165,7 +165,7 @@ class LoggingTests: XCTestCase {
                                                                 duration: 0,
                                                                 source: nil,
                                                                 thumbnailSource: nil))
-        let fileMessage = FileRoomTimelineItem(id: .random,
+        let fileMessage = FileRoomTimelineItem(id: .randomEvent,
                                                timestamp: "",
                                                isOutgoing: false,
                                                isEditable: false,

--- a/UnitTests/Sources/MediaPlayerProviderTests.swift
+++ b/UnitTests/Sources/MediaPlayerProviderTests.swift
@@ -60,7 +60,7 @@ class MediaPlayerProviderTests: XCTestCase {
     }
     
     func testPlayerStates() async throws {
-        let audioPlayerStateId = AudioPlayerStateIdentifier.timelineItemIdentifier(.random)
+        let audioPlayerStateId = AudioPlayerStateIdentifier.timelineItemIdentifier(.randomEvent)
         // By default, there should be no player state
         XCTAssertNil(mediaPlayerProvider.playerState(for: audioPlayerStateId))
         
@@ -76,7 +76,7 @@ class MediaPlayerProviderTests: XCTestCase {
         let audioPlayer = AudioPlayerMock()
         audioPlayer.actions = PassthroughSubject<AudioPlayerAction, Never>().eraseToAnyPublisher()
         
-        let audioPlayerStates = Array(repeating: AudioPlayerState(id: .timelineItemIdentifier(.random), title: "", duration: 0), count: 10)
+        let audioPlayerStates = Array(repeating: AudioPlayerState(id: .timelineItemIdentifier(.randomEvent), title: "", duration: 0), count: 10)
         for audioPlayerState in audioPlayerStates {
             mediaPlayerProvider.register(audioPlayerState: audioPlayerState)
             audioPlayerState.attachAudioPlayer(audioPlayer)
@@ -95,7 +95,7 @@ class MediaPlayerProviderTests: XCTestCase {
         let audioPlayer = AudioPlayerMock()
         audioPlayer.actions = PassthroughSubject<AudioPlayerAction, Never>().eraseToAnyPublisher()
         
-        let audioPlayerStates = Array(repeating: AudioPlayerState(id: .timelineItemIdentifier(.random), title: "", duration: 0), count: 10)
+        let audioPlayerStates = Array(repeating: AudioPlayerState(id: .timelineItemIdentifier(.randomEvent), title: "", duration: 0), count: 10)
         for audioPlayerState in audioPlayerStates {
             mediaPlayerProvider.register(audioPlayerState: audioPlayerState)
             audioPlayerState.attachAudioPlayer(audioPlayer)

--- a/UnitTests/Sources/MessageForwardingScreenViewModelTests.swift
+++ b/UnitTests/Sources/MessageForwardingScreenViewModelTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 @MainActor
 class MessageForwardingScreenViewModelTests: XCTestCase {
-    let forwardingItem = MessageForwardingItem(id: .init(uniqueID: "t1", eventOrTransactionID: .eventId(eventId: "t1")),
+    let forwardingItem = MessageForwardingItem(id: .event(uniqueID: "t1", eventOrTransactionID: .eventId(eventId: "t1")),
                                                roomID: "1",
                                                content: .init(noPointer: .init()))
     var viewModel: MessageForwardingScreenViewModelProtocol!

--- a/UnitTests/Sources/ResolveVerifiedUserSendFailureScreenViewModelTests.swift
+++ b/UnitTests/Sources/ResolveVerifiedUserSendFailureScreenViewModelTests.swift
@@ -61,7 +61,7 @@ class ResolveVerifiedUserSendFailureScreenViewModelTests: XCTestCase {
     
     private func makeViewModel(with failure: TimelineItemSendFailure.VerifiedUser) -> ResolveVerifiedUserSendFailureScreenViewModel {
         ResolveVerifiedUserSendFailureScreenViewModel(failure: failure,
-                                                      itemID: .random,
+                                                      itemID: .randomEvent,
                                                       roomProxy: roomProxy,
                                                       userIndicatorController: UserIndicatorControllerMock())
     }

--- a/UnitTests/Sources/TextBasedRoomTimelineTests.swift
+++ b/UnitTests/Sources/TextBasedRoomTimelineTests.swift
@@ -11,7 +11,7 @@ import XCTest
 final class TextBasedRoomTimelineTests: XCTestCase {
     func testTextRoomTimelineItemWhitespaceEnd() {
         let timestamp = "Now"
-        let timelineItem = TextRoomTimelineItem(id: .random,
+        let timelineItem = TextRoomTimelineItem(id: .randomEvent,
                                                 timestamp: timestamp,
                                                 isOutgoing: true,
                                                 isEditable: true,
@@ -24,7 +24,7 @@ final class TextBasedRoomTimelineTests: XCTestCase {
 
     func testTextRoomTimelineItemWhitespaceEndLonger() {
         let timestamp = "10:00 AM"
-        let timelineItem = TextRoomTimelineItem(id: .random,
+        let timelineItem = TextRoomTimelineItem(id: .randomEvent,
                                                 timestamp: timestamp,
                                                 isOutgoing: true,
                                                 isEditable: true,
@@ -37,7 +37,7 @@ final class TextBasedRoomTimelineTests: XCTestCase {
 
     func testTextRoomTimelineItemWhitespaceEndWithEdit() {
         let timestamp = "Now"
-        var timelineItem = TextRoomTimelineItem(id: .random,
+        var timelineItem = TextRoomTimelineItem(id: .randomEvent,
                                                 timestamp: timestamp,
                                                 isOutgoing: true,
                                                 isEditable: true,
@@ -52,7 +52,7 @@ final class TextBasedRoomTimelineTests: XCTestCase {
 
     func testTextRoomTimelineItemWhitespaceEndWithEditAndAlert() {
         let timestamp = "Now"
-        var timelineItem = TextRoomTimelineItem(id: .random,
+        var timelineItem = TextRoomTimelineItem(id: .randomEvent,
                                                 timestamp: timestamp,
                                                 isOutgoing: true,
                                                 isEditable: true,

--- a/UnitTests/Sources/TimelineViewModelTests.swift
+++ b/UnitTests/Sources/TimelineViewModelTests.swift
@@ -423,7 +423,7 @@ class TimelineViewModelTests: XCTestCase {
 private extension TextRoomTimelineItem {
     init(text: String, sender: String, addReactions: Bool = false, addReadReceipts: [ReadReceipt] = []) {
         let reactions = addReactions ? [AggregatedReaction(accountOwnerID: "bob", key: "🦄", senders: [ReactionSender(id: sender, timestamp: Date())])] : []
-        self.init(id: .random,
+        self.init(id: .randomEvent,
                   timestamp: "10:47 am",
                   isOutgoing: sender == "bob",
                   isEditable: sender == "bob",
@@ -437,13 +437,13 @@ private extension TextRoomTimelineItem {
 
 private extension SeparatorRoomTimelineItem {
     init(uniqueID: String) {
-        self.init(id: .init(uniqueID: uniqueID), text: "")
+        self.init(id: .virtual(uniqueID: uniqueID), text: "")
     }
 }
 
 private extension TextRoomTimelineItem {
     init(eventID: String) {
-        self.init(id: .init(uniqueID: UUID().uuidString, eventOrTransactionID: .eventId(eventId: eventID)),
+        self.init(id: .event(uniqueID: UUID().uuidString, eventOrTransactionID: .eventId(eventId: eventID)),
                   timestamp: "",
                   isOutgoing: false,
                   isEditable: false,


### PR DESCRIPTION
- stop relying on optional `EventOrTransactionId`s and be explicit when setting composer modes from the draft service.