### PR TITLE
Stop the sync loop after each background app refresh.

### DIFF
--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -306,15 +306,24 @@ class ClientProxy: ClientProxyProtocol {
             restartTask = nil
         }
         
+        guard let syncService else {
+            MXLog.warning("No sync service to stop.")
+            completion?()
+            return
+        }
+        
         // Capture the sync service strongly as this method is called on deinit and so the
         // existence of self when the Task executes is questionable and would sometimes crash.
+        // Note: This isn't strictly necessary now given the unwrap above, but leaving the code as
+        // documentation. SE-0371 will allow us to fix this by using an async deinit.
         Task { [syncService] in
             do {
                 defer {
                     completion?()
                 }
                 
-                try await syncService?.stop()
+                try await syncService.stop()
+                MXLog.info("Sync stopped")
             } catch {
                 MXLog.error("Failed stopping the sync service with error: \(error)")
             }


### PR DESCRIPTION
Looking at some logs, we haven't been cleanly stopping the sync loop after a background app refresh.

```
┌2024-11-04T09:08:29.090000Z  INFO elementx: Reachability changed to reachable | AppCoordinator.swift:702 | spans: root                                                                ┤
│2024-11-04T09:08:29.367000Z  INFO elementx: Started background app refresh | AppCoordinator.swift:986 | spans: root                                                                   ┤
│2024-11-04T09:08:29.379000Z  INFO elementx: Successfully scheduled background app refresh task | AppCoordinator.swift:978 | spans: root                                               ┤
│2024-11-04T09:08:29.425000Z  INFO elementx: Starting sync | ClientProxy.swift:269 | spans: root                                                                                       ┤
│2024-11-04T09:08:30.073000Z  INFO elementx: Send queue status changed to enabled: false, reachability: reachable | ClientProxy.swift:183 | spans: root                                ┤
│2024-11-04T09:08:30.074000Z  INFO elementx: Enabling all send queues | ClientProxy.swift:186 | spans: root                                                                            ┤
│2024-11-04T09:08:54.523000Z  INFO elementx: Background app refresh task expired | AppCoordinator.swift:992 | spans: root                                                              ┤
│2024-11-04T09:16:50.154000Z  INFO elementx: Started background app refresh | AppCoordinator.swift:986 | spans: root                                                                   ┤
│2024-11-04T09:16:50.176000Z  INFO elementx: Successfully scheduled background app refresh task | AppCoordinator.swift:978 | spans: root                                               ┤
│2024-11-04T09:16:50.222000Z  INFO elementx: Starting sync | ClientProxy.swift:269 | spans: root                                                                                       ┤
│2024-11-04T09:17:01.244000Z  INFO elementx: Reachability changed to reachable | AppCoordinator.swift:702 | spans: root                                                                ┤
│2024-11-04T09:17:02.095000Z  INFO elementx: Send queue status changed to enabled: false, reachability: reachable | ClientProxy.swift:183 | spans: root                                ┤
│2024-11-04T09:17:02.112000Z  INFO elementx: Enabling all send queues | ClientProxy.swift:186 | spans: root                                                                            ┤
│2024-11-04T09:17:15.691000Z  INFO elementx: Background app refresh task expired | AppCoordinator.swift:992 | spans: root  
```

Note in these logs that the SDK isn't doing anything… If you observe an instance where the task finished successfully, you often see the request from that sync loop iteration failing as soon as the next refresh is run:

```
2024-11-04T08:15:00.481585Z  INFO elementx: Started background app refresh | AppCoordinator.swift:986 | spans: root
** syncing in the background **
2024-11-04T08:15:08.060033Z DEBUG matrix_sdk::http_client::native: Sending request num_attempt=1 | crates/matrix-sdk/src/http_client/native.rs:55 | spans: root > sync_once > send{ … request_id="REQ-54" … }
2024-11-04T08:15:10.364893Z DEBUG matrix_sdk::http_client::native: Sending request num_attempt=1 | crates/matrix-sdk/src/http_client/native.rs:55 | spans: root > sync_once > send{ … request_id="REQ-55" … }
2024-11-04T08:15:10.600407Z  INFO elementx: Background app refresh finished | AppCoordinator.swift:1011 | spans: root
2024-11-04T08:22:58.534036Z  INFO elementx: Reachability changed to reachable | AppCoordinator.swift:702 | spans: root
2024-11-04T08:22:58.533272Z DEBUG matrix_sdk::http_client: Error while sending request: Reqwest(reqwest::Error { kind: Body, source: TimedOut }) | crates/matrix-sdk/src/http_client/mod.rs:234 | spans: root > sync_once{ … request_id="REQ-54" … }
2024-11-04T08:22:58.533289Z DEBUG matrix_sdk::http_client: Error while sending request: Reqwest(reqwest::Error { kind: Request, url: Url { … source: TimedOut }) | crates/matrix-sdk/src/http_client/mod.rs:234 | spans: root > sync_once{ … request_id="REQ-55" … }
2024-11-04T08:22:58.549338Z  INFO elementx: Started background app refresh | AppCoordinator.swift:986 | spans: root
2024-11-04T08:22:58.550098Z  INFO elementx: Successfully scheduled background app refresh task | AppCoordinator.swift:978 | spans: root
2024-11-04T08:22:58.550497Z  INFO elementx: Received room list update: error | ClientProxy.swift:828 | spans: root
2024-11-04T08:22:58.559732Z  INFO elementx: Received sync service update: error | ClientProxy.swift:813 | spans: root
2024-11-04T08:22:58.564970Z  INFO elementx: Starting sync | ClientProxy.swift:269 | spans: root
```

This PR stops the loop when the task has finished or expired to see if it will help fix #3802.