### PR TITLE
feat(posthog): wire support for extra utd error properties

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -8351,7 +8351,7 @@
 			repositoryURL = "https://github.com/element-hq/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 1.0.79;
+				version = 1.0.80;
 			};
 		};
 		701C7BEF8F70F7A83E852DCC /* XCRemoteSwiftPackageReference "GZIP" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/matrix-rust-components-swift",
       "state" : {
-        "revision" : "14fc58ea578bd370f78e45e83ef2f077a3bd683f",
-        "version" : "1.0.79"
+        "revision" : "342dc2f1b6553dba7ed5d6f0a330d77d7fae13c4",
+        "version" : "1.0.80"
       }
     },
     {

--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -5,6 +5,7 @@
 // Please see LICENSE in the repository root for full details.
 //
 
+import AnalyticsEvents
 import AVKit
 import Combine
 import MatrixRustSDK
@@ -382,24 +383,25 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
                     timeToDecryptMs = -1
                 }
                 
-                switch info.cause {
-                case .unknown:
-                    analytics.trackError(context: nil, domain: .E2EE, name: .OlmKeysNotSentError, timeToDecryptMillis: timeToDecryptMs)
-                case .unknownDevice:
-                    analytics.trackError(context: nil, domain: .E2EE, name: .ExpectedSentByInsecureDevice, timeToDecryptMillis: timeToDecryptMs)
-                case .unsignedDevice:
-                    analytics.trackError(context: nil, domain: .E2EE, name: .ExpectedSentByInsecureDevice, timeToDecryptMillis: timeToDecryptMs)
-                case .verificationViolation:
-                    analytics.trackError(context: nil, domain: .E2EE, name: .ExpectedVerificationViolation, timeToDecryptMillis: timeToDecryptMs)
-                case .sentBeforeWeJoined:
-                    analytics.trackError(context: nil, domain: .E2EE, name: .ExpectedDueToMembership, timeToDecryptMillis: timeToDecryptMs)
-                case .historicalMessage:
-                    analytics.trackError(context: nil, domain: .E2EE, name: .HistoricalMessage, timeToDecryptMillis: timeToDecryptMs)
-                case .withheldForUnverifiedOrInsecureDevice:
-                    analytics.trackError(context: nil, domain: .E2EE, name: .RoomKeysWithheldForUnverifiedDevice, timeToDecryptMillis: timeToDecryptMs)
-                case .withheldBySender:
-                    analytics.trackError(context: nil, domain: .E2EE, name: .OlmKeysNotSentError, timeToDecryptMillis: timeToDecryptMs)
+                let errorName: AnalyticsEvent.Error.Name = switch info.cause {
+                case .unknown: .OlmKeysNotSentError
+                case .unknownDevice, .unsignedDevice: .ExpectedSentByInsecureDevice
+                case .verificationViolation: .ExpectedVerificationViolation
+                case .sentBeforeWeJoined: .ExpectedDueToMembership
+                case .historicalMessage: .HistoricalMessage
+                case .withheldForUnverifiedOrInsecureDevice: .RoomKeysWithheldForUnverifiedDevice
+                case .withheldBySender: .OlmKeysNotSentError
                 }
+                
+                analytics.trackError(context: nil,
+                                     domain: .E2EE,
+                                     name: errorName,
+                                     timeToDecryptMillis: timeToDecryptMs,
+                                     eventLocalAgeMillis: Int(truncatingIfNeeded: info.eventLocalAgeMillis),
+                                     isFederated: info.ownHomeserver != info.senderHomeserver,
+                                     isMatrixDotOrg: info.ownHomeserver == "matrix.org",
+                                     userTrustsOwnIdentity: info.userTrustsOwnIdentity,
+                                     wasVisibleToUser: nil)
             }
             .store(in: &cancellables)
                 

--- a/ElementX/Sources/Services/Analytics/AnalyticsService.swift
+++ b/ElementX/Sources/Services/Analytics/AnalyticsService.swift
@@ -122,19 +122,26 @@ extension AnalyticsService {
     /// - Parameter name: The name of the error
     /// - Parameter timeToDecryptMillis: The time it took to decrypt the event in milliseconds, needs to be used only to track UTD errors, otherwise if the error is nort related to UTD it should be nil.
     /// Can be found in `UnableToDecryptInfo`. In case the `UnableToDecryptInfo` contains the value as nil, pass it as `-1`
-    func trackError(context: String?, domain: AnalyticsEvent.Error.Domain, name: AnalyticsEvent.Error.Name, timeToDecryptMillis: Int? = nil) {
+    func trackError(context: String?, domain: AnalyticsEvent.Error.Domain,
+                    name: AnalyticsEvent.Error.Name,
+                    timeToDecryptMillis: Int? = nil,
+                    eventLocalAgeMillis: Int? = nil,
+                    isFederated: Bool? = nil,
+                    isMatrixDotOrg: Bool? = nil,
+                    userTrustsOwnIdentity: Bool? = nil,
+                    wasVisibleToUser: Bool? = nil) {
         // CryptoModule is deprecated
         capture(event: AnalyticsEvent.Error(context: context,
                                             cryptoModule: .Rust,
                                             cryptoSDK: .Rust,
                                             domain: domain,
-                                            eventLocalAgeMillis: nil,
-                                            isFederated: nil,
-                                            isMatrixDotOrg: nil,
+                                            eventLocalAgeMillis: eventLocalAgeMillis,
+                                            isFederated: isFederated,
+                                            isMatrixDotOrg: isMatrixDotOrg,
                                             name: name,
                                             timeToDecryptMillis: timeToDecryptMillis,
-                                            userTrustsOwnIdentity: nil,
-                                            wasVisibleToUser: nil))
+                                            userTrustsOwnIdentity: userTrustsOwnIdentity,
+                                            wasVisibleToUser: wasVisibleToUser))
     }
     
     /// Track the creation of a room

--- a/project.yml
+++ b/project.yml
@@ -61,7 +61,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/element-hq/matrix-rust-components-swift
-    exactVersion: 1.0.79
+    exactVersion: 1.0.80
     # path: ../matrix-rust-sdk
   Compound:
     url: https://github.com/element-hq/compound-ios


### PR DESCRIPTION
Add a few new properties to the UTD reports we send to Posthog.

Part of https://github.com/element-hq/element-meta/issues/2582

Requires https://github.com/matrix-org/matrix-rust-sdk/pull/4404.

EXA equivalent https://github.com/element-hq/element-x-android/pull/4020

### Pull Request Checklist

- [ ] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off).

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
