### PR TITLE
using `roomPreview` API for invited rooms

### DIFF
--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -5831,11 +5831,12 @@ class ElementCallWidgetDriverMock: ElementCallWidgetDriverProtocol {
     }
 }
 class InvitedRoomProxyMock: InvitedRoomProxyProtocol {
-    var info: RoomInfoProxy {
+    var info: BaseRoomInfoProxyProtocol {
         get { return underlyingInfo }
         set(value) { underlyingInfo = value }
     }
-    var underlyingInfo: RoomInfoProxy!
+    var underlyingInfo: BaseRoomInfoProxyProtocol!
+    var inviter: RoomMemberProxyProtocol?
     var id: String {
         get { return underlyingId }
         set(value) { underlyingId = value }
@@ -5909,70 +5910,6 @@ class InvitedRoomProxyMock: InvitedRoomProxyProtocol {
             return await rejectInvitationClosure()
         } else {
             return rejectInvitationReturnValue
-        }
-    }
-    //MARK: - acceptInvitation
-
-    var acceptInvitationUnderlyingCallsCount = 0
-    var acceptInvitationCallsCount: Int {
-        get {
-            if Thread.isMainThread {
-                return acceptInvitationUnderlyingCallsCount
-            } else {
-                var returnValue: Int? = nil
-                DispatchQueue.main.sync {
-                    returnValue = acceptInvitationUnderlyingCallsCount
-                }
-
-                return returnValue!
-            }
-        }
-        set {
-            if Thread.isMainThread {
-                acceptInvitationUnderlyingCallsCount = newValue
-            } else {
-                DispatchQueue.main.sync {
-                    acceptInvitationUnderlyingCallsCount = newValue
-                }
-            }
-        }
-    }
-    var acceptInvitationCalled: Bool {
-        return acceptInvitationCallsCount > 0
-    }
-
-    var acceptInvitationUnderlyingReturnValue: Result<Void, RoomProxyError>!
-    var acceptInvitationReturnValue: Result<Void, RoomProxyError>! {
-        get {
-            if Thread.isMainThread {
-                return acceptInvitationUnderlyingReturnValue
-            } else {
-                var returnValue: Result<Void, RoomProxyError>? = nil
-                DispatchQueue.main.sync {
-                    returnValue = acceptInvitationUnderlyingReturnValue
-                }
-
-                return returnValue!
-            }
-        }
-        set {
-            if Thread.isMainThread {
-                acceptInvitationUnderlyingReturnValue = newValue
-            } else {
-                DispatchQueue.main.sync {
-                    acceptInvitationUnderlyingReturnValue = newValue
-                }
-            }
-        }
-    }
-    var acceptInvitationClosure: (() async -> Result<Void, RoomProxyError>)?
-
-    func acceptInvitation() async -> Result<Void, RoomProxyError> {
-        acceptInvitationCallsCount += 1
-        if let acceptInvitationClosure = acceptInvitationClosure {
-            return await acceptInvitationClosure()
-        } else {
-            return acceptInvitationReturnValue
         }
     }
 }

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -408,7 +408,7 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
             return
         }
         
