### PR TITLE
Fix toolbar icons disappearing on the iPad after backgrounding the app

### DIFF
--- a/ElementX/Sources/Application/Navigation/NavigationCoordinators.swift
+++ b/ElementX/Sources/Application/Navigation/NavigationCoordinators.swift
@@ -412,19 +412,17 @@ class NavigationSplitCoordinator: CoordinatorProtocol, ObservableObject, CustomS
 
 private struct NavigationSplitCoordinatorView: View {
     @State private var columnVisibility = NavigationSplitViewVisibility.all
-    @State private var isInSplitMode = true
     
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @Environment(\.scenePhase) private var scenePhase
     
     @ObservedObject var navigationSplitCoordinator: NavigationSplitCoordinator
     
     var body: some View {
         Group {
-            if isInSplitMode {
-                navigationSplitView
-            } else {
+            if horizontalSizeClass == .compact {
                 navigationStack
+            } else {
+                navigationSplitView
             }
         }
         // This needs to be handled on the top level otherwise sheets
@@ -449,25 +447,6 @@ private struct NavigationSplitCoordinatorView: View {
             }
             .animation(.elementDefault, value: navigationSplitCoordinator.overlayPresentationMode)
             .animation(.elementDefault, value: navigationSplitCoordinator.overlayModule)
-        }
-        // Handle `horizontalSizeClass` changes breaking the navigation bar
-        // https://github.com/element-hq/element-x-ios/issues/617
-        .onChange(of: horizontalSizeClass) { _, newValue in
-            guard scenePhase != .background else {
-                return
-            }
-            
-            isInSplitMode = newValue == .regular
-        }
-        .onChange(of: scenePhase) { _, newValue in
-            guard newValue == .active else {
-                return
-            }
-            
-            isInSplitMode = horizontalSizeClass == .regular
-        }
-        .task {
-            isInSplitMode = horizontalSizeClass == .regular
         }
     }
     


### PR DESCRIPTION
Fixes #1918 - Revert `1a12c729de521d2dcb664bed6b19a75ec139bede` as #617 is no longer reproducible on iOS 18.