### PR TITLE
Security and privacy part 2

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -227,6 +227,7 @@
 		2BBA132149DEBED6624084A8 /* MessageForwardingScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06FAE373A7F20780BA84B59C /* MessageForwardingScreenCoordinator.swift */; };
 		2BBC0EB1E07963810A5D7423 /* ReadMarkerRoomTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 012A284622B32052015F1F89 /* ReadMarkerRoomTimelineView.swift */; };
 		2BBE320EE426A347AAE5C7DA /* IdentityConfirmationScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00AFC5F08734C2EA4EE79C59 /* IdentityConfirmationScreen.swift */; };
+		2BC579CB5CE90CFE07CA0955 /* EditRoomAddressScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41656BC6267D55C56A2AAC08 /* EditRoomAddressScreenCoordinator.swift */; };
 		2C4C750D0039AFABDF24236C /* TemplateScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342BEBC3C5FC3F9943C41C4C /* TemplateScreenViewModelProtocol.swift */; };
 		2C5E832434EE94E21AB3B238 /* EmojiPickerScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3EAE3E9D5EF4A6D5D9C6CFD /* EmojiPickerScreenViewModel.swift */; };
 		2CA61BB208CD82EBDB58CD13 /* VideoRoomTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED0CBEAB5F796BEFBAF7BB6A /* VideoRoomTimelineView.swift */; };
@@ -354,6 +355,7 @@
 		4715FE33667C5899E64DD0E6 /* ResolveVerifiedUserSendFailureScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97287090CA64DAA95386ECED /* ResolveVerifiedUserSendFailureScreen.swift */; };
 		4716587A9BA69ED8FD1B986B /* PollOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6B19D10B102956066AF117B /* PollOptionView.swift */; };
 		47305C0911C9E1AA774A4000 /* TemplateScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA90BD288E5AE6BC643AFDDF /* TemplateScreenCoordinator.swift */; };
+		4764FC9A843D1F9865EDC29C /* EditRoomAddressScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4048547AC50ADCF201684E87 /* EditRoomAddressScreen.swift */; };
 		478C363F63A5DFC3C83E334C /* MediaProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F65E4BB9E82EB8373207CF8 /* MediaProviderMock.swift */; };
 		4799A852132F1744E2825994 /* CreateRoomViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340179A0FC1AD4AEDA7FC134 /* CreateRoomViewModelProtocol.swift */; };
 		4807E8F51DB54F56B25E1C7E /* AppLockSetupSettingsScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8C38663020DF2EB2D13F5E /* AppLockSetupSettingsScreenViewModel.swift */; };
@@ -373,6 +375,7 @@
 		4A9CEEE612D6D8B3DDBD28BA /* RoomListFilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24EC819497BB5F8C4998D760 /* RoomListFilterView.swift */; };
 		4AAA8606FBA290E23D15422E /* AvatarHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC743C7A85E3171BCBF0A653 /* AvatarHeaderView.swift */; };
 		4AD2B5426DBED97196AA4783 /* DeactivateAccountScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82EE3B877D91030248B1242D /* DeactivateAccountScreenViewModelProtocol.swift */; };
+		4B25CDB4AA2C2AC0B4577217 /* EditRoomAddressListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2776E63E02719B20758EB78 /* EditRoomAddressListRow.swift */; };
 		4B978C09567387EF4366BD7A /* MediaLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EF1AC723C2609C7705569CA /* MediaLoaderTests.swift */; };
 		4BAB8222DBA0B4207D1223E0 /* NotificationSettingsProxyMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 382B50F7E379B3DBBD174364 /* NotificationSettingsProxyMock.swift */; };
 		4BB282209EA82015D0DF8F89 /* NavigationStackCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C698E30698EC59302A8EEBD /* NavigationStackCoordinatorTests.swift */; };
@@ -386,6 +389,7 @@
 		4D23D41B8109E010304050F8 /* QRCodeLoginScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA551A98778CEE7366838CE2 /* QRCodeLoginScreenCoordinator.swift */; };
 		4D2B54233C7B2C04B4ABE55A /* EncryptionSettingsFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECB836DD8BE31931F51B8AC9 /* EncryptionSettingsFlowCoordinator.swift */; };
 		4D4D236F0BBCDC4D2CBCCBB5 /* RoomChangePermissionsScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C729D95CB4588D4D9AAC3DFA /* RoomChangePermissionsScreenModels.swift */; };
+		4D66CEBE490B2F118F4CEC8A /* EditRoomAddressScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBD21AF0131AA38FF9534FAD /* EditRoomAddressScreenModels.swift */; };
 		4DAEE2468669848B6C9F55B4 /* TimelineReadReceiptsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33035418BB35754232985871 /* TimelineReadReceiptsView.swift */; };
 		4DEEFB73181C3B023DB42686 /* NetworkMonitorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1575947B7A6FE08C57FE5EE4 /* NetworkMonitorProtocol.swift */; };
 		4E0D9E09B52CEC4C0E6211A8 /* MediaPickerScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64F49FB9EE2913234F06CE68 /* MediaPickerScreenCoordinator.swift */; };
@@ -527,6 +531,7 @@
 		69C7B956B74BEC3DB88224EA /* NavigationSplitCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78913D6E120D46138E97C107 /* NavigationSplitCoordinatorTests.swift */; };
 		69DE29C3E3180BB17D840690 /* ProgressCursorModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97C8E13A1FBA717B0C277ECC /* ProgressCursorModifier.swift */; };
 		6A0E7551E0D1793245F34CDD /* ClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09A267106B9585D3D0CFC0D /* ClientError.swift */; };
+		6A38D0A2BC3943A92D82576E /* EditRoomAddressScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7B18089ED50324583BB2FB7 /* EditRoomAddressScreenViewModelProtocol.swift */; };
 		6A54F52443EC52AC5CD772C0 /* JoinRoomScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 869A8A4632E511351BFE2EC4 /* JoinRoomScreen.swift */; };
 		6A916606A8B92FE8A990A219 /* XCTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85A1941B874A3BE9CDDF43EF /* XCTestCase.swift */; };
 		6AD722DD92E465E56D2885AB /* BugReportScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA919F521E9F0EE3638AFC85 /* BugReportScreen.swift */; };
@@ -814,6 +819,7 @@
 		A20364EE08D902E647C11FB3 /* WebRegistrationScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D851A10FDA55579960DC61 /* WebRegistrationScreenCoordinator.swift */; };
 		A216C83ADCF32BA5EF8A6FBC /* InviteUsersViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845DDBDE5A0887E73D38B826 /* InviteUsersViewModelTests.swift */; };
 		A2172B5A26976F9174228B8A /* AppHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E4AB573FAEBB7B853DD04C /* AppHooks.swift */; };
+		A2357AA4A188BC37085BC6F0 /* EditRoomAddressScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5FDFAA04174CC99FB66391C /* EditRoomAddressScreenViewModel.swift */; };
 		A23B8B27A1436A1049EEF68E /* InfoPlistReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A580295A56B55A856CC4084 /* InfoPlistReader.swift */; };
 		A2434D4DFB49A68E5CD0F53C /* MediaLoaderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A02406480C351B8C6E0682C /* MediaLoaderProtocol.swift */; };
 		A32384E3D85CA65342D3A908 /* TimelineMediaPreviewRedactConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C75FE3F524B575D53787868C /* TimelineMediaPreviewRedactConfirmationView.swift */; };
@@ -1154,6 +1160,7 @@
 		ED564C8C7C43CF5F67000368 /* PlatformViewVersionPredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26813CCE39221FE30BF22CD /* PlatformViewVersionPredicate.swift */; };
 		ED635D7F00FA07E94D3CE1E8 /* PreviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9B796D347E53631576F631C /* PreviewTests.swift */; };
 		ED90A59F068FD0CA27E602ED /* UserProfileListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10DA51DBC8C7E1460DBCCBD /* UserProfileListRow.swift */; };
+		EDB6915EC953BB2A44AA608E /* EditRoomAddressScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 906451FB8CF27C628152BF7A /* EditRoomAddressScreenViewModelTests.swift */; };
 		EDF8919F15DE0FF00EF99E70 /* DocumentPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5567A7EF6F2AB9473236F6 /* DocumentPicker.swift */; };
 		EE4E2C1922BBF5169E213555 /* PillAttachmentViewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B53D6C5C0D14B04D3AB3F6E /* PillAttachmentViewProvider.swift */; };
 		EE56238683BC3ECA9BA00684 /* GlobalSearchScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA4D639E27D5882A6A71AECF /* GlobalSearchScreenViewModelTests.swift */; };
@@ -1638,11 +1645,13 @@
 		3F54FA7C5CB7B342EF9B9B2F /* NoticeRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeRoomTimelineView.swift; sourceTree = "<group>"; };
 		40076C770A5FB83325252973 /* VoiceMessageMediaManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceMessageMediaManager.swift; sourceTree = "<group>"; };
 		40316EFFEAC7B206EE9A55AE /* SecureBackupScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureBackupScreenViewModelTests.swift; sourceTree = "<group>"; };
+		4048547AC50ADCF201684E87 /* EditRoomAddressScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditRoomAddressScreen.swift; sourceTree = "<group>"; };
 		406C90AF8C3E98DF5D4E5430 /* ElementCallServiceConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementCallServiceConstants.swift; sourceTree = "<group>"; };
 		40A66E8BC8D9AE4A08EFB2DF /* RoomInfoProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomInfoProxy.swift; sourceTree = "<group>"; };
 		40B21E611DADDEF00307E7AC /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
 		4100DDE6BF3C566AB66B80CC /* MentionSuggestionItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MentionSuggestionItemView.swift; sourceTree = "<group>"; };
 		4137900E28201C314C835C11 /* RoomScreenFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomScreenFooterView.swift; sourceTree = "<group>"; };
+		41656BC6267D55C56A2AAC08 /* EditRoomAddressScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditRoomAddressScreenCoordinator.swift; sourceTree = "<group>"; };
 		4176C3E20C772DE8D182863C /* LegalInformationScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegalInformationScreen.swift; sourceTree = "<group>"; };
 		419957D7B1C983D7B3B93678 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		41A8571A8A071FB41778C016 /* ExtensionLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionLogger.swift; sourceTree = "<group>"; };
@@ -1999,6 +2008,7 @@
 		8F841F219ACDFC1D3F42FEFB /* RoomChangeRolesScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomChangeRolesScreenViewModelTests.swift; sourceTree = "<group>"; };
 		8FB89DC7F9A4A91020037001 /* AuthenticationStartScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationStartScreenViewModelTests.swift; sourceTree = "<group>"; };
 		8FC803282F9268D49F4ABF14 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
+		906451FB8CF27C628152BF7A /* EditRoomAddressScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditRoomAddressScreenViewModelTests.swift; sourceTree = "<group>"; };
 		90791B9C739C716A40E1B230 /* target.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = target.yml; sourceTree = "<group>"; };
 		907FA4DE17DEA1A3738EFB83 /* AudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorder.swift; sourceTree = "<group>"; };
 		90A55430639712CFACA34F43 /* TextRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextRoomTimelineItem.swift; sourceTree = "<group>"; };
@@ -2342,6 +2352,7 @@
 		D77B3D4950F1707E66E4A45A /* AnalyticsConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsConfiguration.swift; sourceTree = "<group>"; };
 		D77F75B3E9F99864048A422A /* DeactivateAccountScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeactivateAccountScreenViewModelTests.swift; sourceTree = "<group>"; };
 		D79BB714D28C9F588DD69353 /* SecureBackupScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureBackupScreenViewModelProtocol.swift; sourceTree = "<group>"; };
+		D7B18089ED50324583BB2FB7 /* EditRoomAddressScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditRoomAddressScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		D7BB243B26D54EF1A0C422C0 /* NotificationContentBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationContentBuilder.swift; sourceTree = "<group>"; };
 		D7BEB970F500BFB248443FA1 /* BloomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloomView.swift; sourceTree = "<group>"; };
 		D879DC5515B1D42577F96C94 /* RoomSelectionScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomSelectionScreen.swift; sourceTree = "<group>"; };
@@ -2381,6 +2392,7 @@
 		E1A5FEF17ED7E6176D922D4F /* RoomDetailsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomDetailsScreen.swift; sourceTree = "<group>"; };
 		E1E0B4A34E69BD2132BEC521 /* MessageText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageText.swift; sourceTree = "<group>"; };
 		E1ED17433ADC77287F8904F9 /* CallNotificationRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallNotificationRoomTimelineItem.swift; sourceTree = "<group>"; };
+		E2776E63E02719B20758EB78 /* EditRoomAddressListRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditRoomAddressListRow.swift; sourceTree = "<group>"; };
 		E2B1CC9AA154F4D5435BF60A /* Comparable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comparable.swift; sourceTree = "<group>"; };
 		E2F96CCBEAAA7F2185BFA354 /* ClientProxyMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientProxyMock.swift; sourceTree = "<group>"; };
 		E3059CFA00C67D8787273B20 /* ServerSelectionScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSelectionScreenViewModel.swift; sourceTree = "<group>"; };
@@ -2402,6 +2414,7 @@
 		E5E7D4EE7CA295E5039FDA21 /* portrait_test_video.mp4 */ = {isa = PBXFileReference; path = portrait_test_video.mp4; sourceTree = "<group>"; };
 		E5E94DCFEE803E5ABAE8ACCE /* KeychainControllerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainControllerProtocol.swift; sourceTree = "<group>"; };
 		E5F2B6443D1ED8602F328539 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ru; path = ru.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		E5FDFAA04174CC99FB66391C /* EditRoomAddressScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditRoomAddressScreenViewModel.swift; sourceTree = "<group>"; };
 		E60757AFE04391B43EA568B8 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		E6372DD10DED30E7AD7BCE21 /* RoomListFiltersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomListFiltersView.swift; sourceTree = "<group>"; };
 		E65DA46BD5CA83747AE144F3 /* secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = secrets.xcconfig; sourceTree = "<group>"; };
@@ -2432,6 +2445,7 @@
 		EB3B237387B8288A5A938F1B /* UserAgentBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAgentBuilderTests.swift; sourceTree = "<group>"; };
 		EB63761D9F9CE8B23CBD6179 /* PollFormScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollFormScreenModels.swift; sourceTree = "<group>"; };
 		EB76A9AFC6CCAD4998D9B045 /* IdentityConfirmationScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityConfirmationScreenViewModel.swift; sourceTree = "<group>"; };
+		EBD21AF0131AA38FF9534FAD /* EditRoomAddressScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditRoomAddressScreenModels.swift; sourceTree = "<group>"; };
 		EBEB8D9F4940E161B18FE4BC /* UITestsNotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestsNotificationCenter.swift; sourceTree = "<group>"; };
 		EC589E641AE46EFB2962534D /* RoomMemberDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomMemberDetailsViewModelTests.swift; sourceTree = "<group>"; };
 		ECB836DD8BE31931F51B8AC9 /* EncryptionSettingsFlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptionSettingsFlowCoordinator.swift; sourceTree = "<group>"; };
@@ -3213,6 +3227,7 @@
 				D01FD1171FF40E34D707FD00 /* BigIcon.swift */,
 				07934EF08BB39353E4A94272 /* BlurEffectView.swift */,
 				8CC23C63849452BC86EA2852 /* ButtonStyle.swift */,
+				E2776E63E02719B20758EB78 /* EditRoomAddressListRow.swift */,
 				B590BD4507D4F0A377FDE01A /* LoadableAvatarImage.swift */,
 				C352359663A0E52BA20761EE /* LoadableImage.swift */,
 				FFECCE59967018204876D0A5 /* LocationMarkerView.swift */,
@@ -3584,6 +3599,18 @@
 				8E1584F8BCF407BB94F48F04 /* EncryptionResetPasswordScreen.swift */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		45F2BCFD6E9A6F040CC20582 /* EditRoomAddressScreen */ = {
+			isa = PBXGroup;
+			children = (
+				41656BC6267D55C56A2AAC08 /* EditRoomAddressScreenCoordinator.swift */,
+				EBD21AF0131AA38FF9534FAD /* EditRoomAddressScreenModels.swift */,
+				E5FDFAA04174CC99FB66391C /* EditRoomAddressScreenViewModel.swift */,
+				D7B18089ED50324583BB2FB7 /* EditRoomAddressScreenViewModelProtocol.swift */,
+				E0D6D3976CA2762529BAE7D3 /* View */,
+			);
+			path = EditRoomAddressScreen;
 			sourceTree = "<group>";
 		};
 		464C6BFAA853DC755B9C1F60 /* PinnedItemsBanner */ = {
@@ -4129,6 +4156,7 @@
 				3B5E97E9615A158C76B2AB77 /* DateTests.swift */,
 				D77F75B3E9F99864048A422A /* DeactivateAccountScreenViewModelTests.swift */,
 				6D0A27607AB09784C8501B5C /* DeveloperOptionsScreenViewModelTests.swift */,
+				906451FB8CF27C628152BF7A /* EditRoomAddressScreenViewModelTests.swift */,
 				A58E93D91DE3288010390DEE /* EmojiDetectionTests.swift */,
 				099F2D36C141D845A445B1E6 /* EmojiProviderTests.swift */,
 				84B7A28A6606D58D1E38C55A /* ExpiringTaskRunnerTests.swift */,
@@ -5562,6 +5590,14 @@
 			path = View;
 			sourceTree = "<group>";
 		};
