### PR TITLE
Enable identity pinning violation notifications unconditionally

### DIFF
--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -46,7 +46,6 @@ final class AppSettings {
         case publicSearchEnabled
         case fuzzyRoomListSearchEnabled
         case enableOnlySignedDeviceIsolationMode
-        case identityPinningViolationNotificationsEnabled
         case knockingEnabled
         case frequentEmojisEnabled
     }
@@ -284,9 +283,6 @@ final class AppSettings {
     
     @UserPreference(key: UserDefaultsKeys.optimizeMediaUploads, defaultValue: false, storageType: .userDefaults(store))
     var optimizeMediaUploads
-	
-    @UserPreference(key: UserDefaultsKeys.identityPinningViolationNotificationsEnabled, defaultValue: isDevelopmentBuild, storageType: .userDefaults(store))
-    var identityPinningViolationNotificationsEnabled
     
     @UserPreference(key: UserDefaultsKeys.knockingEnabled, defaultValue: false, storageType: .userDefaults(store))
     var knockingEnabled

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -142,9 +142,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
         }
         .store(in: &cancellables)
         
-        let identityStatusChangesPublisher = roomProxy.identityStatusChangesPublisher
-            .receive(on: DispatchQueue.main)
-            .filter { [weak self] _ in self?.appSettings.identityPinningViolationNotificationsEnabled ?? false }
+        let identityStatusChangesPublisher = roomProxy.identityStatusChangesPublisher.receive(on: DispatchQueue.main)
         
         Task { [weak self] in
             for await changes in identityStatusChangesPublisher.values {

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
@@ -49,7 +49,6 @@ protocol DeveloperOptionsProtocol: AnyObject {
     var optimizeMediaUploads: Bool { get set }
     var enableOnlySignedDeviceIsolationMode: Bool { get set }
     var elementCallBaseURLOverride: URL? { get set }
-    var identityPinningViolationNotificationsEnabled: Bool { get set }
     var knockingEnabled: Bool { get set }
     var frequentEmojisEnabled: Bool { get set }
 }

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
@@ -50,10 +50,6 @@ struct DeveloperOptionsScreen: View {
                     Text("Hide image & video previews")
                 }
                 
-                Toggle(isOn: $context.identityPinningViolationNotificationsEnabled) {
-                    Text("Identity pinning violation notifications")
-                }
-                
                 Toggle(isOn: $context.frequentEmojisEnabled) {
                     Text("Show frequently used emojis")
                 }


### PR DESCRIPTION
Enable identity pinning violation notifications unconditionally (remove the feature flag we added when this feature seemed unstable).

([Internal issue](https://github.com/element-hq/element-internal/issues/644)). Part of the Trust and Decorations work.

In #3394 we disabled identity change notifications based on a default-off feature flag, because we found some bugs in the feature. The bugs are fixed and we think it's time to enable the feature unconditionally.

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).

**UI changes have not been tested at all**

.. but this is essentially a revert of #3394 so if someone is able to check I haven't made a basic mistake we might be OK merging it.
