### PR TITLE
Fix race condition when setting up session verification controller subscriptions

### DIFF
--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -156,19 +156,10 @@ class ClientProxy: ClientProxyProtocol {
             self?.ignoredUsersSubject.send(ignoredUsers)
         })
         
-        updateVerificationState(client.encryption().verificationState())
+        await updateVerificationState(client.encryption().verificationState())
         
         verificationStateListenerTaskHandle = client.encryption().verificationStateListener(listener: VerificationStateListenerProxy { [weak self] verificationState in
-            guard let self else { return }
-            
-            updateVerificationState(verificationState)
-            
-            // The session verification controller requires the user's identity which
-            // isn't available before a keys query response. Use the verification
-            // state updates as an aproximation for when that happens.
-            Task {
-                await self.buildSessionVerificationControllerProxyIfPossible(verificationState: verificationState)
-            }
+            Task { await self?.updateVerificationState(verificationState) }
         })
         
         sendQueueListenerTaskHandle = client.subscribeToSendQueueStatus(listener: SendQueueRoomErrorListenerProxy { [weak self] roomID, error in
@@ -727,7 +718,7 @@ class ClientProxy: ClientProxyProtocol {
     
     // MARK: - Private
     
-    private func updateVerificationState(_ verificationState: VerificationState) {
+    private func updateVerificationState(_ verificationState: VerificationState) async {
         let verificationState: SessionVerificationState = switch verificationState {
         case .unknown:
             .unknown
@@ -737,10 +728,17 @@ class ClientProxy: ClientProxyProtocol {
             .verified
         }
         
+        // The session verification controller requires the user's identity which
+        // isn't available before a keys query response. Use the verification
+        // state updates as an aproximation for when that happens.
+        await buildSessionVerificationControllerProxyIfPossible(verificationState: verificationState)
+        
+        // Only update the session verification state after creating a session
+        // verification proxy to avoid race conditions
         verificationStateSubject.send(verificationState)
     }
     
-    private func buildSessionVerificationControllerProxyIfPossible(verificationState: VerificationState) async {
+    private func buildSessionVerificationControllerProxyIfPossible(verificationState: SessionVerificationState) async {
         guard sessionVerificationController == nil, verificationState != .unknown else {
             return
         }


### PR DESCRIPTION
We were running the SessionVerificationController in a task after updating the session verification state, which would result in trying to subscribe to a nil object.