### PR TITLE
Add support for sharing URLs and text.

### DIFF
--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -207,16 +207,13 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
         case .settings, .chatBackupSettings:
             settingsFlowCoordinator.handleAppRoute(appRoute, animated: animated)
         case .share(let payload):
-            switch payload {
-            case .mediaFile(let roomID, _):
-                if let roomID {
-                    stateMachine.processEvent(.selectRoom(roomID: roomID,
-                                                          via: [],
-                                                          entryPoint: .share(payload)),
-                                              userInfo: .init(animated: animated))
-                } else {
-                    stateMachine.processEvent(.showShareExtensionRoomList(sharePayload: payload), userInfo: .init(animated: animated))
-                }
+            if let roomID = payload.roomID {
+                stateMachine.processEvent(.selectRoom(roomID: roomID,
+                                                      via: [],
+                                                      entryPoint: .share(payload)),
+                                          userInfo: .init(animated: animated))
+            } else {
+                stateMachine.processEvent(.showShareExtensionRoomList(sharePayload: payload), userInfo: .init(animated: animated))
             }
         }
     }
@@ -938,6 +935,8 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
                 let sharePayload = switch sharePayload {
                 case .mediaFile(_, let mediaFile):
                     ShareExtensionPayload.mediaFile(roomID: roomID, mediaFile: mediaFile)
+                case .text(_, let text):
+                    ShareExtensionPayload.text(roomID: roomID, text: text)
                 }
                 
                 navigationSplitCoordinator.setSheetCoordinator(nil)

--- a/ElementX/Sources/Mocks/JoinedRoomProxyMock.swift
+++ b/ElementX/Sources/Mocks/JoinedRoomProxyMock.swift
@@ -123,6 +123,7 @@ extension JoinedRoomProxyMock {
         matrixToEventPermalinkReturnValue = .success(.homeDirectory)
         loadDraftReturnValue = .success(nil)
         clearDraftReturnValue = .success(())
+        sendTypingNotificationIsTypingReturnValue = .success(())
     }
 }
 

--- a/ElementX/Sources/Other/Extensions/NSItemProvider.swift
+++ b/ElementX/Sources/Other/Extensions/NSItemProvider.swift
@@ -6,13 +6,26 @@
 //
 
 import Foundation
