### PR TITLE
Fastlane fails resetting the right simulator, use `device` instead of `destination`.

### DIFF
--- a/UITests/Sources/UserSessionScreenTests.swift
+++ b/UITests/Sources/UserSessionScreenTests.swift
@@ -13,6 +13,9 @@ class UserSessionScreenTests: XCTestCase {
     
     func testUserSessionFlows() async throws {
         let app = Application.launch(.userSessionScreen)
+        
+        app.swipeDown() // Make sure the header shows a large title
+        
         try await app.assertScreenshot(.userSessionScreen, step: 1)
 
         app.buttons[A11yIdentifiers.homeScreen.roomName(firstRoomName)].tap()

--- a/UITests/Sources/UserSessionScreenTests.swift
+++ b/UITests/Sources/UserSessionScreenTests.swift
@@ -47,7 +47,7 @@ class UserSessionScreenTests: XCTestCase {
         let textField = app.textFields["Display name"]
         XCTAssert(textField.waitForExistence(timeout: 10))
         
-        let joinButton = app.buttons["Join call now"]
+        let joinButton = app.buttons["Continue"]
         XCTAssert(joinButton.waitForExistence(timeout: 10))
     }
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -84,7 +84,7 @@ lane :unit_tests do |options|
   
   run_tests(
     scheme: "UnitTests",
-    destination: "platform=iOS Simulator,name=iPhone 16,OS=18.0",
+    device: "iPhone 16 (18.0)",
     ensure_devices_found: true,
     result_bundle: true,
     number_of_retries: 3,
@@ -94,7 +94,7 @@ lane :unit_tests do |options|
   if !options[:skip_previews]
     run_tests(
       scheme: "PreviewTests",
-      destination: "platform=iOS Simulator,name=iPhone SE (3rd generation),OS=18.0",
+      device: "iPhone SE (3rd generation) (18.0)",
       ensure_devices_found: true,
       result_bundle: true,
       number_of_retries: 3,
@@ -107,13 +107,13 @@ end
 
 lane :ui_tests do |options|
   create_simulator_if_necessary(
-    name: "iPhone 16",
+    name: "iPhone 16 (18.0)",
     type: "com.apple.CoreSimulator.SimDeviceType.iPhone-16",
     runtime: "com.apple.CoreSimulator.SimRuntime.iOS-18-0"
   )
   
   create_simulator_if_necessary(
-    name: "iPad (10th generation)",
+    name: "iPad (10th generation) (18.0)",
     type: "com.apple.CoreSimulator.SimDeviceType.iPad-10th-generation",
     runtime: "com.apple.CoreSimulator.SimRuntime.iOS-18-0"
   )
@@ -128,7 +128,7 @@ lane :ui_tests do |options|
 
   run_tests(
     scheme: "UITests",
-    devices: ["iPhone 16", "iPad (10th generation)"],
+    devices: ["iPhone 16 (18.0)", "iPad (10th generation) (18.0)"],
     ensure_devices_found: true,
     prelaunch_simulator: true,
     result_bundle: true,
@@ -143,7 +143,7 @@ lane :integration_tests do
   clear_derived_data()
   
   create_simulator_if_necessary(
-    name: "iPhone 16 Pro",
+    name: "iPhone 16 Pro (18.0)",
     type: "com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro",
     runtime: "com.apple.CoreSimulator.SimRuntime.iOS-18-0"
   )
@@ -152,7 +152,7 @@ lane :integration_tests do
 
   run_tests(
     scheme: "IntegrationTests",
-    destination: "platform=iOS Simulator,name=iPhone 16 Pro,OS=18.0",
+    device: "iPhone 16 Pro (18.0)",
     ensure_devices_found: true,
     result_bundle: true,
     reset_simulator: reset_simulator


### PR DESCRIPTION
This seems to have worked for the integration tests https://github.com/element-hq/element-x-ios/actions/runs/11718009383/job/32638954449, let's hope it works for the others too.

```
[07:50:30]: Cruising over to lane 'create_simulator_if_necessary' 🚖
[07:50:30]: --------------------------------------------------------------------
[07:50:30]: Step: xcrun simctl list devices | grep 'iPhone 16 Pro (18.0) ('
[07:50:30]: --------------------------------------------------------------------
[07:50:30]: $ xcrun simctl list devices | grep 'iPhone 16 Pro (18.0) ('
[07:50:30]: --------------------------------------------------------------------
[07:50:30]: Step: xcrun simctl create 'iPhone 16 Pro (18.0)' com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro com.apple.CoreSimulator.SimRuntime.iOS-18-0
[07:50:30]: --------------------------------------------------------------------
[07:50:30]: $ xcrun simctl create 'iPhone 16 Pro (18.0)' com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro com.apple.CoreSimulator.SimRuntime.iOS-18-0
```

```
[07:51:15]: Resetting iPhone 16 Pro
[07:51:15]: Disabling 'Slide to Type' iPhone 16 Pro
```