### PR TITLE
Fix a bug on iOS 17 where you couldn't long press on a message.

### DIFF
--- a/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemBubbledStylerView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemBubbledStylerView.swift
@@ -124,6 +124,12 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
     
     var messageBubbleWithActions: some View {
         messageBubble
+            .onTapGesture {
+                // We need a tap gesture before the long press gesture below, otherwise something
+                // on iOS 17 hijacks the long press and you can't bring up the context menu. This
+                // is no longer an issue on iOS 18. Note: it's fine for this to be empty, we handle
+                // specific taps within the timeline views themselves.
+            }
             .longPressWithFeedback {
                 context.send(viewAction: .displayTimelineItemMenu(itemID: timelineItem.id))
             }


### PR DESCRIPTION
Turns out iOS 17 simulators are hidden now as we target 17.6 and the newest one is 17.5