### PR TITLE
Add a fullscreen button to TimelineMediaPreviewScreen and hook up swiping through the timeline.

### DIFF
--- a/ElementX/Sources/FlowCoordinators/MediaEventsTimelineFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/MediaEventsTimelineFlowCoordinator.swift
@@ -126,8 +126,6 @@ class MediaEventsTimelineFlowCoordinator: FlowCoordinatorProtocol {
             }
             .store(in: &cancellables)
         
-        navigationStackCoordinator.setFullScreenCoverCoordinator(coordinator) {
-            previewContext.completion?()
-        }
+        navigationStackCoordinator.setFullScreenCoverCoordinator(coordinator)
     }
 }

--- a/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewCoordinator.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewCoordinator.swift
@@ -72,6 +72,9 @@ final class TimelineMediaPreviewCoordinator: CoordinatorProtocol {
     }
         
     func toPresentable() -> AnyView {
-        AnyView(TimelineMediaPreviewScreen(context: viewModel.context))
+        // Calling the completion onDisappear isn't ideal, but we don't push away from the screen so it should be
+        // a good enough approximation of didDismiss, given that the only other option is our navigation callbacks
+        // which are essentially willDismiss callbacks and happen too early for this particular completion handler.
+        AnyView(TimelineMediaPreviewScreen(context: viewModel.context, onDisappear: parameters.context.completion))
     }
 }

--- a/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewCoordinator.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewCoordinator.swift
@@ -16,11 +16,12 @@ struct TimelineMediaPreviewContext {
     let viewModel: TimelineViewModelProtocol
     /// The namespace that the navigation transition's `sourceID` should be defined in.
     let namespace: Namespace.ID
-    /// A completion to be called immediately *after* the preview has been dismissed.
+    /// A closure to be called whenever a different preview item is shown. It should also
+    /// be called *after* the preview has been dismissed, with an ID of `nil`.
     ///
     /// This helps work around a bug caused by the flipped scrollview where the zoomed
     /// thumbnail starts off upside down while loading the preview screen.
-    var completion: (() -> Void)?
+    var itemIDHandler: ((TimelineItemIdentifier?) -> Void)?
 }
 
 struct TimelineMediaPreviewCoordinatorParameters {
@@ -75,6 +76,6 @@ final class TimelineMediaPreviewCoordinator: CoordinatorProtocol {
         // Calling the completion onDisappear isn't ideal, but we don't push away from the screen so it should be
         // a good enough approximation of didDismiss, given that the only other option is our navigation callbacks
         // which are essentially willDismiss callbacks and happen too early for this particular completion handler.
-        AnyView(TimelineMediaPreviewScreen(context: viewModel.context, onDisappear: parameters.context.completion))
+        AnyView(TimelineMediaPreviewScreen(context: viewModel.context, itemIDHandler: parameters.context.itemIDHandler))
     }
 }

--- a/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewModels.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewModels.swift
@@ -15,11 +15,19 @@ enum TimelineMediaPreviewViewModelAction: Equatable {
 }
 
 struct TimelineMediaPreviewViewState: BindableState {
+    /// All of the items in the timeline that can be previewed.
     var previewItems: [TimelineMediaPreviewItem]
+    /// The index of the initial item inside of `previewItems` that is to be shown.
+    let initialItemIndex: Int
+    
+    /// The media item that is currently being previewed.
     var currentItem: TimelineMediaPreviewItem
+    /// All of the available actions for the current item.
     var currentItemActions: TimelineItemMenuActions?
     
+    /// The namespace used for the zoom transition.
     let transitionNamespace: Namespace.ID
+    /// A publisher that the view model uses to signal to the QLPreviewController when the current item has been loaded.
     let fileLoadedPublisher = PassthroughSubject<TimelineItemIdentifier, Never>()
     
     var bindings = TimelineMediaPreviewViewStateBindings()
@@ -47,6 +55,21 @@ class TimelineMediaPreviewItem: NSObject, QLPreviewItem, Identifiable {
     
     init(timelineItem: EventBasedMessageTimelineItemProtocol) {
         self.timelineItem = timelineItem
+    }
+    
+    init?(roomTimelineItemViewState: RoomTimelineItemViewState) {
+        switch roomTimelineItemViewState.type {
+        case .audio(let audioRoomTimelineItem):
+            timelineItem = audioRoomTimelineItem
+        case .file(let fileRoomTimelineItem):
+            timelineItem = fileRoomTimelineItem
+        case .image(let imageRoomTimelineItem):
+            timelineItem = imageRoomTimelineItem
+        case .video(let videoRoomTimelineItem):
+            timelineItem = videoRoomTimelineItem
+        default:
+            return nil
+        }
     }
     
     // MARK: Identifiable

--- a/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewDetailsView.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewDetailsView.swift
@@ -180,8 +180,11 @@ struct TimelineMediaPreviewDetailsView_Previews: PreviewProvider, TestablePrevie
                                                         contentType: contentType))
         
         let timelineKind = TimelineKind.media(isPresentedOnRoomScreen ? .roomScreen : .mediaFilesScreen)
