### PR TITLE
Fix the Setup Recovery flow from the home screen banner.

### DIFF
--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -466,6 +466,8 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
                     settingsFlowCoordinator.handleAppRoute(.settings, animated: true)
                 case .presentFeedbackScreen:
                     stateMachine.processEvent(.feedbackScreen)
+                case .presentSecureBackupSettings:
+                    settingsFlowCoordinator.handleAppRoute(.chatBackupSettings, animated: true)
                 case .presentRecoveryKeyScreen:
                     stateMachine.processEvent(.showRecoveryKeyScreen)
                 case .presentEncryptionResetScreen:

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenCoordinator.swift
@@ -20,6 +20,7 @@ enum HomeScreenCoordinatorAction {
     case roomLeft(roomIdentifier: String)
     case presentSettingsScreen
     case presentFeedbackScreen
+    case presentSecureBackupSettings
     case presentRecoveryKeyScreen
     case presentEncryptionResetScreen
     case presentStartChatScreen
@@ -64,6 +65,8 @@ final class HomeScreenCoordinator: CoordinatorProtocol {
                     actionsSubject.send(.presentFeedbackScreen)
                 case .presentSettingsScreen:
                     actionsSubject.send(.presentSettingsScreen)
+                case .presentSecureBackupSettings:
+                    actionsSubject.send(.presentSecureBackupSettings)
                 case .presentRecoveryKeyScreen:
                     actionsSubject.send(.presentRecoveryKeyScreen)
                 case .presentEncryptionResetScreen:

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
@@ -13,6 +13,7 @@ enum HomeScreenViewModelAction {
     case presentRoom(roomIdentifier: String)
     case presentRoomDetails(roomIdentifier: String)
     case roomLeft(roomIdentifier: String)
+    case presentSecureBackupSettings
     case presentRecoveryKeyScreen
     case presentEncryptionResetScreen
     case presentSettingsScreen
@@ -31,7 +32,8 @@ enum HomeScreenViewAction {
     case confirmLeaveRoom(roomIdentifier: String)
     case showSettings
     case startChat
-    case manageRecoveryKey
+    case setupRecovery
+    case confirmRecoveryKey
     case resetEncryption
     case skipRecoveryKeyConfirmation
     case confirmSlidingSyncUpgrade

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -138,7 +138,9 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
             Task { await leaveRoom(roomID: roomIdentifier) }
         case .showSettings:
             actionsSubject.send(.presentSettingsScreen)
-        case .manageRecoveryKey:
+        case .setupRecovery:
+            actionsSubject.send(.presentSecureBackupSettings)
+        case .confirmRecoveryKey:
             actionsSubject.send(.presentRecoveryKeyScreen)
         case .resetEncryption:
             actionsSubject.send(.presentEncryptionResetScreen)

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreenRecoveryKeyConfirmationBanner.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreenRecoveryKeyConfirmationBanner.swift
@@ -16,6 +16,7 @@ struct HomeScreenRecoveryKeyConfirmationBanner: View {
     var title: String { requiresExtraAccountSetup ? L10n.bannerSetUpRecoveryTitle : L10n.confirmRecoveryKeyBannerTitle }
     var message: String { requiresExtraAccountSetup ? L10n.bannerSetUpRecoveryContent : L10n.confirmRecoveryKeyBannerMessage }
     var actionTitle: String { requiresExtraAccountSetup ? L10n.bannerSetUpRecoverySubmit : L10n.confirmRecoveryKeyBannerPrimaryButtonTitle }
+    var primaryAction: HomeScreenViewAction { requiresExtraAccountSetup ? .setupRecovery : .confirmRecoveryKey }
     
     var body: some View {
         VStack(spacing: 16) {
@@ -56,7 +57,7 @@ struct HomeScreenRecoveryKeyConfirmationBanner: View {
     var buttons: some View {
         VStack(spacing: 16) {
             Button(actionTitle) {
-                context.send(viewAction: .manageRecoveryKey)
+                context.send(viewAction: primaryAction)
             }
             .frame(maxWidth: .infinity)
             .buttonStyle(.compound(.primary, size: .medium))


### PR DESCRIPTION
#3482 introduced a slight regression:

When only a single button is shown on the banner the old flow should still be followed, however the update would always present the key recovery screen directly.

This PR reinstates the previous view action for that button.

https://github.com/user-attachments/assets/e7d7e686-9124-4462-a1d7-fee34ced0d77

https://github.com/user-attachments/assets/caa0057d-04f6-4499-a273-a8e7c6e0fa34
