### PR TITLE
Fix flakey `RoomMemberDetailsScreen` preview test.

### DIFF
--- a/ElementX/Sources/Screens/RoomMemberDetailsScreen/View/RoomMemberDetailsScreen.swift
+++ b/ElementX/Sources/Screens/RoomMemberDetailsScreen/View/RoomMemberDetailsScreen.swift
@@ -158,7 +158,7 @@ struct RoomMemberDetailsScreen_Previews: PreviewProvider, TestablePreview {
             
         RoomMemberDetailsScreen(context: ignoredUserViewModel.context)
             .snapshotPreferences(expect: ignoredUserViewModel.context.$viewState.map { state in
-                state.memberDetails?.isIgnored ?? false
+                state.memberDetails?.isIgnored ?? false && state.dmRoomID != nil
             })
             .previewDisplayName("Ignored User")
     }


### PR DESCRIPTION
- was missing sometimes missing the call button because we weren't waiting for the `dmRoomID` resolution