+        let timelineController = MockRoomTimelineController(timelineKind: timelineKind)
+        timelineController.timelineItems = [item]
         return TimelineMediaPreviewViewModel(context: .init(item: item,
-                                                            viewModel: TimelineViewModel.mock(timelineKind: timelineKind),
+                                                            viewModel: TimelineViewModel.mock(timelineKind: timelineKind,
+                                                                                              timelineController: timelineController),
                                                             namespace: previewNamespace),
                                              mediaProvider: MediaProviderMock(configuration: .init()),
                                              photoLibraryManager: PhotoLibraryManagerMock(.init()),

--- a/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewRedactConfirmationView.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewRedactConfirmationView.swift
@@ -138,8 +138,11 @@ struct TimelineMediaPreviewRedactConfirmationView_Previews: PreviewProvider, Tes
                                                         thumbnailInfo: .mockThumbnail,
                                                         contentType: contentType))
         
+        let timelineController = MockRoomTimelineController(timelineKind: .media(.mediaFilesScreen))
+        timelineController.timelineItems = [item]
         return TimelineMediaPreviewViewModel(context: .init(item: item,
-                                                            viewModel: TimelineViewModel.mock,
+                                                            viewModel: TimelineViewModel.mock(timelineKind: timelineController.timelineKind,
+                                                                                              timelineController: timelineController),
                                                             namespace: previewNamespace),
                                              mediaProvider: MediaProviderMock(configuration: .init()),
                                              photoLibraryManager: PhotoLibraryManagerMock(.init()),

--- a/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewScreen.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewScreen.swift
@@ -240,8 +240,12 @@ struct TimelineMediaPreviewScreen_Previews: PreviewProvider {
                                                        thumbnailSource: nil,
                                                        contentType: .pdf))
         
+        let timelineController = MockRoomTimelineController(timelineKind: .media(.mediaFilesScreen))
+        timelineController.timelineItems = [item]
+        
         return TimelineMediaPreviewViewModel(context: .init(item: item,
-                                                            viewModel: TimelineViewModel.mock(timelineKind: .media(.mediaFilesScreen)),
+                                                            viewModel: TimelineViewModel.mock(timelineKind: timelineController.timelineKind,
+                                                                                              timelineController: timelineController),
                                                             namespace: namespace),
                                              mediaProvider: MediaProviderMock(configuration: .init()),
                                              photoLibraryManager: PhotoLibraryManagerMock(.init()),

--- a/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewScreen.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewScreen.swift
@@ -12,6 +12,7 @@ import SwiftUI
 
 struct TimelineMediaPreviewScreen: View {
     @ObservedObject var context: TimelineMediaPreviewViewModel.Context
+    var onDisappear: (() -> Void)?
     
     @State private var isFullScreen = false
     private var toolbarVisibility: Visibility { isFullScreen ? .hidden : .visible }
@@ -36,6 +37,9 @@ struct TimelineMediaPreviewScreen: View {
         }
         .alert(item: $context.alertInfo)
         .preferredColorScheme(.dark)
+        .onDisappear {
+            onDisappear?()
+        }
         .zoomTransition(sourceID: currentItem.id, in: context.viewState.transitionNamespace)
     }
     
@@ -138,6 +142,8 @@ struct TimelineMediaPreviewScreen: View {
     }
 }
 
