### PR TITLE
Fix a bug where the pinned items banner could overlay the composer.

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
@@ -28,6 +28,14 @@ struct RoomScreen: View {
     var body: some View {
         timeline
             .background(Color.compound.bgCanvasDefault.ignoresSafeArea())
+            .overlay(alignment: .top) {
+                Group {
+                    if roomContext.viewState.shouldShowPinnedEventsBanner {
+                        pinnedItemsBanner
+                    }
+                }
+                .animation(.elementDefault, value: roomContext.viewState.shouldShowPinnedEventsBanner)
+            }
             .safeAreaInset(edge: .bottom, spacing: 0) {
                 VStack(spacing: 0) {
                     RoomScreenFooterView(details: roomContext.viewState.footerDetails,
@@ -51,14 +59,6 @@ struct RoomScreen: View {
                         // Make sure the reply header honours the hideTimelineMedia setting too.
                         .environment(\.shouldAutomaticallyLoadImages, !timelineContext.viewState.hideTimelineMedia)
                 }
-            }
-            .overlay(alignment: .top) {
-                Group {
-                    if roomContext.viewState.shouldShowPinnedEventsBanner {
-                        pinnedItemsBanner
-                    }
-                }
-                .animation(.elementDefault, value: roomContext.viewState.shouldShowPinnedEventsBanner)
             }
             .navigationTitle(L10n.screenRoomTitle) // Hidden but used for back button text.
             .navigationBarTitleDisplayMode(.inline)


### PR DESCRIPTION
This PR puts the overlay on just the timeline, and not the timeline + composer. Probably not a final fix given the clipping that takes place, but good enough for now. Closes #3411.

https://github.com/user-attachments/assets/b224196c-21fd-490d-b49f-bdff3a48f8e2

