### PR TITLE
Make sure the Recovery Key option is shown on the IdentityConfirmationScreen when available.

### DIFF
--- a/ElementX/Sources/Screens/Onboarding/IdentityConfirmationScreen/View/IdentityConfirmationScreen.swift
+++ b/ElementX/Sources/Screens/Onboarding/IdentityConfirmationScreen/View/IdentityConfirmationScreen.swift
@@ -104,6 +104,8 @@ struct IdentityConfirmationScreen: View {
 // MARK: - Previews
 
 struct IdentityConfirmationScreen_Previews: PreviewProvider, TestablePreview {
+    static var viewModel = makeViewModel()
+    
     static var previews: some View {
         NavigationStack {
             IdentityConfirmationScreen(context: viewModel.context)
@@ -113,7 +115,7 @@ struct IdentityConfirmationScreen_Previews: PreviewProvider, TestablePreview {
         })
     }
     
-    private static var viewModel: IdentityConfirmationScreenViewModel {
+    static func makeViewModel() -> IdentityConfirmationScreenViewModel {
         let clientProxy = ClientProxyMock(.init())
         let userSession = UserSessionMock(.init(clientProxy: clientProxy))
         userSession.sessionSecurityStatePublisher = CurrentValuePublisher<SessionSecurityState, Never>(.init(verificationState: .unverified, recoveryState: .enabled))


### PR DESCRIPTION
There was a race condition where 2 different states could be processed at the same time:
Even though the method is `@MainActor`, the fact it has an `await` means that if another Task is spawned when a previous one is suspended, there was no guarantee that they would resume in the same order. This PR calls the method using a `for await in` to process the states serially.