+		E0D6D3976CA2762529BAE7D3 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				4048547AC50ADCF201684E87 /* EditRoomAddressScreen.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
 		E2DA161C142B7AB8CC40F752 /* Animation */ = {
 			isa = PBXGroup;
 			children = (
@@ -5595,6 +5631,7 @@
 				90DC2E28718955ED87AD1456 /* CreatePollScreen */,
 				C18958141C8ED6D778F779A4 /* CreateRoom */,
 				6C708A9F46EDE1105C640335 /* DeactivateAccountScreen */,
+				45F2BCFD6E9A6F040CC20582 /* EditRoomAddressScreen */,
 				F5A65D1D3B83593598DC278D /* EmojiPickerScreen */,
 				8656AFF06650360A5D0695FF /* EncryptionReset */,
 				448435400B561C40E514BE1C /* FilePreviewScreen */,
@@ -6579,6 +6616,7 @@
 				CD0088B763CD970CF1CBF8CB /* DateTests.swift in Sources */,
 				80F6C8EFCA4564B67F0D34B0 /* DeactivateAccountScreenViewModelTests.swift in Sources */,
 				864C69CF951BF36D25BE0C03 /* DeveloperOptionsScreenViewModelTests.swift in Sources */,
+				EDB6915EC953BB2A44AA608E /* EditRoomAddressScreenViewModelTests.swift in Sources */,
 				F697284B9B5F2C00CFEA3B12 /* EmojiDetectionTests.swift in Sources */,
 				25618589E0DE0F1E95FC7B5C /* EmojiProviderTests.swift in Sources */,
 				71B62C48B8079D49F3FBC845 /* ExpiringTaskRunnerTests.swift in Sources */,
@@ -6906,6 +6944,12 @@
 				037006FB6DF1374F94E4058D /* Dictionary.swift in Sources */,
 				EDF8919F15DE0FF00EF99E70 /* DocumentPicker.swift in Sources */,
 				4FDC8A9764CFDA90CE035725 /* Duration.swift in Sources */,
+				4B25CDB4AA2C2AC0B4577217 /* EditRoomAddressListRow.swift in Sources */,
+				4764FC9A843D1F9865EDC29C /* EditRoomAddressScreen.swift in Sources */,
+				2BC579CB5CE90CFE07CA0955 /* EditRoomAddressScreenCoordinator.swift in Sources */,
+				4D66CEBE490B2F118F4CEC8A /* EditRoomAddressScreenModels.swift in Sources */,
+				A2357AA4A188BC37085BC6F0 /* EditRoomAddressScreenViewModel.swift in Sources */,
+				6A38D0A2BC3943A92D82576E /* EditRoomAddressScreenViewModelProtocol.swift in Sources */,
 				2955F4C160CFD7794D819C64 /* EffectsScene.swift in Sources */,
 				AE1160076F663BF14E0E893A /* EffectsView.swift in Sources */,
 				FE4593FC2A02AAF92E089565 /* ElementAnimations.swift in Sources */,
@@ -8415,7 +8459,7 @@
 			repositoryURL = "https://github.com/element-hq/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = "25.01.10-2";
+				version = 25.01.13;
 			};
 		};
 		701C7BEF8F70F7A83E852DCC /* XCRemoteSwiftPackageReference "GZIP" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/matrix-rust-components-swift",
       "state" : {
-        "revision" : "cc9cd80aa6954a7945d82c29182f81c5219f635e",
-        "version" : "25.1.10-2"
+        "revision" : "0e9afdf46c3128a0dc13c2d2fcee32ad3298a1a6",
+        "version" : "25.1.13"
       }
     },
     {

--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -1495,7 +1495,7 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
         
         coordinator.actionsPublisher.sink { [weak self] action in
             switch action {
-            case .done:
+            case .dismiss:
                 self?.navigationStackCoordinator.setSheetCoordinator(nil)
             }
         }

--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -1468,7 +1468,9 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
     }
     
     private func presentSecurityAndPrivacyScreen() {
-        let coordinator = SecurityAndPrivacyScreenCoordinator(parameters: .init(roomProxy: roomProxy, clientProxy: userSession.clientProxy))
+        let coordinator = SecurityAndPrivacyScreenCoordinator(parameters: .init(roomProxy: roomProxy,
+                                                                                clientProxy: userSession.clientProxy,
+                                                                                userIndicatorController: userIndicatorController))
         
         coordinator.actionsPublisher.sink { [weak self] action in
             guard let self else { return }

--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -1476,8 +1476,8 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
             guard let self else { return }
             
             switch action {
-            case .done:
-                break
+            case .displayEditAddressScreen:
+                presentEditAddressScreen()
             }
         }
         .store(in: &cancellables)
@@ -1485,6 +1485,24 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
         navigationStackCoordinator.push(coordinator) { [weak self] in
             self?.stateMachine.tryEvent(.dismissSecurityAndPrivacyScreen)
         }
+    }
+    
+    private func presentEditAddressScreen() {
+        let stackCoordinator = NavigationStackCoordinator()
+        let coordinator = EditRoomAddressScreenCoordinator(parameters: .init(roomProxy: roomProxy,
+                                                                             clientProxy: userSession.clientProxy,
+                                                                             userIndicatorController: userIndicatorController))
+        
+        coordinator.actionsPublisher.sink { [weak self] action in
+            switch action {
+            case .done:
+                self?.navigationStackCoordinator.setSheetCoordinator(nil)
+            }
+        }
+        .store(in: &cancellables)
+        
+        stackCoordinator.setRootCoordinator(coordinator)
+        navigationStackCoordinator.setSheetCoordinator(stackCoordinator)
     }
     
     // MARK: - Other flows

--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -1468,7 +1468,7 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
     }
     
     private func presentSecurityAndPrivacyScreen() {
-        let coordinator = SecurityAndPrivacyScreenCoordinator(parameters: .init(roomProxy: roomProxy))
+        let coordinator = SecurityAndPrivacyScreenCoordinator(parameters: .init(roomProxy: roomProxy, clientProxy: userSession.clientProxy))
         
         coordinator.actionsPublisher.sink { [weak self] action in
             guard let self else { return }

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -7227,6 +7227,70 @@ class JoinedRoomProxyMock: JoinedRoomProxyProtocol {
             return withdrawVerificationAndResendUserIDsSendHandleReturnValue
         }
     }
+    //MARK: - isVisibleInRoomDirectory
+
+    var isVisibleInRoomDirectoryUnderlyingCallsCount = 0
+    var isVisibleInRoomDirectoryCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return isVisibleInRoomDirectoryUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = isVisibleInRoomDirectoryUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                isVisibleInRoomDirectoryUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    isVisibleInRoomDirectoryUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var isVisibleInRoomDirectoryCalled: Bool {
+        return isVisibleInRoomDirectoryCallsCount > 0
+    }
+
+    var isVisibleInRoomDirectoryUnderlyingReturnValue: Result<Bool, RoomProxyError>!
+    var isVisibleInRoomDirectoryReturnValue: Result<Bool, RoomProxyError>! {
+        get {
+            if Thread.isMainThread {
+                return isVisibleInRoomDirectoryUnderlyingReturnValue
+            } else {
+                var returnValue: Result<Bool, RoomProxyError>? = nil
+                DispatchQueue.main.sync {
+                    returnValue = isVisibleInRoomDirectoryUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                isVisibleInRoomDirectoryUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    isVisibleInRoomDirectoryUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    var isVisibleInRoomDirectoryClosure: (() async -> Result<Bool, RoomProxyError>)?
+
+    func isVisibleInRoomDirectory() async -> Result<Bool, RoomProxyError> {
+        isVisibleInRoomDirectoryCallsCount += 1
+        if let isVisibleInRoomDirectoryClosure = isVisibleInRoomDirectoryClosure {
+            return await isVisibleInRoomDirectoryClosure()
+        } else {
+            return isVisibleInRoomDirectoryReturnValue
+        }
+    }
     //MARK: - flagAsUnread
 
     var flagAsUnreadUnderlyingCallsCount = 0

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -6223,6 +6223,70 @@ class JoinedRoomProxyMock: JoinedRoomProxyProtocol {
             return messageFilteredTimelineAllowedMessageTypesReturnValue
         }
     }
+    //MARK: - enableEncryption
+
+    var enableEncryptionUnderlyingCallsCount = 0
+    var enableEncryptionCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return enableEncryptionUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = enableEncryptionUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                enableEncryptionUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    enableEncryptionUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var enableEncryptionCalled: Bool {
+        return enableEncryptionCallsCount > 0
+    }
+
+    var enableEncryptionUnderlyingReturnValue: Result<Void, RoomProxyError>!
+    var enableEncryptionReturnValue: Result<Void, RoomProxyError>! {
+        get {
+            if Thread.isMainThread {
+                return enableEncryptionUnderlyingReturnValue
+            } else {
+                var returnValue: Result<Void, RoomProxyError>? = nil
+                DispatchQueue.main.sync {
+                    returnValue = enableEncryptionUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                enableEncryptionUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    enableEncryptionUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    var enableEncryptionClosure: (() async -> Result<Void, RoomProxyError>)?
+
+    func enableEncryption() async -> Result<Void, RoomProxyError> {
+        enableEncryptionCallsCount += 1
+        if let enableEncryptionClosure = enableEncryptionClosure {
+            return await enableEncryptionClosure()
+        } else {
+            return enableEncryptionReturnValue
+        }
+    }
     //MARK: - redact
 
     var redactUnderlyingCallsCount = 0
@@ -7227,6 +7291,146 @@ class JoinedRoomProxyMock: JoinedRoomProxyProtocol {
             return withdrawVerificationAndResendUserIDsSendHandleReturnValue
         }
     }
+    //MARK: - updateJoinRule
+
+    var updateJoinRuleUnderlyingCallsCount = 0
+    var updateJoinRuleCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return updateJoinRuleUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = updateJoinRuleUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                updateJoinRuleUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    updateJoinRuleUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var updateJoinRuleCalled: Bool {
+        return updateJoinRuleCallsCount > 0
+    }
+    var updateJoinRuleReceivedRule: JoinRule?
+    var updateJoinRuleReceivedInvocations: [JoinRule] = []
+
+    var updateJoinRuleUnderlyingReturnValue: Result<Void, RoomProxyError>!
+    var updateJoinRuleReturnValue: Result<Void, RoomProxyError>! {
+        get {
+            if Thread.isMainThread {
+                return updateJoinRuleUnderlyingReturnValue
+            } else {
+                var returnValue: Result<Void, RoomProxyError>? = nil
+                DispatchQueue.main.sync {
+                    returnValue = updateJoinRuleUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                updateJoinRuleUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    updateJoinRuleUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    var updateJoinRuleClosure: ((JoinRule) async -> Result<Void, RoomProxyError>)?
+
+    func updateJoinRule(_ rule: JoinRule) async -> Result<Void, RoomProxyError> {
+        updateJoinRuleCallsCount += 1
+        updateJoinRuleReceivedRule = rule
+        DispatchQueue.main.async {
+            self.updateJoinRuleReceivedInvocations.append(rule)
+        }
+        if let updateJoinRuleClosure = updateJoinRuleClosure {
+            return await updateJoinRuleClosure(rule)
+        } else {
+            return updateJoinRuleReturnValue
+        }
+    }
+    //MARK: - updateHistoryVisibility
+
+    var updateHistoryVisibilityUnderlyingCallsCount = 0
+    var updateHistoryVisibilityCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return updateHistoryVisibilityUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = updateHistoryVisibilityUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                updateHistoryVisibilityUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    updateHistoryVisibilityUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var updateHistoryVisibilityCalled: Bool {
+        return updateHistoryVisibilityCallsCount > 0
+    }
+    var updateHistoryVisibilityReceivedVisibility: RoomHistoryVisibility?
+    var updateHistoryVisibilityReceivedInvocations: [RoomHistoryVisibility] = []
+
+    var updateHistoryVisibilityUnderlyingReturnValue: Result<Void, RoomProxyError>!
+    var updateHistoryVisibilityReturnValue: Result<Void, RoomProxyError>! {
+        get {
+            if Thread.isMainThread {
+                return updateHistoryVisibilityUnderlyingReturnValue
+            } else {
+                var returnValue: Result<Void, RoomProxyError>? = nil
+                DispatchQueue.main.sync {
+                    returnValue = updateHistoryVisibilityUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                updateHistoryVisibilityUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    updateHistoryVisibilityUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    var updateHistoryVisibilityClosure: ((RoomHistoryVisibility) async -> Result<Void, RoomProxyError>)?
+
+    func updateHistoryVisibility(_ visibility: RoomHistoryVisibility) async -> Result<Void, RoomProxyError> {
+        updateHistoryVisibilityCallsCount += 1
+        updateHistoryVisibilityReceivedVisibility = visibility
+        DispatchQueue.main.async {
+            self.updateHistoryVisibilityReceivedInvocations.append(visibility)
+        }
+        if let updateHistoryVisibilityClosure = updateHistoryVisibilityClosure {
+            return await updateHistoryVisibilityClosure(visibility)
+        } else {
+            return updateHistoryVisibilityReturnValue
+        }
+    }
     //MARK: - isVisibleInRoomDirectory
 
     var isVisibleInRoomDirectoryUnderlyingCallsCount = 0
@@ -7289,6 +7493,286 @@ class JoinedRoomProxyMock: JoinedRoomProxyProtocol {
             return await isVisibleInRoomDirectoryClosure()
         } else {
             return isVisibleInRoomDirectoryReturnValue
+        }
+    }
+    //MARK: - updateRoomDirectoryVisibility
+
+    var updateRoomDirectoryVisibilityUnderlyingCallsCount = 0
+    var updateRoomDirectoryVisibilityCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return updateRoomDirectoryVisibilityUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = updateRoomDirectoryVisibilityUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                updateRoomDirectoryVisibilityUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    updateRoomDirectoryVisibilityUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var updateRoomDirectoryVisibilityCalled: Bool {
+        return updateRoomDirectoryVisibilityCallsCount > 0
+    }
+    var updateRoomDirectoryVisibilityReceivedVisibility: RoomVisibility?
+    var updateRoomDirectoryVisibilityReceivedInvocations: [RoomVisibility] = []
+
+    var updateRoomDirectoryVisibilityUnderlyingReturnValue: Result<Void, RoomProxyError>!
+    var updateRoomDirectoryVisibilityReturnValue: Result<Void, RoomProxyError>! {
+        get {
+            if Thread.isMainThread {
+                return updateRoomDirectoryVisibilityUnderlyingReturnValue
+            } else {
+                var returnValue: Result<Void, RoomProxyError>? = nil
+                DispatchQueue.main.sync {
+                    returnValue = updateRoomDirectoryVisibilityUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                updateRoomDirectoryVisibilityUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    updateRoomDirectoryVisibilityUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    var updateRoomDirectoryVisibilityClosure: ((RoomVisibility) async -> Result<Void, RoomProxyError>)?
+
+    func updateRoomDirectoryVisibility(_ visibility: RoomVisibility) async -> Result<Void, RoomProxyError> {
+        updateRoomDirectoryVisibilityCallsCount += 1
+        updateRoomDirectoryVisibilityReceivedVisibility = visibility
+        DispatchQueue.main.async {
+            self.updateRoomDirectoryVisibilityReceivedInvocations.append(visibility)
+        }
+        if let updateRoomDirectoryVisibilityClosure = updateRoomDirectoryVisibilityClosure {
+            return await updateRoomDirectoryVisibilityClosure(visibility)
+        } else {
+            return updateRoomDirectoryVisibilityReturnValue
+        }
+    }
+    //MARK: - updateCanonicalAlias
+
+    var updateCanonicalAliasAltAliasesUnderlyingCallsCount = 0
+    var updateCanonicalAliasAltAliasesCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return updateCanonicalAliasAltAliasesUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = updateCanonicalAliasAltAliasesUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                updateCanonicalAliasAltAliasesUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    updateCanonicalAliasAltAliasesUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var updateCanonicalAliasAltAliasesCalled: Bool {
+        return updateCanonicalAliasAltAliasesCallsCount > 0
+    }
+    var updateCanonicalAliasAltAliasesReceivedArguments: (alias: String?, altAliases: [String])?
+    var updateCanonicalAliasAltAliasesReceivedInvocations: [(alias: String?, altAliases: [String])] = []
+
+    var updateCanonicalAliasAltAliasesUnderlyingReturnValue: Result<Void, RoomProxyError>!
+    var updateCanonicalAliasAltAliasesReturnValue: Result<Void, RoomProxyError>! {
+        get {
+            if Thread.isMainThread {
+                return updateCanonicalAliasAltAliasesUnderlyingReturnValue
+            } else {
+                var returnValue: Result<Void, RoomProxyError>? = nil
+                DispatchQueue.main.sync {
+                    returnValue = updateCanonicalAliasAltAliasesUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                updateCanonicalAliasAltAliasesUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    updateCanonicalAliasAltAliasesUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    var updateCanonicalAliasAltAliasesClosure: ((String?, [String]) async -> Result<Void, RoomProxyError>)?
+
+    func updateCanonicalAlias(_ alias: String?, altAliases: [String]) async -> Result<Void, RoomProxyError> {
+        updateCanonicalAliasAltAliasesCallsCount += 1
+        updateCanonicalAliasAltAliasesReceivedArguments = (alias: alias, altAliases: altAliases)
+        DispatchQueue.main.async {
+            self.updateCanonicalAliasAltAliasesReceivedInvocations.append((alias: alias, altAliases: altAliases))
+        }
+        if let updateCanonicalAliasAltAliasesClosure = updateCanonicalAliasAltAliasesClosure {
+            return await updateCanonicalAliasAltAliasesClosure(alias, altAliases)
+        } else {
+            return updateCanonicalAliasAltAliasesReturnValue
+        }
+    }
+    //MARK: - publishRoomAliasInRoomDirectory
+
+    var publishRoomAliasInRoomDirectoryUnderlyingCallsCount = 0
+    var publishRoomAliasInRoomDirectoryCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return publishRoomAliasInRoomDirectoryUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = publishRoomAliasInRoomDirectoryUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                publishRoomAliasInRoomDirectoryUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    publishRoomAliasInRoomDirectoryUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var publishRoomAliasInRoomDirectoryCalled: Bool {
+        return publishRoomAliasInRoomDirectoryCallsCount > 0
+    }
+    var publishRoomAliasInRoomDirectoryReceivedAlias: String?
+    var publishRoomAliasInRoomDirectoryReceivedInvocations: [String] = []
+
+    var publishRoomAliasInRoomDirectoryUnderlyingReturnValue: Result<Bool, RoomProxyError>!
+    var publishRoomAliasInRoomDirectoryReturnValue: Result<Bool, RoomProxyError>! {
+        get {
+            if Thread.isMainThread {
+                return publishRoomAliasInRoomDirectoryUnderlyingReturnValue
+            } else {
+                var returnValue: Result<Bool, RoomProxyError>? = nil
+                DispatchQueue.main.sync {
+                    returnValue = publishRoomAliasInRoomDirectoryUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                publishRoomAliasInRoomDirectoryUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    publishRoomAliasInRoomDirectoryUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    var publishRoomAliasInRoomDirectoryClosure: ((String) async -> Result<Bool, RoomProxyError>)?
+
+    func publishRoomAliasInRoomDirectory(_ alias: String) async -> Result<Bool, RoomProxyError> {
+        publishRoomAliasInRoomDirectoryCallsCount += 1
+        publishRoomAliasInRoomDirectoryReceivedAlias = alias
+        DispatchQueue.main.async {
+            self.publishRoomAliasInRoomDirectoryReceivedInvocations.append(alias)
+        }
+        if let publishRoomAliasInRoomDirectoryClosure = publishRoomAliasInRoomDirectoryClosure {
+            return await publishRoomAliasInRoomDirectoryClosure(alias)
+        } else {
+            return publishRoomAliasInRoomDirectoryReturnValue
+        }
+    }
+    //MARK: - removeRoomAliasFromRoomDirectory
+
+    var removeRoomAliasFromRoomDirectoryUnderlyingCallsCount = 0
+    var removeRoomAliasFromRoomDirectoryCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return removeRoomAliasFromRoomDirectoryUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = removeRoomAliasFromRoomDirectoryUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                removeRoomAliasFromRoomDirectoryUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    removeRoomAliasFromRoomDirectoryUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var removeRoomAliasFromRoomDirectoryCalled: Bool {
+        return removeRoomAliasFromRoomDirectoryCallsCount > 0
+    }
+    var removeRoomAliasFromRoomDirectoryReceivedAlias: String?
+    var removeRoomAliasFromRoomDirectoryReceivedInvocations: [String] = []
+
+    var removeRoomAliasFromRoomDirectoryUnderlyingReturnValue: Result<Bool, RoomProxyError>!
+    var removeRoomAliasFromRoomDirectoryReturnValue: Result<Bool, RoomProxyError>! {
+        get {
+            if Thread.isMainThread {
+                return removeRoomAliasFromRoomDirectoryUnderlyingReturnValue
+            } else {
+                var returnValue: Result<Bool, RoomProxyError>? = nil
+                DispatchQueue.main.sync {
+                    returnValue = removeRoomAliasFromRoomDirectoryUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                removeRoomAliasFromRoomDirectoryUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    removeRoomAliasFromRoomDirectoryUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    var removeRoomAliasFromRoomDirectoryClosure: ((String) async -> Result<Bool, RoomProxyError>)?
+
+    func removeRoomAliasFromRoomDirectory(_ alias: String) async -> Result<Bool, RoomProxyError> {
+        removeRoomAliasFromRoomDirectoryCallsCount += 1
+        removeRoomAliasFromRoomDirectoryReceivedAlias = alias
+        DispatchQueue.main.async {
+            self.removeRoomAliasFromRoomDirectoryReceivedInvocations.append(alias)
+        }
+        if let removeRoomAliasFromRoomDirectoryClosure = removeRoomAliasFromRoomDirectoryClosure {
+            return await removeRoomAliasFromRoomDirectoryClosure(alias)
+        } else {
+            return removeRoomAliasFromRoomDirectoryReturnValue
         }
     }
     //MARK: - flagAsUnread

--- a/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
@@ -13450,6 +13450,81 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
     }
 
+    //MARK: - publishRoomAliasInRoomDirectory
+
+    open var publishRoomAliasInRoomDirectoryAliasThrowableError: Error?
+    var publishRoomAliasInRoomDirectoryAliasUnderlyingCallsCount = 0
+    open var publishRoomAliasInRoomDirectoryAliasCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return publishRoomAliasInRoomDirectoryAliasUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = publishRoomAliasInRoomDirectoryAliasUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                publishRoomAliasInRoomDirectoryAliasUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    publishRoomAliasInRoomDirectoryAliasUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var publishRoomAliasInRoomDirectoryAliasCalled: Bool {
+        return publishRoomAliasInRoomDirectoryAliasCallsCount > 0
+    }
+    open var publishRoomAliasInRoomDirectoryAliasReceivedAlias: String?
+    open var publishRoomAliasInRoomDirectoryAliasReceivedInvocations: [String] = []
+
+    var publishRoomAliasInRoomDirectoryAliasUnderlyingReturnValue: Bool!
+    open var publishRoomAliasInRoomDirectoryAliasReturnValue: Bool! {
+        get {
+            if Thread.isMainThread {
+                return publishRoomAliasInRoomDirectoryAliasUnderlyingReturnValue
+            } else {
+                var returnValue: Bool? = nil
+                DispatchQueue.main.sync {
+                    returnValue = publishRoomAliasInRoomDirectoryAliasUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                publishRoomAliasInRoomDirectoryAliasUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    publishRoomAliasInRoomDirectoryAliasUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    open var publishRoomAliasInRoomDirectoryAliasClosure: ((String) async throws -> Bool)?
+
+    open override func publishRoomAliasInRoomDirectory(alias: String) async throws -> Bool {
+        if let error = publishRoomAliasInRoomDirectoryAliasThrowableError {
+            throw error
+        }
+        publishRoomAliasInRoomDirectoryAliasCallsCount += 1
+        publishRoomAliasInRoomDirectoryAliasReceivedAlias = alias
+        DispatchQueue.main.async {
+            self.publishRoomAliasInRoomDirectoryAliasReceivedInvocations.append(alias)
+        }
+        if let publishRoomAliasInRoomDirectoryAliasClosure = publishRoomAliasInRoomDirectoryAliasClosure {
+            return try await publishRoomAliasInRoomDirectoryAliasClosure(alias)
+        } else {
+            return publishRoomAliasInRoomDirectoryAliasReturnValue
+        }
+    }
+
     //MARK: - rawName
 
     var rawNameUnderlyingCallsCount = 0
@@ -13599,6 +13674,81 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         removeAvatarCallsCount += 1
         try await removeAvatarClosure?()
+    }
+
+    //MARK: - removeRoomAliasFromRoomDirectory
+
+    open var removeRoomAliasFromRoomDirectoryAliasThrowableError: Error?
+    var removeRoomAliasFromRoomDirectoryAliasUnderlyingCallsCount = 0
+    open var removeRoomAliasFromRoomDirectoryAliasCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return removeRoomAliasFromRoomDirectoryAliasUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = removeRoomAliasFromRoomDirectoryAliasUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                removeRoomAliasFromRoomDirectoryAliasUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    removeRoomAliasFromRoomDirectoryAliasUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var removeRoomAliasFromRoomDirectoryAliasCalled: Bool {
+        return removeRoomAliasFromRoomDirectoryAliasCallsCount > 0
+    }
+    open var removeRoomAliasFromRoomDirectoryAliasReceivedAlias: String?
+    open var removeRoomAliasFromRoomDirectoryAliasReceivedInvocations: [String] = []
+
+    var removeRoomAliasFromRoomDirectoryAliasUnderlyingReturnValue: Bool!
+    open var removeRoomAliasFromRoomDirectoryAliasReturnValue: Bool! {
+        get {
+            if Thread.isMainThread {
+                return removeRoomAliasFromRoomDirectoryAliasUnderlyingReturnValue
+            } else {
+                var returnValue: Bool? = nil
+                DispatchQueue.main.sync {
+                    returnValue = removeRoomAliasFromRoomDirectoryAliasUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                removeRoomAliasFromRoomDirectoryAliasUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    removeRoomAliasFromRoomDirectoryAliasUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    open var removeRoomAliasFromRoomDirectoryAliasClosure: ((String) async throws -> Bool)?
+
+    open override func removeRoomAliasFromRoomDirectory(alias: String) async throws -> Bool {
+        if let error = removeRoomAliasFromRoomDirectoryAliasThrowableError {
+            throw error
+        }
+        removeRoomAliasFromRoomDirectoryAliasCallsCount += 1
+        removeRoomAliasFromRoomDirectoryAliasReceivedAlias = alias
+        DispatchQueue.main.async {
+            self.removeRoomAliasFromRoomDirectoryAliasReceivedInvocations.append(alias)
+        }
+        if let removeRoomAliasFromRoomDirectoryAliasClosure = removeRoomAliasFromRoomDirectoryAliasClosure {
+            return try await removeRoomAliasFromRoomDirectoryAliasClosure(alias)
+        } else {
+            return removeRoomAliasFromRoomDirectoryAliasReturnValue
+        }
     }
 
     //MARK: - reportContent
@@ -14928,16 +15078,16 @@ open class RoomSDKMock: MatrixRustSDK.Room {
 
     //MARK: - updateCanonicalAlias
 
-    open var updateCanonicalAliasNewAliasThrowableError: Error?
-    var updateCanonicalAliasNewAliasUnderlyingCallsCount = 0
-    open var updateCanonicalAliasNewAliasCallsCount: Int {
+    open var updateCanonicalAliasAliasAltAliasesThrowableError: Error?
+    var updateCanonicalAliasAliasAltAliasesUnderlyingCallsCount = 0
+    open var updateCanonicalAliasAliasAltAliasesCallsCount: Int {
         get {
             if Thread.isMainThread {
-                return updateCanonicalAliasNewAliasUnderlyingCallsCount
+                return updateCanonicalAliasAliasAltAliasesUnderlyingCallsCount
             } else {
                 var returnValue: Int? = nil
                 DispatchQueue.main.sync {
-                    returnValue = updateCanonicalAliasNewAliasUnderlyingCallsCount
+                    returnValue = updateCanonicalAliasAliasAltAliasesUnderlyingCallsCount
                 }
 
                 return returnValue!
@@ -14945,31 +15095,31 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         }
         set {
             if Thread.isMainThread {
-                updateCanonicalAliasNewAliasUnderlyingCallsCount = newValue
+                updateCanonicalAliasAliasAltAliasesUnderlyingCallsCount = newValue
             } else {
                 DispatchQueue.main.sync {
-                    updateCanonicalAliasNewAliasUnderlyingCallsCount = newValue
+                    updateCanonicalAliasAliasAltAliasesUnderlyingCallsCount = newValue
                 }
             }
         }
     }
-    open var updateCanonicalAliasNewAliasCalled: Bool {
-        return updateCanonicalAliasNewAliasCallsCount > 0
+    open var updateCanonicalAliasAliasAltAliasesCalled: Bool {
+        return updateCanonicalAliasAliasAltAliasesCallsCount > 0
     }
-    open var updateCanonicalAliasNewAliasReceivedNewAlias: String?
-    open var updateCanonicalAliasNewAliasReceivedInvocations: [String?] = []
-    open var updateCanonicalAliasNewAliasClosure: ((String?) async throws -> Void)?
+    open var updateCanonicalAliasAliasAltAliasesReceivedArguments: (alias: String?, altAliases: [String])?
+    open var updateCanonicalAliasAliasAltAliasesReceivedInvocations: [(alias: String?, altAliases: [String])] = []
+    open var updateCanonicalAliasAliasAltAliasesClosure: ((String?, [String]) async throws -> Void)?
 
-    open override func updateCanonicalAlias(newAlias: String?) async throws {
-        if let error = updateCanonicalAliasNewAliasThrowableError {
+    open override func updateCanonicalAlias(alias: String?, altAliases: [String]) async throws {
+        if let error = updateCanonicalAliasAliasAltAliasesThrowableError {
             throw error
         }
-        updateCanonicalAliasNewAliasCallsCount += 1
-        updateCanonicalAliasNewAliasReceivedNewAlias = newAlias
+        updateCanonicalAliasAliasAltAliasesCallsCount += 1
+        updateCanonicalAliasAliasAltAliasesReceivedArguments = (alias: alias, altAliases: altAliases)
         DispatchQueue.main.async {
-            self.updateCanonicalAliasNewAliasReceivedInvocations.append(newAlias)
+            self.updateCanonicalAliasAliasAltAliasesReceivedInvocations.append((alias: alias, altAliases: altAliases))
         }
-        try await updateCanonicalAliasNewAliasClosure?(newAlias)
+        try await updateCanonicalAliasAliasAltAliasesClosure?(alias, altAliases)
     }
 
     //MARK: - updateHistoryVisibility
@@ -22522,6 +22672,46 @@ open class UserIdentitySDKMock: MatrixRustSDK.UserIdentity {
         }
         pinCallsCount += 1
         try await pinClosure?()
+    }
+
+    //MARK: - withdrawVerification
+
+    open var withdrawVerificationThrowableError: Error?
+    var withdrawVerificationUnderlyingCallsCount = 0
+    open var withdrawVerificationCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return withdrawVerificationUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = withdrawVerificationUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                withdrawVerificationUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    withdrawVerificationUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var withdrawVerificationCalled: Bool {
+        return withdrawVerificationCallsCount > 0
+    }
+    open var withdrawVerificationClosure: (() async throws -> Void)?
+
+    open override func withdrawVerification() async throws {
+        if let error = withdrawVerificationThrowableError {
+            throw error
+        }
+        withdrawVerificationCallsCount += 1
+        try await withdrawVerificationClosure?()
     }
 }
 open class WidgetDriverSDKMock: MatrixRustSDK.WidgetDriver {

--- a/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
@@ -625,52 +625,6 @@ open class ClientSDKMock: MatrixRustSDK.Client {
         }
     }
 
-    //MARK: - createRoomAlias
-
-    open var createRoomAliasRoomAliasRoomIdThrowableError: Error?
-    var createRoomAliasRoomAliasRoomIdUnderlyingCallsCount = 0
-    open var createRoomAliasRoomAliasRoomIdCallsCount: Int {
-        get {
-            if Thread.isMainThread {
-                return createRoomAliasRoomAliasRoomIdUnderlyingCallsCount
-            } else {
-                var returnValue: Int? = nil
-                DispatchQueue.main.sync {
-                    returnValue = createRoomAliasRoomAliasRoomIdUnderlyingCallsCount
-                }
-
-                return returnValue!
-            }
-        }
-        set {
-            if Thread.isMainThread {
-                createRoomAliasRoomAliasRoomIdUnderlyingCallsCount = newValue
-            } else {
-                DispatchQueue.main.sync {
-                    createRoomAliasRoomAliasRoomIdUnderlyingCallsCount = newValue
-                }
-            }
-        }
-    }
-    open var createRoomAliasRoomAliasRoomIdCalled: Bool {
-        return createRoomAliasRoomAliasRoomIdCallsCount > 0
-    }
-    open var createRoomAliasRoomAliasRoomIdReceivedArguments: (roomAlias: String, roomId: String)?
-    open var createRoomAliasRoomAliasRoomIdReceivedInvocations: [(roomAlias: String, roomId: String)] = []
-    open var createRoomAliasRoomAliasRoomIdClosure: ((String, String) async throws -> Void)?
-
-    open override func createRoomAlias(roomAlias: String, roomId: String) async throws {
-        if let error = createRoomAliasRoomAliasRoomIdThrowableError {
-            throw error
-        }
-        createRoomAliasRoomAliasRoomIdCallsCount += 1
-        createRoomAliasRoomAliasRoomIdReceivedArguments = (roomAlias: roomAlias, roomId: roomId)
-        DispatchQueue.main.async {
-            self.createRoomAliasRoomAliasRoomIdReceivedInvocations.append((roomAlias: roomAlias, roomId: roomId))
-        }
-        try await createRoomAliasRoomAliasRoomIdClosure?(roomAlias, roomId)
-    }
-
     //MARK: - customLoginWithJwt
 
     open var customLoginWithJwtJwtInitialDeviceNameDeviceIdThrowableError: Error?
@@ -11326,6 +11280,46 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         try await editEventIdNewContentClosure?(eventId, newContent)
     }
 
+    //MARK: - enableEncryption
+
+    open var enableEncryptionThrowableError: Error?
+    var enableEncryptionUnderlyingCallsCount = 0
+    open var enableEncryptionCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return enableEncryptionUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = enableEncryptionUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                enableEncryptionUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    enableEncryptionUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var enableEncryptionCalled: Bool {
+        return enableEncryptionCallsCount > 0
+    }
+    open var enableEncryptionClosure: (() async throws -> Void)?
+
+    open override func enableEncryption() async throws {
+        if let error = enableEncryptionThrowableError {
+            throw error
+        }
+        enableEncryptionCallsCount += 1
+        try await enableEncryptionClosure?()
+    }
+
     //MARK: - enableSendQueue
 
     var enableSendQueueEnableUnderlyingCallsCount = 0
@@ -11434,6 +11428,75 @@ open class RoomSDKMock: MatrixRustSDK.Room {
             return try await getPowerLevelsClosure()
         } else {
             return getPowerLevelsReturnValue
+        }
+    }
+
+    //MARK: - getRoomVisibility
+
+    open var getRoomVisibilityThrowableError: Error?
+    var getRoomVisibilityUnderlyingCallsCount = 0
+    open var getRoomVisibilityCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return getRoomVisibilityUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = getRoomVisibilityUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                getRoomVisibilityUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    getRoomVisibilityUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var getRoomVisibilityCalled: Bool {
+        return getRoomVisibilityCallsCount > 0
+    }
+
+    var getRoomVisibilityUnderlyingReturnValue: RoomVisibility!
+    open var getRoomVisibilityReturnValue: RoomVisibility! {
+        get {
+            if Thread.isMainThread {
+                return getRoomVisibilityUnderlyingReturnValue
+            } else {
+                var returnValue: RoomVisibility? = nil
+                DispatchQueue.main.sync {
+                    returnValue = getRoomVisibilityUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                getRoomVisibilityUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    getRoomVisibilityUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    open var getRoomVisibilityClosure: (() async throws -> RoomVisibility)?
+
+    open override func getRoomVisibility() async throws -> RoomVisibility {
+        if let error = getRoomVisibilityThrowableError {
+            throw error
+        }
+        getRoomVisibilityCallsCount += 1
+        if let getRoomVisibilityClosure = getRoomVisibilityClosure {
+            return try await getRoomVisibilityClosure()
+        } else {
+            return getRoomVisibilityReturnValue
         }
     }
 
@@ -14863,6 +14926,144 @@ open class RoomSDKMock: MatrixRustSDK.Room {
         try await unbanUserUserIdReasonClosure?(userId, reason)
     }
 
+    //MARK: - updateCanonicalAlias
+
+    open var updateCanonicalAliasNewAliasThrowableError: Error?
+    var updateCanonicalAliasNewAliasUnderlyingCallsCount = 0
+    open var updateCanonicalAliasNewAliasCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return updateCanonicalAliasNewAliasUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = updateCanonicalAliasNewAliasUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                updateCanonicalAliasNewAliasUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    updateCanonicalAliasNewAliasUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var updateCanonicalAliasNewAliasCalled: Bool {
+        return updateCanonicalAliasNewAliasCallsCount > 0
+    }
+    open var updateCanonicalAliasNewAliasReceivedNewAlias: String?
+    open var updateCanonicalAliasNewAliasReceivedInvocations: [String?] = []
+    open var updateCanonicalAliasNewAliasClosure: ((String?) async throws -> Void)?
+
+    open override func updateCanonicalAlias(newAlias: String?) async throws {
+        if let error = updateCanonicalAliasNewAliasThrowableError {
+            throw error
+        }
+        updateCanonicalAliasNewAliasCallsCount += 1
+        updateCanonicalAliasNewAliasReceivedNewAlias = newAlias
+        DispatchQueue.main.async {
+            self.updateCanonicalAliasNewAliasReceivedInvocations.append(newAlias)
+        }
+        try await updateCanonicalAliasNewAliasClosure?(newAlias)
+    }
+
+    //MARK: - updateHistoryVisibility
+
+    open var updateHistoryVisibilityVisibilityThrowableError: Error?
+    var updateHistoryVisibilityVisibilityUnderlyingCallsCount = 0
+    open var updateHistoryVisibilityVisibilityCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return updateHistoryVisibilityVisibilityUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = updateHistoryVisibilityVisibilityUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                updateHistoryVisibilityVisibilityUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    updateHistoryVisibilityVisibilityUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var updateHistoryVisibilityVisibilityCalled: Bool {
+        return updateHistoryVisibilityVisibilityCallsCount > 0
+    }
+    open var updateHistoryVisibilityVisibilityReceivedVisibility: RoomHistoryVisibility?
+    open var updateHistoryVisibilityVisibilityReceivedInvocations: [RoomHistoryVisibility] = []
+    open var updateHistoryVisibilityVisibilityClosure: ((RoomHistoryVisibility) async throws -> Void)?
+
+    open override func updateHistoryVisibility(visibility: RoomHistoryVisibility) async throws {
+        if let error = updateHistoryVisibilityVisibilityThrowableError {
+            throw error
+        }
+        updateHistoryVisibilityVisibilityCallsCount += 1
+        updateHistoryVisibilityVisibilityReceivedVisibility = visibility
+        DispatchQueue.main.async {
+            self.updateHistoryVisibilityVisibilityReceivedInvocations.append(visibility)
+        }
+        try await updateHistoryVisibilityVisibilityClosure?(visibility)
+    }
+
+    //MARK: - updateJoinRules
+
+    open var updateJoinRulesNewRuleThrowableError: Error?
+    var updateJoinRulesNewRuleUnderlyingCallsCount = 0
+    open var updateJoinRulesNewRuleCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return updateJoinRulesNewRuleUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = updateJoinRulesNewRuleUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                updateJoinRulesNewRuleUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    updateJoinRulesNewRuleUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var updateJoinRulesNewRuleCalled: Bool {
+        return updateJoinRulesNewRuleCallsCount > 0
+    }
+    open var updateJoinRulesNewRuleReceivedNewRule: JoinRule?
+    open var updateJoinRulesNewRuleReceivedInvocations: [JoinRule] = []
+    open var updateJoinRulesNewRuleClosure: ((JoinRule) async throws -> Void)?
+
+    open override func updateJoinRules(newRule: JoinRule) async throws {
+        if let error = updateJoinRulesNewRuleThrowableError {
+            throw error
+        }
+        updateJoinRulesNewRuleCallsCount += 1
+        updateJoinRulesNewRuleReceivedNewRule = newRule
+        DispatchQueue.main.async {
+            self.updateJoinRulesNewRuleReceivedInvocations.append(newRule)
+        }
+        try await updateJoinRulesNewRuleClosure?(newRule)
+    }
+
     //MARK: - updatePowerLevelsForUsers
 
     open var updatePowerLevelsForUsersUpdatesThrowableError: Error?
@@ -14907,6 +15108,52 @@ open class RoomSDKMock: MatrixRustSDK.Room {
             self.updatePowerLevelsForUsersUpdatesReceivedInvocations.append(updates)
         }
         try await updatePowerLevelsForUsersUpdatesClosure?(updates)
+    }
+
+    //MARK: - updateRoomVisibility
+
+    open var updateRoomVisibilityVisibilityThrowableError: Error?
+    var updateRoomVisibilityVisibilityUnderlyingCallsCount = 0
+    open var updateRoomVisibilityVisibilityCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return updateRoomVisibilityVisibilityUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = updateRoomVisibilityVisibilityUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                updateRoomVisibilityVisibilityUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    updateRoomVisibilityVisibilityUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var updateRoomVisibilityVisibilityCalled: Bool {
+        return updateRoomVisibilityVisibilityCallsCount > 0
+    }
+    open var updateRoomVisibilityVisibilityReceivedVisibility: RoomVisibility?
+    open var updateRoomVisibilityVisibilityReceivedInvocations: [RoomVisibility] = []
+    open var updateRoomVisibilityVisibilityClosure: ((RoomVisibility) async throws -> Void)?
+
+    open override func updateRoomVisibility(visibility: RoomVisibility) async throws {
+        if let error = updateRoomVisibilityVisibilityThrowableError {
+            throw error
+        }
+        updateRoomVisibilityVisibilityCallsCount += 1
+        updateRoomVisibilityVisibilityReceivedVisibility = visibility
+        DispatchQueue.main.async {
+            self.updateRoomVisibilityVisibilityReceivedInvocations.append(visibility)
+        }
+        try await updateRoomVisibilityVisibilityClosure?(visibility)
     }
 
     //MARK: - uploadAvatar

--- a/ElementX/Sources/Mocks/InvitedRoomProxyMock.swift
+++ b/ElementX/Sources/Mocks/InvitedRoomProxyMock.swift
@@ -60,7 +60,8 @@ extension RoomInfo {
                   numUnreadNotifications: 0,
                   numUnreadMentions: 0,
                   pinnedEventIds: [],
-                  joinRule: .invite)
+                  joinRule: .invite,
+                  historyVisibility: nil)
     }
 }
 

--- a/ElementX/Sources/Mocks/InvitedRoomProxyMock.swift
+++ b/ElementX/Sources/Mocks/InvitedRoomProxyMock.swift
@@ -61,7 +61,7 @@ extension RoomInfo {
                   numUnreadMentions: 0,
                   pinnedEventIds: [],
                   joinRule: .invite,
-                  historyVisibility: nil)
+                  historyVisibility: .shared)
     }
 }
 

--- a/ElementX/Sources/Mocks/JoinedRoomProxyMock.swift
+++ b/ElementX/Sources/Mocks/JoinedRoomProxyMock.swift
@@ -41,6 +41,7 @@ struct JoinedRoomProxyMockConfiguration {
     
     var shouldUseAutoUpdatingTimeline = false
     var joinRule: JoinRule?
+    var isVisibleInPublicDirectory = false
 }
 
 extension JoinedRoomProxyMock {
@@ -127,6 +128,7 @@ extension JoinedRoomProxyMock {
         loadDraftReturnValue = .success(nil)
         clearDraftReturnValue = .success(())
         sendTypingNotificationIsTypingReturnValue = .success(())
+        isVisibleInRoomDirectoryReturnValue = .success(configuration.isVisibleInPublicDirectory)
     }
 }
 
@@ -171,6 +173,6 @@ extension RoomInfo {
                   numUnreadMentions: 0,
                   pinnedEventIds: Array(configuration.pinnedEventIDs),
                   joinRule: configuration.joinRule,
-                  historyVisibility: nil)
+                  historyVisibility: .shared)
     }
 }

--- a/ElementX/Sources/Mocks/JoinedRoomProxyMock.swift
+++ b/ElementX/Sources/Mocks/JoinedRoomProxyMock.swift
@@ -170,6 +170,7 @@ extension RoomInfo {
                   numUnreadNotifications: 0,
                   numUnreadMentions: 0,
                   pinnedEventIds: Array(configuration.pinnedEventIDs),
-                  joinRule: configuration.joinRule)
+                  joinRule: configuration.joinRule,
+                  historyVisibility: nil)
     }
 }

--- a/ElementX/Sources/Mocks/KnockedRoomProxyMock.swift
+++ b/ElementX/Sources/Mocks/KnockedRoomProxyMock.swift
@@ -59,6 +59,6 @@ extension RoomInfo {
                   numUnreadMentions: 0,
                   pinnedEventIds: [],
                   joinRule: .knock,
-                  historyVisibility: nil)
+                  historyVisibility: .shared)
     }
 }

--- a/ElementX/Sources/Mocks/KnockedRoomProxyMock.swift
+++ b/ElementX/Sources/Mocks/KnockedRoomProxyMock.swift
@@ -58,6 +58,7 @@ extension RoomInfo {
                   numUnreadNotifications: 0,
                   numUnreadMentions: 0,
                   pinnedEventIds: [],
-                  joinRule: .knock)
+                  joinRule: .knock,
+                  historyVisibility: nil)
     }
 }

--- a/ElementX/Sources/Other/Extensions/String.swift
+++ b/ElementX/Sources/Other/Extensions/String.swift
@@ -97,3 +97,15 @@ extension String {
         trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 }
+
+extension String {
+    static func makeCanonicalAlias(aliasLocalPart: Self?, serverName: Self?) -> Self? {
+        guard let aliasLocalPart = aliasLocalPart,
+              !aliasLocalPart.isEmpty,
+              let serverName = serverName,
+              !serverName.isEmpty else {
+            return nil
+        }
+        return "#\(aliasLocalPart):\(serverName)"
+    }
+}

--- a/ElementX/Sources/Other/Extensions/String.swift
+++ b/ElementX/Sources/Other/Extensions/String.swift
@@ -100,10 +100,8 @@ extension String {
 
 extension String {
     static func makeCanonicalAlias(aliasLocalPart: Self?, serverName: Self?) -> Self? {
-        guard let aliasLocalPart = aliasLocalPart,
-              !aliasLocalPart.isEmpty,
-              let serverName = serverName,
-              !serverName.isEmpty else {
+        guard let aliasLocalPart, !aliasLocalPart.isEmpty,
+              let serverName, !serverName.isEmpty else {
             return nil
         }
         return "#\(aliasLocalPart):\(serverName)"

--- a/ElementX/Sources/Other/SwiftUI/Views/EditRoomAddressListRow.swift
+++ b/ElementX/Sources/Other/SwiftUI/Views/EditRoomAddressListRow.swift
@@ -1,0 +1,64 @@
+//
+// Copyright 2024 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+// Please see LICENSE in the repository root for full details.
+//
+
+import Compound
+import SwiftUI
+
+struct EditRoomAddressListRow: View {
+    @Binding var aliasLocalPart: String
+    var serverName: String
+    var shouldDisplayError: Bool
+    
+    var body: some View {
+        ListRow(kind: .custom {
+            HStack(spacing: 0) {
+                Text("#")
+                    .font(.compound.bodyLG)
+                    .foregroundStyle(.compound.textSecondary)
+                TextField("", text: $aliasLocalPart)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .textContentType(.URL)
+                    .tint(.compound.iconAccentTertiary)
+                    .font(.compound.bodyLG)
+                    .foregroundStyle(.compound.textPrimary)
+                    .padding(.horizontal, 8)
+                Text(":\(serverName)")
+                    .font(.compound.bodyLG)
+                    .foregroundStyle(.compound.textSecondary)
+            }
+            .padding(ListRowPadding.textFieldInsets)
+            .environment(\.layoutDirection, .leftToRight)
+            .errorBackground(shouldDisplayError)
+        })
+    }
+}
+
+private extension View {
+    func errorBackground(_ shouldDisplay: Bool) -> some View {
+        listRowBackground(shouldDisplay ? AnyView(RoundedRectangle(cornerRadius: 10)
+                .inset(by: 1)
+                .fill(.compound.bgCriticalSubtleHovered)
+                .stroke(Color.compound.borderCriticalPrimary)) : AnyView(Color.compound.bgCanvasDefaultLevel1))
+    }
+}
+
+enum EditRoomAddressErrorState {
+    case alreadyExists
+    case invalidSymbols
+}
+
+extension Set<EditRoomAddressErrorState> {
+    var errorDescription: String? {
+        if contains(.alreadyExists) {
+            return L10n.errorRoomAddressAlreadyExists
+        } else if contains(.invalidSymbols) {
+            return L10n.errorRoomAddressInvalidSymbols
+        }
+        return nil
+    }
+}

--- a/ElementX/Sources/Screens/CreateRoom/CreateRoomModels.swift
+++ b/ElementX/Sources/Screens/CreateRoom/CreateRoomModels.swift
@@ -72,3 +72,14 @@ enum CreateRoomAliasErrorState {
     case alreadyExists
     case invalidSymbols
 }
+
+extension Set<CreateRoomAliasErrorState> {
+    var errorDescription: String? {
+        if contains(.alreadyExists) {
+            return L10n.errorRoomAddressAlreadyExists
+        } else if contains(.invalidSymbols) {
+            return L10n.errorRoomAddressInvalidSymbols
+        }
+        return nil
+    }
+}

--- a/ElementX/Sources/Screens/CreateRoom/CreateRoomViewModel.swift
+++ b/ElementX/Sources/Screens/CreateRoom/CreateRoomViewModel.swift
@@ -212,7 +212,7 @@ class CreateRoomViewModel: CreateRoomViewModelType, CreateRoomViewModelProtocol 
         if state.isKnockingFeatureEnabled, !createRoomParameters.isRoomPrivate {
             guard let canonicalAlias = String.makeCanonicalAlias(aliasLocalPart: createRoomParameters.aliasLocalPart,
                                                                  serverName: state.serverName),
-                  isRoomAliasFormatValid(alias: canonicalAlias) else {
+                isRoomAliasFormatValid(alias: canonicalAlias) else {
                 state.aliasErrors = [.invalidSymbols]
                 return
             }

--- a/ElementX/Sources/Screens/CreateRoom/CreateRoomViewModel.swift
+++ b/ElementX/Sources/Screens/CreateRoom/CreateRoomViewModel.swift
@@ -154,7 +154,8 @@ class CreateRoomViewModel: CreateRoomViewModelType, CreateRoomViewModelProtocol 
                 
                 guard state.isKnockingFeatureEnabled,
                       !state.bindings.isRoomPrivate,
-                      let canonicalAlias = canonicalAlias(aliasLocalPart: aliasLocalPart) else {
+                      let canonicalAlias = String.makeCanonicalAlias(aliasLocalPart: aliasLocalPart,
+                                                                     serverName: state.serverName) else {
                     // While is empty or private room we don't change or display the error
                     return
                 }
@@ -209,7 +210,8 @@ class CreateRoomViewModel: CreateRoomViewModelType, CreateRoomViewModelProtocol 
         
         // Better to double check the errors also when trying to create the room
         if state.isKnockingFeatureEnabled, !createRoomParameters.isRoomPrivate {
-            guard let canonicalAlias = canonicalAlias(aliasLocalPart: createRoomParameters.aliasLocalPart),
+            guard let canonicalAlias = String.makeCanonicalAlias(aliasLocalPart: createRoomParameters.aliasLocalPart,
+                                                                 serverName: state.serverName),
                   isRoomAliasFormatValid(alias: canonicalAlias) else {
                 state.aliasErrors = [.invalidSymbols]
                 return
@@ -269,14 +271,6 @@ class CreateRoomViewModel: CreateRoomViewModelType, CreateRoomViewModelProtocol 
                                                  title: L10n.commonError,
                                                  message: L10n.screenStartChatErrorStartingChat)
         }
-    }
-    
-    private func canonicalAlias(aliasLocalPart: String?) -> String? {
-        guard let aliasLocalPart,
-              !aliasLocalPart.isEmpty else {
-            return nil
-        }
-        return "#\(aliasLocalPart):\(state.serverName)"
     }
     
     // MARK: Loading indicator

--- a/ElementX/Sources/Screens/CreateRoom/CreateRoomViewModel.swift
+++ b/ElementX/Sources/Screens/CreateRoom/CreateRoomViewModel.swift
@@ -271,7 +271,7 @@ class CreateRoomViewModel: CreateRoomViewModelType, CreateRoomViewModelProtocol 
         }
     }
     
-    func canonicalAlias(aliasLocalPart: String?) -> String? {
+    private func canonicalAlias(aliasLocalPart: String?) -> String? {
         guard let aliasLocalPart,
               !aliasLocalPart.isEmpty else {
             return nil

--- a/ElementX/Sources/Screens/CreateRoom/View/CreateRoomScreen.swift
+++ b/ElementX/Sources/Screens/CreateRoom/View/CreateRoomScreen.swift
@@ -190,35 +190,17 @@ struct CreateRoomScreen: View {
     
     private var roomAliasSection: some View {
         Section {
-            ListRow(kind: .custom {
-                HStack(spacing: 0) {
-                    Text("#")
-                        .font(.compound.bodyLG)
-                        .foregroundStyle(.compound.textSecondary)
-                    TextField("", text: aliasBinding)
-                        .textInputAutocapitalization(.never)
-                        .autocorrectionDisabled()
-                        .textContentType(.URL)
-                        .focused($focus, equals: .alias)
-                        .tint(.compound.iconAccentTertiary)
-                        .font(.compound.bodyLG)
-                        .foregroundStyle(.compound.textPrimary)
-                        .padding(.horizontal, 8)
-                    Text(":\(context.viewState.serverName)")
-                        .font(.compound.bodyLG)
-                        .foregroundStyle(.compound.textSecondary)
-                }
-                .padding(ListRowPadding.textFieldInsets)
-                .environment(\.layoutDirection, .leftToRight)
-                .errorBackground(!context.viewState.aliasErrors.isEmpty)
-            })
-            .id(Focus.alias)
+            EditRoomAddressListRow(aliasLocalPart: aliasBinding,
+                                   serverName: context.viewState.serverName,
+                                   shouldDisplayError: context.viewState.aliasErrors.errorDescription != nil)
+                .focused($focus, equals: .alias)
+                .id(Focus.alias)
         } header: {
             Text(L10n.screenCreateRoomRoomAddressSectionTitle)
                 .compoundListSectionHeader()
         } footer: {
             VStack(alignment: .leading, spacing: 12) {
-                if let errorDescription = context.viewState.aliasErrorDescription {
+                if let errorDescription = context.viewState.aliasErrors.errorDescription {
                     Label(errorDescription, icon: \.error, iconSize: .xSmall, relativeTo: .compound.bodySM)
                         .foregroundStyle(.compound.textCriticalPrimary)
                         .font(.compound.bodySM)
@@ -238,15 +220,6 @@ struct CreateRoomScreen: View {
             }
             .disabled(!context.viewState.canCreateRoom)
         }
-    }
-}
-
-private extension View {
-    func errorBackground(_ shouldDisplay: Bool) -> some View {
-        listRowBackground(shouldDisplay ? AnyView(RoundedRectangle(cornerRadius: 10)
-                .inset(by: 1)
-                .fill(.compound.bgCriticalSubtleHovered)
-                .stroke(Color.compound.borderCriticalPrimary)) : AnyView(Color.compound.bgCanvasDefaultLevel1))
     }
 }
 

--- a/ElementX/Sources/Screens/EditRoomAddressScreen/EditRoomAddressScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/EditRoomAddressScreen/EditRoomAddressScreenCoordinator.swift
@@ -17,7 +17,7 @@ struct EditRoomAddressScreenCoordinatorParameters {
 }
 
 enum EditRoomAddressScreenCoordinatorAction {
-    case done
+    case dismiss
 }
 
 final class EditRoomAddressScreenCoordinator: CoordinatorProtocol {
@@ -42,8 +42,8 @@ final class EditRoomAddressScreenCoordinator: CoordinatorProtocol {
             
             guard let self else { return }
             switch action {
-            case .done:
-                actionsSubject.send(.done)
+            case .cancel:
+                actionsSubject.send(.dismiss)
             }
         }
         .store(in: &cancellables)

--- a/ElementX/Sources/Screens/EditRoomAddressScreen/EditRoomAddressScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/EditRoomAddressScreen/EditRoomAddressScreenCoordinator.swift
@@ -1,0 +1,55 @@
+//
+// Copyright 2022-2024 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+// Please see LICENSE in the repository root for full details.
+//
+
+// periphery:ignore:all - this is just a editRoomAddress remove this comment once generating the final file
+
+import Combine
+import SwiftUI
+
+struct EditRoomAddressScreenCoordinatorParameters {
+    let roomProxy: JoinedRoomProxyProtocol
+    let clientProxy: ClientProxyProtocol
+    let userIndicatorController: UserIndicatorControllerProtocol
+}
+
+enum EditRoomAddressScreenCoordinatorAction {
+    case done
+}
+
+final class EditRoomAddressScreenCoordinator: CoordinatorProtocol {
+    private let viewModel: EditRoomAddressScreenViewModelProtocol
+    
+    private var cancellables = Set<AnyCancellable>()
+ 
+    private let actionsSubject: PassthroughSubject<EditRoomAddressScreenCoordinatorAction, Never> = .init()
+    var actionsPublisher: AnyPublisher<EditRoomAddressScreenCoordinatorAction, Never> {
+        actionsSubject.eraseToAnyPublisher()
+    }
+    
+    init(parameters: EditRoomAddressScreenCoordinatorParameters) {
+        viewModel = EditRoomAddressScreenViewModel(roomProxy: parameters.roomProxy,
+                                                   clientProxy: parameters.clientProxy,
+                                                   userIndicatorController: parameters.userIndicatorController)
+    }
+    
+    func start() {
+        viewModel.actionsPublisher.sink { [weak self] action in
+            MXLog.info("Coordinator: received view model action: \(action)")
+            
+            guard let self else { return }
+            switch action {
+            case .done:
+                actionsSubject.send(.done)
+            }
+        }
+        .store(in: &cancellables)
+    }
+        
+    func toPresentable() -> AnyView {
+        AnyView(EditRoomAddressScreen(context: viewModel.context))
+    }
+}

--- a/ElementX/Sources/Screens/EditRoomAddressScreen/EditRoomAddressScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/EditRoomAddressScreen/EditRoomAddressScreenCoordinator.swift
@@ -42,7 +42,7 @@ final class EditRoomAddressScreenCoordinator: CoordinatorProtocol {
             
             guard let self else { return }
             switch action {
-            case .cancel:
+            case .dismiss:
                 actionsSubject.send(.dismiss)
             }
         }

--- a/ElementX/Sources/Screens/EditRoomAddressScreen/EditRoomAddressScreenModels.swift
+++ b/ElementX/Sources/Screens/EditRoomAddressScreen/EditRoomAddressScreenModels.swift
@@ -14,18 +14,22 @@ enum EditRoomAddressScreenViewModelAction {
 struct EditRoomAddressScreenViewState: BindableState {
     let serverName: String
     var currentAliasLocalPart: String?
-    var desiredAliasLocalPart: String
     var aliasErrors: Set<EditRoomAddressErrorState> = []
     
     var canSave: Bool {
-        currentAliasLocalPart != desiredAliasLocalPart &&
-            !aliasErrors.isEmpty &&
-            !desiredAliasLocalPart.isEmpty
+        currentAliasLocalPart != bindings.desiredAliasLocalPart &&
+            aliasErrors.isEmpty &&
+            !bindings.desiredAliasLocalPart.isEmpty
     }
+    
+    var bindings: EditRoomAddressScreenViewStateBindings
+}
+
+struct EditRoomAddressScreenViewStateBindings {
+    var desiredAliasLocalPart: String
 }
 
 enum EditRoomAddressScreenViewAction {
     case save
     case cancel
-    case updateAliasLocalPart(String)
 }

--- a/ElementX/Sources/Screens/EditRoomAddressScreen/EditRoomAddressScreenModels.swift
+++ b/ElementX/Sources/Screens/EditRoomAddressScreen/EditRoomAddressScreenModels.swift
@@ -8,18 +8,24 @@
 import Foundation
 
 enum EditRoomAddressScreenViewModelAction {
-    case done
+    case cancel
 }
 
 struct EditRoomAddressScreenViewState: BindableState {
     let serverName: String
-    var bindings: EditRoomAddressScreenViewStateBindings
-}
-
-struct EditRoomAddressScreenViewStateBindings {
-    var aliasLocalPart: String
+    var currentAliasLocalPart: String?
+    var desiredAliasLocalPart: String
+    var aliasErrors: Set<EditRoomAddressErrorState> = []
+    
+    var canSave: Bool {
+        currentAliasLocalPart != desiredAliasLocalPart &&
+            !aliasErrors.isEmpty &&
+            !desiredAliasLocalPart.isEmpty
+    }
 }
 
 enum EditRoomAddressScreenViewAction {
-    case done
+    case save
+    case cancel
+    case updateAliasLocalPart(String)
 }

--- a/ElementX/Sources/Screens/EditRoomAddressScreen/EditRoomAddressScreenModels.swift
+++ b/ElementX/Sources/Screens/EditRoomAddressScreen/EditRoomAddressScreenModels.swift
@@ -1,0 +1,25 @@
+//
+// Copyright 2022-2024 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+// Please see LICENSE in the repository root for full details.
+//
+
+import Foundation
+
+enum EditRoomAddressScreenViewModelAction {
+    case done
+}
+
+struct EditRoomAddressScreenViewState: BindableState {
+    let serverName: String
+    var bindings: EditRoomAddressScreenViewStateBindings
+}
+
+struct EditRoomAddressScreenViewStateBindings {
+    var aliasLocalPart: String
+}
+
+enum EditRoomAddressScreenViewAction {
+    case done
+}

--- a/ElementX/Sources/Screens/EditRoomAddressScreen/EditRoomAddressScreenModels.swift
+++ b/ElementX/Sources/Screens/EditRoomAddressScreen/EditRoomAddressScreenModels.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum EditRoomAddressScreenViewModelAction {
-    case cancel
+    case dismiss
 }
 
 struct EditRoomAddressScreenViewState: BindableState {

--- a/ElementX/Sources/Screens/EditRoomAddressScreen/EditRoomAddressScreenViewModel.swift
+++ b/ElementX/Sources/Screens/EditRoomAddressScreen/EditRoomAddressScreenViewModel.swift
@@ -1,0 +1,52 @@
+//
+// Copyright 2022-2024 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+// Please see LICENSE in the repository root for full details.
+//
+
+import Combine
+import MatrixRustSDK
+import SwiftUI
+
+typealias EditRoomAddressScreenViewModelType = StateStoreViewModel<EditRoomAddressScreenViewState, EditRoomAddressScreenViewAction>
+
+class EditRoomAddressScreenViewModel: EditRoomAddressScreenViewModelType, EditRoomAddressScreenViewModelProtocol {
+    let roomProxy: JoinedRoomProxyProtocol
+    let clientProxy: ClientProxyProtocol
+    let userIndicatorController: UserIndicatorControllerProtocol
+    
+    private let actionsSubject: PassthroughSubject<EditRoomAddressScreenViewModelAction, Never> = .init()
+    var actionsPublisher: AnyPublisher<EditRoomAddressScreenViewModelAction, Never> {
+        actionsSubject.eraseToAnyPublisher()
+    }
+
+    init(roomProxy: JoinedRoomProxyProtocol,
+         clientProxy: ClientProxyProtocol,
+         userIndicatorController: UserIndicatorControllerProtocol) {
+        self.roomProxy = roomProxy
+        self.clientProxy = clientProxy
+        self.userIndicatorController = userIndicatorController
+        
+        var aliasLocalPart = ""
+        if let canonicalAlias = roomProxy.infoPublisher.value.canonicalAlias {
+            aliasLocalPart = canonicalAlias.dropFirst().split(separator: ":").first.flatMap(String.init) ?? ""
+        } else if let displayName = roomProxy.infoPublisher.value.displayName {
+            aliasLocalPart = roomAliasNameFromRoomDisplayName(roomName: displayName)
+        }
+        
+        super.init(initialViewState: EditRoomAddressScreenViewState(serverName: clientProxy.userIDServerName ?? "",
+                                                                    bindings: .init(aliasLocalPart: aliasLocalPart)))
+    }
+    
+    // MARK: - Public
+    
+    override func process(viewAction: EditRoomAddressScreenViewAction) {
+        MXLog.info("View model: received view action: \(viewAction)")
+        
+        switch viewAction {
+        case .done:
+            actionsSubject.send(.done)
+        }
+    }
+}

--- a/ElementX/Sources/Screens/EditRoomAddressScreen/EditRoomAddressScreenViewModel.swift
+++ b/ElementX/Sources/Screens/EditRoomAddressScreen/EditRoomAddressScreenViewModel.swift
@@ -157,13 +157,13 @@ class EditRoomAddressScreenViewModel: EditRoomAddressScreenViewModelType, EditRo
     private static let loadingIndicatorIdentifier = "\(EditRoomAddressScreenViewModel.self)-Loading"
     
     private func showLoadingIndicator() {
-        ServiceLocator.shared.userIndicatorController.submitIndicator(UserIndicator(id: Self.loadingIndicatorIdentifier,
-                                                                                    type: .modal,
-                                                                                    title: L10n.commonLoading,
-                                                                                    persistent: true))
+        userIndicatorController.submitIndicator(UserIndicator(id: Self.loadingIndicatorIdentifier,
+                                                              type: .modal,
+                                                              title: L10n.commonLoading,
+                                                              persistent: true))
     }
     
     private func hideLoadingIndicator() {
-        ServiceLocator.shared.userIndicatorController.retractIndicatorWithId(Self.loadingIndicatorIdentifier)
+        userIndicatorController.retractIndicatorWithId(Self.loadingIndicatorIdentifier)
     }
 }

--- a/ElementX/Sources/Screens/EditRoomAddressScreen/EditRoomAddressScreenViewModel.swift
+++ b/ElementX/Sources/Screens/EditRoomAddressScreen/EditRoomAddressScreenViewModel.swift
@@ -36,7 +36,7 @@ class EditRoomAddressScreenViewModel: EditRoomAddressScreenViewModelType, EditRo
         }
         
         super.init(initialViewState: EditRoomAddressScreenViewState(serverName: clientProxy.userIDServerName ?? "",
-                                                                    bindings: .init(aliasLocalPart: aliasLocalPart)))
+                                                                    desiredAliasLocalPart: aliasLocalPart))
     }
     
     // MARK: - Public
@@ -45,8 +45,13 @@ class EditRoomAddressScreenViewModel: EditRoomAddressScreenViewModelType, EditRo
         MXLog.info("View model: received view action: \(viewAction)")
         
         switch viewAction {
-        case .done:
-            actionsSubject.send(.done)
+        case .save:
+            // TODO: Handle the save action
+            break
+        case .cancel:
+            actionsSubject.send(.cancel)
+        case .updateAliasLocalPart(let updatedValue):
+            break
         }
     }
 }

--- a/ElementX/Sources/Screens/EditRoomAddressScreen/EditRoomAddressScreenViewModel.swift
+++ b/ElementX/Sources/Screens/EditRoomAddressScreen/EditRoomAddressScreenViewModel.swift
@@ -23,7 +23,8 @@ class EditRoomAddressScreenViewModel: EditRoomAddressScreenViewModelType, EditRo
     
     @CancellableTask private var checkAliasAvailabilityTask: Task<Void, Never>?
 
-    init(roomProxy: JoinedRoomProxyProtocol,
+    init(initialViewState: EditRoomAddressScreenViewState? = nil,
+         roomProxy: JoinedRoomProxyProtocol,
          clientProxy: ClientProxyProtocol,
          userIndicatorController: UserIndicatorControllerProtocol) {
         self.roomProxy = roomProxy
@@ -37,9 +38,13 @@ class EditRoomAddressScreenViewModel: EditRoomAddressScreenViewModelType, EditRo
             aliasLocalPart = roomAliasNameFromRoomDisplayName(roomName: displayName)
         }
         
-        super.init(initialViewState: EditRoomAddressScreenViewState(serverName: clientProxy.userIDServerName ?? "",
-                                                                    currentAliasLocalPart: aliasLocalPart,
-                                                                    bindings: .init(desiredAliasLocalPart: aliasLocalPart)))
+        if let initialViewState {
+            super.init(initialViewState: initialViewState)
+        } else {
+            super.init(initialViewState: EditRoomAddressScreenViewState(serverName: clientProxy.userIDServerName ?? "",
+                                                                        currentAliasLocalPart: aliasLocalPart,
+                                                                        bindings: .init(desiredAliasLocalPart: aliasLocalPart)))
+        }
         setupSubscriptions()
     }
     
@@ -60,7 +65,7 @@ class EditRoomAddressScreenViewModel: EditRoomAddressScreenViewModelType, EditRo
         context.$viewState
             .map(\.bindings.desiredAliasLocalPart)
             .removeDuplicates()
-            .debounce(for: 1, scheduler: DispatchQueue.main)
+            .debounce(for: 0.5, scheduler: DispatchQueue.main)
             .sink { [weak self] aliasLocalPart in
                 guard let self else {
                     return

--- a/ElementX/Sources/Screens/EditRoomAddressScreen/EditRoomAddressScreenViewModelProtocol.swift
+++ b/ElementX/Sources/Screens/EditRoomAddressScreen/EditRoomAddressScreenViewModelProtocol.swift
@@ -1,0 +1,14 @@
+//
+// Copyright 2022-2024 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+// Please see LICENSE in the repository root for full details.
+//
+
+import Combine
+
+@MainActor
+protocol EditRoomAddressScreenViewModelProtocol {
+    var actionsPublisher: AnyPublisher<EditRoomAddressScreenViewModelAction, Never> { get }
+    var context: EditRoomAddressScreenViewModelType.Context { get }
+}

--- a/ElementX/Sources/Screens/EditRoomAddressScreen/View/EditRoomAddressScreen.swift
+++ b/ElementX/Sources/Screens/EditRoomAddressScreen/View/EditRoomAddressScreen.swift
@@ -11,24 +11,74 @@ import SwiftUI
 struct EditRoomAddressScreen: View {
     @ObservedObject var context: EditRoomAddressScreenViewModel.Context
     
+    private var aliasBinding: Binding<String> {
+        .init(get: {
+            context.viewState.desiredAliasLocalPart
+        }, set: {
+            context.send(viewAction: .updateAliasLocalPart($0))
+        })
+    }
+    
     var body: some View {
         Form {
-            EmptyView()
+            Section {
+                EditRoomAddressListRow(aliasLocalPart: aliasBinding,
+                                       serverName: context.viewState.serverName, shouldDisplayError: context.viewState.aliasErrors.errorDescription != nil)
+            } footer: {
+                VStack(alignment: .leading, spacing: 12) {
+                    if let errorDescription = context.viewState.aliasErrors.errorDescription {
+                        Label(errorDescription, icon: \.error, iconSize: .xSmall, relativeTo: .compound.bodySM)
+                            .foregroundStyle(.compound.textCriticalPrimary)
+                            .font(.compound.bodySM)
+                    }
+                    Text(L10n.screenCreateRoomRoomAddressSectionFooter)
+                        .compoundListSectionFooter()
+                        .font(.compound.bodySM)
+                }
+            }
         }
         .compoundList()
         .navigationBarTitleDisplayMode(.inline)
+        .navigationTitle(L10n.screenEditRoomAddressTitle)
+        .toolbar { toolbar }
+    }
+    
+    @ToolbarContentBuilder
+    var toolbar: some ToolbarContent {
+        ToolbarItem(placement: .confirmationAction) {
+            Button(L10n.actionSave) {
+                context.send(viewAction: .save)
+            }
+            .disabled(!context.viewState.canSave)
+        }
+        ToolbarItem(placement: .cancellationAction) {
+            Button(L10n.actionCreate) {
+                context.send(viewAction: .save)
+            }
+        }
     }
 }
 
 // MARK: - Previews
 
 struct EditRoomAddressScreen_Previews: PreviewProvider, TestablePreview {
-    static let viewModel = EditRoomAddressScreenViewModel(roomProxy: JoinedRoomProxyMock(.init()),
-                                                          clientProxy: ClientProxyMock(.init()),
-                                                          userIndicatorController: UserIndicatorControllerMock())
+    static let noAliasviewModel = EditRoomAddressScreenViewModel(roomProxy: JoinedRoomProxyMock(.init(name: "Room Name")),
+                                                                 clientProxy: ClientProxyMock(.init(userIDServerName: "matrix.org")),
+                                                                 userIndicatorController: UserIndicatorControllerMock())
+    
+    static let aliasviewModel = EditRoomAddressScreenViewModel(roomProxy: JoinedRoomProxyMock(.init(name: "Room Name", canonicalAlias: "#room-alias:matrix.org")),
+                                                               clientProxy: ClientProxyMock(.init(userIDServerName: "matrix.org")),
+                                                               userIndicatorController: UserIndicatorControllerMock())
+    
     static var previews: some View {
         NavigationStack {
-            EditRoomAddressScreen(context: viewModel.context)
+            EditRoomAddressScreen(context: noAliasviewModel.context)
         }
+        .previewDisplayName("No alias")
+        
+        NavigationStack {
+            EditRoomAddressScreen(context: aliasviewModel.context)
+        }
+        .previewDisplayName("With alias")
     }
 }

--- a/ElementX/Sources/Screens/EditRoomAddressScreen/View/EditRoomAddressScreen.swift
+++ b/ElementX/Sources/Screens/EditRoomAddressScreen/View/EditRoomAddressScreen.swift
@@ -1,0 +1,34 @@
+//
+// Copyright 2022-2024 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+// Please see LICENSE in the repository root for full details.
+//
+
+import Compound
+import SwiftUI
+
+struct EditRoomAddressScreen: View {
+    @ObservedObject var context: EditRoomAddressScreenViewModel.Context
+    
+    var body: some View {
+        Form {
+            EmptyView()
+        }
+        .compoundList()
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+// MARK: - Previews
+
+struct EditRoomAddressScreen_Previews: PreviewProvider, TestablePreview {
+    static let viewModel = EditRoomAddressScreenViewModel(roomProxy: JoinedRoomProxyMock(.init()),
+                                                          clientProxy: ClientProxyMock(.init()),
+                                                          userIndicatorController: UserIndicatorControllerMock())
+    static var previews: some View {
+        NavigationStack {
+            EditRoomAddressScreen(context: viewModel.context)
+        }
+    }
+}

--- a/ElementX/Sources/Screens/EditRoomAddressScreen/View/EditRoomAddressScreen.swift
+++ b/ElementX/Sources/Screens/EditRoomAddressScreen/View/EditRoomAddressScreen.swift
@@ -91,11 +91,17 @@ struct EditRoomAddressScreen_Previews: PreviewProvider, TestablePreview {
         NavigationStack {
             EditRoomAddressScreen(context: invalidSymbolsViewModel.context)
         }
+        .snapshotPreferences(expect: invalidSymbolsViewModel.context.$viewState.map { state in
+            !state.aliasErrors.isEmpty
+        })
         .previewDisplayName("Invalid symbols")
         
         NavigationStack {
             EditRoomAddressScreen(context: alreadyExistingViewModel.context)
         }
+        .snapshotPreferences(expect: alreadyExistingViewModel.context.$viewState.map { state in
+            !state.aliasErrors.isEmpty
+        })
         .previewDisplayName("Already existing")
     }
 }

--- a/ElementX/Sources/Screens/EditRoomAddressScreen/View/EditRoomAddressScreen.swift
+++ b/ElementX/Sources/Screens/EditRoomAddressScreen/View/EditRoomAddressScreen.swift
@@ -77,7 +77,9 @@ struct EditRoomAddressScreen_Previews: PreviewProvider, TestablePreview {
     static let alreadyExistingViewModel = {
         let clientProxy = ClientProxyMock(.init(userIDServerName: "matrix.org"))
         clientProxy.isAliasAvailableReturnValue = .success(false)
-        return EditRoomAddressScreenViewModel(roomProxy: JoinedRoomProxyMock(.init(name: "Room Name")),
+        return EditRoomAddressScreenViewModel(initialViewState: .init(serverName: "matrix.org",
+                                                                      bindings: .init(desiredAliasLocalPart: "whatever")),
+                                              roomProxy: JoinedRoomProxyMock(.init(name: "Room Name")),
                                               clientProxy: clientProxy,
                                               userIndicatorController: UserIndicatorControllerMock())
     }()

--- a/ElementX/Sources/Screens/EditRoomAddressScreen/View/EditRoomAddressScreen.swift
+++ b/ElementX/Sources/Screens/EditRoomAddressScreen/View/EditRoomAddressScreen.swift
@@ -91,13 +91,11 @@ struct EditRoomAddressScreen_Previews: PreviewProvider, TestablePreview {
         NavigationStack {
             EditRoomAddressScreen(context: invalidSymbolsViewModel.context)
         }
-        .snapshotPreferences(delay: 1.2)
         .previewDisplayName("Invalid symbols")
         
         NavigationStack {
             EditRoomAddressScreen(context: alreadyExistingViewModel.context)
         }
-        .snapshotPreferences(delay: 1.2)
         .previewDisplayName("Already existing")
     }
 }

--- a/ElementX/Sources/Screens/EditRoomAddressScreen/View/EditRoomAddressScreen.swift
+++ b/ElementX/Sources/Screens/EditRoomAddressScreen/View/EditRoomAddressScreen.swift
@@ -91,11 +91,13 @@ struct EditRoomAddressScreen_Previews: PreviewProvider, TestablePreview {
         NavigationStack {
             EditRoomAddressScreen(context: invalidSymbolsViewModel.context)
         }
+        .snapshotPreferences(delay: 1.2)
         .previewDisplayName("Invalid symbols")
         
         NavigationStack {
             EditRoomAddressScreen(context: alreadyExistingViewModel.context)
         }
+        .snapshotPreferences(delay: 1.2)
         .previewDisplayName("Already existing")
     }
 }

--- a/ElementX/Sources/Screens/EditRoomAddressScreen/View/EditRoomAddressScreen.swift
+++ b/ElementX/Sources/Screens/EditRoomAddressScreen/View/EditRoomAddressScreen.swift
@@ -19,6 +19,11 @@ struct EditRoomAddressScreen: View {
                     .onChange(of: context.desiredAliasLocalPart) { _, newAliasLocalPart in
                         context.desiredAliasLocalPart = newAliasLocalPart.lowercased()
                     }
+                    .onSubmit {
+                        if context.viewState.canSave {
+                            context.send(viewAction: .save)
+                        }
+                    }
             } footer: {
                 VStack(alignment: .leading, spacing: 12) {
                     if let errorDescription = context.viewState.aliasErrors.errorDescription {
@@ -47,8 +52,8 @@ struct EditRoomAddressScreen: View {
             .disabled(!context.viewState.canSave)
         }
         ToolbarItem(placement: .cancellationAction) {
-            Button(L10n.actionCreate) {
-                context.send(viewAction: .save)
+            Button(L10n.actionCancel) {
+                context.send(viewAction: .cancel)
             }
         }
     }

--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenCoordinator.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct SecurityAndPrivacyScreenCoordinatorParameters {
     let roomProxy: JoinedRoomProxyProtocol
     let clientProxy: ClientProxyProtocol
+    let userIndicatorController: UserIndicatorControllerProtocol
 }
 
 enum SecurityAndPrivacyScreenCoordinatorAction {
@@ -32,8 +33,9 @@ final class SecurityAndPrivacyScreenCoordinator: CoordinatorProtocol {
     
     init(parameters: SecurityAndPrivacyScreenCoordinatorParameters) {
         self.parameters = parameters
-        
-        viewModel = SecurityAndPrivacyScreenViewModel(roomProxy: parameters.roomProxy, clientProxy: parameters.clientProxy)
+        viewModel = SecurityAndPrivacyScreenViewModel(roomProxy: parameters.roomProxy,
+                                                      clientProxy: parameters.clientProxy,
+                                                      userIndicatorController: parameters.userIndicatorController)
     }
     
     func start() {

--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenCoordinator.swift
@@ -15,13 +15,10 @@ struct SecurityAndPrivacyScreenCoordinatorParameters {
 }
 
 enum SecurityAndPrivacyScreenCoordinatorAction {
-    case done
-    
-    // Consider adding CustomStringConvertible conformance if the actions contain PII
+    case displayEditAddressScreen
 }
 
 final class SecurityAndPrivacyScreenCoordinator: CoordinatorProtocol {
-    private let parameters: SecurityAndPrivacyScreenCoordinatorParameters
     private let viewModel: SecurityAndPrivacyScreenViewModelProtocol
     
     private var cancellables = Set<AnyCancellable>()
@@ -32,7 +29,6 @@ final class SecurityAndPrivacyScreenCoordinator: CoordinatorProtocol {
     }
     
     init(parameters: SecurityAndPrivacyScreenCoordinatorParameters) {
-        self.parameters = parameters
         viewModel = SecurityAndPrivacyScreenViewModel(roomProxy: parameters.roomProxy,
                                                       clientProxy: parameters.clientProxy,
                                                       userIndicatorController: parameters.userIndicatorController)
@@ -44,8 +40,8 @@ final class SecurityAndPrivacyScreenCoordinator: CoordinatorProtocol {
             
             guard let self else { return }
             switch action {
-            case .done:
-                actionsSubject.send(.done)
+            case .displayEditAddressScreen:
+                actionsSubject.send(.displayEditAddressScreen)
             }
         }
         .store(in: &cancellables)

--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenCoordinator.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct SecurityAndPrivacyScreenCoordinatorParameters {
     let roomProxy: JoinedRoomProxyProtocol
+    let clientProxy: ClientProxyProtocol
 }
 
 enum SecurityAndPrivacyScreenCoordinatorAction {
@@ -32,7 +33,7 @@ final class SecurityAndPrivacyScreenCoordinator: CoordinatorProtocol {
     init(parameters: SecurityAndPrivacyScreenCoordinatorParameters) {
         self.parameters = parameters
         
-        viewModel = SecurityAndPrivacyScreenViewModel(roomProxy: parameters.roomProxy)
+        viewModel = SecurityAndPrivacyScreenViewModel(roomProxy: parameters.roomProxy, clientProxy: parameters.clientProxy)
     }
     
     func start() {

--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenModels.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenModels.swift
@@ -12,12 +12,17 @@ enum SecurityAndPrivacyScreenViewModelAction {
 }
 
 struct SecurityAndPrivacyScreenViewState: BindableState {
-    var bindings: SecurityAndPrivacyScreenViewStateBindings
-    
+    let serverName: String
     var currentSettings: SecurityAndPrivacySettings
+    var bindings: SecurityAndPrivacyScreenViewStateBindings
+    var canonicalAlias: String?
     
-    var hasChanges: Bool {
+    private var hasChanges: Bool {
         currentSettings != bindings.desiredSettings
+    }
+    
+    var isSaveDisabled: Bool {
+        !hasChanges || currentSettings.isVisibileInRoomDirectory == nil
     }
     
     var availableVisibilityOptions: [SecurityAndPrivacyHistoryVisibility] {
@@ -29,15 +34,19 @@ struct SecurityAndPrivacyScreenViewState: BindableState {
         }
         return options
     }
-    
-    init(accessType: SecurityAndPrivacyRoomAccessType,
+        
+    init(serverName: String,
+         accessType: SecurityAndPrivacyRoomAccessType,
          isEncryptionEnabled: Bool,
-         historyVisibility: SecurityAndPrivacyHistoryVisibility) {
+         historyVisibility: SecurityAndPrivacyHistoryVisibility,
+         canonicalAlias: String?) {
+        self.serverName = serverName
         let settings = SecurityAndPrivacySettings(accessType: accessType,
                                                   isEncryptionEnabled: isEncryptionEnabled,
                                                   historyVisibility: historyVisibility)
         currentSettings = settings
         bindings = SecurityAndPrivacyScreenViewStateBindings(desiredSettings: settings)
+        self.canonicalAlias = canonicalAlias
     }
 }
 
@@ -66,6 +75,7 @@ enum SecurityAndPrivacyAlertType {
 enum SecurityAndPrivacyScreenViewAction {
     case save
     case tryUpdatingEncryption(Bool)
+    case editAddress
 }
 
 enum SecurityAndPrivacyHistoryVisibility {

--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenModels.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenModels.swift
@@ -22,7 +22,10 @@ struct SecurityAndPrivacyScreenViewState: BindableState {
     }
     
     var isSaveDisabled: Bool {
-        !hasChanges || currentSettings.isVisibileInRoomDirectory == nil
+        !hasChanges ||
+            (bindings.desiredSettings.isVisibileInRoomDirectory == nil &&
+                bindings.desiredSettings.accessType != .inviteOnly &&
+                canonicalAlias != nil)
     }
     
     var availableVisibilityOptions: [SecurityAndPrivacyHistoryVisibility] {

--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenModels.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenModels.swift
@@ -23,7 +23,7 @@ struct SecurityAndPrivacyScreenViewState: BindableState {
     
     var isSaveDisabled: Bool {
         !hasChanges ||
-            (bindings.desiredSettings.isVisibileInRoomDirectory == nil &&
+            (currentSettings.isVisibileInRoomDirectory == nil &&
                 bindings.desiredSettings.accessType != .inviteOnly &&
                 canonicalAlias != nil)
     }
@@ -69,6 +69,7 @@ enum SecurityAndPrivacyRoomAccessType {
     case inviteOnly
     case askToJoin
     case anyone
+    case spaceUsers
 }
 
 enum SecurityAndPrivacyAlertType {
@@ -85,4 +86,13 @@ enum SecurityAndPrivacyHistoryVisibility {
     case sinceSelection
     case sinceInvite
     case anyone
+    
+    var fallbackOption: Self {
+        switch self {
+        case .sinceInvite, .sinceSelection:
+            return .sinceSelection
+        case .anyone:
+            return .sinceInvite
+        }
+    }
 }

--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenModels.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenModels.swift
@@ -50,6 +50,7 @@ struct SecurityAndPrivacySettings: Equatable {
     var accessType: SecurityAndPrivacyRoomAccessType
     var isEncryptionEnabled: Bool
     var historyVisibility: SecurityAndPrivacyHistoryVisibility
+    var isVisibileInRoomDirectory: Bool?
 }
 
 enum SecurityAndPrivacyRoomAccessType {
@@ -71,13 +72,4 @@ enum SecurityAndPrivacyHistoryVisibility {
     case sinceSelection
     case sinceInvite
     case anyone
-    
-    var isAllowedInPublicRoom: Bool {
-        switch self {
-        case .anyone, .sinceSelection:
-            true
-        default:
-            false
-        }
-    }
 }

--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenModels.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenModels.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum SecurityAndPrivacyScreenViewModelAction {
-    case done
+    case displayEditAddressScreen
 }
 
 struct SecurityAndPrivacyScreenViewState: BindableState {
@@ -41,15 +41,13 @@ struct SecurityAndPrivacyScreenViewState: BindableState {
     init(serverName: String,
          accessType: SecurityAndPrivacyRoomAccessType,
          isEncryptionEnabled: Bool,
-         historyVisibility: SecurityAndPrivacyHistoryVisibility,
-         canonicalAlias: String?) {
+         historyVisibility: SecurityAndPrivacyHistoryVisibility) {
         self.serverName = serverName
         let settings = SecurityAndPrivacySettings(accessType: accessType,
                                                   isEncryptionEnabled: isEncryptionEnabled,
                                                   historyVisibility: historyVisibility)
         currentSettings = settings
         bindings = SecurityAndPrivacyScreenViewStateBindings(desiredSettings: settings)
-        self.canonicalAlias = canonicalAlias
     }
 }
 

--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenModels.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenModels.swift
@@ -20,6 +20,16 @@ struct SecurityAndPrivacyScreenViewState: BindableState {
         currentSettings != bindings.desiredSettings
     }
     
+    var availableVisibilityOptions: [SecurityAndPrivacyHistoryVisibility] {
+        var options = [SecurityAndPrivacyHistoryVisibility.sinceSelection]
+        if !bindings.desiredSettings.isEncryptionEnabled, bindings.desiredSettings.accessType == .anyone {
+            options.append(.anyone)
+        } else {
+            options.append(.sinceInvite)
+        }
+        return options
+    }
+    
     init(accessType: SecurityAndPrivacyRoomAccessType,
          isEncryptionEnabled: Bool,
          historyVisibility: SecurityAndPrivacyHistoryVisibility) {

--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenModels.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenModels.swift
@@ -21,8 +21,11 @@ struct SecurityAndPrivacyScreenViewState: BindableState {
     }
     
     init(accessType: SecurityAndPrivacyRoomAccessType,
-         isEncryptionEnabled: Bool) {
-        let settings = SecurityAndPrivacySettings(accessType: accessType, isEncryptionEnabled: isEncryptionEnabled)
+         isEncryptionEnabled: Bool,
+         historyVisibility: SecurityAndPrivacyHistoryVisibility) {
+        let settings = SecurityAndPrivacySettings(accessType: accessType,
+                                                  isEncryptionEnabled: isEncryptionEnabled,
+                                                  historyVisibility: historyVisibility)
         currentSettings = settings
         bindings = SecurityAndPrivacyScreenViewStateBindings(desiredSettings: settings)
     }
@@ -36,6 +39,7 @@ struct SecurityAndPrivacyScreenViewStateBindings {
 struct SecurityAndPrivacySettings: Equatable {
     var accessType: SecurityAndPrivacyRoomAccessType
     var isEncryptionEnabled: Bool
+    var historyVisibility: SecurityAndPrivacyHistoryVisibility
 }
 
 enum SecurityAndPrivacyRoomAccessType {
@@ -51,4 +55,19 @@ enum SecurityAndPrivacyAlertType {
 enum SecurityAndPrivacyScreenViewAction {
     case save
     case tryUpdatingEncryption(Bool)
+}
+
+enum SecurityAndPrivacyHistoryVisibility {
+    case sinceSelection
+    case sinceInvite
+    case anyone
+    
+    var isAllowedInPublicRoom: Bool {
+        switch self {
+        case .anyone, .sinceSelection:
+            true
+        default:
+            false
+        }
+    }
 }

--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenViewModel.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenViewModel.swift
@@ -31,8 +31,7 @@ class SecurityAndPrivacyScreenViewModel: SecurityAndPrivacyScreenViewModelType, 
         super.init(initialViewState: SecurityAndPrivacyScreenViewState(serverName: clientProxy.userIDServerName ?? "",
                                                                        accessType: roomProxy.infoPublisher.value.roomAccessType,
                                                                        isEncryptionEnabled: roomProxy.isEncrypted,
-                                                                       historyVisibility: roomProxy.infoPublisher.value.historyVisibility.toSecurityAndPrivacyHistoryVisibility,
-                                                                       canonicalAlias: canonicalAlias))
+                                                                       historyVisibility: roomProxy.infoPublisher.value.historyVisibility.toSecurityAndPrivacyHistoryVisibility))
         
         setupRoomDirectoryVisibility()
         setupSubscriptions()
@@ -45,7 +44,8 @@ class SecurityAndPrivacyScreenViewModel: SecurityAndPrivacyScreenViewModelType, 
         
         switch viewAction {
         case .save:
-            actionsSubject.send(.done)
+            // TODO: Implement save action
+            break
         case .tryUpdatingEncryption(let updatedValue):
             if updatedValue {
                 state.bindings.alertInfo = .init(id: .enableEncryption,
@@ -57,8 +57,7 @@ class SecurityAndPrivacyScreenViewModel: SecurityAndPrivacyScreenViewModelType, 
                 state.bindings.desiredSettings.isEncryptionEnabled = false
             }
         case .editAddress:
-            // TODO: Implement navigation to a view that allows editing or adding an address
-            break
+            actionsSubject.send(.displayEditAddressScreen)
         }
     }
     
@@ -78,6 +77,13 @@ class SecurityAndPrivacyScreenViewModel: SecurityAndPrivacyScreenViewModelType, 
                     state.bindings.desiredSettings.historyVisibility = desiredHistoryVisbility.fallbackOption
                 }
             }
+            .store(in: &cancellables)
+        
+        roomProxy.infoPublisher
+            .map(\.canonicalAlias)
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .weakAssign(to: \.state.canonicalAlias, on: self)
             .store(in: &cancellables)
     }
     

--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenViewModel.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenViewModel.swift
@@ -54,12 +54,15 @@ class SecurityAndPrivacyScreenViewModel: SecurityAndPrivacyScreenViewModelType, 
     private func setupSubscriptions() {
         context.$viewState
             .map(\.availableVisibilityOptions)
-            .dropFirst()
             .removeDuplicates()
+            // To allow the view to update properly
             .receive(on: DispatchQueue.main)
-            // When the available options changes always default to `sinceSelection`
-            .sink { [weak self] _ in
-                self?.state.bindings.desiredSettings.historyVisibility = .sinceSelection
+            // When the available options changes always default to `sinceSelection` if the currently selected option is not available
+            .sink { [weak self] availableVisibilityOptions in
+                guard let self else { return }
+                if !availableVisibilityOptions.contains(state.bindings.desiredSettings.historyVisibility) {
+                    state.bindings.desiredSettings.historyVisibility = .sinceSelection
+                }
             }
             .store(in: &cancellables)
     }

--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenViewModel.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenViewModel.swift
@@ -77,21 +77,16 @@ class SecurityAndPrivacyScreenViewModel: SecurityAndPrivacyScreenViewModelType, 
     }
     
     private func setupRoomDirectoryVisibility() {
-        if state.canonicalAlias != nil {
-            Task {
-                switch await roomProxy.isVisibleInRoomDirectory() {
-                case .success(let value):
-                    state.bindings.desiredSettings.isVisibileInRoomDirectory = value
-                    state.currentSettings.isVisibileInRoomDirectory = value
-                case .failure:
-                    // TODO: Ask design, maybe we should present an alert or display some kind of error?
-                    state.bindings.desiredSettings.isVisibileInRoomDirectory = false
-                    state.bindings.desiredSettings.isVisibileInRoomDirectory = false
-                }
+        Task {
+            switch await roomProxy.isVisibleInRoomDirectory() {
+            case .success(let value):
+                state.bindings.desiredSettings.isVisibileInRoomDirectory = value
+                state.currentSettings.isVisibileInRoomDirectory = value
+            case .failure:
+                // TODO: Ask design, maybe we should present an alert or display some kind of error?
+                state.bindings.desiredSettings.isVisibileInRoomDirectory = false
+                state.bindings.desiredSettings.isVisibileInRoomDirectory = false
             }
-        } else {
-            state.bindings.desiredSettings.isVisibileInRoomDirectory = false
-            state.bindings.desiredSettings.isVisibileInRoomDirectory = false
         }
     }
 }

--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenViewModel.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenViewModel.swift
@@ -27,7 +27,6 @@ class SecurityAndPrivacyScreenViewModel: SecurityAndPrivacyScreenViewModelType, 
         self.roomProxy = roomProxy
         self.clientProxy = clientProxy
         self.userIndicatorController = userIndicatorController
-        let canonicalAlias = roomProxy.infoPublisher.value.canonicalAlias
         super.init(initialViewState: SecurityAndPrivacyScreenViewState(serverName: clientProxy.userIDServerName ?? "",
                                                                        accessType: roomProxy.infoPublisher.value.roomAccessType,
                                                                        isEncryptionEnabled: roomProxy.isEncrypted,

--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenViewModel.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenViewModel.swift
@@ -53,29 +53,13 @@ class SecurityAndPrivacyScreenViewModel: SecurityAndPrivacyScreenViewModelType, 
     
     private func setupSubscriptions() {
         context.$viewState
-            .map(\.bindings.desiredSettings.accessType)
+            .map(\.availableVisibilityOptions)
+            .dropFirst()
             .removeDuplicates()
-            // Use this otherwise the value won't update properly in the view
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] desiredAcessType in
-                guard let self else { return }
-                if (desiredAcessType == .anyone && !state.bindings.desiredSettings.historyVisibility.isAllowedInPublicRoom) ||
-                    (desiredAcessType != .anyone && state.bindings.desiredSettings.historyVisibility == .anyone) {
-                    self.state.bindings.desiredSettings.historyVisibility = .sinceSelection
-                }
-            }
-            .store(in: &cancellables)
-        
-        context.$viewState
-            .map(\.bindings.desiredSettings.isEncryptionEnabled)
-            .removeDuplicates()
-            // Use this otherwise the value won't update properly in the view
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] desiredIsEncryptionEnabled in
-                guard let self else { return }
-                if desiredIsEncryptionEnabled, state.bindings.desiredSettings.historyVisibility == .anyone {
-                    self.state.bindings.desiredSettings.historyVisibility = .sinceSelection
-                }
+            // When the available options changes always default to `sinceSelection`
+            .sink { [weak self] _ in
+                self?.state.bindings.desiredSettings.historyVisibility = .sinceSelection
             }
             .store(in: &cancellables)
     }

--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenViewModel.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenViewModel.swift
@@ -71,9 +71,9 @@ class SecurityAndPrivacyScreenViewModel: SecurityAndPrivacyScreenViewModelType, 
             // When the available options changes always default to `sinceSelection` if the currently selected option is not available
             .sink { [weak self] availableVisibilityOptions in
                 guard let self else { return }
-                let desiredHistoryVisbility = state.bindings.desiredSettings.historyVisibility
-                if !availableVisibilityOptions.contains(desiredHistoryVisbility) {
-                    state.bindings.desiredSettings.historyVisibility = desiredHistoryVisbility.fallbackOption
+                let desiredHistoryVisibility = state.bindings.desiredSettings.historyVisibility
+                if !availableVisibilityOptions.contains(desiredHistoryVisibility) {
+                    state.bindings.desiredSettings.historyVisibility = desiredHistoryVisibility.fallbackOption
                 }
             }
             .store(in: &cancellables)

--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenViewModel.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Combine
+import MatrixRustSDK
 import SwiftUI
 
 typealias SecurityAndPrivacyScreenViewModelType = StateStoreViewModel<SecurityAndPrivacyScreenViewState, SecurityAndPrivacyScreenViewAction>
@@ -17,11 +18,14 @@ class SecurityAndPrivacyScreenViewModel: SecurityAndPrivacyScreenViewModelType, 
     var actionsPublisher: AnyPublisher<SecurityAndPrivacyScreenViewModelAction, Never> {
         actionsSubject.eraseToAnyPublisher()
     }
-
+    
     init(roomProxy: JoinedRoomProxyProtocol) {
         self.roomProxy = roomProxy
         super.init(initialViewState: SecurityAndPrivacyScreenViewState(accessType: roomProxy.infoPublisher.value.roomAccessType,
-                                                                       isEncryptionEnabled: roomProxy.isEncrypted))
+                                                                       isEncryptionEnabled: roomProxy.isEncrypted,
+                                                                       historyVisibility: roomProxy.infoPublisher.value.historyVisibility.toSecurityAndPrivacyHistoryVisibility))
+        
+        setupSubscriptions()
     }
     
     // MARK: - Public
@@ -37,14 +41,43 @@ class SecurityAndPrivacyScreenViewModel: SecurityAndPrivacyScreenViewModelType, 
                 state.bindings.alertInfo = .init(id: .enableEncryption,
                                                  title: L10n.screenSecurityAndPrivacyEnableEncryptionAlertTitle,
                                                  message: L10n.screenSecurityAndPrivacyEnableEncryptionAlertDescription,
-                                                 primaryButton: .init(title: L10n.screenSecurityAndPrivacyEnableEncryptionAlertConfirmButtonTitle) { [weak self] in
-                                                     self?.state.bindings.desiredSettings.isEncryptionEnabled = true
-                                                 },
+                                                 primaryButton: .init(title: L10n.screenSecurityAndPrivacyEnableEncryptionAlertConfirmButtonTitle) { [weak self] in self?.state.bindings.desiredSettings.isEncryptionEnabled = true },
                                                  secondaryButton: .init(title: L10n.actionCancel, role: .cancel, action: nil))
             } else {
                 state.bindings.desiredSettings.isEncryptionEnabled = false
             }
         }
+    }
+    
+    // MARK: - Private
+    
+    private func setupSubscriptions() {
+        context.$viewState
+            .map(\.bindings.desiredSettings.accessType)
+            .removeDuplicates()
+            // Use this otherwise the value won't update properly in the view
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] desiredAcessType in
+                guard let self else { return }
+                if (desiredAcessType == .anyone && !state.bindings.desiredSettings.historyVisibility.isAllowedInPublicRoom) ||
+                    (desiredAcessType != .anyone && state.bindings.desiredSettings.historyVisibility == .anyone) {
+                    self.state.bindings.desiredSettings.historyVisibility = .sinceSelection
+                }
+            }
+            .store(in: &cancellables)
+        
+        context.$viewState
+            .map(\.bindings.desiredSettings.isEncryptionEnabled)
+            .removeDuplicates()
+            // Use this otherwise the value won't update properly in the view
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] desiredIsEncryptionEnabled in
+                guard let self else { return }
+                if desiredIsEncryptionEnabled, state.bindings.desiredSettings.historyVisibility == .anyone {
+                    self.state.bindings.desiredSettings.historyVisibility = .sinceSelection
+                }
+            }
+            .store(in: &cancellables)
     }
 }
 
@@ -56,6 +89,19 @@ private extension RoomInfoProxy {
         case .knock, .knockRestricted:
             return .askToJoin
         default:
+            return .anyone
+        }
+    }
+}
+
+private extension RoomHistoryVisibility? {
+    var toSecurityAndPrivacyHistoryVisibility: SecurityAndPrivacyHistoryVisibility {
+        switch self {
+        case .joined, .invited:
+            return .sinceInvite
+        case .shared, .custom, .none:
+            return .sinceSelection
+        case .worldReadable:
             return .anyone
         }
     }

--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/View/SecurityAndPrivacyScreen.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/View/SecurityAndPrivacyScreen.swift
@@ -212,7 +212,6 @@ struct SecurityAndPrivacyScreen_Previews: PreviewProvider, TestablePreview {
         NavigationStack {
             SecurityAndPrivacyScreen(context: publicViewModel.context)
         }
-        .snapshotPreferences(delay: 0.1)
         .previewDisplayName("Public room")
         
         NavigationStack {
@@ -223,7 +222,6 @@ struct SecurityAndPrivacyScreen_Previews: PreviewProvider, TestablePreview {
         NavigationStack {
             SecurityAndPrivacyScreen(context: restrictedViewModel.context)
         }
-        .snapshotPreferences(delay: 0.1)
         .previewDisplayName("Restricted room")
     }
 }

--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/View/SecurityAndPrivacyScreen.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/View/SecurityAndPrivacyScreen.swift
@@ -14,6 +14,11 @@ struct SecurityAndPrivacyScreen: View {
     var body: some View {
         Form {
             roomAccessSection
+            if context.desiredSettings.accessType != .inviteOnly {
+                visibilitySection
+                addressSection
+                roomDirectoryVisibilitySection
+            }
             encryptionSection
             historySection
         }
@@ -43,7 +48,7 @@ struct SecurityAndPrivacyScreen: View {
     
     @ViewBuilder
     private var encryptionSection: some View {
-        let encryptionBinding = Binding<Bool>(get: {
+        let binding = Binding<Bool>(get: {
             context.desiredSettings.isEncryptionEnabled
         }, set: { newValue in
             context.send(viewAction: .tryUpdatingEncryption(newValue))
@@ -51,7 +56,7 @@ struct SecurityAndPrivacyScreen: View {
         
         Section {
             ListRow(label: .plain(title: L10n.screenSecurityAndPrivacyEncryptionToggleTitle),
-                    kind: .toggle(encryptionBinding))
+                    kind: .toggle(binding))
                 // We don't allow editing the encryption state if the current setting on the server is `enabled`
                 .disabled(context.viewState.currentSettings.isEncryptionEnabled)
         } header: {
@@ -84,6 +89,48 @@ struct SecurityAndPrivacyScreen: View {
         }
     }
     
+    private var visibilitySection: some View {
+        Section {
+            EmptyView()
+        } header: {
+            Text(L10n.screenSecurityAndPrivacyRoomVisibilitySectionTitle)
+                .compoundListSectionHeader()
+        } footer: {
+            Text(L10n.screenSecurityAndPrivacyRoomVisibilitySectionDescription)
+                .compoundListSectionFooter()
+        }
+    }
+    
+    private var addressSection: some View {
+        Section {
+            EmptyView()
+        } header: {
+            Text(L10n.screenSecurityAndPrivacyRoomAddressSectionTitle)
+                .compoundListSectionHeader()
+        } footer: {
+            Text(L10n.screenSecurityAndPrivacyRoomAddressSectionFooter)
+                .compoundListSectionFooter()
+        }
+    }
+    
+    @ViewBuilder
+    private var roomDirectoryVisibilitySection: some View {
+        let binding = Binding<Bool>(get: {
+            context.desiredSettings.isVisibileInRoomDirectory ?? false
+        }, set: { newValue in
+            context.desiredSettings.isVisibileInRoomDirectory = newValue
+        })
+        
+        Section {
+            ListRow(label: .plain(title: L10n.screenSecurityAndPrivacyRoomDirectoryVisibilityToggleTitle),
+                    details: .isWaiting(context.desiredSettings.isVisibileInRoomDirectory == nil),
+                    kind: context.desiredSettings.isVisibileInRoomDirectory == nil ? .label : .toggle(binding))
+        } footer: {
+            Text(L10n.screenSecurityAndPrivacyRoomDirectoryVisibilitySectionFooter)
+                .compoundListSectionFooter()
+        }
+    }
+    
     @ToolbarContentBuilder
     var toolbar: some ToolbarContent {
         ToolbarItem(placement: .confirmationAction) {
@@ -101,7 +148,7 @@ struct SecurityAndPrivacyScreen: View {
 struct SecurityAndPrivacyScreen_Previews: PreviewProvider {
     static let inviteOnlyViewModel = SecurityAndPrivacyScreenViewModel(roomProxy: JoinedRoomProxyMock(.init(joinRule: .invite)))
     
-    static let publicViewModel = SecurityAndPrivacyScreenViewModel(roomProxy: JoinedRoomProxyMock(.init(isEncrypted: false, joinRule: .public)))
+    static let publicViewModel = SecurityAndPrivacyScreenViewModel(roomProxy: JoinedRoomProxyMock(.init(isEncrypted: false, joinRule: .public, isVisibleInPublicDirectory: true)))
     
     static var previews: some View {
         NavigationStack {
@@ -112,6 +159,7 @@ struct SecurityAndPrivacyScreen_Previews: PreviewProvider {
         NavigationStack {
             SecurityAndPrivacyScreen(context: publicViewModel.context)
         }
+        .snapshotPreferences(delay: 0.1)
         .previewDisplayName("Public room")
     }
 }

--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/View/SecurityAndPrivacyScreen.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/View/SecurityAndPrivacyScreen.swift
@@ -212,6 +212,9 @@ struct SecurityAndPrivacyScreen_Previews: PreviewProvider, TestablePreview {
         NavigationStack {
             SecurityAndPrivacyScreen(context: publicViewModel.context)
         }
+        .snapshotPreferences(expect: publicViewModel.context.$viewState.map { state in
+            state.currentSettings.isVisibileInRoomDirectory == true
+        })
         .previewDisplayName("Public room")
         
         NavigationStack {
@@ -222,6 +225,9 @@ struct SecurityAndPrivacyScreen_Previews: PreviewProvider, TestablePreview {
         NavigationStack {
             SecurityAndPrivacyScreen(context: restrictedViewModel.context)
         }
+        .snapshotPreferences(expect: restrictedViewModel.context.$viewState.map { state in
+            state.currentSettings.isVisibileInRoomDirectory == true
+        })
         .previewDisplayName("Restricted room")
     }
 }

--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/View/SecurityAndPrivacyScreen.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/View/SecurityAndPrivacyScreen.swift
@@ -65,14 +65,18 @@ struct SecurityAndPrivacyScreen: View {
     
     private var historySection: some View {
         Section {
-            ListRow(label: .plain(title: L10n.screenSecurityAndPrivacyRoomHistorySinceSelectingOptionTitle),
-                    kind: .selection(isSelected: context.desiredSettings.historyVisibility == .sinceSelection) { context.desiredSettings.historyVisibility = .sinceSelection })
-            if context.desiredSettings.accessType == .anyone, !context.desiredSettings.isEncryptionEnabled {
-                ListRow(label: .plain(title: L10n.screenSecurityAndPrivacyRoomHistoryAnyoneOptionTitle),
-                        kind: .selection(isSelected: context.desiredSettings.historyVisibility == .anyone) { context.desiredSettings.historyVisibility = .anyone })
-            } else {
-                ListRow(label: .plain(title: L10n.screenSecurityAndPrivacyRoomHistorySinceInviteOptionTitle),
-                        kind: .selection(isSelected: context.desiredSettings.historyVisibility == .sinceInvite) { context.desiredSettings.historyVisibility = .sinceInvite })
+            ForEach(context.viewState.availableVisibilityOptions, id: \.self) { option in
+                switch option {
+                case .sinceSelection:
+                    ListRow(label: .plain(title: L10n.screenSecurityAndPrivacyRoomHistorySinceSelectingOptionTitle),
+                            kind: .selection(isSelected: context.desiredSettings.historyVisibility == .sinceSelection) { context.desiredSettings.historyVisibility = .sinceSelection })
+                case .anyone:
+                    ListRow(label: .plain(title: L10n.screenSecurityAndPrivacyRoomHistoryAnyoneOptionTitle),
+                            kind: .selection(isSelected: context.desiredSettings.historyVisibility == .anyone) { context.desiredSettings.historyVisibility = .anyone })
+                case .sinceInvite:
+                    ListRow(label: .plain(title: L10n.screenSecurityAndPrivacyRoomHistorySinceInviteOptionTitle),
+                            kind: .selection(isSelected: context.desiredSettings.historyVisibility == .sinceInvite) { context.desiredSettings.historyVisibility = .sinceInvite })
+                }
             }
         } header: {
             Text(L10n.screenSecurityAndPrivacyRoomHistorySectionHeader)

--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/View/SecurityAndPrivacyScreen.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/View/SecurityAndPrivacyScreen.swift
@@ -45,6 +45,14 @@ struct SecurityAndPrivacyScreen: View {
             ListRow(label: .plain(title: L10n.screenSecurityAndPrivacyRoomAccessAnyoneOptionTitle,
                                   description: L10n.screenSecurityAndPrivacyRoomAccessAnyoneOptionDescription),
                     kind: .selection(isSelected: context.desiredSettings.accessType == .anyone) { context.desiredSettings.accessType = .anyone })
+            
+            if context.viewState.currentSettings.accessType == .spaceUsers {
+                ListRow(label: .plain(title: L10n.screenSecurityAndPrivacyRoomAccessSpaceMembersOptionTitle,
+                                      description: L10n.screenSecurityAndPrivacyRoomAccessSpaceMembersOptionDescription),
+                        kind: .selection(isSelected: context.desiredSettings.accessType == .spaceUsers) { })
+                    // This is not supported so it will always be disabled and has no handler
+                    .disabled(true)
+            }
         } header: {
             Text(L10n.screenSecurityAndPrivacyRoomAccessSectionHeader)
                 .compoundListSectionHeader()
@@ -172,17 +180,28 @@ struct SecurityAndPrivacyScreen: View {
 // MARK: - Previews
 
 struct SecurityAndPrivacyScreen_Previews: PreviewProvider, TestablePreview {
-    static let inviteOnlyViewModel = SecurityAndPrivacyScreenViewModel(roomProxy: JoinedRoomProxyMock(.init(joinRule: .invite)), clientProxy: ClientProxyMock(.init()))
+    static let inviteOnlyViewModel = SecurityAndPrivacyScreenViewModel(roomProxy: JoinedRoomProxyMock(.init(joinRule: .invite)),
+                                                                       clientProxy: ClientProxyMock(.init()),
+                                                                       userIndicatorController: UserIndicatorControllerMock())
     
     static let publicViewModel = SecurityAndPrivacyScreenViewModel(roomProxy: JoinedRoomProxyMock(.init(isEncrypted: false,
                                                                                                         canonicalAlias: "#room:matrix.org",
                                                                                                         joinRule: .public,
                                                                                                         isVisibleInPublicDirectory: true)),
-                                                                   clientProxy: ClientProxyMock(.init(userIDServerName: "matrix.org")))
+                                                                   clientProxy: ClientProxyMock(.init(userIDServerName: "matrix.org")),
+                                                                   userIndicatorController: UserIndicatorControllerMock())
     
     static let publicNoAddressViewModel = SecurityAndPrivacyScreenViewModel(roomProxy: JoinedRoomProxyMock(.init(isEncrypted: false,
                                                                                                                  joinRule: .public)),
-                                                                            clientProxy: ClientProxyMock(.init(userIDServerName: "matrix.org")))
+                                                                            clientProxy: ClientProxyMock(.init(userIDServerName: "matrix.org")),
+                                                                            userIndicatorController: UserIndicatorControllerMock())
+    
+    static let restrictedViewModel = SecurityAndPrivacyScreenViewModel(roomProxy: JoinedRoomProxyMock(.init(isEncrypted: false,
+                                                                                                            canonicalAlias: "#room:matrix.org",
+                                                                                                            joinRule: .restricted(rules: []),
+                                                                                                            isVisibleInPublicDirectory: true)),
+                                                                       clientProxy: ClientProxyMock(.init(userIDServerName: "matrix.org")),
+                                                                       userIndicatorController: UserIndicatorControllerMock())
     
     static var previews: some View {
         NavigationStack {
@@ -200,5 +219,11 @@ struct SecurityAndPrivacyScreen_Previews: PreviewProvider, TestablePreview {
             SecurityAndPrivacyScreen(context: publicNoAddressViewModel.context)
         }
         .previewDisplayName("Public room without address")
+        
+        NavigationStack {
+            SecurityAndPrivacyScreen(context: restrictedViewModel.context)
+        }
+        .snapshotPreferences(delay: 0.1)
+        .previewDisplayName("Restricted room")
     }
 }

--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/View/SecurityAndPrivacyScreen.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/View/SecurityAndPrivacyScreen.swift
@@ -15,6 +15,7 @@ struct SecurityAndPrivacyScreen: View {
         Form {
             roomAccessSection
             encryptionSection
+            historySection
         }
         .compoundList()
         .navigationBarTitleDisplayMode(.inline)
@@ -62,6 +63,23 @@ struct SecurityAndPrivacyScreen: View {
         }
     }
     
+    private var historySection: some View {
+        Section {
+            ListRow(label: .plain(title: L10n.screenSecurityAndPrivacyRoomHistorySinceSelectingOptionTitle),
+                    kind: .selection(isSelected: context.desiredSettings.historyVisibility == .sinceSelection) { context.desiredSettings.historyVisibility = .sinceSelection })
+            if context.desiredSettings.accessType == .anyone, !context.desiredSettings.isEncryptionEnabled {
+                ListRow(label: .plain(title: L10n.screenSecurityAndPrivacyRoomHistoryAnyoneOptionTitle),
+                        kind: .selection(isSelected: context.desiredSettings.historyVisibility == .anyone) { context.desiredSettings.historyVisibility = .anyone })
+            } else {
+                ListRow(label: .plain(title: L10n.screenSecurityAndPrivacyRoomHistorySinceInviteOptionTitle),
+                        kind: .selection(isSelected: context.desiredSettings.historyVisibility == .sinceInvite) { context.desiredSettings.historyVisibility = .sinceInvite })
+            }
+        } header: {
+            Text(L10n.screenSecurityAndPrivacyRoomHistorySectionHeader)
+                .compoundListSectionHeader()
+        }
+    }
+    
     @ToolbarContentBuilder
     var toolbar: some ToolbarContent {
         ToolbarItem(placement: .confirmationAction) {
@@ -79,9 +97,17 @@ struct SecurityAndPrivacyScreen: View {
 struct SecurityAndPrivacyScreen_Previews: PreviewProvider {
     static let inviteOnlyViewModel = SecurityAndPrivacyScreenViewModel(roomProxy: JoinedRoomProxyMock(.init(joinRule: .invite)))
     
+    static let publicViewModel = SecurityAndPrivacyScreenViewModel(roomProxy: JoinedRoomProxyMock(.init(isEncrypted: false, joinRule: .public)))
+    
     static var previews: some View {
         NavigationStack {
             SecurityAndPrivacyScreen(context: inviteOnlyViewModel.context)
         }
+        .previewDisplayName("Private invite only room")
+        
+        NavigationStack {
+            SecurityAndPrivacyScreen(context: publicViewModel.context)
+        }
+        .previewDisplayName("Public room")
     }
 }

--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/View/SecurityAndPrivacyScreen.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/View/SecurityAndPrivacyScreen.swift
@@ -167,7 +167,7 @@ struct SecurityAndPrivacyScreen: View {
     }
     
     @ToolbarContentBuilder
-    var toolbar: some ToolbarContent {
+    private var toolbar: some ToolbarContent {
         ToolbarItem(placement: .confirmationAction) {
             Button(L10n.actionSave) {
                 context.send(viewAction: .save)

--- a/ElementX/Sources/Services/Media/MediaUploadingPreprocessor.swift
+++ b/ElementX/Sources/Services/Media/MediaUploadingPreprocessor.swift
@@ -175,7 +175,8 @@ struct MediaUploadingPreprocessor {
                                       size: fileSize,
                                       thumbnailInfo: thumbnailInfo,
                                       thumbnailSource: nil,
-                                      blurhash: thumbnailResult.blurhash)
+                                      blurhash: thumbnailResult.blurhash,
+                                      isAnimated: nil)
             
             let mediaInfo = MediaInfo.image(imageURL: url, thumbnailURL: thumbnailResult.url, imageInfo: imageInfo)
             

--- a/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
@@ -359,6 +359,15 @@ class JoinedRoomProxy: JoinedRoomProxyProtocol {
         }
     }
     
+    func isVisibleInRoomDirectory() async -> Result<Bool, RoomProxyError> {
+        do {
+            return try await .success(room.getRoomVisibility() == .public)
+        } catch {
+            MXLog.error("Failed checking if room is visible in room directory with error: \(error)")
+            return .failure(.sdkError(error))
+        }
+    }
+    
     // MARK: - Room flags
     
     func flagAsUnread(_ isUnread: Bool) async -> Result<Void, RoomProxyError> {

--- a/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
@@ -190,6 +190,16 @@ class JoinedRoomProxy: JoinedRoomProxyProtocol {
         }
     }
     
+    func enableEncryption() async -> Result<Void, RoomProxyError> {
+        do {
+            try await room.enableEncryption()
+            return .success(())
+        } catch {
+            MXLog.error("Failed enabling encryption with error: \(error)")
+            return .failure(.sdkError(error))
+        }
+    }
+    
     func redact(_ eventID: String) async -> Result<Void, RoomProxyError> {
         do {
             try await room.redact(eventId: eventID, reason: nil)
@@ -359,11 +369,75 @@ class JoinedRoomProxy: JoinedRoomProxyProtocol {
         }
     }
     
+    // MARK: - Privacy settings
+    
+    func updateJoinRule(_ rule: JoinRule) async -> Result<Void, RoomProxyError> {
+        do {
+            try await room.updateJoinRules(newRule: rule)
+            return .success(())
+        } catch {
+            MXLog.error("Failed updating join rule with error: \(error)")
+            return .failure(.sdkError(error))
+        }
+    }
+    
+    func updateHistoryVisibility(_ visibility: RoomHistoryVisibility) async -> Result<Void, RoomProxyError> {
+        do {
+            try await room.updateHistoryVisibility(visibility: visibility)
+            return .success(())
+        } catch {
+            MXLog.error("Failed updating history visibility with error: \(error)")
+            return .failure(.sdkError(error))
+        }
+    }
+    
     func isVisibleInRoomDirectory() async -> Result<Bool, RoomProxyError> {
         do {
             return try await .success(room.getRoomVisibility() == .public)
         } catch {
             MXLog.error("Failed checking if room is visible in room directory with error: \(error)")
+            return .failure(.sdkError(error))
+        }
+    }
+    
+    func updateRoomDirectoryVisibility(_ visibility: RoomVisibility) async -> Result<Void, RoomProxyError> {
+        do {
+            try await room.updateRoomVisibility(visibility: visibility)
+            return .success(())
+        } catch {
+            MXLog.error("Failed updating room directory visibility with error: \(error)")
+            return .failure(.sdkError(error))
+        }
+    }
+    
+    // MARK: - Canonical Alias
+    
+    func updateCanonicalAlias(_ alias: String?, altAliases: [String]) async -> Result<Void, RoomProxyError> {
+        do {
+            try await room.updateCanonicalAlias(alias: alias, altAliases: altAliases)
+            return .success(())
+        } catch {
+            MXLog.error("Failed updating canonical alias with error: \(error)")
+            return .failure(.sdkError(error))
+        }
+    }
+    
+    func publishRoomAliasInRoomDirectory(_ alias: String) async -> Result<Bool, RoomProxyError> {
+        do {
+            let result = try await room.publishRoomAliasInRoomDirectory(alias: alias)
+            return .success(result)
+        } catch {
+            MXLog.error("Failed publishing the room's alias in the room directory with error: \(error)")
+            return .failure(.sdkError(error))
+        }
+    }
+    
+    func removeRoomAliasFromRoomDirectory(_ alias: String) async -> Result<Bool, RoomProxyError> {
+        do {
+            let result = try await room.removeRoomAliasFromRoomDirectory(alias: alias)
+            return .success(result)
+        } catch {
+            MXLog.error("Failed removing the room's alias in the room directory with error: \(error)")
             return .failure(.sdkError(error))
         }
     }

--- a/ElementX/Sources/Services/Room/RoomInfoProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomInfoProxy.swift
@@ -66,6 +66,7 @@ struct RoomInfoProxy: BaseRoomInfoProxyProtocol {
     var unreadMentionsCount: UInt { UInt(roomInfo.numUnreadMentions) }
     var pinnedEventIDs: Set<String> { Set(roomInfo.pinnedEventIds) }
     var joinRule: JoinRule? { roomInfo.joinRule }
+    var historyVisibility: RoomHistoryVisibility? { roomInfo.historyVisibility }
 }
 
 struct RoomPreviewInfoProxy: BaseRoomInfoProxyProtocol {

--- a/ElementX/Sources/Services/Room/RoomInfoProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomInfoProxy.swift
@@ -66,7 +66,7 @@ struct RoomInfoProxy: BaseRoomInfoProxyProtocol {
     var unreadMentionsCount: UInt { UInt(roomInfo.numUnreadMentions) }
     var pinnedEventIDs: Set<String> { Set(roomInfo.pinnedEventIds) }
     var joinRule: JoinRule? { roomInfo.joinRule }
-    var historyVisibility: RoomHistoryVisibility? { roomInfo.historyVisibility }
+    var historyVisibility: RoomHistoryVisibility { roomInfo.historyVisibility }
 }
 
 struct RoomPreviewInfoProxy: BaseRoomInfoProxyProtocol {

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -79,6 +79,8 @@ protocol JoinedRoomProxyProtocol: RoomProxyProtocol {
     
     func messageFilteredTimeline(allowedMessageTypes: [RoomMessageEventMessageType]) async -> Result<TimelineProxyProtocol, RoomProxyError>
     
+    func enableEncryption() async -> Result<Void, RoomProxyError>
+    
     func redact(_ eventID: String) async -> Result<Void, RoomProxyError>
     
     func reportContent(_ eventID: String, reason: String?) async -> Result<Void, RoomProxyError>
@@ -110,7 +112,20 @@ protocol JoinedRoomProxyProtocol: RoomProxyProtocol {
     
     func withdrawVerificationAndResend(userIDs: [String], sendHandle: SendHandleProxy) async -> Result<Void, RoomProxyError>
     
+    // MARK: - Privacy settings
+    
+    func updateJoinRule(_ rule: JoinRule) async -> Result<Void, RoomProxyError>
+    func updateHistoryVisibility(_ visibility: RoomHistoryVisibility) async -> Result<Void, RoomProxyError>
+    
     func isVisibleInRoomDirectory() async -> Result<Bool, RoomProxyError>
+    func updateRoomDirectoryVisibility(_ visibility: RoomVisibility) async -> Result<Void, RoomProxyError>
+    
+    // MARK: - Canonical Alias
+    
+    func updateCanonicalAlias(_ alias: String?, altAliases: [String]) async -> Result<Void, RoomProxyError>
+    
+    func publishRoomAliasInRoomDirectory(_ alias: String) async -> Result<Bool, RoomProxyError>
+    func removeRoomAliasFromRoomDirectory(_ alias: String) async -> Result<Bool, RoomProxyError>
     
     // MARK: - Room Flags
     

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -110,6 +110,8 @@ protocol JoinedRoomProxyProtocol: RoomProxyProtocol {
     
     func withdrawVerificationAndResend(userIDs: [String], sendHandle: SendHandleProxy) async -> Result<Void, RoomProxyError>
     
+    func isVisibleInRoomDirectory() async -> Result<Bool, RoomProxyError>
+    
     // MARK: - Room Flags
     
     func flagAsUnread(_ isUnread: Bool) async -> Result<Void, RoomProxyError>

--- a/PreviewTests/Sources/GeneratedPreviewTests.swift
+++ b/PreviewTests/Sources/GeneratedPreviewTests.swift
@@ -143,6 +143,12 @@ extension PreviewTests {
         }
     }
 
+    func test_editRoomAddressScreen() async throws {
+        for preview in EditRoomAddressScreen_Previews._allPreviews {
+            try await assertSnapshots(matching: preview)
+        }
+    }
+
     func test_emojiPickerScreenHeaderView() async throws {
         for preview in EmojiPickerScreenHeaderView_Previews._allPreviews {
             try await assertSnapshots(matching: preview)
@@ -781,6 +787,12 @@ extension PreviewTests {
 
     func test_secureBackupScreen() async throws {
         for preview in SecureBackupScreen_Previews._allPreviews {
+            try await assertSnapshots(matching: preview)
+        }
+    }
+
+    func test_securityAndPrivacyScreen() async throws {
+        for preview in SecurityAndPrivacyScreen_Previews._allPreviews {
             try await assertSnapshots(matching: preview)
         }
     }

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-en-GB.Already-existing.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-en-GB.Already-existing.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a87e3ba95167089163c3e617aa0181eb6b843c3b36490beb2ba9e6b4b6c0d4e8
-size 115010
+oid sha256:ed820a7cbe2fee94312fdc4300be84340e2b83c420617785236966591f7b0ad8
+size 115635

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-en-GB.Already-existing.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-en-GB.Already-existing.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a87e3ba95167089163c3e617aa0181eb6b843c3b36490beb2ba9e6b4b6c0d4e8
+size 115010

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-en-GB.Invalid-symbols.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-en-GB.Invalid-symbols.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f29a21f22adecc29c25e2ff2462e8eee997027f8b465b1f8517116c8009aaee0
+size 120559

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-en-GB.Invalid-symbols.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-en-GB.Invalid-symbols.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f29a21f22adecc29c25e2ff2462e8eee997027f8b465b1f8517116c8009aaee0
-size 120559
+oid sha256:084b4cea984f0b2952cb57776278d6866260b6fa72b472c68508b46f6be9d0fc
+size 120798

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-en-GB.No-alias.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-en-GB.No-alias.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:779f925f338b63b3facfecc8d5b55f0943ca807f466b37dc7520c991b5329db1
-size 102930
+oid sha256:dd9afbafee47a33dfa211d290b3737873fb55e8706ec7b6cf3c74f1820da86ce
+size 103048

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-en-GB.No-alias.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-en-GB.No-alias.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:779f925f338b63b3facfecc8d5b55f0943ca807f466b37dc7520c991b5329db1
+size 102930

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-en-GB.With-alias.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-en-GB.With-alias.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3e6063b7f355454450fbadae40337aad192b9b5b86752aa2ff73a31bc650eb24
-size 102946
+oid sha256:f7beccc3c1111498a63be05cb11da67baf56146c893f9fa329089dd375ce69a5
+size 103075

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-en-GB.With-alias.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-en-GB.With-alias.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e6063b7f355454450fbadae40337aad192b9b5b86752aa2ff73a31bc650eb24
+size 102946

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-pseudo.Already-existing.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-pseudo.Already-existing.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c5b09168a7a24cdf7fa629b8b8e25daf96f59acb7447726d17c7e92efaf3be9
+size 134099

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-pseudo.Already-existing.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-pseudo.Already-existing.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8c5b09168a7a24cdf7fa629b8b8e25daf96f59acb7447726d17c7e92efaf3be9
-size 134099
+oid sha256:584ca7225cf3d8e129ac815d5893ffffef9df93c647c4f16d1155eb96f7a1679
+size 134771

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-pseudo.Invalid-symbols.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-pseudo.Invalid-symbols.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:15b35d405a0133b299a04141aaa4f1d9fe4455cd7a7619d72bde8236647ea292
-size 143130
+oid sha256:f2cc05f40aad619c43b543c947e557174964cd860fcfa80257fa766aa88ebfad
+size 143415

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-pseudo.Invalid-symbols.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-pseudo.Invalid-symbols.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15b35d405a0133b299a04141aaa4f1d9fe4455cd7a7619d72bde8236647ea292
+size 143130

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-pseudo.No-alias.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-pseudo.No-alias.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ba59cf05d8dee7c7ca838cb5d8c30aabd593653808e983858936e78dc276213
+size 111751

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-pseudo.No-alias.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-pseudo.No-alias.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8ba59cf05d8dee7c7ca838cb5d8c30aabd593653808e983858936e78dc276213
-size 111751
+oid sha256:ef1930d51d5f0634aa06250abe7740029b3d8fc2f3ba319653e54aaf3bacccfb
+size 111971

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-pseudo.With-alias.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-pseudo.With-alias.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6a3b316514b3e1eee18d28cce2be2cf830f6ccd660c7580880a148c99fd0607
+size 111752

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-pseudo.With-alias.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPad-pseudo.With-alias.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f6a3b316514b3e1eee18d28cce2be2cf830f6ccd660c7580880a148c99fd0607
-size 111752
+oid sha256:d3552554ad8eb6998cd13a1b329d1e823563e18f04de4afff9b2b2fee4275a0a
+size 111972

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-en-GB.Already-existing.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-en-GB.Already-existing.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:057fca529839e0f76b763d1b0343097fcbba62d526964bfafbba61baf896234e
-size 69853
+oid sha256:c1298b7f77d89e0a0409b56636d36ccdcc38c765fb709b19031d8eb6d7cccd1e
+size 70278

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-en-GB.Already-existing.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-en-GB.Already-existing.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:057fca529839e0f76b763d1b0343097fcbba62d526964bfafbba61baf896234e
+size 69853

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-en-GB.Invalid-symbols.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-en-GB.Invalid-symbols.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b9cecf193ca96d0a8922aa5721470fa496e2e893c8a9508e60daa542b794cd5f
-size 73844
+oid sha256:60ecce7bb6772f0693322b77b88125f7010bf8236a3f04747e856ad03e46e65a
+size 73972

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-en-GB.Invalid-symbols.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-en-GB.Invalid-symbols.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9cecf193ca96d0a8922aa5721470fa496e2e893c8a9508e60daa542b794cd5f
+size 73844

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-en-GB.No-alias.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-en-GB.No-alias.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c63ff6645297abea3d35e852c6cb86787b53ef540a600fd316c691834696e5a2
-size 54730
+oid sha256:b8bb258d0a65f5ab6bd36ce68909417e220b7336bac504ed9ba1c9ca77e3dc8b
+size 54967

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-en-GB.No-alias.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-en-GB.No-alias.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c63ff6645297abea3d35e852c6cb86787b53ef540a600fd316c691834696e5a2
+size 54730

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-en-GB.With-alias.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-en-GB.With-alias.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:40aaec4d676074fff5eb50099f9fbd8c0154a01ebf4cf0a0a884421ae5ec7e72
-size 54511
+oid sha256:3231612e474ca5ed2a5681162fecabada27d3407b28be708c7f43d9efa80aaa7
+size 54754

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-en-GB.With-alias.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-en-GB.With-alias.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40aaec4d676074fff5eb50099f9fbd8c0154a01ebf4cf0a0a884421ae5ec7e72
+size 54511

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-pseudo.Already-existing.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-pseudo.Already-existing.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b064650ae934cebf42cdd502a012aabb48f39ac75131144da2af5860395ee7cd
+size 92962

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-pseudo.Already-existing.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-pseudo.Already-existing.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b064650ae934cebf42cdd502a012aabb48f39ac75131144da2af5860395ee7cd
-size 92962
+oid sha256:5bd8f03a48240719376911cfcbb0b972e7f6295c0d052b93d33948606e88ce0b
+size 93574

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-pseudo.Invalid-symbols.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-pseudo.Invalid-symbols.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:afbf14b0a76c31f4643d5cfe84d3e5befb9e4eb44e0f401338d8479db5f124c0
+size 101369

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-pseudo.Invalid-symbols.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-pseudo.Invalid-symbols.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:afbf14b0a76c31f4643d5cfe84d3e5befb9e4eb44e0f401338d8479db5f124c0
-size 101369
+oid sha256:a350ef87ce4dbce1b2020bed6932aee53fe34e118e72045f68d9a857879ed135
+size 101676

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-pseudo.No-alias.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-pseudo.No-alias.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:18575d4584ddffe621d225380cd8385b09595fade5fed78c7b2f3f3cc81bc032
-size 68272
+oid sha256:7dc96671de7a8e204694533122addb9a64f705bf1818d6a0f46a1ba535571a1e
+size 68334

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-pseudo.No-alias.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-pseudo.No-alias.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18575d4584ddffe621d225380cd8385b09595fade5fed78c7b2f3f3cc81bc032
+size 68272

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-pseudo.With-alias.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-pseudo.With-alias.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b6d5752d4c32685186221ae0df822f988c5725e57973725d9bb824012919c1bb
-size 68080
+oid sha256:dcd12e17832a79ab7a4f7bbcb7973e1ab267e2a0d40b850b5dac6b342bdf4eb6
+size 68151

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-pseudo.With-alias.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_editRoomAddressScreen-iPhone-16-pseudo.With-alias.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6d5752d4c32685186221ae0df822f988c5725e57973725d9bb824012919c1bb
+size 68080

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPad-en-GB.Private-invite-only-room.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPad-en-GB.Private-invite-only-room.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0f8cd3542eb8dd9c7dbb553d37a154cd0cc932333e31ad2e69a37b2b8acacf7
+size 163760

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPad-en-GB.Public-room-without-address.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPad-en-GB.Public-room-without-address.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4396683e4cab8545f4b66c415d45d1715cb6ff1bb0cb50eb99550c8b33f9fca1
+size 189113

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPad-en-GB.Public-room.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPad-en-GB.Public-room.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc13f5619bcf5ded950861338375147fce1859e992680de40b279b805a3ae987
+size 217894

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPad-en-GB.Restricted-room.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPad-en-GB.Restricted-room.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:527832138f736cd387b754335932b59c5e34625fe26a2f2d24780cc153ff526b
+size 217589

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPad-pseudo.Private-invite-only-room.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPad-pseudo.Private-invite-only-room.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19e542bbd4a2cb27b587e90432a4499ee2cad27d4a859139eefaee2a09165c69
+size 192471

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPad-pseudo.Public-room-without-address.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPad-pseudo.Public-room-without-address.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65f2a4d8f484853aec99db22f3edd79d3aeb22b86c5c99f22545b1dbe0d997c0
+size 239270

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPad-pseudo.Public-room.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPad-pseudo.Public-room.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5b37bec8fcde0df53e345db40f55148854cdfa4be37cf79409abf498b39f368
+size 266058

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPad-pseudo.Restricted-room.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPad-pseudo.Restricted-room.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:892a0fcb4bb2cf99d025ac954ed6abaf162aa3f172a6c0b690bbe8b647940248
+size 264851

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPhone-16-en-GB.Private-invite-only-room.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPhone-16-en-GB.Private-invite-only-room.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a88826a30f9541308c0cdab66add64b240a62271515455054a347695c3aa2cc4
+size 108223

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPhone-16-en-GB.Public-room-without-address.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPhone-16-en-GB.Public-room-without-address.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e1d4a3efbbcc9a95eb8bdade3f4a94820d2dff3eac58939ef1c001915f10c52
+size 134514

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPhone-16-en-GB.Public-room.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPhone-16-en-GB.Public-room.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b5d2893837ef5fef4b805162a67e951a796f0f83c393d871ef6ab18a099403a
+size 146429

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPhone-16-en-GB.Restricted-room.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPhone-16-en-GB.Restricted-room.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9603ac222e27850a359500794e23a4398c5bdd37b4965c8eae18aae1dac07b81
+size 146037

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPhone-16-pseudo.Private-invite-only-room.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPhone-16-pseudo.Private-invite-only-room.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68bb453000d5cc1dafeab24769c6b362756b157f4432ab4037c39a4fd10383ea
+size 157801

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPhone-16-pseudo.Public-room-without-address.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPhone-16-pseudo.Public-room-without-address.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d0d71cd5103ff844500ec7f3610214940628827dc8edab434f9c22e46dd929a
+size 169589

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPhone-16-pseudo.Public-room.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPhone-16-pseudo.Public-room.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9326d4ef2ae49c1650a2fa842782b00451456c65de98231546c6273617777b56
+size 183485

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPhone-16-pseudo.Restricted-room.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_securityAndPrivacyScreen-iPhone-16-pseudo.Restricted-room.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f79a51e74d4df02fce286a31c9c31174b12a6b9f5e846b1e0beaf02b1d06535b
+size 184789

--- a/UnitTests/Sources/EditRoomAddressScreenViewModelTests.swift
+++ b/UnitTests/Sources/EditRoomAddressScreenViewModelTests.swift
@@ -1,0 +1,21 @@
+//
+// Copyright 2022-2024 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+// Please see LICENSE in the repository root for full details.
+//
+
+import XCTest
+
+@testable import ElementX
+
+@MainActor
+class EditRoomAddressScreenViewModelTests: XCTestCase {
+    var viewModel: EditRoomAddressScreenViewModelProtocol!
+    
+    var context: EditRoomAddressScreenViewModelType.Context {
+        viewModel.context
+    }
+    
+    override func setUpWithError() throws { }
+}

--- a/project.yml
+++ b/project.yml
@@ -61,7 +61,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/element-hq/matrix-rust-components-swift
-    exactVersion: 25.01.10-2
+    exactVersion: 25.01.13
     # path: ../matrix-rust-sdk
   Compound:
     url: https://github.com/element-hq/compound-ios


### PR DESCRIPTION
WIP, requires some SDK API that are still in review

What is left to do:

- [x] - Handle the save actions in both the edit address screen and the security and privacy screen
- [x] - This may require some pairing with the SDK team, to understand what is the correct to call these APIs based on the codependent states of the view
- [ ] - There might be some redesigns incoming regarding the room address part to handle admins from different HSs
- [ ] - Unit tests