+// MARK: - QuickLook
+
 private struct QuickLookView: UIViewControllerRepresentable {
     let viewModelContext: TimelineMediaPreviewViewModel.Context
 
@@ -151,6 +157,8 @@ private struct QuickLookView: UIViewControllerRepresentable {
     func makeCoordinator() -> Coordinator {
         Coordinator(viewModelContext: viewModelContext)
     }
+    
+    // MARK: Coordinator
     
     class Coordinator: NSObject, QLPreviewControllerDataSource, QLPreviewControllerDelegate {
         private let viewModelContext: TimelineMediaPreviewViewModel.Context
@@ -171,6 +179,8 @@ private struct QuickLookView: UIViewControllerRepresentable {
             viewModelContext.viewState.previewItems[index]
         }
     }
+    
+    // MARK: UIKit
     
     class PreviewController: QLPreviewController {
         let coordinator: Coordinator

--- a/ElementX/Sources/Screens/MediaEventsTimelineScreen/MediaEventsTimelineScreenViewModel.swift
+++ b/ElementX/Sources/Screens/MediaEventsTimelineScreen/MediaEventsTimelineScreenViewModel.swift
@@ -157,8 +157,8 @@ class MediaEventsTimelineScreenViewModel: MediaEventsTimelineScreenViewModelType
         
         actionsSubject.send(.viewItem(.init(item: item,
                                             viewModel: activeTimelineViewModel,
-                                            namespace: namespace) { [weak self] in
-                self?.state.currentPreviewItemID = nil
+                                            namespace: namespace) { [weak self] itemID in
+                self?.state.currentPreviewItemID = itemID
             }))
         
         // Set the current item in the next run loop so that (hopefully) the presentation will be ready before we flip the thumbnail.

--- a/ElementX/Sources/Screens/MediaEventsTimelineScreen/View/MediaEventsTimelineScreen.swift
+++ b/ElementX/Sources/Screens/MediaEventsTimelineScreen/View/MediaEventsTimelineScreen.swift
@@ -211,12 +211,12 @@ struct MediaEventsTimelineScreen: View {
     }
     
     func scale(for item: RoomTimelineItemViewState, isGridLayout: Bool) -> CGSize {
-        guard item.identifier != context.viewState.currentPreviewItemID else {
+        if item.identifier == context.viewState.currentPreviewItemID, #available(iOS 18.0, *) {
             // Remove the flip when presenting a preview so that the zoom transition is the right way up 🙃
-            return CGSize(width: 1, height: 1)
+            CGSize(width: 1, height: 1)
+        } else {
+            CGSize(width: isGridLayout ? -1 : 1, height: -1)
         }
-        
-        return CGSize(width: isGridLayout ? -1 : 1, height: -1)
     }
 }
 

--- a/UnitTests/Sources/TimelineMediaPreviewViewModelTests.swift
+++ b/UnitTests/Sources/TimelineMediaPreviewViewModelTests.swift
@@ -104,7 +104,6 @@ class TimelineMediaPreviewViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.state.currentItem.contentType, "JPEG image")
         
         // When choosing to save the image.
-        let item = context.viewState.currentItem
         let deferred = deferFulfillment(context.$viewState) { $0.bindings.alertInfo != nil }
         context.send(viewAction: .saveCurrentItem)
         try await deferred.fulfill()
@@ -164,7 +163,7 @@ class TimelineMediaPreviewViewModelTests: XCTestCase {
     
     private func loadInitialItem() async throws {
         let deferred = deferFulfillment(viewModel.state.fileLoadedPublisher) { _ in true }
-        context.send(viewAction: .updateCurrentItem(context.viewState.previewItems[0]))
+        context.send(viewAction: .updateCurrentItem(context.viewState.previewItems[context.viewState.initialItemIndex]))
         try await deferred.fulfill()
     }
     


### PR DESCRIPTION
Not ideal, but a good enough workaround for now as adding a tap gesture would conflict with the preview controller.

Additionally adds a second attempt to stop the thumbnail appearing upside-down while dismissing the view (should work on iOS 18.1 and 18.2 this time, although there is occasionally a small flicker).

Additionally additionally, all of the items in the media events timeline are now loaded into the preview controller so that you can swipe between them. (Pagination not included).

https://github.com/user-attachments/assets/d690bea9-ba3b-4aed-8c2d-94917c7a858c