-        switch await roomProxy.acceptInvitation() {
+        switch await userSession.clientProxy.joinRoom(roomID, via: []) {
         case .success:
             actionsSubject.send(.presentRoom(roomIdentifier: roomID))
             analyticsService.trackJoinedRoom(isDM: roomProxy.info.isDirect,

--- a/ElementX/Sources/Screens/JoinRoomScreen/JoinRoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/JoinRoomScreen/JoinRoomScreenViewModel.swift
@@ -109,7 +109,7 @@ class JoinRoomScreenViewModel: JoinRoomScreenViewModelType, JoinRoomScreenViewMo
         case .joined(let joinedRoomProxy):
             roomPreviewInfo = joinedRoomProxy.infoPublisher.value
         case .invited(let invitedRoomProxy):
-            inviter = invitedRoomProxy.info.inviter.flatMap(RoomInviterDetails.init)
+            inviter = invitedRoomProxy.inviter.map(RoomInviterDetails.init)
             roomPreviewInfo = invitedRoomProxy.info
         case .knocked(let knockedRoomProxy):
             roomPreviewInfo = knockedRoomProxy.info

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -930,16 +930,15 @@ class ClientProxy: ClientProxyProtocol {
             switch roomListItem.membership() {
             case .invited:
                 return try await .invited(InvitedRoomProxy(roomListItem: roomListItem,
-                                                           room: roomListItem.invitedRoom()))
+                                                           roomPreview: roomListItem.previewRoom(via: []),
+                                                           ownUserID: userID))
             case .knocked:
                 if appSettings.knockingEnabled {
                     return try await .knocked(KnockedRoomProxy(roomListItem: roomListItem,
                                                                roomPreview: roomListItem.previewRoom(via: []),
                                                                ownUserID: userID))
-                } else {
-                    return try await .invited(InvitedRoomProxy(roomListItem: roomListItem,
-                                                               room: roomListItem.invitedRoom()))
                 }
+                return nil
             case .joined:
                 if roomListItem.isTimelineInitialized() == false {
                     try await roomListItem.initTimeline(eventTypeFilter: eventFilters, internalIdPrefix: nil)

--- a/ElementX/Sources/Services/Room/KnockedRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/KnockedRoomProxy.swift
@@ -13,16 +13,15 @@ class KnockedRoomProxy: KnockedRoomProxyProtocol {
     private let roomListItem: RoomListItemProtocol
     private let roomPreview: RoomPreviewProtocol
     let info: BaseRoomInfoProxyProtocol
+    let ownUserID: String
     
     // A room identifier is constant and lazy stops it from being fetched
     // multiple times over FFI
     lazy var id = info.id
-    
-    let ownUserID: String
-    
+        
     init(roomListItem: RoomListItemProtocol,
          roomPreview: RoomPreviewProtocol,
-         ownUserID: String) async throws {
+         ownUserID: String) throws {
         self.roomListItem = roomListItem
         self.roomPreview = roomPreview
         self.ownUserID = ownUserID

--- a/ElementX/Sources/Services/Room/RoomInfoProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomInfoProxy.swift
@@ -16,6 +16,8 @@ protocol BaseRoomInfoProxyProtocol {
     var canonicalAlias: String? { get }
     var avatarURL: URL? { get }
     var activeMembersCount: Int { get }
+    var isDirect: Bool { get }
+    var isSpace: Bool { get }
 }
 
 struct RoomInfoProxy: BaseRoomInfoProxyProtocol {
@@ -70,12 +72,29 @@ struct RoomPreviewInfoProxy: BaseRoomInfoProxyProtocol {
     
     var id: String { roomPreviewInfo.roomId }
     var displayName: String? { roomPreviewInfo.name }
+    
+    /// The room's avatar info for use in a ``RoomAvatarImage``.
     var avatar: RoomAvatar {
+        // TODO: The heroes are missing so we can't handle the direct invite case yet, waiting for an update of the SDK
+//        if isDirect, avatarURL == nil {
+//            if heroes.count == 1 {
+//                return .heroes(heroes.map(UserProfileProxy.init))
+//            }
+//        }
+        
         .room(id: id, name: displayName, avatarURL: avatarURL)
     }
-
+    
     var topic: String? { roomPreviewInfo.topic }
     var canonicalAlias: String? { roomPreviewInfo.canonicalAlias }
     var avatarURL: URL? { roomPreviewInfo.avatarUrl.flatMap(URL.init) }
-    var activeMembersCount: Int { Int(roomPreviewInfo.numJoinedMembers) }
+    var isDirect: Bool { roomPreviewInfo.isDirect ?? false }
+    var isSpace: Bool { roomPreviewInfo.roomType == .space }
+    
+    var activeMembersCount: Int {
+        guard let numActiveMembers = roomPreviewInfo.numActiveMembers else {
+            return Int(roomPreviewInfo.numJoinedMembers)
+        }
+        return Int(numActiveMembers)
+    }
 }

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -33,9 +33,9 @@ protocol RoomProxyProtocol {
 
 // sourcery: AutoMockable
 protocol InvitedRoomProxyProtocol: RoomProxyProtocol {
-    var info: RoomInfoProxy { get }
+    var info: BaseRoomInfoProxyProtocol { get }
+    var inviter: RoomMemberProxyProtocol? { get }
     func rejectInvitation() async -> Result<Void, RoomProxyError>
-    func acceptInvitation() async -> Result<Void, RoomProxyError>
 }
 
 // sourcery: AutoMockable


### PR DESCRIPTION
In this way we can get rid of the deprecated `invitedRoom` API