### PR TITLE
Fix a bug where you're shown the remove caption action when it isn't available.

### DIFF
--- a/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenuActionProvider.swift
+++ b/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenuActionProvider.swift
@@ -83,7 +83,7 @@ struct TimelineItemMenuActionProvider {
             actions.append(.copyCaption)
         }
         
-        if item.hasMediaCaption {
+        if item.isEditable, item.hasMediaCaption {
             actions.append(.removeCaption)
         }
         


### PR DESCRIPTION
I missed this when we re-ordered the action menu.