### PR TITLE
Possible fix for the join room screen not updating

### DIFF
--- a/ElementX/Sources/Screens/JoinRoomScreen/JoinRoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/JoinRoomScreen/JoinRoomScreenViewModel.swift
@@ -95,13 +95,6 @@ class JoinRoomScreenViewModel: JoinRoomScreenViewModelType, JoinRoomScreenViewMo
         // See if we known about the room locally and, if so, have that
         // take priority over the preview one.
         if let room = await clientProxy.roomForIdentifier(roomID) {
-            // We also need to update the room preview
-            switch await clientProxy.roomPreviewForIdentifier(roomID, via: via) {
-            case .success(let updatedPreview):
-                roomPreview = updatedPreview
-            case .failure:
-                break
-            }
             self.room = room
             await updateRoomDetails()
         }
@@ -216,7 +209,7 @@ class JoinRoomScreenViewModel: JoinRoomScreenViewModelType, JoinRoomScreenViewMo
                                                     message: state.bindings.knockMessage.isBlank ? nil : state.bindings.knockMessage) {
             case .success:
                 // The room should become knocked through the sync
-                await updateRoom()
+                await loadRoomDetails()
             case .failure(let error):
                 MXLog.error("Failed knocking room alias: \(alias) with error: \(error)")
                 userIndicatorController.submitIndicator(.init(title: L10n.errorUnknown))
@@ -227,7 +220,7 @@ class JoinRoomScreenViewModel: JoinRoomScreenViewModelType, JoinRoomScreenViewMo
                                                message: state.bindings.knockMessage.isBlank ? nil : state.bindings.knockMessage) {
             case .success:
                 // The room should become knocked through the sync
-                await updateRoom()
+                await loadRoomDetails()
             case .failure(let error):
                 MXLog.error("Failed knocking room id: \(roomID) with error: \(error)")
                 userIndicatorController.submitIndicator(.init(title: L10n.errorUnknown))


### PR DESCRIPTION
Not sure if this is the best way to fix the issue given the API change to the room preview API that has been made, but once the request was sent, the state of the joined room was not updated, since the room preview was checked first but never updated.
Example:


https://github.com/user-attachments/assets/5ef8afdf-e98b-4f5b-bf82-9de989c42665

This should however fix the issue:

https://github.com/user-attachments/assets/7996607e-dc63-486d-8e80-193078e69090

