### PR TITLE
Move timeline item tap gestures to the items themselves instead of the bubbled styler

### DIFF
--- a/ElementX/Sources/Other/SwiftUI/Views/LoadableImage.swift
+++ b/ElementX/Sources/Other/SwiftUI/Views/LoadableImage.swift
@@ -204,7 +204,7 @@ private struct LoadableImageContent<TransformerView: View, PlaceholderView: View
         ZStack {
             Color.black.opacity(0.6)
                 .contentShape(.rect)
-                .onTapGesture { /* Empty gesture to block the itemTapped action */ }
+                .onTapGesture { /* Empty gesture to block the `mediaTapped` action */ }
             
             // Don't use a real Button as it sometimes triggers simultaneously with the long press gesture.
             Text(L10n.actionShow)

--- a/ElementX/Sources/Screens/Timeline/TimelineModels.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineModels.swift
@@ -43,7 +43,7 @@ enum TimelineViewAction {
     case itemAppeared(itemID: TimelineItemIdentifier)
     case itemDisappeared(itemID: TimelineItemIdentifier)
     
-    case itemTapped(itemID: TimelineItemIdentifier)
+    case mediaTapped(itemID: TimelineItemIdentifier)
     case itemSendInfoTapped(itemID: TimelineItemIdentifier)
     case toggleReaction(key: String, itemID: TimelineItemIdentifier)
     case sendReadReceiptIfNeeded(TimelineItemIdentifier)

--- a/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
@@ -128,8 +128,8 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
             Task { await timelineController.processItemAppearance(id) }
         case .itemDisappeared(let id):
             Task { await timelineController.processItemDisappearance(id) }
-        case .itemTapped(let id):
-            Task { await handleItemTapped(with: id) }
+        case .mediaTapped(let id):
+            Task { await handleMediaTapped(with: id) }
         case .itemSendInfoTapped(let itemID):
             handleItemSendInfoTapped(itemID: itemID)
         case .toggleReaction(let emoji, let itemID):
@@ -533,7 +533,7 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
         await timelineController.sendReadReceipt(for: lastVisibleItemID)
     }
 
-    private func handleItemTapped(with itemID: TimelineItemIdentifier) async {
+    private func handleMediaTapped(with itemID: TimelineItemIdentifier) async {
         state.showLoading = true
         let action = await timelineInteractionHandler.processItemTap(itemID)
 

--- a/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemBubbledStylerView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemBubbledStylerView.swift
@@ -391,6 +391,7 @@ struct TimelineItemBubbledStylerView_Previews: PreviewProvider, TestablePreview 
             }
         }
         .environmentObject(viewModel.context)
+        .environment(\.timelineContext, viewModel.context)
     }
     
     static var replies: some View {
@@ -422,6 +423,7 @@ struct TimelineItemBubbledStylerView_Previews: PreviewProvider, TestablePreview 
                                                   groupStyle: .single))
         }
         .environmentObject(viewModel.context)
+        .environment(\.timelineContext, viewModel.context)
     }
     
     static var threads: some View {
@@ -429,6 +431,7 @@ struct TimelineItemBubbledStylerView_Previews: PreviewProvider, TestablePreview 
             MockTimelineContent(isThreaded: true)
         }
         .environmentObject(viewModel.context)
+        .environment(\.timelineContext, viewModel.context)
     }
       
     static var pinned: some View {
@@ -436,6 +439,7 @@ struct TimelineItemBubbledStylerView_Previews: PreviewProvider, TestablePreview 
             MockTimelineContent(isPinned: true)
         }
         .environmentObject(viewModelWithPins.context)
+        .environment(\.timelineContext, viewModel.context)
     }
     
     static var encryptionAuthenticity: some View {
@@ -518,6 +522,7 @@ struct TimelineItemBubbledStylerView_Previews: PreviewProvider, TestablePreview 
                                                                        waveform: EstimatedWaveform.mockWaveform))
         }
         .environmentObject(viewModel.context)
+        .environment(\.timelineContext, viewModel.context)
     }
 }
 

