### PR TITLE
Better handling for editing alias in case of different HS

### DIFF
--- a/ElementX/Sources/Screens/EditRoomAddressScreen/EditRoomAddressScreenViewModel.swift
+++ b/ElementX/Sources/Screens/EditRoomAddressScreen/EditRoomAddressScreenViewModel.swift
@@ -129,13 +129,13 @@ class EditRoomAddressScreenViewModel: EditRoomAddressScreenViewModelType, EditRo
             hideLoadingIndicator()
         }
         
-        guard let canonicalAlias = String.makeCanonicalAlias(aliasLocalPart: state.bindings.desiredAliasLocalPart, serverName: state.serverName),
-              isRoomAliasFormatValid(alias: canonicalAlias) else {
+        guard let desiredCanonicalAlias = String.makeCanonicalAlias(aliasLocalPart: state.bindings.desiredAliasLocalPart, serverName: state.serverName),
+              isRoomAliasFormatValid(alias: desiredCanonicalAlias) else {
             state.aliasErrors = [.invalidSymbols]
             return
         }
         
-        switch await clientProxy.isAliasAvailable(canonicalAlias) {
+        switch await clientProxy.isAliasAvailable(desiredCanonicalAlias) {
         case .success(true):
             break
         case .success(false):
@@ -146,24 +146,38 @@ class EditRoomAddressScreenViewModel: EditRoomAddressScreenViewModelType, EditRo
             return
         }
         
-        let oldAlias = roomProxy.infoPublisher.value.firstAliasMatching(serverName: clientProxy.userIDServerName, useFallback: false)
+        let savedAliasFromHomeserver = roomProxy.infoPublisher.value.firstAliasMatching(serverName: state.serverName, useFallback: false)
+        let savedCanonicalAlias = roomProxy.infoPublisher.value.canonicalAlias
         
-        // First publish the new alias
-        if case .failure = await roomProxy.publishRoomAliasInRoomDirectory(canonicalAlias) {
+        // First publish the desired new alias in the room directory
+        if case .failure = await roomProxy.publishRoomAliasInRoomDirectory(desiredCanonicalAlias) {
             userIndicatorController.submitIndicator(.init(title: L10n.errorUnknown))
             return
         }
         
-        // Then set it as the main alias
-        if case .failure = await roomProxy.updateCanonicalAlias(canonicalAlias, altAliases: []) {
-            userIndicatorController.submitIndicator(.init(title: L10n.errorUnknown))
-            return
+        // Then try remove the old alias from the room directory on our current HS
+        if let savedAliasFromHomeserver {
+            if case .failure = await roomProxy.removeRoomAliasFromRoomDirectory(savedAliasFromHomeserver) {
+                userIndicatorController.submitIndicator(.init(title: L10n.errorUnknown))
+                return
+            }
         }
         
-        // And finally delete the old one
-        if let oldAlias, case .failure = await roomProxy.removeRoomAliasFromRoomDirectory(oldAlias) {
-            userIndicatorController.submitIndicator(.init(title: L10n.errorUnknown))
-            return
+        // Finally update the canonical alias state..
+        // Allow to update the canonical alias only if the saved canonical alias matches the homeserver or if there is no canonical alias
+        if savedCanonicalAlias == nil || savedCanonicalAlias?.hasSuffix(state.serverName) == true {
+            if case .failure = await roomProxy.updateCanonicalAlias(desiredCanonicalAlias, altAliases: roomProxy.infoPublisher.value.alternativeAliases) {
+                userIndicatorController.submitIndicator(.init(title: L10n.errorUnknown))
+                return
+            }
+            // Otherwise, update the alternative aliases and keep the current canonical alia
+        } else {
+            var newAlternativeAliases = roomProxy.infoPublisher.value.alternativeAliases
+            newAlternativeAliases.append(desiredCanonicalAlias)
+            if case .failure = await roomProxy.updateCanonicalAlias(savedCanonicalAlias, altAliases: newAlternativeAliases) {
+                userIndicatorController.submitIndicator(.init(title: L10n.errorUnknown))
+                return
+            }
         }
         
         actionsSubject.send(.dismiss)


### PR DESCRIPTION
We only update the alias if the new alias belongs to the same homeserver or one did not exist yet, otherwise we add it in the list of the alternative ones