### PR TITLE
Disable semantic commits from Renovate

### DIFF
--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -39,8 +39,10 @@ if hasPngs {
 }
 
 // Check for nice PR titles
+let prTitle = danger.github.pullRequest.title
 let fixesRegex = try! Regex("(Fixes|Fix) #\\d+")
-if danger.github.pullRequest.title.hasSuffix("…") || danger.github.pullRequest.title.starts(with: fixesRegex) {
+let semanticRegex = try! Regex("\\w+\\(\\w+\\):")
+if prTitle.hasSuffix("…") || prTitle.starts(with: fixesRegex) || prTitle.starts(with: semanticRegex) {
     fail("Please provide a complete title that can be used as a changelog entry.")
 }
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    ":semanticCommitsDisabled"
   ],
   "labels" : [
     "pr-misc"


### PR DESCRIPTION
Configured as documented [here](https://docs.renovatebot.com/semantic-commits/). We don't need semantic commits as we have the changelog labels.