### PR TITLE
Update compound.

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -7978,7 +7978,7 @@
 			repositoryURL = "https://github.com/element-hq/compound-ios";
 			requirement = {
 				kind = revision;
-				revision = e3f9665621872f60d3652579c3f0dc7bf806e72c;
+				revision = 950a8884e269194e6030cbddabebbb116cdfe02a;
 			};
 		};
 		F76A08D0EA29A07A54F4EB4D /* XCRemoteSwiftPackageReference "swift-collections" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/compound-design-tokens",
       "state" : {
-        "revision" : "976db67b849775799b4153e7894d61e90fc96888",
-        "version" : "1.9.0"
+        "revision" : "f9510e9d309b5aeefe9a7ef6b8c073c84337d4e9",
+        "version" : "1.9.1"
       }
     },
     {
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/compound-ios",
       "state" : {
-        "revision" : "e3f9665621872f60d3652579c3f0dc7bf806e72c"
+        "revision" : "950a8884e269194e6030cbddabebbb116cdfe02a"
       }
     },
     {

--- a/project.yml
+++ b/project.yml
@@ -64,7 +64,7 @@ packages:
     # path: ../matrix-rust-sdk
   Compound:
     url: https://github.com/element-hq/compound-ios
-    revision: e3f9665621872f60d3652579c3f0dc7bf806e72c
+    revision: 950a8884e269194e6030cbddabebbb116cdfe02a
     # path: ../compound-ios
   AnalyticsEvents:
     url: https://github.com/matrix-org/matrix-analytics-events


### PR DESCRIPTION
Changes the temporary tokens to be soft-deprecated to hide all of the warnings (as we haven't addressed them yet).