### PR TITLE
Fix a bug where the security banner has the wrong state when out of sync.

### DIFF
--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
@@ -78,7 +78,7 @@ enum HomeScreenSecurityBannerMode: Equatable {
         }
     }
     
-    var isShow: Bool {
+    var isShown: Bool {
         switch self {
         case .show: true
         default: false

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
@@ -66,7 +66,7 @@ enum HomeScreenRoomListMode: CustomStringConvertible {
     }
 }
 
-enum HomeScreenSecurityBannerMode {
+enum HomeScreenSecurityBannerMode: Equatable {
     case none
     case dismissed
     case show(HomeScreenRecoveryKeyConfirmationBanner.State)

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
@@ -66,10 +66,28 @@ enum HomeScreenRoomListMode: CustomStringConvertible {
     }
 }
 
-enum HomeScreenBannerMode {
+enum HomeScreenSecurityBannerMode {
     case none
     case dismissed
-    case show
+    case show(HomeScreenRecoveryKeyConfirmationBanner.State)
+    
+    var isDismissed: Bool {
+        switch self {
+        case .dismissed: true
+        default: false
+        }
+    }
+    
+    var isShow: Bool {
+        switch self {
+        case .show: true
+        default: false
+        }
+    }
+}
+
+enum HomeScreenMigrationBannerMode {
+    case none, show, dismissed
 }
 
 struct HomeScreenViewState: BindableState {
@@ -77,8 +95,8 @@ struct HomeScreenViewState: BindableState {
     var userDisplayName: String?
     var userAvatarURL: URL?
     
-    var securityBannerMode = HomeScreenBannerMode.none
-    var slidingSyncMigrationBannerMode = HomeScreenBannerMode.none
+    var securityBannerMode = HomeScreenSecurityBannerMode.none
+    var slidingSyncMigrationBannerMode = HomeScreenMigrationBannerMode.none
     
     var requiresExtraAccountSetup = false
         

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -58,13 +58,12 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
                 switch (securityState.verificationState, securityState.recoveryState) {
                 case (.verified, .disabled):
                     state.requiresExtraAccountSetup = true
-                    state.securityBannerMode = .show
+                    if !state.securityBannerMode.isDismissed {
+                        state.securityBannerMode = .show(.setUpRecovery)
+                    }
                 case (.verified, .incomplete):
                     state.requiresExtraAccountSetup = true
-                    
-                    if state.securityBannerMode != .dismissed {
-                        state.securityBannerMode = .show
-                    }
+                    state.securityBannerMode = .show(.recoveryOutOfSync)
                 default:
                     state.securityBannerMode = .none
                     state.requiresExtraAccountSetup = false

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -55,13 +55,13 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
             .sink { [weak self] securityState in
                 guard let self else { return }
                 
-                switch (securityState.verificationState, securityState.recoveryState) {
-                case (.verified, .disabled):
+                switch securityState.recoveryState {
+                case .disabled:
                     state.requiresExtraAccountSetup = true
                     if !state.securityBannerMode.isDismissed {
                         state.securityBannerMode = .show(.setUpRecovery)
                     }
-                case (.verified, .incomplete):
+                case .incomplete:
                     state.requiresExtraAccountSetup = true
                     state.securityBannerMode = .show(.recoveryOutOfSync)
                 default:

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreenContent.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreenContent.swift
@@ -120,7 +120,7 @@ struct HomeScreenContent: View {
     private var topSection: some View {
         // An empty VStack causes glitches within the room list
         if context.viewState.shouldShowFilters ||
-            context.viewState.securityBannerMode == .show ||
+            context.viewState.securityBannerMode.isShow ||
             context.viewState.slidingSyncMigrationBannerMode == .show {
             VStack(spacing: 0) {
                 if context.viewState.shouldShowFilters {
@@ -129,8 +129,8 @@ struct HomeScreenContent: View {
             
                 if context.viewState.slidingSyncMigrationBannerMode == .show {
                     HomeScreenSlidingSyncMigrationBanner(context: context)
-                } else if context.viewState.securityBannerMode == .show {
-                    HomeScreenRecoveryKeyConfirmationBanner(requiresExtraAccountSetup: context.viewState.requiresExtraAccountSetup, context: context)
+                } else if case let .show(state) = context.viewState.securityBannerMode {
+                    HomeScreenRecoveryKeyConfirmationBanner(state: state, context: context)
                 }
             }
             .background(Color.compound.bgCanvasDefault)

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreenContent.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreenContent.swift
@@ -120,7 +120,7 @@ struct HomeScreenContent: View {
     private var topSection: some View {
         // An empty VStack causes glitches within the room list
         if context.viewState.shouldShowFilters ||
-            context.viewState.securityBannerMode.isShow ||
+            context.viewState.securityBannerMode.isShown ||
             context.viewState.slidingSyncMigrationBannerMode == .show {
             VStack(spacing: 0) {
                 if context.viewState.shouldShowFilters {

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreenRecoveryKeyConfirmationBanner.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreenRecoveryKeyConfirmationBanner.swift
@@ -10,13 +10,37 @@ import Compound
 import SwiftUI
 
 struct HomeScreenRecoveryKeyConfirmationBanner: View {
-    let requiresExtraAccountSetup: Bool
+    enum State { case setUpRecovery, recoveryOutOfSync }
+    let state: State
     var context: HomeScreenViewModel.Context
     
-    var title: String { requiresExtraAccountSetup ? L10n.bannerSetUpRecoveryTitle : L10n.confirmRecoveryKeyBannerTitle }
-    var message: String { requiresExtraAccountSetup ? L10n.bannerSetUpRecoveryContent : L10n.confirmRecoveryKeyBannerMessage }
-    var actionTitle: String { requiresExtraAccountSetup ? L10n.bannerSetUpRecoverySubmit : L10n.confirmRecoveryKeyBannerPrimaryButtonTitle }
-    var primaryAction: HomeScreenViewAction { requiresExtraAccountSetup ? .setupRecovery : .confirmRecoveryKey }
+    var title: String {
+        switch state {
+        case .setUpRecovery: L10n.bannerSetUpRecoveryTitle
+        case .recoveryOutOfSync: L10n.confirmRecoveryKeyBannerTitle
+        }
+    }
+
+    var message: String {
+        switch state {
+        case .setUpRecovery: L10n.bannerSetUpRecoveryContent
+        case .recoveryOutOfSync: L10n.confirmRecoveryKeyBannerMessage
+        }
+    }
+
+    var actionTitle: String {
+        switch state {
+        case .setUpRecovery: L10n.bannerSetUpRecoverySubmit
+        case .recoveryOutOfSync: L10n.confirmRecoveryKeyBannerPrimaryButtonTitle
+        }
+    }
+
+    var primaryAction: HomeScreenViewAction {
+        switch state {
+        case .setUpRecovery: .setupRecovery
+        case .recoveryOutOfSync: .confirmRecoveryKey
+        }
+    }
     
     var body: some View {
         VStack(spacing: 16) {
@@ -37,7 +61,7 @@ struct HomeScreenRecoveryKeyConfirmationBanner: View {
                     .foregroundColor(.compound.textPrimary)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 
-                if requiresExtraAccountSetup {
+                if state == .setUpRecovery {
                     Button {
                         context.send(viewAction: .skipRecoveryKeyConfirmation)
                     } label: {
@@ -63,7 +87,7 @@ struct HomeScreenRecoveryKeyConfirmationBanner: View {
             .buttonStyle(.compound(.primary, size: .medium))
             .accessibilityIdentifier(A11yIdentifiers.homeScreen.recoveryKeyConfirmationBannerContinue)
             
-            if !requiresExtraAccountSetup {
+            if state == .recoveryOutOfSync {
                 Button {
                     context.send(viewAction: .resetEncryption)
                 } label: {
@@ -81,10 +105,10 @@ struct HomeScreenRecoveryKeyConfirmationBanner_Previews: PreviewProvider, Testab
     static let viewModel = buildViewModel()
     
     static var previews: some View {
-        HomeScreenRecoveryKeyConfirmationBanner(requiresExtraAccountSetup: true,
+        HomeScreenRecoveryKeyConfirmationBanner(state: .setUpRecovery,
                                                 context: viewModel.context)
             .previewDisplayName("Set up recovery")
-        HomeScreenRecoveryKeyConfirmationBanner(requiresExtraAccountSetup: false,
+        HomeScreenRecoveryKeyConfirmationBanner(state: .recoveryOutOfSync,
                                                 context: viewModel.context)
             .previewDisplayName("Out of sync")
     }


### PR DESCRIPTION
`requiresExtraAccountSetup` isn't useful for this so a state enum is added. Additionally handles the close button only being visible for the out of sync banner and adds unit tests for all of this.