### PR TITLE
Update the SDK.

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -8166,8 +8166,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/element-hq/matrix-rust-components-swift";
 			requirement = {
-				kind = revision;
-				revision = 50769941247cc87760c8d3c3a28f8753555c19fb;
+				kind = exactVersion;
+				version = 1.0.73;
 			};
 		};
 		701C7BEF8F70F7A83E852DCC /* XCRemoteSwiftPackageReference "GZIP" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -149,7 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/matrix-rust-components-swift",
       "state" : {
-        "revision" : "50769941247cc87760c8d3c3a28f8753555c19fb"
+        "revision" : "b3f97292695e8d63469c0d3ec608eb74423c6a2e",
+        "version" : "1.0.73"
       }
     },
     {

--- a/project.yml
+++ b/project.yml
@@ -61,8 +61,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/element-hq/matrix-rust-components-swift
-    revision: 50769941247cc87760c8d3c3a28f8753555c19fb
-    # exactVersion: 1.0.70
+    exactVersion: 1.0.73
     # path: ../matrix-rust-sdk
   Compound:
     url: https://github.com/element-hq/compound-ios


### PR DESCRIPTION
Go back from a pinned commit to a release that uses dynamic linking.