### PR TITLE
Warn and block sending on verification violation

### DIFF
--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -4682,6 +4682,76 @@ class ClientProxyMock: ClientProxyProtocol, @unchecked Sendable {
             return pinUserIdentityReturnValue
         }
     }
+    //MARK: - withdrawUserIdentityVerification
+
+    var withdrawUserIdentityVerificationUnderlyingCallsCount = 0
+    var withdrawUserIdentityVerificationCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return withdrawUserIdentityVerificationUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = withdrawUserIdentityVerificationUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                withdrawUserIdentityVerificationUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    withdrawUserIdentityVerificationUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var withdrawUserIdentityVerificationCalled: Bool {
+        return withdrawUserIdentityVerificationCallsCount > 0
+    }
+    var withdrawUserIdentityVerificationReceivedUserID: String?
+    var withdrawUserIdentityVerificationReceivedInvocations: [String] = []
+
+    var withdrawUserIdentityVerificationUnderlyingReturnValue: Result<Void, ClientProxyError>!
+    var withdrawUserIdentityVerificationReturnValue: Result<Void, ClientProxyError>! {
+        get {
+            if Thread.isMainThread {
+                return withdrawUserIdentityVerificationUnderlyingReturnValue
+            } else {
+                var returnValue: Result<Void, ClientProxyError>? = nil
+                DispatchQueue.main.sync {
+                    returnValue = withdrawUserIdentityVerificationUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                withdrawUserIdentityVerificationUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    withdrawUserIdentityVerificationUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    var withdrawUserIdentityVerificationClosure: ((String) async -> Result<Void, ClientProxyError>)?
+
+    func withdrawUserIdentityVerification(_ userID: String) async -> Result<Void, ClientProxyError> {
+        withdrawUserIdentityVerificationCallsCount += 1
+        withdrawUserIdentityVerificationReceivedUserID = userID
+        DispatchQueue.main.async {
+            self.withdrawUserIdentityVerificationReceivedInvocations.append(userID)
+        }
+        if let withdrawUserIdentityVerificationClosure = withdrawUserIdentityVerificationClosure {
+            return await withdrawUserIdentityVerificationClosure(userID)
+        } else {
+            return withdrawUserIdentityVerificationReturnValue
+        }
+    }
     //MARK: - resetIdentity
 
     var resetIdentityUnderlyingCallsCount = 0

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarModels.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarModels.swift
@@ -66,6 +66,8 @@ enum ComposerAttachmentType {
 struct ComposerToolbarViewState: BindableState {
     var composerMode: ComposerMode = .default
     var composerEmpty = true
+    /// Could be false if sending is disabled in the room
+    var canSend = true
     var suggestions: [SuggestionItem] = []
     var audioPlayerState: AudioPlayerState
     var audioRecorderState: AudioRecorderState
@@ -97,6 +99,10 @@ struct ComposerToolbarViewState: BindableState {
     }
     
     var sendButtonDisabled: Bool {
+        if !canSend {
+            return true
+        }
+        
         if case .previewVoiceMessage = composerMode {
             return false
         }

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarViewModel.swift
@@ -18,8 +18,10 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
     private var initialText: String?
     private let wysiwygViewModel: WysiwygComposerViewModel
     private let completionSuggestionService: CompletionSuggestionServiceProtocol
+    private let roomProxy: JoinedRoomProxyProtocol
     private let analyticsService: AnalyticsService
     private let draftService: ComposerDraftServiceProtocol
+    private var identityPinningViolations = [String: RoomMemberProxyProtocol]()
     
     private let mentionBuilder: MentionBuilderProtocol
     private let attributedStringBuilder: AttributedStringBuilderProtocol
@@ -43,6 +45,7 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
     private var replyLoadingTask: Task<Void, Never>?
 
     init(initialText: String? = nil,
+         roomProxy: JoinedRoomProxyProtocol,
          wysiwygViewModel: WysiwygComposerViewModel,
          completionSuggestionService: CompletionSuggestionServiceProtocol,
          mediaProvider: MediaProviderProtocol,
@@ -53,6 +56,7 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
         self.wysiwygViewModel = wysiwygViewModel
         self.completionSuggestionService = completionSuggestionService
         self.analyticsService = analyticsService
+        self.roomProxy = roomProxy
         draftService = composerDraftService
         
         mentionBuilder = MentionBuilder()
@@ -120,6 +124,19 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
         
         setupMentionsHandling(mentionDisplayHelper: mentionDisplayHelper)
         focusComposerIfHardwareKeyboardConnected()
+        
+        let identityStatusChangesPublisher = roomProxy.identityStatusChangesPublisher.receive(on: DispatchQueue.main)
+
+        Task { [weak self] in
+            for await changes in identityStatusChangesPublisher.values {
+                guard !Task.isCancelled else {
+                    return
+                }
+
+                await self?.processIdentityStatusChanges(changes)
+            }
+        }
+        .store(in: &cancellables)
     }
     
     // MARK: - Public
@@ -476,6 +493,25 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
                 state.bindings.plainComposerText = attributedString
             }
         }
+    }
+    
+    private func processIdentityStatusChanges(_ changes: [IdentityStatusChange]) async {
+        for change in changes {
+            switch change.changedTo {
+            case .verificationViolation:
+                guard case let .success(member) = await roomProxy.getMember(userID: change.userId) else {
+                    MXLog.error("Failed retrieving room member for identity status change: \(change)")
+                    continue
+                }
+
+                identityPinningViolations[change.userId] = member
+            default:
+                // clear
+                identityPinningViolations[change.userId] = nil
+            }
+        }
+
+        state.canSend = identityPinningViolations.isEmpty
     }
 
     private func set(mode: ComposerMode) {

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/ComposerToolbar.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/ComposerToolbar.swift
@@ -44,6 +44,7 @@ struct ComposerToolbar: View {
                     .offset(y: -frame.height)
             }
         }
+        .disabled(!context.viewState.canSend)
         .alert(item: $context.alertInfo)
     }
     
@@ -297,7 +298,7 @@ struct ComposerToolbar: View {
 
 struct ComposerToolbar_Previews: PreviewProvider, TestablePreview {
     static let wysiwygViewModel = WysiwygComposerViewModel()
-    static let composerViewModel = ComposerToolbarViewModel(wysiwygViewModel: wysiwygViewModel,
+    static let composerViewModel = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(), wysiwygViewModel: wysiwygViewModel,
                                                             completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init(suggestions: suggestions)),
                                                             mediaProvider: MediaProviderMock(configuration: .init()),
                                                             mentionDisplayHelper: ComposerMentionDisplayHelper.mock,
@@ -331,6 +332,11 @@ struct ComposerToolbar_Previews: PreviewProvider, TestablePreview {
             ComposerToolbar.replyLoadingPreviewMock(isLoading: false)
         }
         .previewDisplayName("Reply")
+        
+        VStack(spacing: 8) {
+            ComposerToolbar.disabledPreviewMock()
+        }
+        .previewDisplayName("Disabled")
     }
 }
 
@@ -338,7 +344,7 @@ extension ComposerToolbar {
     static func mock(focused: Bool = true) -> ComposerToolbar {
         let wysiwygViewModel = WysiwygComposerViewModel()
         var composerViewModel: ComposerToolbarViewModel {
-            let model = ComposerToolbarViewModel(wysiwygViewModel: wysiwygViewModel,
+            let model = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(), wysiwygViewModel: wysiwygViewModel,
                                                  completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
                                                  mediaProvider: MediaProviderMock(configuration: .init()),
                                                  mentionDisplayHelper: ComposerMentionDisplayHelper.mock,
@@ -355,7 +361,7 @@ extension ComposerToolbar {
     static func textWithVoiceMessage(focused: Bool = true) -> ComposerToolbar {
         let wysiwygViewModel = WysiwygComposerViewModel()
         var composerViewModel: ComposerToolbarViewModel {
-            let model = ComposerToolbarViewModel(wysiwygViewModel: wysiwygViewModel,
+            let model = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(), wysiwygViewModel: wysiwygViewModel,
                                                  completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
                                                  mediaProvider: MediaProviderMock(configuration: .init()),
                                                  mentionDisplayHelper: ComposerMentionDisplayHelper.mock,
@@ -372,7 +378,7 @@ extension ComposerToolbar {
     static func voiceMessageRecordingMock() -> ComposerToolbar {
         let wysiwygViewModel = WysiwygComposerViewModel()
         var composerViewModel: ComposerToolbarViewModel {
-            let model = ComposerToolbarViewModel(wysiwygViewModel: wysiwygViewModel,
+            let model = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(), wysiwygViewModel: wysiwygViewModel,
                                                  completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
                                                  mediaProvider: MediaProviderMock(configuration: .init()),
                                                  mentionDisplayHelper: ComposerMentionDisplayHelper.mock,
@@ -390,7 +396,7 @@ extension ComposerToolbar {
         let wysiwygViewModel = WysiwygComposerViewModel()
         let waveformData: [Float] = Array(repeating: 1.0, count: 1000)
         var composerViewModel: ComposerToolbarViewModel {
-            let model = ComposerToolbarViewModel(wysiwygViewModel: wysiwygViewModel,
+            let model = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(), wysiwygViewModel: wysiwygViewModel,
                                                  completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
                                                  mediaProvider: MediaProviderMock(configuration: .init()),
                                                  mentionDisplayHelper: ComposerMentionDisplayHelper.mock,
@@ -411,7 +417,7 @@ extension ComposerToolbar {
     static func replyLoadingPreviewMock(isLoading: Bool) -> ComposerToolbar {
         let wysiwygViewModel = WysiwygComposerViewModel()
         var composerViewModel: ComposerToolbarViewModel {
-            let model = ComposerToolbarViewModel(wysiwygViewModel: wysiwygViewModel,
+            let model = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(), wysiwygViewModel: wysiwygViewModel,
                                                  completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
                                                  mediaProvider: MediaProviderMock(configuration: .init()),
                                                  mentionDisplayHelper: ComposerMentionDisplayHelper.mock,
@@ -424,6 +430,23 @@ extension ComposerToolbar {
                        replyDetails: .loaded(sender: .init(id: "",
                                                            displayName: "Test"),
                                              eventID: "", eventContent: .message(.text(.init(body: "Hello World!")))), isThread: false)
+            return model
+        }
+        return ComposerToolbar(context: composerViewModel.context,
+                               wysiwygViewModel: wysiwygViewModel,
+                               keyCommands: [])
+    }
+    
+    static func disabledPreviewMock() -> ComposerToolbar {
+        let wysiwygViewModel = WysiwygComposerViewModel()
+        var composerViewModel: ComposerToolbarViewModel {
+            let model = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(), wysiwygViewModel: wysiwygViewModel,
+                                                 completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
+                                                 mediaProvider: MediaProviderMock(configuration: .init()),
+                                                 mentionDisplayHelper: ComposerMentionDisplayHelper.mock,
+                                                 analyticsService: ServiceLocator.shared.analytics,
+                                                 composerDraftService: ComposerDraftServiceMock())
+            model.state.canSend = false
             return model
         }
         return ComposerToolbar(context: composerViewModel.context,

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/ComposerToolbar.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/ComposerToolbar.swift
@@ -5,7 +5,9 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+import Combine
 import Compound
+import MatrixRustSDK
 import SwiftUI
 import WysiwygComposer
 
@@ -298,7 +300,7 @@ struct ComposerToolbar: View {
 
 struct ComposerToolbar_Previews: PreviewProvider, TestablePreview {
     static let wysiwygViewModel = WysiwygComposerViewModel()
-    static let composerViewModel = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(), wysiwygViewModel: wysiwygViewModel,
+    static let composerViewModel = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(.init()), wysiwygViewModel: wysiwygViewModel,
                                                             completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init(suggestions: suggestions)),
                                                             mediaProvider: MediaProviderMock(configuration: .init()),
                                                             mentionDisplayHelper: ComposerMentionDisplayHelper.mock,
@@ -344,7 +346,7 @@ extension ComposerToolbar {
     static func mock(focused: Bool = true) -> ComposerToolbar {
         let wysiwygViewModel = WysiwygComposerViewModel()
         var composerViewModel: ComposerToolbarViewModel {
-            let model = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(), wysiwygViewModel: wysiwygViewModel,
+            let model = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(.init()), wysiwygViewModel: wysiwygViewModel,
                                                  completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
                                                  mediaProvider: MediaProviderMock(configuration: .init()),
                                                  mentionDisplayHelper: ComposerMentionDisplayHelper.mock,
@@ -361,7 +363,7 @@ extension ComposerToolbar {
     static func textWithVoiceMessage(focused: Bool = true) -> ComposerToolbar {
         let wysiwygViewModel = WysiwygComposerViewModel()
         var composerViewModel: ComposerToolbarViewModel {
-            let model = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(), wysiwygViewModel: wysiwygViewModel,
+            let model = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(.init()), wysiwygViewModel: wysiwygViewModel,
                                                  completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
                                                  mediaProvider: MediaProviderMock(configuration: .init()),
                                                  mentionDisplayHelper: ComposerMentionDisplayHelper.mock,
@@ -378,7 +380,7 @@ extension ComposerToolbar {
     static func voiceMessageRecordingMock() -> ComposerToolbar {
         let wysiwygViewModel = WysiwygComposerViewModel()
         var composerViewModel: ComposerToolbarViewModel {
-            let model = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(), wysiwygViewModel: wysiwygViewModel,
+            let model = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(.init()), wysiwygViewModel: wysiwygViewModel,
                                                  completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
                                                  mediaProvider: MediaProviderMock(configuration: .init()),
                                                  mentionDisplayHelper: ComposerMentionDisplayHelper.mock,
@@ -396,7 +398,7 @@ extension ComposerToolbar {
         let wysiwygViewModel = WysiwygComposerViewModel()
         let waveformData: [Float] = Array(repeating: 1.0, count: 1000)
         var composerViewModel: ComposerToolbarViewModel {
-            let model = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(), wysiwygViewModel: wysiwygViewModel,
+            let model = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(.init()), wysiwygViewModel: wysiwygViewModel,
                                                  completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
                                                  mediaProvider: MediaProviderMock(configuration: .init()),
                                                  mentionDisplayHelper: ComposerMentionDisplayHelper.mock,
@@ -417,7 +419,7 @@ extension ComposerToolbar {
     static func replyLoadingPreviewMock(isLoading: Bool) -> ComposerToolbar {
         let wysiwygViewModel = WysiwygComposerViewModel()
         var composerViewModel: ComposerToolbarViewModel {
-            let model = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(), wysiwygViewModel: wysiwygViewModel,
+            let model = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(.init()), wysiwygViewModel: wysiwygViewModel,
                                                  completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
                                                  mediaProvider: MediaProviderMock(configuration: .init()),
                                                  mentionDisplayHelper: ComposerMentionDisplayHelper.mock,
@@ -440,7 +442,7 @@ extension ComposerToolbar {
     static func disabledPreviewMock() -> ComposerToolbar {
         let wysiwygViewModel = WysiwygComposerViewModel()
         var composerViewModel: ComposerToolbarViewModel {
-            let model = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(), wysiwygViewModel: wysiwygViewModel,
+            let model = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(.init()), wysiwygViewModel: wysiwygViewModel,
                                                  completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
                                                  mediaProvider: MediaProviderMock(configuration: .init()),
                                                  mentionDisplayHelper: ComposerMentionDisplayHelper.mock,

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/ComposerToolbar.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/ComposerToolbar.swift
@@ -300,7 +300,8 @@ struct ComposerToolbar: View {
 
 struct ComposerToolbar_Previews: PreviewProvider, TestablePreview {
     static let wysiwygViewModel = WysiwygComposerViewModel()
-    static let composerViewModel = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(.init()), wysiwygViewModel: wysiwygViewModel,
+    static let composerViewModel = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(.init()),
+                                                            wysiwygViewModel: wysiwygViewModel,
                                                             completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init(suggestions: suggestions)),
                                                             mediaProvider: MediaProviderMock(configuration: .init()),
                                                             mentionDisplayHelper: ComposerMentionDisplayHelper.mock,
@@ -346,7 +347,8 @@ extension ComposerToolbar {
     static func mock(focused: Bool = true) -> ComposerToolbar {
         let wysiwygViewModel = WysiwygComposerViewModel()
         var composerViewModel: ComposerToolbarViewModel {
-            let model = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(.init()), wysiwygViewModel: wysiwygViewModel,
+            let model = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(.init()),
+                                                 wysiwygViewModel: wysiwygViewModel,
                                                  completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
                                                  mediaProvider: MediaProviderMock(configuration: .init()),
                                                  mentionDisplayHelper: ComposerMentionDisplayHelper.mock,
@@ -363,7 +365,8 @@ extension ComposerToolbar {
     static func textWithVoiceMessage(focused: Bool = true) -> ComposerToolbar {
         let wysiwygViewModel = WysiwygComposerViewModel()
         var composerViewModel: ComposerToolbarViewModel {
-            let model = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(.init()), wysiwygViewModel: wysiwygViewModel,
+            let model = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(.init()),
+                                                 wysiwygViewModel: wysiwygViewModel,
                                                  completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
                                                  mediaProvider: MediaProviderMock(configuration: .init()),
                                                  mentionDisplayHelper: ComposerMentionDisplayHelper.mock,
@@ -380,7 +383,8 @@ extension ComposerToolbar {
     static func voiceMessageRecordingMock() -> ComposerToolbar {
         let wysiwygViewModel = WysiwygComposerViewModel()
         var composerViewModel: ComposerToolbarViewModel {
-            let model = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(.init()), wysiwygViewModel: wysiwygViewModel,
+            let model = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(.init()),
+                                                 wysiwygViewModel: wysiwygViewModel,
                                                  completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
                                                  mediaProvider: MediaProviderMock(configuration: .init()),
                                                  mentionDisplayHelper: ComposerMentionDisplayHelper.mock,
@@ -398,7 +402,8 @@ extension ComposerToolbar {
         let wysiwygViewModel = WysiwygComposerViewModel()
         let waveformData: [Float] = Array(repeating: 1.0, count: 1000)
         var composerViewModel: ComposerToolbarViewModel {
-            let model = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(.init()), wysiwygViewModel: wysiwygViewModel,
+            let model = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(.init()),
+                                                 wysiwygViewModel: wysiwygViewModel,
                                                  completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
                                                  mediaProvider: MediaProviderMock(configuration: .init()),
                                                  mentionDisplayHelper: ComposerMentionDisplayHelper.mock,
@@ -419,7 +424,8 @@ extension ComposerToolbar {
     static func replyLoadingPreviewMock(isLoading: Bool) -> ComposerToolbar {
         let wysiwygViewModel = WysiwygComposerViewModel()
         var composerViewModel: ComposerToolbarViewModel {
-            let model = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(.init()), wysiwygViewModel: wysiwygViewModel,
+            let model = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(.init()),
+                                                 wysiwygViewModel: wysiwygViewModel,
                                                  completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
                                                  mediaProvider: MediaProviderMock(configuration: .init()),
                                                  mentionDisplayHelper: ComposerMentionDisplayHelper.mock,
@@ -442,7 +448,8 @@ extension ComposerToolbar {
     static func disabledPreviewMock() -> ComposerToolbar {
         let wysiwygViewModel = WysiwygComposerViewModel()
         var composerViewModel: ComposerToolbarViewModel {
-            let model = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(.init()), wysiwygViewModel: wysiwygViewModel,
+            let model = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(.init()),
+                                                 wysiwygViewModel: wysiwygViewModel,
                                                  completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
                                                  mediaProvider: MediaProviderMock(configuration: .init()),
                                                  mentionDisplayHelper: ComposerMentionDisplayHelper.mock,

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/RoomAttachmentPicker.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/RoomAttachmentPicker.swift
@@ -86,7 +86,7 @@ private struct RoomAttachmentPickerButtonStyle: ButtonStyle {
 }
 
 struct RoomAttachmentPicker_Previews: PreviewProvider, TestablePreview {
-    static let viewModel = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(),
+    static let viewModel = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(.init()),
                                                     wysiwygViewModel: WysiwygComposerViewModel(),
                                                     completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
                                                     mediaProvider: MediaProviderMock(configuration: .init()),

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/RoomAttachmentPicker.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/RoomAttachmentPicker.swift
@@ -12,6 +12,8 @@ import WysiwygComposer
 struct RoomAttachmentPicker: View {
     @ObservedObject var context: ComposerToolbarViewModel.Context
     
+    @Environment(\.isEnabled) private var isEnabled
+    
     var body: some View {
         // Use a menu instead of the popover/sheet shown in Figma because overriding the colour scheme
         // results in a rendering bug on 17.1: https://github.com/element-hq/element-x-ios/issues/2157
@@ -20,6 +22,9 @@ struct RoomAttachmentPicker: View {
         } label: {
             CompoundIcon(asset: Asset.Images.composerAttachment, size: .custom(30), relativeTo: .compound.headingLG)
                 .scaledPadding(7, relativeTo: .compound.headingLG)
+                .foregroundColor(
+                    isEnabled ? .compound.iconPrimary : .compound.iconDisabled
+                )
         }
         .buttonStyle(RoomAttachmentPickerButtonStyle())
         .accessibilityLabel(L10n.actionAddToTimeline)
@@ -81,7 +86,8 @@ private struct RoomAttachmentPickerButtonStyle: ButtonStyle {
 }
 
 struct RoomAttachmentPicker_Previews: PreviewProvider, TestablePreview {
-    static let viewModel = ComposerToolbarViewModel(wysiwygViewModel: WysiwygComposerViewModel(),
+    static let viewModel = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(),
+                                                    wysiwygViewModel: WysiwygComposerViewModel(),
                                                     completionSuggestionService: CompletionSuggestionServiceMock(configuration: .init()),
                                                     mediaProvider: MediaProviderMock(configuration: .init()),
                                                     mentionDisplayHelper: ComposerMentionDisplayHelper.mock,

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/VoiceMessageRecordingButton.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/VoiceMessageRecordingButton.swift
@@ -14,6 +14,8 @@ enum VoiceMessageRecordingButtonMode {
 }
 
 struct VoiceMessageRecordingButton: View {
+    @Environment(\.isEnabled) private var isEnabled
+    
     let mode: VoiceMessageRecordingButtonMode
     var startRecording: (() -> Void)?
     var stopRecording: (() -> Void)?
@@ -33,7 +35,9 @@ struct VoiceMessageRecordingButton: View {
             switch mode {
             case .idle:
                 CompoundIcon(\.micOn, size: .medium, relativeTo: .compound.headingLG)
-                    .foregroundColor(.compound.iconSecondary)
+                    .foregroundColor(
+                        isEnabled ? .compound.iconSecondary : .compound.iconDisabled
+                    )
                     .scaledPadding(10, relativeTo: .compound.headingLG)
             case .recording:
                 CompoundIcon(asset: Asset.Images.stopRecording, size: .medium, relativeTo: .compound.headingLG)

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
@@ -90,7 +90,8 @@ final class RoomScreenCoordinator: CoordinatorProtocol {
                                                     maxCompressedHeight: ComposerConstant.maxHeight,
                                                     maxExpandedHeight: ComposerConstant.maxHeight,
                                                     parserStyle: .elementX)
-        let composerViewModel = ComposerToolbarViewModel(initialText: parameters.sharedText, roomProxy: parameters.roomProxy,
+        let composerViewModel = ComposerToolbarViewModel(initialText: parameters.sharedText,
+                                                         roomProxy: parameters.roomProxy,
                                                          wysiwygViewModel: wysiwygViewModel,
                                                          completionSuggestionService: parameters.completionSuggestionService,
                                                          mediaProvider: parameters.mediaProvider,

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
@@ -90,7 +90,7 @@ final class RoomScreenCoordinator: CoordinatorProtocol {
                                                     maxCompressedHeight: ComposerConstant.maxHeight,
                                                     maxExpandedHeight: ComposerConstant.maxHeight,
                                                     parserStyle: .elementX)
-        let composerViewModel = ComposerToolbarViewModel(initialText: parameters.sharedText,
+        let composerViewModel = ComposerToolbarViewModel(initialText: parameters.sharedText, roomProxy: parameters.roomProxy,
                                                          wysiwygViewModel: wysiwygViewModel,
                                                          completionSuggestionService: parameters.completionSuggestionService,
                                                          mediaProvider: parameters.mediaProvider,

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
@@ -71,10 +71,12 @@ struct RoomScreenViewStateBindings { }
 
 enum RoomScreenFooterViewAction {
     case resolvePinViolation(userID: String)
+    case resolveVerificationViolation(userID: String)
 }
 
 enum RoomScreenFooterViewDetails {
     case pinViolation(member: RoomMemberProxyProtocol, learnMoreURL: URL)
+    case verificationViolation(member: RoomMemberProxyProtocol, learnMoreURL: URL)
 }
 
 enum PinnedEventsBannerState: Equatable {

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -227,7 +227,6 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
 
                 identityVerificationViolations[change.userId] = member
             default:
-                // clear all
                 identityVerificationViolations[change.userId] = nil
                 identityPinningViolations[change.userId] = nil
             }

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -25,6 +25,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
     private let pinnedEventStringBuilder: RoomEventStringBuilder
     
     private var identityPinningViolations = [String: RoomMemberProxyProtocol]()
+    private var identityVerificationViolations = [String: RoomMemberProxyProtocol]()
     
     private let actionsSubject: PassthroughSubject<RoomScreenViewModelAction, Never> = .init()
     var actions: AnyPublisher<RoomScreenViewModelAction, Never> {
@@ -102,6 +103,8 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
             switch action {
             case .resolvePinViolation(let userID):
                 Task { await resolveIdentityPinningViolation(userID) }
+            case .resolveVerificationViolation(let userID):
+                Task { await resolveIdentityVerificationViolation(userID) }
             }
         case .acceptKnock(let eventID):
             Task { await acceptKnock(eventID: eventID) }
@@ -209,21 +212,31 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
     private func processIdentityStatusChanges(_ changes: [IdentityStatusChange]) async {
         for change in changes {
             switch change.changedTo {
-            case .pinned:
-                identityPinningViolations[change.userId] = nil
             case .pinViolation:
                 guard case let .success(member) = await roomProxy.getMember(userID: change.userId) else {
                     MXLog.error("Failed retrieving room member for identity status change: \(change)")
                     continue
                 }
-                        
+                
                 identityPinningViolations[change.userId] = member
+            case .verificationViolation:
+                guard case let .success(member) = await roomProxy.getMember(userID: change.userId) else {
+                    MXLog.error("Failed retrieving room member for identity status change: \(change)")
+                    continue
+                }
+
+                identityVerificationViolations[change.userId] = member
             default:
-                break
+                // clear all
+                identityVerificationViolations[change.userId] = nil
+                identityPinningViolations[change.userId] = nil
             }
         }
         
-        if let member = identityPinningViolations.values.first {
+        if let member = identityVerificationViolations.values.first {
+            state.footerDetails = .verificationViolation(member: member,
+                                                         learnMoreURL: appSettings.identityPinningViolationDetailsURL)
+        } else if let member = identityPinningViolations.values.first {
             state.footerDetails = .pinViolation(member: member,
                                                 learnMoreURL: appSettings.identityPinningViolationDetailsURL)
         } else {
@@ -239,6 +252,18 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
         showLoadingIndicator()
         
         if case .failure = await clientProxy.pinUserIdentity(userID) {
+            userIndicatorController.alertInfo = .init(id: .init(), title: L10n.commonError)
+        }
+    }
+    
+    private func resolveIdentityVerificationViolation(_ userID: String) async {
+        defer {
+            hideLoadingIndicator()
+        }
+
+        showLoadingIndicator()
+
+        if case .failure = await clientProxy.withdrawUserIdentityVerification(userID) {
             userIndicatorController.alertInfo = .init(id: .init(), title: L10n.commonError)
         }
     }

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomScreenFooterView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomScreenFooterView.swift
@@ -15,17 +15,25 @@ struct RoomScreenFooterView: View {
     var body: some View {
         if let details {
             ZStack(alignment: .top) {
-                VStack(spacing: 0) {
-                    Color.compound.borderInfoSubtle
-                        .frame(height: 1)
-                    LinearGradient(colors: [.compound.bgInfoSubtle, .compound.bgCanvasDefault],
-                                   startPoint: .top,
-                                   endPoint: .bottom)
-                }
-                
                 switch details {
                 case .pinViolation(let member, let learnMoreURL):
+                    VStack(spacing: 0) {
+                        Color.compound.borderInfoSubtle
+                            .frame(height: 1)
+                        LinearGradient(colors: [.compound.bgInfoSubtle, .compound.bgCanvasDefault],
+                                       startPoint: .top,
+                                       endPoint: .bottom)
+                    }
                     pinViolation(member: member, learnMoreURL: learnMoreURL)
+                case .verificationViolation(member: let member, learnMoreURL: let learnMoreURL):
+                    VStack(spacing: 0) {
+                        Color.compound.borderCriticalSubtle
+                            .frame(height: 1)
+                        LinearGradient(colors: [.compound.bgCriticalSubtle, .compound.bgCanvasDefault],
+                                       startPoint: .top,
+                                       endPoint: .bottom)
+                    }
+                    verificationViolation(member: member, learnMoreURL: learnMoreURL)
                 }
             }
             .padding(.top, 8)
@@ -60,11 +68,55 @@ struct RoomScreenFooterView: View {
         .padding(.bottom, 8)
     }
     
+    private func verificationViolation(member: RoomMemberProxyProtocol,
+                                       learnMoreURL: URL) -> some View {
+        VStack(spacing: 16) {
+            HStack(spacing: 16) {
+                LoadableAvatarImage(url: member.avatarURL,
+                                    name: member.disambiguatedDisplayName,
+                                    contentID: member.userID,
+                                    avatarSize: .user(on: .timeline),
+                                    mediaProvider: mediaProvider)
+                
+                Text(verificationViolationDescriptionWithLearnMoreLink(displayName: member.displayName,
+                                                                       userID: member.userID,
+                                                                       url: learnMoreURL))
+                    .font(.compound.bodyMD)
+                    .foregroundColor(.compound.textCriticalPrimary)
+            }
+            
+            Button(L10n.cryptoIdentityChangeWithdrawVerificationAction) {
+                callback(.resolveVerificationViolation(userID: member.userID))
+            }
+            .buttonStyle(.compound(.primary, size: .medium))
+        }
+        .padding(.top, 16)
+        .padding(.horizontal, 16)
+        .padding(.bottom, 8)
+    }
+    
     private func pinViolationDescriptionWithLearnMoreLink(displayName: String?, userID: String, url: URL) -> AttributedString {
         let userIDPlaceholder = "{mxid}"
         let linkPlaceholder = "{link}"
         let displayName = displayName ?? fallbackDisplayName(userID)
         var description = AttributedString(L10n.cryptoIdentityChangePinViolationNew(displayName, userIDPlaceholder, linkPlaceholder))
+        
+        var userIDString = AttributedString(L10n.cryptoIdentityChangePinViolationNewUserId(userID))
+        userIDString.bold()
+        description.replace(userIDPlaceholder, with: userIDString)
+        
+        var linkString = AttributedString(L10n.actionLearnMore)
+        linkString.link = url
+        linkString.bold()
+        description.replace(linkPlaceholder, with: linkString)
+        return description
+    }
+    
+    private func verificationViolationDescriptionWithLearnMoreLink(displayName: String?, userID: String, url: URL) -> AttributedString {
+        let userIDPlaceholder = "{mxid}"
+        let linkPlaceholder = "{link}"
+        let displayName = displayName ?? fallbackDisplayName(userID)
+        var description = AttributedString(L10n.cryptoIdentityChangeVerificationViolationNew(displayName, userIDPlaceholder, linkPlaceholder))
         
         var userIDString = AttributedString(L10n.cryptoIdentityChangePinViolationNewUserId(userID))
         userIDString.bold()
@@ -89,10 +141,15 @@ struct RoomScreenFooterView_Previews: PreviewProvider, TestablePreview {
     static let noNameDetails: RoomScreenFooterViewDetails = .pinViolation(member: RoomMemberProxyMock.mockNoName,
                                                                           learnMoreURL: "https://element.io/")
     
+    static let verificationViolationDetails: RoomScreenFooterViewDetails = .verificationViolation(member: RoomMemberProxyMock.mockBob,
+                                                                                                  learnMoreURL: "https://element.io/")
+    
     static var previews: some View {
         RoomScreenFooterView(details: bobDetails, mediaProvider: MediaProviderMock(configuration: .init())) { _ in }
             .previewDisplayName("With displayname")
         RoomScreenFooterView(details: noNameDetails, mediaProvider: MediaProviderMock(configuration: .init())) { _ in }
             .previewDisplayName("Without displayname")
+        RoomScreenFooterView(details: verificationViolationDetails, mediaProvider: MediaProviderMock(configuration: .init())) { _ in }
+            .previewDisplayName("Verification Violation")
     }
 }

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -1005,6 +1005,22 @@ class ClientProxy: ClientProxyProtocol {
         }
     }
     
+    func withdrawUserIdentityVerification(_ userID: String) async -> Result<Void, ClientProxyError> {
+        MXLog.info("Withdrawing current identity verification for user: \(userID)")
+        
+        do {
+            guard let userIdentity = try await client.encryption().userIdentity(userId: userID) else {
+                MXLog.error("Failed retrieving identity for user: \(userID)")
+                return .failure(.failedRetrievingUserIdentity)
+            }
+            
+            return try await .success(userIdentity.withdrawVerification())
+        } catch {
+            MXLog.error("Failed withdrawing current identity verification for user: \(error)")
+            return .failure(.sdkError(error))
+        }
+    }
+    
     func resetIdentity() async -> Result<IdentityResetHandle?, ClientProxyError> {
         do {
             return try await .success(client.encryption().resetIdentity())

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -204,6 +204,7 @@ protocol ClientProxyProtocol: AnyObject, MediaLoaderProtocol {
     func curve25519Base64() async -> String?
     
     func pinUserIdentity(_ userID: String) async -> Result<Void, ClientProxyError>
+    func withdrawUserIdentityVerification(_ userID: String) async -> Result<Void, ClientProxyError>
     func resetIdentity() async -> Result<IdentityResetHandle?, ClientProxyError>
     
     func userIdentity(for userID: String) async -> Result<UserIdentity?, ClientProxyError>

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_composerToolbar-iPad-en-GB.Disabled.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_composerToolbar-iPad-en-GB.Disabled.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a582ff37f77d4a6106eb386f136598990ed0821fed095db3705680356fe5d30d
+size 75209

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_composerToolbar-iPad-pseudo.Disabled.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_composerToolbar-iPad-pseudo.Disabled.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5664b9a568d35763da35eea9ecac2732971d6b76baef992d387eb689916f13e3
+size 75627

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_composerToolbar-iPhone-16-en-GB.Disabled.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_composerToolbar-iPhone-16-en-GB.Disabled.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe562e2446e07d30c5b2b93c19d567ea4f1be3ed503c8029c72aad22a74800aa
+size 34263

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_composerToolbar-iPhone-16-pseudo.Disabled.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_composerToolbar-iPhone-16-pseudo.Disabled.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:820597003dbb92d692e7fc45314af9fff8b50ffc42cede115b65ce12ebf992a0
+size 34687

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_roomScreenFooterView-iPad-en-GB.Verification-Violation.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_roomScreenFooterView-iPad-en-GB.Verification-Violation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf9ffd7c5b2d3e1ac7ccafbae7656f91c12c87e434910931ce77628ea9b4dd7d
+size 162432

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_roomScreenFooterView-iPad-pseudo.Verification-Violation.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_roomScreenFooterView-iPad-pseudo.Verification-Violation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee6a0474e411cc8ea9352b32e0386fb9c7c36c6bbe3871441426f4ea623ded9d
+size 174972

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_roomScreenFooterView-iPhone-16-en-GB.Verification-Violation.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_roomScreenFooterView-iPhone-16-en-GB.Verification-Violation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a2ac111a641041292a796bb237a01ba4eca8edf0c78363c2baaa4f33df44947
+size 79626

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_roomScreenFooterView-iPhone-16-pseudo.Verification-Violation.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_roomScreenFooterView-iPhone-16-pseudo.Verification-Violation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7c3d5e1f0a2a0fa3c2f5ebab008ad186c5479b08880337b97028f64f523a39f
+size 112397

--- a/UnitTests/Sources/ComposerToolbarViewModelTests.swift
+++ b/UnitTests/Sources/ComposerToolbarViewModelTests.swift
@@ -7,6 +7,7 @@
 
 import Combine
 @testable import ElementX
+import MatrixRustSDK
 import XCTest
 
 import WysiwygComposer
@@ -93,7 +94,9 @@ class ComposerToolbarViewModelTests: XCTestCase {
         let suggestions: [SuggestionItem] = [.user(item: MentionSuggestionItem(id: "@user_mention_1:matrix.org", displayName: "User 1", avatarURL: nil, range: .init())),
                                              .user(item: MentionSuggestionItem(id: "@user_mention_2:matrix.org", displayName: "User 2", avatarURL: .mockMXCAvatar, range: .init()))]
         let mockCompletionSuggestionService = CompletionSuggestionServiceMock(configuration: .init(suggestions: suggestions))
-        viewModel = ComposerToolbarViewModel(wysiwygViewModel: wysiwygViewModel,
+        
+        viewModel = ComposerToolbarViewModel(roomProxy: JoinedRoomProxyMock(.init()),
+                                             wysiwygViewModel: wysiwygViewModel,
                                              completionSuggestionService: mockCompletionSuggestionService,
                                              mediaProvider: MediaProviderMock(configuration: .init()),
                                              mentionDisplayHelper: ComposerMentionDisplayHelper.mock,
@@ -632,6 +635,177 @@ class ComposerToolbarViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.context.plainComposerText, NSAttributedString(string: sharedText))
     }
     
+    // MARK: - Identity Violation
+    
+    func testVerificationViolationDisablesComposer() {
+        let mockCompletionSuggestionService = CompletionSuggestionServiceMock(configuration: .init())
+        
+        let roomProxyMock = JoinedRoomProxyMock(.init(name: "Test"))
+        let roomMemberProxyMock = RoomMemberProxyMock(with: .init(userID: "@alice:localhost", membership: .join))
+        
+        roomProxyMock.getMemberUserIDClosure = { _ in
+            .success(roomMemberProxyMock)
+        }
+    
+        let mockSubject = CurrentValueSubject<[IdentityStatusChange], Never>([IdentityStatusChange(userId: "@alice:localhost", changedTo: .verificationViolation)])
+        
+        roomProxyMock.underlyingIdentityStatusChangesPublisher = mockSubject.asCurrentValuePublisher()
+        
+        viewModel = ComposerToolbarViewModel(roomProxy: roomProxyMock,
+                                             wysiwygViewModel: wysiwygViewModel,
+                                             completionSuggestionService: mockCompletionSuggestionService,
+                                             mediaProvider: MediaProviderMock(configuration: .init()),
+                                             mentionDisplayHelper: ComposerMentionDisplayHelper.mock,
+                                             analyticsService: ServiceLocator.shared.analytics,
+                                             composerDraftService: draftServiceMock)
+        
+        let expectation1 = expectation(description: "Composer is disabled")
+        let cancellable = viewModel
+            .context
+            .$viewState
+            .map(\.canSend)
+            .sink { canSend in
+                if !canSend {
+                    expectation1.fulfill()
+                }
+            }
+        
+        wait(for: [expectation1], timeout: 2.0)
+        cancellable.cancel()
+        
+        let expectation2 = expectation(description: "Composer is enabled")
+        let cancellable2 = viewModel
+            .context
+            .$viewState
+            .map(\.canSend)
+            .sink { canSend in
+                if canSend {
+                    expectation2.fulfill()
+                }
+            }
+        
+        mockSubject.send([IdentityStatusChange(userId: "@alice:localhost", changedTo: .pinned)])
+        
+        wait(for: [expectation2], timeout: 2.0)
+        cancellable2.cancel()
+    }
+    
+    func testMultipleViolation() {
+        let mockCompletionSuggestionService = CompletionSuggestionServiceMock(configuration: .init())
+        
+        let roomProxyMock = JoinedRoomProxyMock(.init(name: "Test"))
+        
+        let aliceRoomMemberProxyMock = RoomMemberProxyMock(with: .init(userID: "@alice:localhost", membership: .join))
+        let bobRoomMemberProxyMock = RoomMemberProxyMock(with: .init(userID: "@bob:localhost", membership: .join))
+        
+        roomProxyMock.getMemberUserIDClosure = { userId in
+            if userId == "@alice:localhost" {
+                return .success(aliceRoomMemberProxyMock)
+            } else if userId == "@bob:localhost" {
+                return .success(bobRoomMemberProxyMock)
+            } else {
+                return .failure(.sdkError(ClientProxyMockError.generic))
+            }
+        }
+    
+        // There are 2 violations, ensure that resolving the first one is not enough
+        let mockSubject = CurrentValueSubject<[IdentityStatusChange], Never>([
+            IdentityStatusChange(userId: "@alice:localhost", changedTo: .verificationViolation),
+            IdentityStatusChange(userId: "@bob:localhost", changedTo: .verificationViolation)
+        ])
+        
+        roomProxyMock.underlyingIdentityStatusChangesPublisher = mockSubject.asCurrentValuePublisher()
+        
+        viewModel = ComposerToolbarViewModel(roomProxy: roomProxyMock,
+                                             wysiwygViewModel: wysiwygViewModel,
+                                             completionSuggestionService: mockCompletionSuggestionService,
+                                             mediaProvider: MediaProviderMock(configuration: .init()),
+                                             mentionDisplayHelper: ComposerMentionDisplayHelper.mock,
+                                             analyticsService: ServiceLocator.shared.analytics,
+                                             composerDraftService: draftServiceMock)
+        
+        let expectation1 = expectation(description: "Composer is disabled")
+        let cancellable = viewModel
+            .context
+            .$viewState
+            .map(\.canSend)
+            .sink { canSend in
+                if !canSend {
+                    expectation1.fulfill()
+                }
+            }
+        
+        wait(for: [expectation1], timeout: 2.0)
+        cancellable.cancel()
+        
+        let expectation2 = expectation(description: "Composer is still disabled")
+        let cancellable2 = viewModel
+            .context
+            .$viewState
+            .map(\.canSend)
+            .sink { canSend in
+                if !canSend {
+                    expectation2.fulfill()
+                }
+            }
+        
+        mockSubject.send([IdentityStatusChange(userId: "@alice:localhost", changedTo: .pinned)])
+        
+        wait(for: [expectation2], timeout: 2.0)
+        cancellable2.cancel()
+        
+        let expectation3 = expectation(description: "Composer is now enabled")
+        let cancellable3 = viewModel
+            .context
+            .$viewState
+            .map(\.canSend)
+            .sink { canSend in
+                if canSend {
+                    expectation3.fulfill()
+                }
+            }
+        
+        mockSubject.send([IdentityStatusChange(userId: "@bob:localhost", changedTo: .pinned)])
+        
+        wait(for: [expectation3], timeout: 2.0)
+        cancellable3.cancel()
+    }
+    
+    func testPinViolationDoesNotDisableComposer() {
+        let mockCompletionSuggestionService = CompletionSuggestionServiceMock(configuration: .init())
+        
+        let roomProxyMock = JoinedRoomProxyMock(.init(name: "Test"))
+        let roomMemberProxyMock = RoomMemberProxyMock(with: .init(userID: "@alice:localhost", membership: .join))
+        
+        roomProxyMock.getMemberUserIDClosure = { _ in
+            .success(roomMemberProxyMock)
+        }
+        
+        roomProxyMock.underlyingIdentityStatusChangesPublisher = CurrentValueSubject([IdentityStatusChange(userId: "@alice:localhost", changedTo: .pinViolation)]).asCurrentValuePublisher()
+        
+        viewModel = ComposerToolbarViewModel(roomProxy: roomProxyMock,
+                                             wysiwygViewModel: wysiwygViewModel,
+                                             completionSuggestionService: mockCompletionSuggestionService,
+                                             mediaProvider: MediaProviderMock(configuration: .init()),
+                                             mentionDisplayHelper: ComposerMentionDisplayHelper.mock,
+                                             analyticsService: ServiceLocator.shared.analytics,
+                                             composerDraftService: draftServiceMock)
+        
+        let expectation = expectation(description: "Composer should be enabled")
+        let cancellable = viewModel
+            .context
+            .$viewState
+            .map(\.canSend)
+            .sink { canSend in
+                if canSend {
+                    expectation.fulfill()
+                }
+            }
+        
+        wait(for: [expectation], timeout: 2.0)
+        cancellable.cancel()
+    }
+    
     // MARK: - Helpers
     
     private func setUpViewModel(initialText: String? = nil, loadDraftClosure: (() async -> Result<ComposerDraftProxy?, ComposerDraftServiceError>)? = nil) {
@@ -643,6 +817,7 @@ class ComposerToolbarViewModelTests: XCTestCase {
         }
         
         viewModel = ComposerToolbarViewModel(initialText: initialText,
+                                             roomProxy: JoinedRoomProxyMock(.init()),
                                              wysiwygViewModel: wysiwygViewModel,
                                              completionSuggestionService: completionSuggestionServiceMock,
                                              mediaProvider: MediaProviderMock(configuration: .init()),


### PR DESCRIPTION
### Pull Request Checklist

Part of https://github.com/element-hq/element-meta/issues/2492 (still partial as there is no way to verify other users yet on EX, so you can only withdraw the verification requirement).
EXI counterpart of EXA https://github.com/element-hq/element-x-android/pull/4126

Adds support for identity violation detection. Will show a warning notice and block sending (notice that sending would fail anyhow in that case).
![image](https://github.com/user-attachments/assets/85542eb6-b502-433e-b0c8-08ca471b8247)


![withdraw_exi](https://github.com/user-attachments/assets/77ede48e-f99e-46c5-9bfb-7d4faa522fb0)