### PR TITLE
Media upload tweaks

### DIFF
--- a/ElementX/Sources/Screens/MediaUploadPreviewScreen/MediaUploadPreviewScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/MediaUploadPreviewScreen/MediaUploadPreviewScreenCoordinator.swift
@@ -52,6 +52,10 @@ final class MediaUploadPreviewScreenCoordinator: CoordinatorProtocol {
             .store(in: &cancellables)
     }
     
+    func stop() {
+        viewModel.stopProcessing()
+    }
+    
     func toPresentable() -> AnyView {
         AnyView(MediaUploadPreviewScreen(context: viewModel.context))
     }

--- a/ElementX/Sources/Screens/MediaUploadPreviewScreen/MediaUploadPreviewScreenViewModelProtocol.swift
+++ b/ElementX/Sources/Screens/MediaUploadPreviewScreen/MediaUploadPreviewScreenViewModelProtocol.swift
@@ -11,4 +11,7 @@ import Combine
 protocol MediaUploadPreviewScreenViewModelProtocol {
     var actions: AnyPublisher<MediaUploadPreviewScreenViewModelAction, Never> { get }
     var context: MediaUploadPreviewScreenViewModelType.Context { get }
+    
+    /// Stops any ongoing media processing tasks.
+    func stopProcessing()
 }

--- a/UnitTests/Sources/MediaUploadPreviewScreenViewModelTests.swift
+++ b/UnitTests/Sources/MediaUploadPreviewScreenViewModelTests.swift
@@ -138,8 +138,13 @@ class MediaUploadPreviewScreenViewModelTests: XCTestCase {
     }
     
     private func send() async throws {
+        XCTAssertFalse(context.viewState.shouldDisableInteraction, "Attempting to send when interaction is disabled.")
+        
         let deferred = deferFulfillment(viewModel.actions) { $0 == .dismiss }
         context.send(viewAction: .send)
+        
+        XCTAssertTrue(context.viewState.shouldDisableInteraction, "The interaction should be disabled while sending.")
+        
         try await deferred.fulfill()
     }
 }


### PR DESCRIPTION
The PR makes a few tweaks to the media upload screen:

- Automatically focusses the caption composer when a hardware keyboard is attached.
- Adds key handlers to the caption composer to `send` (enter) and `cancel` (escape).
- Fixes a bug where interaction wasn't disabled until processing had completed (it was waiting for sending to start).
- Starts processing the media as soon as the screen is presented. This means that
    - the screen is unlikely to block anymore for images, audio and files (instant sending!)
    - the screen should block for less time for videos

https://github.com/user-attachments/assets/a0febf3c-8d25-4633-b34c-1266bd53c882

This is the iOS counterpart to https://github.com/element-hq/element-x-android/pull/3943