### PR TITLE
Fix the overlapping scrollbars on the room list filters on macOS.

### DIFF
--- a/ElementX/Sources/Screens/HomeScreen/View/Filters/RoomListFiltersView.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/Filters/RoomListFiltersView.swift
@@ -12,6 +12,10 @@ struct RoomListFiltersView: View {
     @Binding var state: RoomListFiltersState
     @Namespace private var namespace
     
+    /// When you connect a mouse on macOS the scrollbars aren't hidden. This is some extra padding
+    /// applied to the scroll view content to make sure the bars don't overlap the filters.
+    private var macScrollBarPadding: CGFloat { ProcessInfo.processInfo.isiOSAppOnMac ? 16 : 0 }
+    
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView(.horizontal) {
@@ -39,11 +43,13 @@ struct RoomListFiltersView: View {
                                 .matchedGeometryEffect(id: filter.id, in: namespace)
                         }
                     }
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, macScrollBarPadding)
                 }
             }
             .scrollIndicators(.hidden)
-            .padding(.leading, 16)
             .padding(.vertical, 12)
+            .padding(.bottom, -macScrollBarPadding)
         }
     }
     


### PR DESCRIPTION
This PR makes 2 changes:

- Fix the filters scroll view content so that if isn't clipped on the leading edge and has matching padding on the trailing edge
- Add some extra padding to the content on macOS so that any scroll bars don't overlap (the padding is then removed from the view itself so no extra space is take up). Fixes #2583

| Before iPhone | After iPhone |
| - | - |
| ![before iphone](https://github.com/user-attachments/assets/2287aa89-4625-41e0-8935-484a0f45ccf2) | ![after iphone](https://github.com/user-attachments/assets/9a9aedab-ef55-4610-9fed-62d6444e50e5) |


| Mouse macOS | No mouse macOS |
| - | - |
| <img width="247" alt="mouse macOS" src="https://github.com/user-attachments/assets/5a32ce69-22a4-4c09-903a-8d5b058d76ed" /> | <img width="247" alt="no mouse macOS" src="https://github.com/user-attachments/assets/78332589-9423-4e64-a02e-e1ae510296a6" /> |
