### PR TITLE
Update the strings for out of sync Key Storage.

### DIFF
--- a/ElementX/Resources/Localizations/en.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Localizable.strings
@@ -641,7 +641,7 @@
 "screen_recovery_key_change_title" = "Change recovery key?";
 "screen_recovery_key_confirm_create_new_recovery_key" = "Create new recovery key";
 "screen_recovery_key_confirm_description" = "Make sure nobody can see this screen!";
-"screen_recovery_key_confirm_error_content" = "Please try again to confirm access to your chat backup.";
+"screen_recovery_key_confirm_error_content" = "Please try again to confirm access to your key storage.";
 "screen_recovery_key_confirm_error_title" = "Incorrect recovery key";
 "screen_recovery_key_confirm_key_description" = "If you have a security key or security phrase, this will work too.";
 "screen_recovery_key_confirm_key_placeholder" = "Enter…";

--- a/ElementX/Resources/Localizations/en.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Localizable.strings
@@ -466,7 +466,7 @@
 "screen_chat_backup_key_storage_toggle_title" = "Allow key storage";
 "screen_chat_backup_recovery_action_change" = "Change recovery key";
 "screen_chat_backup_recovery_action_change_description" = "Recover your cryptographic identity and message history with a recovery key if you’ve lost all your existing devices.";
-"screen_chat_backup_recovery_action_confirm_description" = "Your chat backup is currently out of sync.";
+"screen_chat_backup_recovery_action_confirm_description" = "Your key storage is currently out of sync.";
 "screen_chat_backup_recovery_action_setup_description" = "Get access to your encrypted messages if you lose all your devices or are signed out of %1$@ everywhere.";
 "screen_create_account_title" = "Create account";
 "screen_create_new_recovery_key_list_item_1" = "Open %1$@ in a desktop device";

--- a/ElementX/Resources/Localizations/en.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Localizable.strings
@@ -116,7 +116,6 @@
 "banner_migrate_to_native_sliding_sync_force_logout_title" = "Your homeserver no longer supports the old protocol. Please log out and log back in to continue using the app.";
 "banner_migrate_to_native_sliding_sync_title" = "Upgrade available";
 "banner_set_up_recovery_content" = "Recover your cryptographic identity and message history with a recovery key if you have lost all your existing devices.";
-"banner_set_up_recovery_submit" = "Set up recovery";
 "banner_set_up_recovery_title" = "Set up recovery to protect your account";
 "common_about" = "About";
 "common_acceptable_use_policy" = "Acceptable use policy";
@@ -247,8 +246,10 @@
 "common.you" = "You";
 "common_unable_to_decrypt_insecure_device" = "Sent from an insecure device";
 "common_unable_to_decrypt_verification_violation" = "Sender's verified identity has changed";
-"confirm_recovery_key_banner_message" = "Your chat backup is currently out of sync. You need to enter your recovery key to maintain access to your chat backup.";
-"confirm_recovery_key_banner_title" = "Enter your recovery key";
+"confirm_recovery_key_banner_message" = "Confirm your recovery key to maintain access to your key storage and message history.";
+"confirm_recovery_key_banner_primary_button_title" = "Enter your recovery key";
+"confirm_recovery_key_banner_secondary_button_title" = "Forgot your recovery key?";
+"confirm_recovery_key_banner_title" = "Your key storage is out of sync";
 "crash_detection_dialog_content" = "%1$@ crashed the last time it was used. Would you like to share a crash report with us?";
 "crypto_identity_change_pin_violation" = "%1$@'s identity appears to have changed. %2$@";
 "crypto_identity_change_pin_violation_new" = "%1$@’s %2$@ identity appears to have changed. %3$@";
@@ -466,7 +467,6 @@
 "screen_chat_backup_recovery_action_change" = "Change recovery key";
 "screen_chat_backup_recovery_action_change_description" = "Recover your cryptographic identity and message history with a recovery key if you’ve lost all your existing devices.";
 "screen_chat_backup_recovery_action_confirm_description" = "Your chat backup is currently out of sync.";
-"screen_chat_backup_recovery_action_setup" = "Set up recovery";
 "screen_chat_backup_recovery_action_setup_description" = "Get access to your encrypted messages if you lose all your devices or are signed out of %1$@ everywhere.";
 "screen_create_account_title" = "Create account";
 "screen_create_new_recovery_key_list_item_1" = "Open %1$@ in a desktop device";
