### PR TITLE
feat(crypto): Support for new UtdCause for historical messages

### DIFF
--- a/ElementX/Resources/Localizations/en.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Localizable.strings
@@ -1035,6 +1035,7 @@
 "test_language_identifier" = "en";
 "test_untranslated_default_language_identifier" = "en";
 "timeline_decryption_failure_historical_event_no_key_backup" = "Historical messages are not available on this device";
+"timeline_decryption_failure_historical_event_unverified_device" = "You need to verify this device for access to historical messages";
 "timeline_decryption_failure_historical_event_user_not_joined" = "You don't have access to this message";
 "timeline_decryption_failure_unable_to_decrypt" = "Unable to decrypt message";
 "timeline_decryption_failure_withheld_unverified" = "This message was blocked either because you did not verify your device or because the sender needs to verify your identity.";

--- a/ElementX/Sources/Generated/Strings.swift
+++ b/ElementX/Sources/Generated/Strings.swift
@@ -2592,6 +2592,8 @@ internal enum L10n {
   internal static var testUntranslatedDefaultLanguageIdentifier: String { return L10n.tr("Localizable", "test_untranslated_default_language_identifier") }
   /// Historical messages are not available on this device
   internal static var timelineDecryptionFailureHistoricalEventNoKeyBackup: String { return L10n.tr("Localizable", "timeline_decryption_failure_historical_event_no_key_backup") }
+  /// You need to verify this device for access to historical messages
+  internal static var timelineDecryptionFailureHistoricalEventUnverifiedDevice: String { return L10n.tr("Localizable", "timeline_decryption_failure_historical_event_unverified_device") }
   /// You don't have access to this message
   internal static var timelineDecryptionFailureHistoricalEventUserNotJoined: String { return L10n.tr("Localizable", "timeline_decryption_failure_historical_event_user_not_joined") }
   /// Unable to decrypt message

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/EncryptedRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/EncryptedRoomTimelineView.swift
@@ -18,7 +18,8 @@ struct EncryptedRoomTimelineView: View {
             case .unknown:
                 return \.time
             case .sentBeforeWeJoined,
-                 .historicalMessage,
+                 .historicalMessageAndBackupDisabled,
+                 .historicalMessageAndDeviceIsUnverified,
                  .verificationViolation,
                  .insecureDevice,
                  .witheldBySender,

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/Other/EncryptedRoomTimelineItem.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/Other/EncryptedRoomTimelineItem.swift
@@ -19,7 +19,8 @@ struct EncryptedRoomTimelineItem: EventBasedTimelineItemProtocol, Equatable {
         case verificationViolation
         case insecureDevice
         case unknown
-        case historicalMessage
+        case historicalMessageAndBackupDisabled
+        case historicalMessageAndDeviceIsUnverified
         case witheldBySender
         case withheldForUnverifiedOrInsecureDevice
     }

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
@@ -153,9 +153,12 @@ struct RoomTimelineItemFactory: RoomTimelineItemFactoryProtocol {
             case .sentBeforeWeJoined:
                 encryptionType = .megolmV1AesSha2(sessionID: sessionID, cause: .sentBeforeWeJoined)
                 errorLabel = L10n.commonUnableToDecryptNoAccess
-            case .historicalMessageAndBackupIsDisabled, .historicalMessageAndDeviceIsUnverified:
-                encryptionType = .megolmV1AesSha2(sessionID: sessionID, cause: .historicalMessage)
+            case .historicalMessageAndBackupIsDisabled:
+                encryptionType = .megolmV1AesSha2(sessionID: sessionID, cause: .historicalMessageAndBackupDisabled)
                 errorLabel = L10n.timelineDecryptionFailureHistoricalEventNoKeyBackup
+            case .historicalMessageAndDeviceIsUnverified:
+                encryptionType = .megolmV1AesSha2(sessionID: sessionID, cause: .historicalMessageAndDeviceIsUnverified)
+                errorLabel = L10n.timelineDecryptionFailureHistoricalEventUnverifiedDevice
             case .withheldForUnverifiedOrInsecureDevice:
                 encryptionType = .megolmV1AesSha2(sessionID: sessionID, cause: .withheldForUnverifiedOrInsecureDevice)
                 errorLabel = L10n.timelineDecryptionFailureWithheldUnverified


### PR DESCRIPTION
Depends on https://github.com/matrix-org/matrix-rust-sdk/pull/4384

Adds support for new Historical expected UTDs (posthog and display of errors in timeline)

part of https://github.com/element-hq/element-meta/issues/2638
EXA equivalent: https://github.com/element-hq/element-x-android/pull/4044

### Pull Request Checklist

- [ ] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
