### PR TITLE
Add the event cache to the Rust tracing configuration.

### DIFF
--- a/ElementX/Sources/Other/Logging/TracingConfiguration.swift
+++ b/ElementX/Sources/Other/Logging/TracingConfiguration.swift
@@ -61,6 +61,8 @@ struct TracingConfiguration {
         case matrix_sdk_sliding_sync = "matrix_sdk::sliding_sync"
         case matrix_sdk_base_sliding_sync = "matrix_sdk_base::sliding_sync"
         case matrix_sdk_ui_timeline = "matrix_sdk_ui::timeline"
+        case matrix_sdk_event_cache = "matrix_sdk::event_cache"
+        case matrix_sdk_sqlite_event_cache_store = "matrix_sdk_sqlite::event_cache_store"
     }
     
     // The `common` target is excluded because 3rd-party crates might end up logging user data.
@@ -74,7 +76,9 @@ struct TracingConfiguration {
         .matrix_sdk_http_client: .debug,
         .matrix_sdk_sliding_sync: .info,
         .matrix_sdk_base_sliding_sync: .info,
-        .matrix_sdk_ui_timeline: .info
+        .matrix_sdk_ui_timeline: .info,
+        .matrix_sdk_event_cache: .info,
+        .matrix_sdk_sqlite_event_cache_store: .info
     ]
     
     let filter: String

--- a/UnitTests/Sources/TracingConfigurationTests.swift
+++ b/UnitTests/Sources/TracingConfigurationTests.swift
@@ -13,23 +13,23 @@ class TracingConfigurationTests: XCTestCase {
     func testConfiguration() { // swiftlint:disable line_length
         var filter = TracingConfiguration(logLevel: .error, currentTarget: "tests", filePrefix: nil).filter
         
-        XCTAssertEqual(filter, "hyper=warn,matrix_sdk_ffi=info,matrix_sdk::client=trace,matrix_sdk_crypto=debug,matrix_sdk_crypto::olm::account=trace,matrix_sdk::oidc=trace,matrix_sdk::http_client=debug,matrix_sdk::sliding_sync=info,matrix_sdk_base::sliding_sync=info,matrix_sdk_ui::timeline=info,tests=error")
+        XCTAssertEqual(filter, "hyper=warn,matrix_sdk_ffi=info,matrix_sdk::client=trace,matrix_sdk_crypto=debug,matrix_sdk_crypto::olm::account=trace,matrix_sdk::oidc=trace,matrix_sdk::http_client=debug,matrix_sdk::sliding_sync=info,matrix_sdk_base::sliding_sync=info,matrix_sdk_ui::timeline=info,matrix_sdk::event_cache=info,matrix_sdk_sqlite::event_cache_store=info,tests=error")
         
         filter = TracingConfiguration(logLevel: .warn, currentTarget: "tests", filePrefix: nil).filter
         
-        XCTAssertEqual(filter, "hyper=warn,matrix_sdk_ffi=info,matrix_sdk::client=trace,matrix_sdk_crypto=debug,matrix_sdk_crypto::olm::account=trace,matrix_sdk::oidc=trace,matrix_sdk::http_client=debug,matrix_sdk::sliding_sync=info,matrix_sdk_base::sliding_sync=info,matrix_sdk_ui::timeline=info,tests=warn")
+        XCTAssertEqual(filter, "hyper=warn,matrix_sdk_ffi=info,matrix_sdk::client=trace,matrix_sdk_crypto=debug,matrix_sdk_crypto::olm::account=trace,matrix_sdk::oidc=trace,matrix_sdk::http_client=debug,matrix_sdk::sliding_sync=info,matrix_sdk_base::sliding_sync=info,matrix_sdk_ui::timeline=info,matrix_sdk::event_cache=info,matrix_sdk_sqlite::event_cache_store=info,tests=warn")
         
         filter = TracingConfiguration(logLevel: .info, currentTarget: "tests", filePrefix: nil).filter
         
-        XCTAssertEqual(filter, "hyper=warn,matrix_sdk_ffi=info,matrix_sdk::client=trace,matrix_sdk_crypto=debug,matrix_sdk_crypto::olm::account=trace,matrix_sdk::oidc=trace,matrix_sdk::http_client=debug,matrix_sdk::sliding_sync=info,matrix_sdk_base::sliding_sync=info,matrix_sdk_ui::timeline=info,tests=info")
+        XCTAssertEqual(filter, "hyper=warn,matrix_sdk_ffi=info,matrix_sdk::client=trace,matrix_sdk_crypto=debug,matrix_sdk_crypto::olm::account=trace,matrix_sdk::oidc=trace,matrix_sdk::http_client=debug,matrix_sdk::sliding_sync=info,matrix_sdk_base::sliding_sync=info,matrix_sdk_ui::timeline=info,matrix_sdk::event_cache=info,matrix_sdk_sqlite::event_cache_store=info,tests=info")
         
         filter = TracingConfiguration(logLevel: .debug, currentTarget: "tests", filePrefix: nil).filter
         
-        XCTAssertEqual(filter, "hyper=warn,matrix_sdk_ffi=debug,matrix_sdk::client=trace,matrix_sdk_crypto=debug,matrix_sdk_crypto::olm::account=trace,matrix_sdk::oidc=trace,matrix_sdk::http_client=debug,matrix_sdk::sliding_sync=debug,matrix_sdk_base::sliding_sync=debug,matrix_sdk_ui::timeline=debug,tests=debug")
+        XCTAssertEqual(filter, "hyper=warn,matrix_sdk_ffi=debug,matrix_sdk::client=trace,matrix_sdk_crypto=debug,matrix_sdk_crypto::olm::account=trace,matrix_sdk::oidc=trace,matrix_sdk::http_client=debug,matrix_sdk::sliding_sync=debug,matrix_sdk_base::sliding_sync=debug,matrix_sdk_ui::timeline=debug,matrix_sdk::event_cache=debug,matrix_sdk_sqlite::event_cache_store=debug,tests=debug")
         
         filter = TracingConfiguration(logLevel: .trace, currentTarget: "tests", filePrefix: nil).filter
         
-        XCTAssertEqual(filter, "hyper=warn,matrix_sdk_ffi=trace,matrix_sdk::client=trace,matrix_sdk_crypto=trace,matrix_sdk_crypto::olm::account=trace,matrix_sdk::oidc=trace,matrix_sdk::http_client=trace,matrix_sdk::sliding_sync=trace,matrix_sdk_base::sliding_sync=trace,matrix_sdk_ui::timeline=trace,tests=trace")
+        XCTAssertEqual(filter, "hyper=warn,matrix_sdk_ffi=trace,matrix_sdk::client=trace,matrix_sdk_crypto=trace,matrix_sdk_crypto::olm::account=trace,matrix_sdk::oidc=trace,matrix_sdk::http_client=trace,matrix_sdk::sliding_sync=trace,matrix_sdk_base::sliding_sync=trace,matrix_sdk_ui::timeline=trace,matrix_sdk::event_cache=trace,matrix_sdk_sqlite::event_cache_store=trace,tests=trace")
     } // swiftlint:enable line_length
     
     func testLevelOrdering() {


### PR DESCRIPTION
Defaults to `info`, allows configuring it lower in the developer options screen.