@@ -789,7 +789,6 @@
 "screen_room_timeline_less_reactions" = "Show less";
 "screen_room_timeline_message_copied" = "Message copied";
 "screen_room_timeline_no_permission_to_post" = "You do not have permission to post to this room";
-"screen_room_timeline_reactions_show_less" = "Show less";
 "screen_room_timeline_reactions_show_more" = "Show more";
 "screen_room_timeline_read_marker_title" = "New";
 "screen_room_title" = "Chat";
@@ -839,7 +838,6 @@
 "screen_session_verification_ready_subtitle" = "Compare a unique set of emojis.";
 "screen_session_verification_request_accepted_subtitle" = "Compare the unique emoji, ensuring they appear in the same order.";
 "screen_session_verification_request_details_timestamp" = "Signed in";
-"screen_session_verification_request_failure_subtitle" = "Either the request timed out, the request was denied, or there was a verification mismatch.";
 "screen_session_verification_request_failure_title" = "Verification failed";
 "screen_session_verification_request_footer" = "Only continue if you initiated this verification.";
 "screen_session_verification_request_subtitle" = "Verify the other device to keep your message history secure.";
@@ -995,6 +993,7 @@
 "troubleshoot_notifications_test_unified_push_failure" = "No push distributors found.";
 "troubleshoot_notifications_test_unified_push_title" = "Check UnifiedPush";
 "a11y_poll" = "Poll";
+"banner_set_up_recovery_submit" = "Set up recovery";
 "dialog_title_error" = "Error";
 "dialog_title_success" = "Success";
 "notification_fallback_content" = "Notification";
@@ -1015,6 +1014,7 @@
 "screen_blocked_users_unblock_alert_title" = "Unblock user";
 "screen_bug_report_rash_logs_alert_title" = "%1$@ crashed the last time it was used. Would you like to share a crash report with us?";
 "screen_chat_backup_recovery_action_confirm" = "Enter recovery key";
+"screen_chat_backup_recovery_action_setup" = "Set up recovery";
 "screen_create_poll_cancel_confirmation_content_ios" = "Your changes won’t be saved";
 "screen_create_room_add_people_title" = "Invite people";
 "screen_create_room_room_name_label" = "Room name";
@@ -1055,8 +1055,10 @@
 "screen_room_error_failed_processing_media" = "Failed processing media to upload, please try again.";
 "screen_room_member_list_manage_member_remove_confirmation_ban" = "Remove and ban member";
 "screen_room_notification_settings_mode_mentions_and_keywords" = "Mentions and Keywords only";
+"screen_room_timeline_reactions_show_less" = "Show less";
 "screen_roomlist_filter_people" = "People";
 "screen_server_confirmation_change_server" = "Change account provider";
+"screen_session_verification_request_failure_subtitle" = "Either the request timed out, the request was denied, or there was a verification mismatch.";
 "screen_signout_confirmation_dialog_submit" = "Sign out";
 "screen_signout_confirmation_dialog_title" = "Sign out";
 "screen_signout_key_backup_offline_title" = "Your keys are still being backed up";

