### PR TITLE
Fix the media upload preview screen on macOS.

### DIFF
--- a/ElementX/Sources/Screens/MediaUploadPreviewScreen/View/MediaUploadPreviewScreen.swift
+++ b/ElementX/Sources/Screens/MediaUploadPreviewScreen/View/MediaUploadPreviewScreen.swift
@@ -10,11 +10,12 @@ import QuickLook
 import SwiftUI
 
 struct MediaUploadPreviewScreen: View {
+    @Environment(\.colorScheme) private var colorScheme
+    
     @ObservedObject var context: MediaUploadPreviewScreenViewModel.Context
     
-    var title: String {
-        ProcessInfo.processInfo.isiOSAppOnMac ? context.viewState.title ?? "" : ""
-    }
+    var title: String { ProcessInfo.processInfo.isiOSAppOnMac ? context.viewState.title ?? "" : "" }
+    var colorSchemeOverride: ColorScheme { ProcessInfo.processInfo.isiOSAppOnMac ? colorScheme : .dark }
     
     var body: some View {
         mainContent
@@ -31,7 +32,7 @@ struct MediaUploadPreviewScreen: View {
             .toolbar { toolbar }
             .disabled(context.viewState.shouldDisableInteraction)
             .interactiveDismissDisabled()
-            .preferredColorScheme(.dark)
+            .preferredColorScheme(colorSchemeOverride)
     }
     
     @ViewBuilder
@@ -40,6 +41,7 @@ struct MediaUploadPreviewScreen: View {
             Text(title)
                 .font(.compound.headingMD)
                 .foregroundColor(.compound.textSecondary)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
             PreviewView(fileURL: context.viewState.url,
                         title: context.viewState.title)


### PR DESCRIPTION
The composer was in the wrong place, and forcing dark mode looks so weird when we aren't actually showing a preview.

| Before | After |
| - | - |
| <img width="493" alt="image" src="https://github.com/user-attachments/assets/afcf9b11-4f73-440e-82c9-a6e0578ea9f0"> | <img width="490" alt="Screenshot 2024-11-20 at 5 52 14 pm" src="https://github.com/user-attachments/assets/5c31c9b5-c108-4978-b020-2c0f187bd7a8"> |
