### PR TITLE
Enable the media browser feature 🖼️

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -8427,7 +8427,7 @@
 			repositoryURL = "https://github.com/element-hq/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 1.0.82;
+				version = 1.0.83;
 			};
 		};
 		701C7BEF8F70F7A83E852DCC /* XCRemoteSwiftPackageReference "GZIP" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/matrix-rust-components-swift",
       "state" : {
-        "revision" : "043fcb8c80bbb6257f3f2075f2a72b8c9fdcbed2",
-        "version" : "1.0.82"
+        "revision" : "0d20974d1c44225596b24af1ec1f36716dd6e512",
+        "version" : "1.0.83"
       }
     },
     {

--- a/ElementX/Resources/Localizations/en.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Localizable.strings
@@ -145,6 +145,7 @@
 "common_developer_options" = "Developer options";
 "common_device_id" = "Device ID";
 "common_direct_chat" = "Direct chat";
+"common_download_failed" = "Download failed";
 "common_downloading" = "Downloading";
 "common_edited_suffix" = "(edited)";
 "common_editing" = "Editing";
@@ -160,6 +161,8 @@
 "common_favourite" = "Favourite";
 "common_favourited" = "Favourited";
 "common_file" = "File";
+"common_file_deleted" = "File deleted";
+"common_file_saved" = "File saved";
 "common_forward_message" = "Forward message";
 "common_frequently_used" = "Frequently used";
 "common_gif" = "GIF";
@@ -625,6 +628,7 @@
 "screen_login_title_with_homeserver" = "Sign in to %1$@";
 "screen_media_browser_delete_confirmation_subtitle" = "This file will be removed from the room and members won’t have access to it.";
 "screen_media_browser_delete_confirmation_title" = "Delete file?";
+"screen_media_browser_download_error_message" = "Check your internet connection and try again.";
 "screen_media_browser_files_empty_state_subtitle" = "Documents, audio files, and voice messages uploaded to this room will be shown here.";
 "screen_media_browser_files_empty_state_title" = "No files uploaded yet";
 "screen_media_browser_list_loading_files" = "Loading files…";

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -50,7 +50,6 @@ final class AppSettings {
         case enableOnlySignedDeviceIsolationMode
         case knockingEnabled
         case createMediaCaptionsEnabled
-        case mediaBrowserEnabled
         case eventCacheEnabled
     }
     
@@ -294,9 +293,6 @@ final class AppSettings {
     
     @UserPreference(key: UserDefaultsKeys.createMediaCaptionsEnabled, defaultValue: false, storageType: .userDefaults(store))
     var createMediaCaptionsEnabled
-    
-    @UserPreference(key: UserDefaultsKeys.mediaBrowserEnabled, defaultValue: false, storageType: .userDefaults(store))
-    var mediaBrowserEnabled
     
     #endif
     

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -49,7 +49,6 @@ final class AppSettings {
         case fuzzyRoomListSearchEnabled
         case enableOnlySignedDeviceIsolationMode
         case knockingEnabled
-        case createMediaCaptionsEnabled
         case eventCacheEnabled
     }
     
@@ -290,9 +289,6 @@ final class AppSettings {
     
     @UserPreference(key: UserDefaultsKeys.knockingEnabled, defaultValue: false, storageType: .userDefaults(store))
     var knockingEnabled
-    
-    @UserPreference(key: UserDefaultsKeys.createMediaCaptionsEnabled, defaultValue: false, storageType: .userDefaults(store))
-    var createMediaCaptionsEnabled
     
     #endif
     

--- a/ElementX/Sources/Generated/Strings.swift
+++ b/ElementX/Sources/Generated/Strings.swift
@@ -330,6 +330,8 @@ internal enum L10n {
   internal static var commonDeviceId: String { return L10n.tr("Localizable", "common_device_id") }
   /// Direct chat
   internal static var commonDirectChat: String { return L10n.tr("Localizable", "common_direct_chat") }
+  /// Download failed
+  internal static var commonDownloadFailed: String { return L10n.tr("Localizable", "common_download_failed") }
   /// Downloading
   internal static var commonDownloading: String { return L10n.tr("Localizable", "common_downloading") }
   /// (edited)
@@ -362,6 +364,10 @@ internal enum L10n {
   internal static var commonFavourited: String { return L10n.tr("Localizable", "common_favourited") }
   /// File
   internal static var commonFile: String { return L10n.tr("Localizable", "common_file") }
+  /// File deleted
+  internal static var commonFileDeleted: String { return L10n.tr("Localizable", "common_file_deleted") }
+  /// File saved
+  internal static var commonFileSaved: String { return L10n.tr("Localizable", "common_file_saved") }
   /// Forward message
   internal static var commonForwardMessage: String { return L10n.tr("Localizable", "common_forward_message") }
   /// Frequently used
@@ -1396,6 +1402,8 @@ internal enum L10n {
   internal static var screenMediaBrowserDeleteConfirmationSubtitle: String { return L10n.tr("Localizable", "screen_media_browser_delete_confirmation_subtitle") }
   /// Delete file?
   internal static var screenMediaBrowserDeleteConfirmationTitle: String { return L10n.tr("Localizable", "screen_media_browser_delete_confirmation_title") }
+  /// Check your internet connection and try again.
+  internal static var screenMediaBrowserDownloadErrorMessage: String { return L10n.tr("Localizable", "screen_media_browser_download_error_message") }
   /// Documents, audio files, and voice messages uploaded to this room will be shown here.
   internal static var screenMediaBrowserFilesEmptyStateSubtitle: String { return L10n.tr("Localizable", "screen_media_browser_files_empty_state_subtitle") }
   /// No files uploaded yet

--- a/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewModels.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewModels.swift
@@ -52,6 +52,7 @@ enum TimelineMediaPreviewAlertType {
 class TimelineMediaPreviewItem: NSObject, QLPreviewItem, Identifiable {
     let timelineItem: EventBasedMessageTimelineItemProtocol
     var fileHandle: MediaFileHandleProxy?
+    var downloadError: Error?
     
     init(timelineItem: EventBasedMessageTimelineItemProtocol) {
         self.timelineItem = timelineItem

--- a/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewViewModel.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewViewModel.swift
@@ -80,21 +80,21 @@ class TimelineMediaPreviewViewModel: TimelineMediaPreviewViewModelType {
     }
     
     private func updateCurrentItem(_ previewItem: TimelineMediaPreviewItem) async {
+        previewItem.downloadError = nil // Clear any existing error.
         state.currentItem = previewItem
         currentItemIDHandler?(previewItem.id)
+        
         rebuildCurrentItemActions()
         
         if previewItem.fileHandle == nil, let source = previewItem.mediaSource {
-            showDownloadingIndicator(itemID: previewItem.id)
-            defer { hideDownloadingIndicator(itemID: previewItem.id) }
-            
             switch await mediaProvider.loadFileFromSource(source, filename: previewItem.filename) {
             case .success(let handle):
                 previewItem.fileHandle = handle
                 state.fileLoadedPublisher.send(previewItem.id)
             case .failure(let error):
                 MXLog.error("Failed loading media: \(error)")
-                showDownloadErrorIndicator()
+                context.objectWillChange.send() // Manually trigger the SwiftUI view update.
+                previewItem.downloadError = error
             }
         }
     }
@@ -156,39 +156,17 @@ class TimelineMediaPreviewViewModel: TimelineMediaPreviewViewModelType {
     
     // MARK: - Indicators
     
-    private func showDownloadingIndicator(itemID: TimelineItemIdentifier) {
-        let indicatorID = makeDownloadIndicatorID(itemID: itemID)
-        userIndicatorController.submitIndicator(UserIndicator(id: indicatorID,
-                                                              type: .toast(progress: .indeterminate),
-                                                              title: L10n.commonDownloading,
-                                                              persistent: true),
-                                                delay: .seconds(0.1)) // Don't show the indicator when the SDK loads the file from the store.
-    }
-    
-    private func hideDownloadingIndicator(itemID: TimelineItemIdentifier) {
-        let indicatorID = makeDownloadIndicatorID(itemID: itemID)
-        userIndicatorController.retractIndicatorWithId(indicatorID)
-    }
-    
-    // FIXME: Add the strings and correct indicator types
-    private func showDownloadErrorIndicator() {
-        userIndicatorController.submitIndicator(UserIndicator(id: downloadErrorIndicatorID,
-                                                              type: .modal,
-                                                              title: L10n.errorUnknown,
-                                                              iconName: "exclamationmark.circle.fill"))
-    }
-    
     private func showRedactedIndicator() {
         userIndicatorController.submitIndicator(UserIndicator(id: statusIndicatorID,
                                                               type: .toast,
-                                                              title: "File deleted",
+                                                              title: L10n.commonFileDeleted,
                                                               iconName: "checkmark"))
     }
     
     private func showSavedIndicator() {
         userIndicatorController.submitIndicator(UserIndicator(id: statusIndicatorID,
                                                               type: .toast,
-                                                              title: "File saved",
+                                                              title: L10n.commonFileSaved,
                                                               iconName: "checkmark"))
     }
     
@@ -200,10 +178,4 @@ class TimelineMediaPreviewViewModel: TimelineMediaPreviewViewModelType {
     }
     
     private var statusIndicatorID: String { "\(Self.self)-Status" }
-    
-    // Separate indicator IDs for downloads as these can be triggered in the background when swiping between items
-    private var downloadErrorIndicatorID: String { "\(Self.self)-DownloadError" }
-    private func makeDownloadIndicatorID(itemID: TimelineItemIdentifier) -> String {
-        "\(Self.self)-Download-\(itemID.uniqueID.id)"
-    }
 }

--- a/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewViewModel.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewViewModel.swift
@@ -108,7 +108,6 @@ class TimelineMediaPreviewViewModel: TimelineMediaPreviewViewModelType {
                                                       pinnedEventIDs: timelineContext.viewState.pinnedEventIDs,
                                                       isDM: timelineContext.viewState.isEncryptedOneToOneRoom,
                                                       isViewSourceEnabled: timelineContext.viewState.isViewSourceEnabled,
-                                                      isCreateMediaCaptionsEnabled: timelineContext.viewState.isCreateMediaCaptionsEnabled,
                                                       timelineKind: timelineContext.viewState.timelineKind,
                                                       emojiProvider: timelineContext.viewState.emojiProvider)
         state.currentItemActions = provider.makeActions()

--- a/ElementX/Sources/Screens/PinnedEventsTimelineScreen/View/PinnedEventsTimelineScreen.swift
+++ b/ElementX/Sources/Screens/PinnedEventsTimelineScreen/View/PinnedEventsTimelineScreen.swift
@@ -37,7 +37,6 @@ struct PinnedEventsTimelineScreen: View {
                                                              pinnedEventIDs: timelineContext.viewState.pinnedEventIDs,
                                                              isDM: timelineContext.viewState.isEncryptedOneToOneRoom,
                                                              isViewSourceEnabled: timelineContext.viewState.isViewSourceEnabled,
-                                                             isCreateMediaCaptionsEnabled: timelineContext.viewState.isCreateMediaCaptionsEnabled,
                                                              timelineKind: timelineContext.viewState.timelineKind,
                                                              emojiProvider: timelineContext.viewState.emojiProvider)
                     .makeActions()

--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenModels.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenModels.swift
@@ -63,8 +63,6 @@ struct RoomDetailsScreenViewState: BindableState {
         knockingEnabled && dmRecipient == nil && canEditRolesOrPermissions
     }
     
-    var mediaBrowserEnabled = false
-    
     var canEdit: Bool {
         !isDirect && (canEditRoomName || canEditRoomTopic || canEditRoomAvatar)
     }

--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
@@ -79,10 +79,6 @@ class RoomDetailsScreenViewModel: RoomDetailsScreenViewModelType, RoomDetailsScr
             .weakAssign(to: \.state.knockingEnabled, on: self)
             .store(in: &cancellables)
         
-        appSettings.$mediaBrowserEnabled
-            .weakAssign(to: \.state.mediaBrowserEnabled, on: self)
-            .store(in: &cancellables)
-        
         appMediator.networkMonitor.reachabilityPublisher
             .filter { $0 == .reachable }
             .receive(on: DispatchQueue.main)

--- a/ElementX/Sources/Screens/RoomDetailsScreen/View/RoomDetailsScreen.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/View/RoomDetailsScreen.swift
@@ -170,12 +170,10 @@ struct RoomDetailsScreen: View {
                     })
                     .accessibilityIdentifier(A11yIdentifiers.roomDetailsScreen.pollsHistory)
             
-            if context.viewState.mediaBrowserEnabled {
-                ListRow(label: .default(title: L10n.screenMediaBrowserTitle, icon: \.image),
-                        kind: .navigationLink {
-                            context.send(viewAction: .processTapMediaEvents)
-                        })
-            }
+            ListRow(label: .default(title: L10n.screenMediaBrowserTitle, icon: \.image),
+                    kind: .navigationLink {
+                        context.send(viewAction: .processTapMediaEvents)
+                    })
         }
     }
     

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
@@ -75,7 +75,6 @@ struct RoomScreen: View {
                                                              pinnedEventIDs: timelineContext.viewState.pinnedEventIDs,
                                                              isDM: timelineContext.viewState.isEncryptedOneToOneRoom,
                                                              isViewSourceEnabled: timelineContext.viewState.isViewSourceEnabled,
-                                                             isCreateMediaCaptionsEnabled: timelineContext.viewState.isCreateMediaCaptionsEnabled,
                                                              timelineKind: timelineContext.viewState.timelineKind,
                                                              emojiProvider: timelineContext.viewState.emojiProvider)
                     .makeActions()

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
@@ -50,7 +50,6 @@ protocol DeveloperOptionsProtocol: AnyObject {
     var enableOnlySignedDeviceIsolationMode: Bool { get set }
     var elementCallBaseURLOverride: URL? { get set }
     var knockingEnabled: Bool { get set }
-    var createMediaCaptionsEnabled: Bool { get set }
     var eventCacheEnabled: Bool { get set }
 }
 

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
@@ -51,7 +51,6 @@ protocol DeveloperOptionsProtocol: AnyObject {
     var elementCallBaseURLOverride: URL? { get set }
     var knockingEnabled: Bool { get set }
     var createMediaCaptionsEnabled: Bool { get set }
-    var mediaBrowserEnabled: Bool { get set }
     var eventCacheEnabled: Bool { get set }
 }
 

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
@@ -62,10 +62,6 @@ struct DeveloperOptionsScreen: View {
                 Toggle(isOn: $context.hideTimelineMedia) {
                     Text("Hide image & video previews")
                 }
-                
-                Toggle(isOn: $context.createMediaCaptionsEnabled) {
-                    Text("Allow creation of media captions")
-                }
             }
             
             Section("Join rules") {

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
@@ -66,10 +66,6 @@ struct DeveloperOptionsScreen: View {
                 Toggle(isOn: $context.createMediaCaptionsEnabled) {
                     Text("Allow creation of media captions")
                 }
-                
-                Toggle(isOn: $context.mediaBrowserEnabled) {
-                    Text("Enable the media browser")
-                }
             }
             
             Section("Join rules") {

--- a/ElementX/Sources/Screens/Timeline/TimelineModels.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineModels.swift
@@ -99,7 +99,6 @@ struct TimelineViewState: BindableState {
     var canCurrentUserRedactSelf = false
     var canCurrentUserPin = false
     var isViewSourceEnabled: Bool
-    var isCreateMediaCaptionsEnabled: Bool
     var hideTimelineMedia: Bool
         
     // The `pinnedEventIDs` are used only to determine if an item is already pinned or not.

--- a/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
@@ -81,7 +81,6 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
                                                        timelineState: TimelineState(focussedEvent: focussedEventID.map { .init(eventID: $0, appearance: .immediate) }),
                                                        ownUserID: roomProxy.ownUserID,
                                                        isViewSourceEnabled: appSettings.viewSourceEnabled,
-                                                       isCreateMediaCaptionsEnabled: appSettings.createMediaCaptionsEnabled,
                                                        hideTimelineMedia: appSettings.hideTimelineMedia,
                                                        pinnedEventIDs: roomProxy.infoPublisher.value.pinnedEventIDs,
                                                        bindings: .init(reactionsCollapsed: [:]),
@@ -447,10 +446,6 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
         
         appSettings.$viewSourceEnabled
             .weakAssign(to: \.state.isViewSourceEnabled, on: self)
-            .store(in: &cancellables)
-        
-        appSettings.$createMediaCaptionsEnabled
-            .weakAssign(to: \.state.isCreateMediaCaptionsEnabled, on: self)
             .store(in: &cancellables)
         
         appSettings.$hideTimelineMedia

--- a/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenu.swift
+++ b/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenu.swift
@@ -344,7 +344,6 @@ struct TimelineItemMenu_Previews: PreviewProvider, TestablePreview {
                                                       pinnedEventIDs: [],
                                                       isDM: true,
                                                       isViewSourceEnabled: true,
-                                                      isCreateMediaCaptionsEnabled: true,
                                                       timelineKind: .live,
                                                       emojiProvider: EmojiProvider(appSettings: ServiceLocator.shared.settings))
         guard let actions = provider.makeActions() else { return nil }

--- a/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenuActionProvider.swift
+++ b/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenuActionProvider.swift
@@ -16,7 +16,6 @@ struct TimelineItemMenuActionProvider {
     let pinnedEventIDs: Set<String>
     let isDM: Bool
     let isViewSourceEnabled: Bool
-    let isCreateMediaCaptionsEnabled: Bool
     let timelineKind: TimelineKind
     let emojiProvider: EmojiProviderProtocol
     
@@ -63,7 +62,7 @@ struct TimelineItemMenuActionProvider {
             if item.supportsMediaCaption {
                 if item.hasMediaCaption {
                     actions.append(.editCaption)
-                } else if isCreateMediaCaptionsEnabled {
+                } else {
                     actions.append(.addCaption)
                 }
             } else if item is PollRoomTimelineItem {

--- a/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemBubbledStylerView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemBubbledStylerView.swift
@@ -149,7 +149,6 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
                                                               pinnedEventIDs: context.viewState.pinnedEventIDs,
                                                               isDM: context.viewState.isEncryptedOneToOneRoom,
                                                               isViewSourceEnabled: context.viewState.isViewSourceEnabled,
-                                                              isCreateMediaCaptionsEnabled: context.viewState.isCreateMediaCaptionsEnabled,
                                                               timelineKind: context.viewState.timelineKind,
                                                               emojiProvider: context.viewState.emojiProvider)
                 TimelineItemMacContextMenu(item: timelineItem, actionProvider: provider) { action in

--- a/project.yml
+++ b/project.yml
@@ -61,7 +61,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/element-hq/matrix-rust-components-swift
-    exactVersion: 1.0.82
+    exactVersion: 1.0.83
     # path: ../matrix-rust-sdk
   Compound:
     url: https://github.com/element-hq/compound-ios


### PR DESCRIPTION
This PR makes the following changes:

- Moves the download indicator from a toast to a custom overlay on the screen.
- Localises a handful of strings that were waiting for confirmation (adding a download error state).
- Removes the feature flag for the media browser.
- Updates the SDK to [0.9.0](https://github.com/matrix-org/matrix-rust-sdk/releases/tag/matrix-sdk-0.9.0) ready for release.