--- a/ElementX/Sources/Generated/Strings.swift
+++ b/ElementX/Sources/Generated/Strings.swift
@@ -1043,7 +1043,7 @@ internal enum L10n {
   internal static var screenChatBackupRecoveryActionChangeDescription: String { return L10n.tr("Localizable", "screen_chat_backup_recovery_action_change_description") }
   /// Enter recovery key
   internal static var screenChatBackupRecoveryActionConfirm: String { return L10n.tr("Localizable", "screen_chat_backup_recovery_action_confirm") }
-  /// Your chat backup is currently out of sync.
+  /// Your key storage is currently out of sync.
   internal static var screenChatBackupRecoveryActionConfirmDescription: String { return L10n.tr("Localizable", "screen_chat_backup_recovery_action_confirm_description") }
   /// Set up recovery
   internal static var screenChatBackupRecoveryActionSetup: String { return L10n.tr("Localizable", "screen_chat_backup_recovery_action_setup") }

--- a/ElementX/Sources/Generated/Strings.swift
+++ b/ElementX/Sources/Generated/Strings.swift
@@ -536,9 +536,13 @@ internal enum L10n {
   internal static var commonWaiting: String { return L10n.tr("Localizable", "common_waiting") }
   /// Waiting for this message
   internal static var commonWaitingForDecryptionKey: String { return L10n.tr("Localizable", "common_waiting_for_decryption_key") }
-  /// Your chat backup is currently out of sync. You need to enter your recovery key to maintain access to your chat backup.
+  /// Confirm your recovery key to maintain access to your key storage and message history.
   internal static var confirmRecoveryKeyBannerMessage: String { return L10n.tr("Localizable", "confirm_recovery_key_banner_message") }
   /// Enter your recovery key
+  internal static var confirmRecoveryKeyBannerPrimaryButtonTitle: String { return L10n.tr("Localizable", "confirm_recovery_key_banner_primary_button_title") }
+  /// Forgot your recovery key?
+  internal static var confirmRecoveryKeyBannerSecondaryButtonTitle: String { return L10n.tr("Localizable", "confirm_recovery_key_banner_secondary_button_title") }
+  /// Your key storage is out of sync
   internal static var confirmRecoveryKeyBannerTitle: String { return L10n.tr("Localizable", "confirm_recovery_key_banner_title") }
   /// %1$@ crashed the last time it was used. Would you like to share a crash report with us?
   internal static func crashDetectionDialogContent(_ p1: Any) -> String {

--- a/ElementX/Sources/Generated/Strings.swift
+++ b/ElementX/Sources/Generated/Strings.swift
@@ -1520,7 +1520,7 @@ internal enum L10n {
   internal static var screenRecoveryKeyConfirmCreateNewRecoveryKey: String { return L10n.tr("Localizable", "screen_recovery_key_confirm_create_new_recovery_key") }
   /// Make sure nobody can see this screen!
   internal static var screenRecoveryKeyConfirmDescription: String { return L10n.tr("Localizable", "screen_recovery_key_confirm_description") }
-  /// Please try again to confirm access to your chat backup.
+  /// Please try again to confirm access to your key storage.
   internal static var screenRecoveryKeyConfirmErrorContent: String { return L10n.tr("Localizable", "screen_recovery_key_confirm_error_content") }
   /// Incorrect recovery key
   internal static var screenRecoveryKeyConfirmErrorTitle: String { return L10n.tr("Localizable", "screen_recovery_key_confirm_error_title") }

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreenRecoveryKeyConfirmationBanner.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreenRecoveryKeyConfirmationBanner.swift
@@ -6,6 +6,7 @@
 //
 
 import Combine
+import Compound
 import SwiftUI
 
 struct HomeScreenRecoveryKeyConfirmationBanner: View {
@@ -14,18 +15,28 @@ struct HomeScreenRecoveryKeyConfirmationBanner: View {
     
     var title: String { requiresExtraAccountSetup ? L10n.bannerSetUpRecoveryTitle : L10n.confirmRecoveryKeyBannerTitle }
     var message: String { requiresExtraAccountSetup ? L10n.bannerSetUpRecoveryContent : L10n.confirmRecoveryKeyBannerMessage }
-    var actionTitle: String { requiresExtraAccountSetup ? L10n.bannerSetUpRecoverySubmit : L10n.actionContinue }
+    var actionTitle: String { requiresExtraAccountSetup ? L10n.bannerSetUpRecoverySubmit : L10n.confirmRecoveryKeyBannerPrimaryButtonTitle }
     
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            VStack(alignment: .leading, spacing: 4) {
-                HStack(spacing: 16) {
-                    Text(title)
-                        .font(.compound.bodyLGSemibold)
-                        .foregroundColor(.compound.textPrimary)
-                    
-                    Spacer()
-                    
+        VStack(spacing: 16) {
+            content
+            buttons
+        }
+        .padding(16)
+        .background(Color.compound.bgSubtleSecondary)
+        .cornerRadius(14)
+        .padding(.horizontal, 16)
+    }
+    
+    var content: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(alignment: .firstTextBaseline, spacing: 16) {
+                Text(title)
+                    .font(.compound.bodyLGSemibold)
+                    .foregroundColor(.compound.textPrimary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                
+                if requiresExtraAccountSetup {
                     Button {
                         context.send(viewAction: .skipRecoveryKeyConfirmation)
                     } label: {
@@ -34,22 +45,27 @@ struct HomeScreenRecoveryKeyConfirmationBanner: View {
                             .frame(width: 12, height: 12)
                     }
                 }
-                Text(message)
-                    .font(.compound.bodyMD)
-                    .foregroundColor(.compound.textSecondary)
             }
             
+            Text(message)
+                .font(.compound.bodyMD)
+                .foregroundColor(.compound.textSecondary)
+        }
+    }
+    
+    var buttons: some View {
+        VStack(spacing: 16) {
             Button(actionTitle) {
                 context.send(viewAction: .confirmRecoveryKey)
             }
             .frame(maxWidth: .infinity)
             .buttonStyle(.compound(.primary, size: .medium))
             .accessibilityIdentifier(A11yIdentifiers.homeScreen.recoveryKeyConfirmationBannerContinue)
+            
+            if !requiresExtraAccountSetup {
+                // Missing encryption reset button to goes here once the flow exists.
+            }
         }
-        .padding(16)
-        .background(Color.compound.bgSubtleSecondary)
-        .cornerRadius(14)
-        .padding(.horizontal, 16)
     }
 }
 

--- a/ElementX/Sources/Screens/SecureBackup/SecureBackupRecoveryKeyScreen/SecureBackupRecoveryKeyScreenViewModel.swift
+++ b/ElementX/Sources/Screens/SecureBackup/SecureBackupRecoveryKeyScreen/SecureBackupRecoveryKeyScreenViewModel.swift
@@ -65,7 +65,9 @@ class SecureBackupRecoveryKeyScreenViewModel: SecureBackupRecoveryKeyScreenViewM
                     actionsSubject.send(.done(mode: context.viewState.mode))
                 case .failure(let error):
                     MXLog.error("Failed confirming recovery key with error: \(error)")
-                    state.bindings.alertInfo = .init(id: .init())
+                    state.bindings.alertInfo = .init(id: .init(),
+                                                     title: L10n.screenRecoveryKeyConfirmErrorTitle,
+                                                     message: L10n.screenRecoveryKeyConfirmErrorContent)
                 }
                 
                 hideLoadingIndicator()

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_homeScreenRecoveryKeyConfirmationBanner-iPad-en-GB.Out-of-sync.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_homeScreenRecoveryKeyConfirmationBanner-iPad-en-GB.Out-of-sync.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a4755216723bde1c66554701adf2fefec3f6a4b2949d66ac5875a801b1cd3d8f
-size 95958
+oid sha256:d425040e4de7d03d440c14ad4c1255e9ecd0950e913e340e6828780b008dddbb
+size 98068

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_homeScreenRecoveryKeyConfirmationBanner-iPad-en-GB.Set-up-recovery.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_homeScreenRecoveryKeyConfirmationBanner-iPad-en-GB.Set-up-recovery.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e84c622fbb683ac69fa5eb646de5bd340c6105cb08dddd7ab5ecae9d55299583
+oid sha256:580afc74fbb53628ec66643e67c643fab23ea1e2e0717de0f8622534b0cf1724
 size 101351

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_homeScreenRecoveryKeyConfirmationBanner-iPad-pseudo.Out-of-sync.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_homeScreenRecoveryKeyConfirmationBanner-iPad-pseudo.Out-of-sync.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2ea3d780c157fc77da9a75f73d8b482f7d23eb539a67e854dba0ba44deda6173
-size 110663
+oid sha256:946bbda26c484f64738933c2c4fd3f4b8d095079d38947ef55c17deb4660b1a6
+size 109879

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_homeScreenRecoveryKeyConfirmationBanner-iPad-pseudo.Set-up-recovery.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_homeScreenRecoveryKeyConfirmationBanner-iPad-pseudo.Set-up-recovery.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:934180921dd8b9c7feeb270fcf3a6d1a2847edba5fc4ea4c820a95b60080c218
-size 119120
+oid sha256:b1c9b76234430e9d6d446ffd28220b1f6a370fc2239885fc55fff282e413b3d2
+size 119143

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_homeScreenRecoveryKeyConfirmationBanner-iPhone-16-en-GB.Out-of-sync.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_homeScreenRecoveryKeyConfirmationBanner-iPhone-16-en-GB.Out-of-sync.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c788a03807032eac004c08138a80590a7cecf1c6a4d229a612fbfd9a2f8cf489
-size 58527
+oid sha256:32b70c1911a7a413e0d6ae1748e3ea05929e951503629ead0b2fe3773f0bdd9d
+size 56470

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_homeScreenRecoveryKeyConfirmationBanner-iPhone-16-en-GB.Set-up-recovery.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_homeScreenRecoveryKeyConfirmationBanner-iPhone-16-en-GB.Set-up-recovery.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aec6cef7b010741b2db19085da28d43c3a1a511a658fa957236d665d5aaf6429
-size 65400
+oid sha256:adf6a9788518c6b10fb2c7369358b86004fba197f97913f2b74fade671e62046
+size 65418

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_homeScreenRecoveryKeyConfirmationBanner-iPhone-16-pseudo.Out-of-sync.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_homeScreenRecoveryKeyConfirmationBanner-iPhone-16-pseudo.Out-of-sync.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b7284ecd8fd558b1ae9a746d27f690ef931bfccf4fb1308c2d7778ba3795a158
-size 79847
+oid sha256:e9e6a4ef76a75e88c0a87e177fd11ec6d1bb9b1b6f843692d002f93b4fa75690
+size 79643

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_homeScreenRecoveryKeyConfirmationBanner-iPhone-16-pseudo.Set-up-recovery.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_homeScreenRecoveryKeyConfirmationBanner-iPhone-16-pseudo.Set-up-recovery.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:338ad333cedcb48ce8ea5ba3573956f122e9a48fd411249f803b32c8b755a75b
-size 92631
+oid sha256:894d0d1de52a98c6446e955ce68c1d7c2f0d14496742c357410653c8a1c12a61
+size 92453

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_secureBackupScreen-iPad-en-GB.Recovery-incomplete.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_secureBackupScreen-iPad-en-GB.Recovery-incomplete.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ff079b6cd61f2c0fb2c4a7a66dd1cdbc297b9ee0951fad8274b0d279507544ca
-size 91489
+oid sha256:1074a4fc754d8adea55068deb0371423986258a6a33052983360a71d26a08c77
+size 91504

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_secureBackupScreen-iPad-pseudo.Recovery-incomplete.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_secureBackupScreen-iPad-pseudo.Recovery-incomplete.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:47fe19f5a821b1ef13956f05ea55ec4f9d22ec8846a5596b318eec1cc0974071
-size 94488
+oid sha256:e9e29742d2bd0b51b691f90bcda2b3575804ce4bdab3cdecdfc5b80572edba53
+size 96179

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_secureBackupScreen-iPhone-16-en-GB.Recovery-incomplete.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_secureBackupScreen-iPhone-16-en-GB.Recovery-incomplete.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fb3b0d4c592e7dd54650f94bcdbf1d3763dd946c7f8c753b024a27d24e3d7cdb
-size 45210
+oid sha256:9634914eb74dce6716f80606d010fc3f32a25f84f8734c42db5944dcbd41e4d4
+size 44940

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_secureBackupScreen-iPhone-16-pseudo.Recovery-incomplete.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_secureBackupScreen-iPhone-16-pseudo.Recovery-incomplete.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0709b19f855c68b6c72d16a6377ef96a388ffec5604c2d66492c8602cfa11e90
-size 53200
+oid sha256:0aa9d066e4646d6f0dc322d02514343fc9677a5ff33b71c1c4171063ccb98a1a
+size 52909


### PR DESCRIPTION
This PR is an initial part of #3399 to get the strings in sync with everything done for https://github.com/element-hq/element-meta/issues/2590. I've tweaked the banner a bit too to match the Figma, preparing it for the secondary button to be added.

Unfortunately it looks like updated flows will require somewhat of a re-write so this will be handled separately, likely after the next RC.

<img width="409" alt="Screenshot 2024-10-31 at 10 15 49 am" src="https://github.com/user-attachments/assets/91c7bde7-da30-4b5f-9759-357bb9640ced">
