### PR TITLE
Autofocus emoji search and send the first result with the return key on macOS.

### DIFF
--- a/ElementX/Sources/Screens/EmojiPickerScreen/View/EmojiPickerScreen.swift
+++ b/ElementX/Sources/Screens/EmojiPickerScreen/View/EmojiPickerScreen.swift
@@ -83,7 +83,7 @@ struct EmojiPickerScreen: View {
         // No sure-fire way to detect that the submit came from a h/w keyboard on iOS/iPadOS.
         guard ProcessInfo.processInfo.isiOSAppOnMac else { return }
         
-        if let emoji = context.viewState.categories.first?.emojis.first {
+        if !searchString.isBlank, let emoji = context.viewState.categories.first?.emojis.first {
             context.send(viewAction: .emojiTapped(emoji: emoji))
         }
     }

--- a/ElementX/Sources/Screens/EmojiPickerScreen/View/EmojiPickerScreen.swift
+++ b/ElementX/Sources/Screens/EmojiPickerScreen/View/EmojiPickerScreen.swift
@@ -51,6 +51,8 @@ struct EmojiPickerScreen: View {
             .toolbar { toolbar }
             .isSearching($isSearching)
             .searchable(text: $searchString, placement: .navigationBarDrawer(displayMode: .always))
+            .focusSearchIfHardwareKeyboardAvailable()
+            .onSubmit(of: .search, sendFirstEmojiOnMac)
             .compoundSearchField()
         }
         .presentationDetents([.medium, .large])
@@ -74,6 +76,15 @@ struct EmojiPickerScreen: View {
             Button { context.send(viewAction: .dismiss) } label: {
                 Text(L10n.actionCancel)
             }
+        }
+    }
+    
+    func sendFirstEmojiOnMac() {
+        // No sure-fire way to detect that the submit came from a h/w keyboard on iOS/iPadOS.
+        guard ProcessInfo.processInfo.isiOSAppOnMac else { return }
+        
+        if let emoji = context.viewState.categories.first?.emojis.first {
+            context.send(viewAction: .emojiTapped(emoji: emoji))
         }
     }
 }


### PR DESCRIPTION
Useful for search terms like `wave`, `+1`, `melt` etc. 

https://github.com/user-attachments/assets/1a910d20-7653-4ad3-b5de-349eb7346da3

