### PR TITLE
Include missing gems until Fastlane is updated for Ruby 3.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
       base64
       nkf
       rexml
+    abbrev (0.1.2)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     artifactory (3.0.17)
@@ -179,12 +180,14 @@ GEM
     mini_mime (1.1.5)
     multi_json (1.15.0)
     multipart-post (2.4.1)
+    mutex_m (0.3.0)
     nanaimo (0.4.0)
     naturally (2.2.1)
     netrc (0.11.0)
     nkf (0.2.0)
     optparse (0.6.0)
     os (1.1.4)
+    ostruct (0.6.1)
     plist (3.7.1)
     public_suffix (5.1.1)
     rake (13.2.1)
@@ -244,12 +247,15 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  abbrev
   fastlane
   fastlane-plugin-browserstack
   fastlane-plugin-diawi!
   fastlane-plugin-sentry
   fastlane-plugin-xcconfig
   fastlane-plugin-xcodegen
+  mutex_m
+  ostruct
   semantic
   xcode-install
 

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -7,3 +7,9 @@ gem 'fastlane-plugin-xcodegen'
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-browserstack'
 gem 'fastlane-plugin-xcconfig'
+
+# Until Fastlane includes them directly.
+# https://github.com/fastlane/fastlane/issues/29183
+gem "abbrev"
+gem "mutex_m"
+gem "ostruct"


### PR DESCRIPTION
As mentioned in https://github.com/fastlane/fastlane/issues/29183#issuecomment-2567093826

Tested and Xcode Cloud seems happy now.