--- a/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemBubbledStylerView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemBubbledStylerView.swift
@@ -124,11 +124,6 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
     
     var messageBubbleWithActions: some View {
         messageBubble
-            .onTapGesture {
-                context.send(viewAction: .itemTapped(itemID: timelineItem.id))
-            }
-            // We need a tap gesture before this long one so that it doesn't
-            // steal away the gestures from the scroll view
             .longPressWithFeedback {
                 context.send(viewAction: .displayTimelineItemMenu(itemID: timelineItem.id))
             }

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/AudioRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/AudioRoomTimelineView.swift
@@ -9,21 +9,18 @@ import Foundation
 import SwiftUI
 
 struct AudioRoomTimelineView: View {
-    @EnvironmentObject private var context: TimelineViewModel.Context
     let timelineItem: AudioRoomTimelineItem
     
     var body: some View {
         TimelineStyler(timelineItem: timelineItem) {
-            MediaFileRoomTimelineContent(filename: timelineItem.content.filename,
+            MediaFileRoomTimelineContent(timelineItemID: timelineItem.id,
+                                         filename: timelineItem.content.filename,
                                          fileSize: timelineItem.content.fileSize,
                                          caption: timelineItem.content.caption,
                                          formattedCaption: timelineItem.content.formattedCaption,
                                          additionalWhitespaces: timelineItem.additionalWhitespaces(),
                                          isAudioFile: true)
-            .accessibilityLabel(L10n.commonAudio)
-            .onTapGesture {
-                context.send(viewAction: .itemTapped(itemID: timelineItem.id))
-            }
+                .accessibilityLabel(L10n.commonAudio)
         }
     }
 }

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/AudioRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/AudioRoomTimelineView.swift
@@ -9,6 +9,7 @@ import Foundation
 import SwiftUI
 
 struct AudioRoomTimelineView: View {
+    @EnvironmentObject private var context: TimelineViewModel.Context
     let timelineItem: AudioRoomTimelineItem
     
     var body: some View {
@@ -19,7 +20,10 @@ struct AudioRoomTimelineView: View {
                                          formattedCaption: timelineItem.content.formattedCaption,
                                          additionalWhitespaces: timelineItem.additionalWhitespaces(),
                                          isAudioFile: true)
-                .accessibilityLabel(L10n.commonAudio)
+            .accessibilityLabel(L10n.commonAudio)
+            .onTapGesture {
+                context.send(viewAction: .itemTapped(itemID: timelineItem.id))
+            }
         }
     }
 }

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/CallNotificationRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/CallNotificationRoomTimelineView.swift
@@ -10,7 +10,7 @@ import Foundation
 import SwiftUI
 
 struct CallNotificationRoomTimelineView: View {
-    @EnvironmentObject private var context: TimelineViewModel.Context
+    @Environment(\.timelineContext) private var context
     
     let timelineItem: CallNotificationRoomTimelineItem
     
@@ -20,7 +20,7 @@ struct CallNotificationRoomTimelineView: View {
                                 name: timelineItem.sender.displayName ?? timelineItem.sender.id,
                                 contentID: timelineItem.sender.id,
                                 avatarSize: .user(on: .timeline),
-                                mediaProvider: context.mediaProvider)
+                                mediaProvider: context?.mediaProvider)
                 .accessibilityHidden(true)
             
             VStack(alignment: .leading, spacing: 0) {

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/FileRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/FileRoomTimelineView.swift
@@ -21,7 +21,7 @@ struct FileRoomTimelineView: View {
                                          additionalWhitespaces: timelineItem.additionalWhitespaces())
             .accessibilityLabel(L10n.commonFile)
             .onTapGesture {
-                context?.send(viewAction: .itemTapped(itemID: timelineItem.id))
+                context?.send(viewAction: .mediaTapped(itemID: timelineItem.id))
             }
         }
     }

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/FileRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/FileRoomTimelineView.swift
@@ -9,7 +9,7 @@ import Compound
 import SwiftUI
 
 struct FileRoomTimelineView: View {
-    @EnvironmentObject private var context: TimelineViewModel.Context
+    @Environment(\.timelineContext) private var context
     let timelineItem: FileRoomTimelineItem
     
     var body: some View {
@@ -21,7 +21,7 @@ struct FileRoomTimelineView: View {
                                          additionalWhitespaces: timelineItem.additionalWhitespaces())
             .accessibilityLabel(L10n.commonFile)
             .onTapGesture {
-                context.send(viewAction: .itemTapped(itemID: timelineItem.id))
+                context?.send(viewAction: .itemTapped(itemID: timelineItem.id))
             }
         }
     }

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/FileRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/FileRoomTimelineView.swift
@@ -9,20 +9,17 @@ import Compound
 import SwiftUI
 
 struct FileRoomTimelineView: View {
-    @Environment(\.timelineContext) private var context
     let timelineItem: FileRoomTimelineItem
     
     var body: some View {
         TimelineStyler(timelineItem: timelineItem) {
-            MediaFileRoomTimelineContent(filename: timelineItem.content.filename,
+            MediaFileRoomTimelineContent(timelineItemID: timelineItem.id,
+                                         filename: timelineItem.content.filename,
                                          fileSize: timelineItem.content.fileSize,
                                          caption: timelineItem.content.caption,
                                          formattedCaption: timelineItem.content.formattedCaption,
                                          additionalWhitespaces: timelineItem.additionalWhitespaces())
-            .accessibilityLabel(L10n.commonFile)
-            .onTapGesture {
-                context?.send(viewAction: .mediaTapped(itemID: timelineItem.id))
-            }
+                .accessibilityLabel(L10n.commonFile)
         }
     }
 }
@@ -30,6 +27,9 @@ struct FileRoomTimelineView: View {
 // MARK: Content
 
 struct MediaFileRoomTimelineContent: View {
+    @Environment(\.timelineContext) private var context
+    
+    let timelineItemID: TimelineItemIdentifier
     let filename: String
     let fileSize: UInt?
     let caption: String?
@@ -44,6 +44,9 @@ struct MediaFileRoomTimelineContent: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             filePreview
+                .onTapGesture {
+                    context?.send(viewAction: .mediaTapped(itemID: timelineItemID))
+                }
             
             if let formattedCaption {
                 FormattedBodyText(attributedString: formattedCaption,

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/FileRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/FileRoomTimelineView.swift
@@ -9,6 +9,7 @@ import Compound
 import SwiftUI
 
 struct FileRoomTimelineView: View {
+    @EnvironmentObject private var context: TimelineViewModel.Context
     let timelineItem: FileRoomTimelineItem
     
     var body: some View {
@@ -18,7 +19,10 @@ struct FileRoomTimelineView: View {
                                          caption: timelineItem.content.caption,
                                          formattedCaption: timelineItem.content.formattedCaption,
                                          additionalWhitespaces: timelineItem.additionalWhitespaces())
-                .accessibilityLabel(L10n.commonFile)
+            .accessibilityLabel(L10n.commonFile)
+            .onTapGesture {
+                context.send(viewAction: .itemTapped(itemID: timelineItem.id))
+            }
         }
     }
 }

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/ImageRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/ImageRoomTimelineView.swift
@@ -76,6 +76,7 @@ struct ImageRoomTimelineView_Previews: PreviewProvider, TestablePreview {
     static var previews: some View {
         body
             .environmentObject(viewModel.context)
+            .environment(\.timelineContext, viewModel.context)
     }
     
     static var body: some View {

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/ImageRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/ImageRoomTimelineView.swift
@@ -23,6 +23,9 @@ struct ImageRoomTimelineView: View {
                     // This clip shape is distinct from the one in the styler as that one
                     // operates on the entire message so wouldn't round the bottom corners.
                     .clipShape(RoundedRectangle(cornerRadius: hasMediaCaption ? 6 : 0))
+                    .onTapGesture {
+                        context.send(viewAction: .itemTapped(itemID: timelineItem.id))
+                    }
                 
                 if let attributedCaption = timelineItem.content.formattedCaption {
                     FormattedBodyText(attributedString: attributedCaption,

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/ImageRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/ImageRoomTimelineView.swift
@@ -24,7 +24,7 @@ struct ImageRoomTimelineView: View {
                     // operates on the entire message so wouldn't round the bottom corners.
                     .clipShape(RoundedRectangle(cornerRadius: hasMediaCaption ? 6 : 0))
                     .onTapGesture {
-                        context?.send(viewAction: .itemTapped(itemID: timelineItem.id))
+                        context?.send(viewAction: .mediaTapped(itemID: timelineItem.id))
                     }
                 
                 if let attributedCaption = timelineItem.content.formattedCaption {

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/ImageRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/ImageRoomTimelineView.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 struct ImageRoomTimelineView: View {
-    @EnvironmentObject private var context: TimelineViewModel.Context
+    @Environment(\.timelineContext) private var context
     let timelineItem: ImageRoomTimelineItem
     
     var hasMediaCaption: Bool { timelineItem.content.caption != nil }
@@ -24,7 +24,7 @@ struct ImageRoomTimelineView: View {
                     // operates on the entire message so wouldn't round the bottom corners.
                     .clipShape(RoundedRectangle(cornerRadius: hasMediaCaption ? 6 : 0))
                     .onTapGesture {
-                        context.send(viewAction: .itemTapped(itemID: timelineItem.id))
+                        context?.send(viewAction: .itemTapped(itemID: timelineItem.id))
                     }
                 
                 if let attributedCaption = timelineItem.content.formattedCaption {
@@ -47,7 +47,7 @@ struct ImageRoomTimelineView: View {
                           mediaType: .timelineItem(uniqueID: timelineItem.id.uniqueID.id),
                           blurhash: timelineItem.content.blurhash,
                           size: timelineItem.content.imageInfo.size,
-                          mediaProvider: context.mediaProvider) {
+                          mediaProvider: context?.mediaProvider) {
                 placeholder
             }
             .timelineMediaFrame(imageInfo: timelineItem.content.imageInfo)
@@ -56,7 +56,7 @@ struct ImageRoomTimelineView: View {
                           mediaType: .timelineItem(uniqueID: timelineItem.id.uniqueID.id),
                           blurhash: timelineItem.content.blurhash,
                           size: timelineItem.content.thumbnailInfo?.size ?? timelineItem.content.imageInfo.size,
-                          mediaProvider: context.mediaProvider) {
+                          mediaProvider: context?.mediaProvider) {
                 placeholder
             }
             .timelineMediaFrame(imageInfo: timelineItem.content.thumbnailInfo ?? timelineItem.content.imageInfo)

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/LocationRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/LocationRoomTimelineView.swift
@@ -17,7 +17,7 @@ struct LocationRoomTimelineView: View {
                 .accessibilityElement(children: .ignore)
                 .accessibilityLabel(accessibilityLabel)
                 .onTapGesture {
-                    context?.send(viewAction: .itemTapped(itemID: timelineItem.id))
+                    context?.send(viewAction: .mediaTapped(itemID: timelineItem.id))
                 }
         }
     }

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/LocationRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/LocationRoomTimelineView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct LocationRoomTimelineView: View {
-    @EnvironmentObject private var context: TimelineViewModel.Context
+    @Environment(\.timelineContext) private var context
     let timelineItem: LocationRoomTimelineItem
     
     var body: some View {
@@ -17,7 +17,7 @@ struct LocationRoomTimelineView: View {
                 .accessibilityElement(children: .ignore)
                 .accessibilityLabel(accessibilityLabel)
                 .onTapGesture {
-                    context.send(viewAction: .itemTapped(itemID: timelineItem.id))
+                    context?.send(viewAction: .itemTapped(itemID: timelineItem.id))
                 }
         }
     }

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/LocationRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/LocationRoomTimelineView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct LocationRoomTimelineView: View {
+    @EnvironmentObject private var context: TimelineViewModel.Context
     let timelineItem: LocationRoomTimelineItem
     
     var body: some View {
@@ -15,6 +16,9 @@ struct LocationRoomTimelineView: View {
             mainContent
                 .accessibilityElement(children: .ignore)
                 .accessibilityLabel(accessibilityLabel)
+                .onTapGesture {
+                    context.send(viewAction: .itemTapped(itemID: timelineItem.id))
+                }
         }
     }
                                     

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/StickerRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/StickerRoomTimelineView.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 struct StickerRoomTimelineView: View {
-    @EnvironmentObject private var context: TimelineViewModel.Context
+    @Environment(\.timelineContext) private var context
     let timelineItem: StickerRoomTimelineItem
     
     var body: some View {
@@ -18,14 +18,14 @@ struct StickerRoomTimelineView: View {
                           mediaType: .timelineItem(uniqueID: timelineItem.id.uniqueID.id),
                           blurhash: timelineItem.blurhash,
                           size: timelineItem.imageInfo.size,
-                          mediaProvider: context.mediaProvider) {
+                          mediaProvider: context?.mediaProvider) {
                 placeholder
             }
             .timelineMediaFrame(imageInfo: timelineItem.imageInfo)
             .accessibilityElement(children: .ignore)
             .accessibilityLabel("\(L10n.commonSticker), \(timelineItem.body)")
             .onTapGesture {
-                context.send(viewAction: .itemTapped(itemID: timelineItem.id))
+                context?.send(viewAction: .itemTapped(itemID: timelineItem.id))
             }
         }
     }

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/StickerRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/StickerRoomTimelineView.swift
@@ -24,6 +24,9 @@ struct StickerRoomTimelineView: View {
             .timelineMediaFrame(imageInfo: timelineItem.imageInfo)
             .accessibilityElement(children: .ignore)
             .accessibilityLabel("\(L10n.commonSticker), \(timelineItem.body)")
+            .onTapGesture {
+                context.send(viewAction: .itemTapped(itemID: timelineItem.id))
+            }
         }
     }
     

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/StickerRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/StickerRoomTimelineView.swift
@@ -41,7 +41,9 @@ struct StickerRoomTimelineView_Previews: PreviewProvider, TestablePreview {
     static let viewModel = TimelineViewModel.mock
     
     static var previews: some View {
-        body.environmentObject(viewModel.context)
+        body
+            .environmentObject(viewModel.context)
+            .environment(\.timelineContext, viewModel.context)
     }
     
     static var body: some View {

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/StickerRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/StickerRoomTimelineView.swift
@@ -25,7 +25,7 @@ struct StickerRoomTimelineView: View {
             .accessibilityElement(children: .ignore)
             .accessibilityLabel("\(L10n.commonSticker), \(timelineItem.body)")
             .onTapGesture {
-                context?.send(viewAction: .itemTapped(itemID: timelineItem.id))
+                context?.send(viewAction: .mediaTapped(itemID: timelineItem.id))
             }
         }
     }

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/VideoRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/VideoRoomTimelineView.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 struct VideoRoomTimelineView: View {
-    @EnvironmentObject private var context: TimelineViewModel.Context
+    @Environment(\.timelineContext) private var context
     let timelineItem: VideoRoomTimelineItem
     
     private var hasMediaCaption: Bool { timelineItem.content.caption != nil }
@@ -25,7 +25,7 @@ struct VideoRoomTimelineView: View {
                     // operates on the entire message so wouldn't round the bottom corners.
                     .clipShape(RoundedRectangle(cornerRadius: hasMediaCaption ? 6 : 0))
                     .onTapGesture {
-                        context.send(viewAction: .itemTapped(itemID: timelineItem.id))
+                        context?.send(viewAction: .itemTapped(itemID: timelineItem.id))
                     }
                 
                 if let attributedCaption = timelineItem.content.formattedCaption {
@@ -48,7 +48,7 @@ struct VideoRoomTimelineView: View {
                           mediaType: .timelineItem(uniqueID: timelineItem.id.uniqueID.id),
                           blurhash: timelineItem.content.blurhash,
                           size: timelineItem.content.thumbnailInfo?.size,
-                          mediaProvider: context.mediaProvider) { imageView in
+                          mediaProvider: context?.mediaProvider) { imageView in
                 imageView
                     .overlay { playIcon }
             } placeholder: {

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/VideoRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/VideoRoomTimelineView.swift
@@ -24,6 +24,9 @@ struct VideoRoomTimelineView: View {
                     // This clip shape is distinct from the one in the styler as that one
                     // operates on the entire message so wouldn't round the bottom corners.
                     .clipShape(RoundedRectangle(cornerRadius: hasMediaCaption ? 6 : 0))
+                    .onTapGesture {
+                        context.send(viewAction: .itemTapped(itemID: timelineItem.id))
+                    }
                 
                 if let attributedCaption = timelineItem.content.formattedCaption {
                     FormattedBodyText(attributedString: attributedCaption,

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/VideoRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/VideoRoomTimelineView.swift
@@ -25,7 +25,7 @@ struct VideoRoomTimelineView: View {
                     // operates on the entire message so wouldn't round the bottom corners.
                     .clipShape(RoundedRectangle(cornerRadius: hasMediaCaption ? 6 : 0))
                     .onTapGesture {
-                        context?.send(viewAction: .itemTapped(itemID: timelineItem.id))
+                        context?.send(viewAction: .mediaTapped(itemID: timelineItem.id))
                     }
                 
                 if let attributedCaption = timelineItem.content.formattedCaption {

--- a/ElementX/Sources/Screens/Timeline/View/TimelineSenderAvatarView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineSenderAvatarView.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 struct TimelineSenderAvatarView: View {
-    @EnvironmentObject private var context: TimelineViewModel.Context
+    @Environment(\.timelineContext) private var context
 
     let timelineItem: EventBasedTimelineItemProtocol
         
@@ -18,7 +18,7 @@ struct TimelineSenderAvatarView: View {
                             name: timelineItem.sender.displayName,
                             contentID: timelineItem.sender.id,
                             avatarSize: .user(on: .timeline),
-                            mediaProvider: context.mediaProvider)
+                            mediaProvider: context?.mediaProvider)
             .overlay {
                 Circle().stroke(Color.compound.bgCanvasDefault, lineWidth: 3)
             }

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/VoiceMessages/VoiceMessageRoomTimelineView.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/VoiceMessages/VoiceMessageRoomTimelineView.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 struct VoiceMessageRoomTimelineView: View {
-    @EnvironmentObject private var context: TimelineViewModel.Context
+    @Environment(\.timelineContext) private var context
     private let timelineItem: VoiceMessageRoomTimelineItem
     private let playerState: AudioPlayerState
     @State private var resumePlaybackAfterScrubbing = false
@@ -31,22 +31,22 @@ struct VoiceMessageRoomTimelineView: View {
     }
     
     private func onPlaybackPlayPause() {
-        context.send(viewAction: .handleAudioPlayerAction(.playPause(itemID: timelineItem.id)))
+        context?.send(viewAction: .handleAudioPlayerAction(.playPause(itemID: timelineItem.id)))
     }
     
     private func onPlaybackSeek(_ progress: Double) {
-        context.send(viewAction: .handleAudioPlayerAction(.seek(itemID: timelineItem.id, progress: progress)))
+        context?.send(viewAction: .handleAudioPlayerAction(.seek(itemID: timelineItem.id, progress: progress)))
     }
     
     private func onPlaybackScrubbing(_ dragging: Bool) {
         if dragging {
             if playerState.playbackState == .playing {
                 resumePlaybackAfterScrubbing = true
-                context.send(viewAction: .handleAudioPlayerAction(.playPause(itemID: timelineItem.id)))
+                context?.send(viewAction: .handleAudioPlayerAction(.playPause(itemID: timelineItem.id)))
             }
         } else {
             if resumePlaybackAfterScrubbing {
-                context.send(viewAction: .handleAudioPlayerAction(.playPause(itemID: timelineItem.id)))
+                context?.send(viewAction: .handleAudioPlayerAction(.playPause(itemID: timelineItem.id)))
                 resumePlaybackAfterScrubbing = false
             }
         }


### PR DESCRIPTION
While not much came out of the `UIGestureRecognizerRepresentable` prototypes we can at least move the normal tap to within the cells themselves. This will for example fix images opening in full screen when tapping on the caption text.