-import UIKit
+import SwiftUI
 import UniformTypeIdentifiers
 
 extension NSItemProvider {
     struct PreferredContentType {
         let type: UTType
         let fileExtension: String
+    }
+    
+    func loadTransferable<T: Transferable>(type transferableType: T.Type) async -> T? {
+        try? await withCheckedContinuation { continuation in
+            _ = loadTransferable(type: T.self) { result in
+                continuation.resume(returning: result)
+            }
+        }
+        .get()
+    }
+    
+    func loadString() async -> String? {
+        try? await loadItem(forTypeIdentifier: UTType.text.identifier) as? String
     }
     
     func storeData() async -> URL? {

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarViewModel.swift
@@ -210,7 +210,7 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
                 set(text: plainText)
             }
         case .setFocus:
-            state.bindings.composerFocused = false
+            state.bindings.composerFocused = true
         case .removeFocus:
             state.bindings.composerFocused = false
         case .clear:

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarViewModel.swift
@@ -15,6 +15,7 @@ import WysiwygComposer
 typealias ComposerToolbarViewModelType = StateStoreViewModel<ComposerToolbarViewState, ComposerToolbarViewAction>
 
 final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerToolbarViewModelProtocol {
+    private var initialText: String?
     private let wysiwygViewModel: WysiwygComposerViewModel
     private let completionSuggestionService: CompletionSuggestionServiceProtocol
     private let analyticsService: AnalyticsService
@@ -41,12 +42,14 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
     
     private var replyLoadingTask: Task<Void, Never>?
 
-    init(wysiwygViewModel: WysiwygComposerViewModel,
+    init(initialText: String? = nil,
+         wysiwygViewModel: WysiwygComposerViewModel,
          completionSuggestionService: CompletionSuggestionServiceProtocol,
          mediaProvider: MediaProviderProtocol,
          mentionDisplayHelper: MentionDisplayHelper,
          analyticsService: AnalyticsService,
          composerDraftService: ComposerDraftServiceProtocol) {
+        self.initialText = initialText
         self.wysiwygViewModel = wysiwygViewModel
         self.completionSuggestionService = completionSuggestionService
         self.analyticsService = analyticsService
@@ -206,6 +209,8 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
             } else {
                 set(text: plainText)
             }
+        case .setFocus:
+            state.bindings.composerFocused = false
         case .removeFocus:
             state.bindings.composerFocused = false
         case .clear:
@@ -219,8 +224,12 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
         }
     }
     
-    func loadDraft() {
-        Task {
+    func loadDraft() async {
+        if let initialText {
+            set(text: initialText)
+            set(mode: .default)
+            state.bindings.composerFocused = true
+        } else {
             guard case let .success(draft) = await draftService.loadDraft(),
                   let draft else {
                 return

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarViewModelProtocol.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarViewModelProtocol.swift
@@ -15,6 +15,6 @@ protocol ComposerToolbarViewModelProtocol {
     var keyCommands: [WysiwygKeyCommand] { get }
 
     func process(timelineAction: TimelineComposerAction)
-    func loadDraft()
+    func loadDraft() async
     func saveDraft()
 }

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
@@ -183,6 +183,10 @@ final class RoomScreenCoordinator: CoordinatorProtocol {
         Task { await timelineViewModel.focusOnEvent(eventID: eventID) }
     }
     
+    func shareText(_ string: String) {
+        composerViewModel.process(timelineAction: .setText(plainText: string, htmlText: nil))
+    }
+    
     func stop() {
         composerViewModel.saveDraft()
         timelineViewModel.stop()

--- a/ElementX/Sources/Screens/Timeline/TimelineModels.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineModels.swift
@@ -79,6 +79,7 @@ enum TimelineViewAction {
 enum TimelineComposerAction {
     case setMode(mode: ComposerMode)
     case setText(plainText: String, htmlText: String?)
+    case setFocus
     case removeFocus
     case clear
 }

--- a/ElementX/Sources/ShareExtension/ShareExtensionModels.swift
+++ b/ElementX/Sources/ShareExtension/ShareExtensionModels.swift
@@ -13,6 +13,15 @@ enum ShareExtensionConstants {
 
 enum ShareExtensionPayload: Hashable, Codable {
     case mediaFile(roomID: String?, mediaFile: ShareExtensionMediaFile)
+    case text(roomID: String?, text: String)
+    
+    var roomID: String? {
+        switch self {
+        case .mediaFile(let roomID, _),
+             .text(let roomID, _):
+            roomID
+        }
+    }
 }
 
 struct ShareExtensionMediaFile: Hashable, Codable {

--- a/ShareExtension/Sources/ShareExtensionViewController.swift
+++ b/ShareExtension/Sources/ShareExtensionViewController.swift
@@ -42,14 +42,18 @@ class ShareExtensionViewController: UIViewController {
             return nil
         }
         
-        guard let fileURL = await itemProvider.storeData() else {
-            MXLog.error("Failed storing NSItemProvider data \(itemProvider)")
+        let roomID = (extensionContext?.intent as? INSendMessageIntent)?.conversationIdentifier
+        
+        if let fileURL = await itemProvider.storeData() {
+            return .mediaFile(roomID: roomID, mediaFile: .init(url: fileURL, suggestedName: fileURL.lastPathComponent))
+        } else if let url = await itemProvider.loadTransferable(type: URL.self) {
+            return .text(roomID: roomID, text: url.absoluteString)
+        } else if let string = await itemProvider.loadString() {
+            return .text(roomID: roomID, text: string)
+        } else {
+            MXLog.error("Failed loading NSItemProvider data: \(itemProvider)")
             return nil
         }
-        
-        let roomID = (extensionContext?.intent as? INSendMessageIntent)?.conversationIdentifier
-                
-        return .mediaFile(roomID: roomID, mediaFile: .init(url: fileURL, suggestedName: fileURL.lastPathComponent))
     }
     
     private func openMainApp(payload: ShareExtensionPayload) async {

--- a/ShareExtension/SupportingFiles/Info.plist
+++ b/ShareExtension/SupportingFiles/Info.plist
@@ -36,6 +36,10 @@
 				<integer>1</integer>
 				<key>NSExtensionActivationSupportsMovieWithMaxCount</key>
 				<integer>1</integer>
+				<key>NSExtensionActivationSupportsText</key>
+				<true/>
+				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
+				<integer>1</integer>
 			</dict>
 		</dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/UnitTests/Sources/RoomFlowCoordinatorTests.swift
+++ b/UnitTests/Sources/RoomFlowCoordinatorTests.swift
@@ -218,7 +218,7 @@ class RoomFlowCoordinatorTests: XCTestCase {
         XCTAssert(navigationStackCoordinator.stackCoordinators.first is RoomScreenCoordinator)
     }
     
-    func testShareRoute() async throws {
+    func testShareMediaRoute() async throws {
         await setupRoomFlowCoordinator()
         
         try await process(route: .room(roomID: "1", via: []))
@@ -241,6 +241,31 @@ class RoomFlowCoordinatorTests: XCTestCase {
         
         XCTAssertEqual(navigationStackCoordinator.stackCoordinators.count, 0)
         XCTAssertTrue((navigationStackCoordinator.sheetCoordinator as? NavigationStackCoordinator)?.rootCoordinator is MediaUploadPreviewScreenCoordinator)
+    }
+    
+    func testShareTextRoute() async throws {
+        await setupRoomFlowCoordinator()
+        
+        try await process(route: .room(roomID: "1", via: []))
+        XCTAssert(navigationStackCoordinator.rootCoordinator is RoomScreenCoordinator)
+        XCTAssertEqual(navigationStackCoordinator.stackCoordinators.count, 0)
+        
+        let sharePayload: ShareExtensionPayload = .text(roomID: "1", text: "Important text")
+        try await process(route: .share(sharePayload))
+        
+        XCTAssert(navigationStackCoordinator.rootCoordinator is RoomScreenCoordinator)
+        XCTAssertEqual(navigationStackCoordinator.stackCoordinators.count, 0)
+        
+        XCTAssertNil(navigationStackCoordinator.sheetCoordinator, "The media upload sheet shouldn't be shown when sharing text.")
+        
+        try await process(route: .childRoom(roomID: "2", via: []))
+        XCTAssertNil(navigationStackCoordinator.sheetCoordinator)
+        XCTAssertEqual(navigationStackCoordinator.stackCoordinators.count, 1)
+        
+        try await process(route: .share(sharePayload))
+        
+        XCTAssertEqual(navigationStackCoordinator.stackCoordinators.count, 0)
+        XCTAssertNil(navigationStackCoordinator.sheetCoordinator, "The media upload sheet shouldn't be shown when sharing text.")
     }
     
     // MARK: - Private

--- a/UnitTests/Sources/UserSessionFlowCoordinatorTests.swift
+++ b/UnitTests/Sources/UserSessionFlowCoordinatorTests.swift
@@ -242,7 +242,7 @@ class UserSessionFlowCoordinatorTests: XCTestCase {
                        "A new timeline should be created for the same room ID, so that the screen isn't stale while loading.")
     }
     
-    func testShareRouteWithoutRoom() async throws {
+    func testShareMediaRouteWithoutRoom() async throws {
         try await process(route: .settings, expectedState: .settingsScreen(selectedRoomID: nil))
         XCTAssertTrue((splitCoordinator?.sheetCoordinator as? NavigationStackCoordinator)?.rootCoordinator is SettingsScreenCoordinator)
         
@@ -253,7 +253,7 @@ class UserSessionFlowCoordinatorTests: XCTestCase {
         XCTAssertTrue((splitCoordinator?.sheetCoordinator as? NavigationStackCoordinator)?.rootCoordinator is RoomSelectionScreenCoordinator)
     }
     
-    func testShareRouteWithRoom() async throws {
+    func testShareMediaRouteWithRoom() async throws {
         try await process(route: .event(eventID: "1", roomID: "1", via: []), expectedState: .roomList(selectedRoomID: "1"))
         XCTAssertTrue(detailNavigationStack?.rootCoordinator is RoomScreenCoordinator)
         
@@ -263,6 +263,29 @@ class UserSessionFlowCoordinatorTests: XCTestCase {
         
         XCTAssertTrue(detailNavigationStack?.rootCoordinator is RoomScreenCoordinator)
         XCTAssertTrue((splitCoordinator?.sheetCoordinator as? NavigationStackCoordinator)?.rootCoordinator is MediaUploadPreviewScreenCoordinator)
+    }
+    
+    func testShareTextRouteWithoutRoom() async throws {
+        try await process(route: .settings, expectedState: .settingsScreen(selectedRoomID: nil))
+        XCTAssertTrue((splitCoordinator?.sheetCoordinator as? NavigationStackCoordinator)?.rootCoordinator is SettingsScreenCoordinator)
+        
+        let sharePayload: ShareExtensionPayload = .text(roomID: nil, text: "Important Text")
+        try await process(route: .share(sharePayload),
+                          expectedState: .shareExtensionRoomList(sharePayload: sharePayload))
+        
+        XCTAssertTrue((splitCoordinator?.sheetCoordinator as? NavigationStackCoordinator)?.rootCoordinator is RoomSelectionScreenCoordinator)
+    }
+    
+    func testShareTextRouteWithRoom() async throws {
+        try await process(route: .event(eventID: "1", roomID: "1", via: []), expectedState: .roomList(selectedRoomID: "1"))
+        XCTAssertTrue(detailNavigationStack?.rootCoordinator is RoomScreenCoordinator)
+        
+        let sharePayload: ShareExtensionPayload = .text(roomID: "2", text: "Important text")
+        try await process(route: .share(sharePayload),
+                          expectedState: .roomList(selectedRoomID: "2"))
+        
+        XCTAssertTrue(detailNavigationStack?.rootCoordinator is RoomScreenCoordinator)
+        XCTAssertNil(splitCoordinator?.sheetCoordinator, "The media upload sheet shouldn't be shown when sharing text.")
     }
     
     // MARK: - Private


### PR DESCRIPTION
This PR makes the following changes:

- Add URL/Text as supported types in the share extension
- Fall back to loading a URL and then a string in the share extension
- Send both of these into the composer for the user to confirm before sending.
- If sharing starts a new flow we pass the initial text in the init, otherwise it is set into the existing composer.

https://github.com/user-attachments/assets/cb956f5d-bf4e-4262-9965-c98ad7b80fc7
