### PR TITLE
Fix the interactive dismiss gesture of media previews on iOS 18.2

### DIFF
--- a/ElementX/Sources/FlowCoordinators/MediaEventsTimelineFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/MediaEventsTimelineFlowCoordinator.swift
@@ -126,8 +126,6 @@ class MediaEventsTimelineFlowCoordinator: FlowCoordinatorProtocol {
             }
             .store(in: &cancellables)
         
-        navigationStackCoordinator.setFullScreenCoverCoordinator(coordinator) {
-            previewContext.completion?()
-        }
+        navigationStackCoordinator.setFullScreenCoverCoordinator(coordinator)
     }
 }

--- a/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewCoordinator.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewCoordinator.swift
@@ -72,6 +72,9 @@ final class TimelineMediaPreviewCoordinator: CoordinatorProtocol {
     }
         
     func toPresentable() -> AnyView {
-        AnyView(TimelineMediaPreviewScreen(context: viewModel.context))
+        // Calling the completion onDisappear isn't ideal, but we don't push away from the screen so it should be
+        // a good enough approximation of didDismiss, given that the only other option is our navigation callbacks
+        // which are essentially willDismiss callbacks and happen too early for this particular completion handler.
+        AnyView(TimelineMediaPreviewScreen(context: viewModel.context, onDisappear: parameters.context.completion))
     }
 }


### PR DESCRIPTION
The root view was being ignored (well for gestures anyway) as it was clear.