### PR TITLE
Detect the timeline start/end when swiping through media files.

### DIFF
--- a/ElementX/Resources/Localizations/en-US.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en-US.lproj/Localizable.strings
@@ -414,6 +414,8 @@
 "screen_knock_requests_list_title" = "Requests to join";
 "screen_media_details_file_format" = "File format";
 "screen_media_details_filename" = "File name";
+"screen_media_details_no_more_files_to_show" = "No more files to show";
+"screen_media_details_no_more_media_to_show" = "No more media to show";
 "screen_media_details_redact_confirmation_message" = "This file will be removed from the room and members won’t have access to it.";
 "screen_media_details_redact_confirmation_title" = "Delete file?";
 "screen_media_details_uploaded_by" = "Uploaded by";
@@ -478,8 +480,6 @@
 "screen_timeline_item_menu_send_failure_changed_identity" = "Message not sent because %1$@’s verified identity has changed.";
 "screen_timeline_item_menu_send_failure_unsigned_device" = "Message not sent because %1$@ has not verified all devices.";
 "screen_timeline_item_menu_send_failure_you_unsigned_device" = "Message not sent because you have not verified one or more of your devices.";
-"screen.media_details.no_more_files_to_show" = "No more files to show";
-"screen.media_details.no_more_media_to_show" = "No more media to show";
 "screen_account_provider_form_hint" = "Homeserver address";
 "screen_account_provider_form_notice" = "Enter a search term or a domain address.";
 "screen_account_provider_form_subtitle" = "Search for a company, community, or private server.";

--- a/ElementX/Resources/Localizations/en.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Localizable.strings
@@ -414,6 +414,8 @@
 "screen_knock_requests_list_title" = "Requests to join";
 "screen_media_details_file_format" = "File format";
 "screen_media_details_filename" = "File name";
+"screen_media_details_no_more_files_to_show" = "No more files to show";
+"screen_media_details_no_more_media_to_show" = "No more media to show";
 "screen_media_details_redact_confirmation_message" = "This file will be removed from the room and members won’t have access to it.";
 "screen_media_details_redact_confirmation_title" = "Delete file?";
 "screen_media_details_uploaded_by" = "Uploaded by";
@@ -478,8 +480,6 @@
 "screen_timeline_item_menu_send_failure_changed_identity" = "Message not sent because %1$@’s verified identity has changed.";
 "screen_timeline_item_menu_send_failure_unsigned_device" = "Message not sent because %1$@ has not verified all devices.";
 "screen_timeline_item_menu_send_failure_you_unsigned_device" = "Message not sent because you have not verified one or more of your devices.";
-"screen.media_details.no_more_files_to_show" = "No more files to show";
-"screen.media_details.no_more_media_to_show" = "No more media to show";
 "screen_account_provider_form_hint" = "Homeserver address";
 "screen_account_provider_form_notice" = "Enter a search term or a domain address.";
 "screen_account_provider_form_subtitle" = "Search for a company, community, or private server.";

--- a/ElementX/Sources/Generated/Strings.swift
+++ b/ElementX/Sources/Generated/Strings.swift
@@ -1458,6 +1458,10 @@ internal enum L10n {
   internal static var screenMediaDetailsFileFormat: String { return L10n.tr("Localizable", "screen_media_details_file_format") }
   /// File name
   internal static var screenMediaDetailsFilename: String { return L10n.tr("Localizable", "screen_media_details_filename") }
+  /// No more files to show
+  internal static var screenMediaDetailsNoMoreFilesToShow: String { return L10n.tr("Localizable", "screen_media_details_no_more_files_to_show") }
+  /// No more media to show
+  internal static var screenMediaDetailsNoMoreMediaToShow: String { return L10n.tr("Localizable", "screen_media_details_no_more_media_to_show") }
   /// This file will be removed from the room and members won’t have access to it.
   internal static var screenMediaDetailsRedactConfirmationMessage: String { return L10n.tr("Localizable", "screen_media_details_redact_confirmation_message") }
   /// Delete file?
@@ -2803,15 +2807,6 @@ internal enum L10n {
     internal static var sendTo: String { return L10n.tr("Localizable", "common.send_to") }
     /// You
     internal static var you: String { return L10n.tr("Localizable", "common.you") }
-  }
-
-  internal enum Screen {
-    internal enum MediaDetails {
-      /// No more files to show
-      internal static var noMoreFilesToShow: String { return L10n.tr("Localizable", "screen.media_details.no_more_files_to_show") }
-      /// No more media to show
-      internal static var noMoreMediaToShow: String { return L10n.tr("Localizable", "screen.media_details.no_more_media_to_show") }
-    }
   }
 }
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length

--- a/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewDataSource.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewDataSource.swift
@@ -19,7 +19,7 @@ import QuickLook
 /// in the data.
 class TimelineMediaPreviewDataSource: NSObject, QLPreviewControllerDataSource {
     /// All of the items in the timeline that can be previewed.
-    private(set) var previewItems: [TimelineMediaPreviewItem]
+    private(set) var previewItems: [TimelineMediaPreviewItem.Media]
     let previewItemsPaginationPublisher = PassthroughSubject<Void, Never>()
     
     private let initialItem: EventBasedMessageTimelineItemProtocol
@@ -27,30 +27,37 @@ class TimelineMediaPreviewDataSource: NSObject, QLPreviewControllerDataSource {
     let initialItemIndex: Int
     
     /// The media item that is currently being previewed.
-    private(set) var currentItem: TimelineMediaPreviewItem?
+    private(set) var currentItem: TimelineMediaPreviewItem
     
     private var backwardPadding: Int
     private var forwardPadding: Int
     
-    init(itemViewStates: [RoomTimelineItemViewState], initialItem: EventBasedMessageTimelineItemProtocol, initialPadding: Int = 100) {
-        previewItems = itemViewStates.compactMap(TimelineMediaPreviewItem.init)
+    var paginationState: PaginationState
+    
+    init(itemViewStates: [RoomTimelineItemViewState],
+         initialItem: EventBasedMessageTimelineItemProtocol,
+         initialPadding: Int = 100,
+         paginationState: PaginationState) {
+        previewItems = itemViewStates.compactMap(TimelineMediaPreviewItem.Media.init)
         self.initialItem = initialItem
         
         let initialItemArrayIndex = previewItems.firstIndex { $0.id == initialItem.id } ?? 0
         initialItemIndex = initialItemArrayIndex + initialPadding
-        currentItem = previewItems[initialItemArrayIndex]
+        currentItem = .media(previewItems[initialItemArrayIndex])
         
         backwardPadding = initialPadding
         forwardPadding = initialPadding
+        
+        self.paginationState = paginationState
     }
     
-    func updateCurrentItem(_ item: TimelineMediaPreviewItem?) {
+    func updateCurrentItem(_ item: TimelineMediaPreviewItem) {
         currentItem = item
     }
     
     func updatePreviewItems(itemViewStates: [RoomTimelineItemViewState]) {
-        let newItems: [TimelineMediaPreviewItem] = itemViewStates.compactMap { itemViewState in
-            guard let newItem = TimelineMediaPreviewItem(roomTimelineItemViewState: itemViewState) else { return nil }
+        let newItems: [TimelineMediaPreviewItem.Media] = itemViewStates.compactMap { itemViewState in
+            guard let newItem = TimelineMediaPreviewItem.Media(roomTimelineItemViewState: itemViewState) else { return nil }
             
             // If an item already exists use that instead to preserve the file handle, download error etc.
             if let oldItem = previewItems.first(where: { $0.id == newItem.id }) {
@@ -91,6 +98,9 @@ class TimelineMediaPreviewDataSource: NSObject, QLPreviewControllerDataSource {
     
     // MARK: - QLPreviewControllerDataSource
     
+    var firstPreviewItemIndex: Int { backwardPadding }
+    var lastPreviewItemIndex: Int { backwardPadding + previewItems.count - 1 }
+    
     func numberOfPreviewItems(in controller: QLPreviewController) -> Int {
         previewItems.count + backwardPadding + forwardPadding
     }
@@ -98,167 +108,183 @@ class TimelineMediaPreviewDataSource: NSObject, QLPreviewControllerDataSource {
     func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> any QLPreviewItem {
         let arrayIndex = index - backwardPadding
         
-        if arrayIndex >= 0, arrayIndex < previewItems.count {
-            return previewItems[arrayIndex]
+        if index < firstPreviewItemIndex {
+            return paginationState.backward == .timelineEndReached ? TimelineMediaPreviewItem.Loading.timelineStart : .paginating
+        } else if index > lastPreviewItemIndex {
+            return paginationState.forward == .timelineEndReached ? TimelineMediaPreviewItem.Loading.timelineEnd : .paginating
         } else {
-            return TimelineMediaPreviewLoadingItem.shared
+            return previewItems[arrayIndex]
         }
     }
 }
 
 // MARK: - TimelineMediaPreviewItem
 
-/// Wraps a media file and title to be previewed with QuickLook.
-class TimelineMediaPreviewItem: NSObject, QLPreviewItem, Identifiable {
-    fileprivate(set) var timelineItem: EventBasedMessageTimelineItemProtocol
-    var fileHandle: MediaFileHandleProxy?
-    var downloadError: Error?
+enum TimelineMediaPreviewItem: Equatable {
+    case media(Media)
+    case loading(Loading)
     
-    init(timelineItem: EventBasedMessageTimelineItemProtocol) {
-        self.timelineItem = timelineItem
-    }
-    
-    init?(roomTimelineItemViewState: RoomTimelineItemViewState) {
-        switch roomTimelineItemViewState.type {
-        case .audio(let audioRoomTimelineItem):
-            timelineItem = audioRoomTimelineItem
-        case .file(let fileRoomTimelineItem):
-            timelineItem = fileRoomTimelineItem
-        case .image(let imageRoomTimelineItem):
-            timelineItem = imageRoomTimelineItem
-        case .video(let videoRoomTimelineItem):
-            timelineItem = videoRoomTimelineItem
-        default:
-            return nil
-        }
-    }
-    
-    // MARK: Identifiable
-    
-    var id: TimelineItemIdentifier { timelineItem.id }
-    
-    // MARK: QLPreviewItem
-    
-    var previewItemURL: URL? {
-        // Falling back to a clear image allows the presentation animation to work when
-        // the item is in the event cache and just needs to be loaded from the store.
-        fileHandle?.url ?? Bundle.main.url(forResource: "clear", withExtension: "png")
-    }
-    
-    var previewItemTitle: String? {
-        filename
-    }
-    
-    // MARK: Event details
-    
-    var sender: TimelineItemSender {
-        timelineItem.sender
-    }
-    
-    var timestamp: Date {
-        timelineItem.timestamp
-    }
-    
-    // MARK: Media details
-    
-    var mediaSource: MediaSourceProxy? {
-        switch timelineItem {
-        case let audioItem as AudioRoomTimelineItem:
-            audioItem.content.source
-        case let fileItem as FileRoomTimelineItem:
-            fileItem.content.source
-        case let imageItem as ImageRoomTimelineItem:
-            imageItem.content.imageInfo.source
-        case let videoItem as VideoRoomTimelineItem:
-            videoItem.content.videoInfo.source
-        default:
-            nil
-        }
-    }
-    
-    var thumbnailMediaSource: MediaSourceProxy? {
-        switch timelineItem {
-        case let fileItem as FileRoomTimelineItem:
-            fileItem.content.thumbnailSource
-        case let imageItem as ImageRoomTimelineItem:
-            imageItem.content.thumbnailInfo?.source
-        case let videoItem as VideoRoomTimelineItem:
-            videoItem.content.thumbnailInfo?.source
-        default:
-            nil
-        }
-    }
-    
-    var filename: String? {
-        switch timelineItem {
-        case let audioItem as AudioRoomTimelineItem:
-            audioItem.content.filename
-        case let fileItem as FileRoomTimelineItem:
-            fileItem.content.filename
-        case let imageItem as ImageRoomTimelineItem:
-            imageItem.content.filename
-        case let videoItem as VideoRoomTimelineItem:
-            videoItem.content.filename
-        default:
-            nil
-        }
-    }
-    
-    var fileSize: Double? {
-        previewItemURL.flatMap { try? FileManager.default.sizeForItem(at: $0) } ?? expectedFileSize
-    }
-    
-    private var expectedFileSize: Double? {
-        let fileSize: UInt? = switch timelineItem {
-        case let audioItem as AudioRoomTimelineItem:
-            audioItem.content.fileSize
-        case let fileItem as FileRoomTimelineItem:
-            fileItem.content.fileSize
-        case let imageItem as ImageRoomTimelineItem:
-            imageItem.content.imageInfo.fileSize
-        case let videoItem as VideoRoomTimelineItem:
-            videoItem.content.videoInfo.fileSize
-        default:
-            nil
+    /// Wraps a media file and title to be previewed with QuickLook.
+    class Media: NSObject, QLPreviewItem, Identifiable {
+        fileprivate(set) var timelineItem: EventBasedMessageTimelineItemProtocol
+        var fileHandle: MediaFileHandleProxy?
+        var downloadError: Error?
+        
+        init(timelineItem: EventBasedMessageTimelineItemProtocol) {
+            self.timelineItem = timelineItem
         }
         
-        return fileSize.map(Double.init)
-    }
-    
-    var caption: String? {
-        timelineItem.mediaCaption
-    }
-    
-    var contentType: String? {
-        switch timelineItem {
-        case let audioItem as AudioRoomTimelineItem:
-            audioItem.content.contentType?.localizedDescription
-        case let fileItem as FileRoomTimelineItem:
-            fileItem.content.contentType?.localizedDescription
-        case let imageItem as ImageRoomTimelineItem:
-            imageItem.content.contentType?.localizedDescription
-        case let videoItem as VideoRoomTimelineItem:
-            videoItem.content.contentType?.localizedDescription
-        default:
-            nil
+        init?(roomTimelineItemViewState: RoomTimelineItemViewState) {
+            switch roomTimelineItemViewState.type {
+            case .audio(let audioRoomTimelineItem):
+                timelineItem = audioRoomTimelineItem
+            case .file(let fileRoomTimelineItem):
+                timelineItem = fileRoomTimelineItem
+            case .image(let imageRoomTimelineItem):
+                timelineItem = imageRoomTimelineItem
+            case .video(let videoRoomTimelineItem):
+                timelineItem = videoRoomTimelineItem
+            default:
+                return nil
+            }
+        }
+        
+        // MARK: Identifiable
+        
+        var id: TimelineItemIdentifier { timelineItem.id }
+        
+        // MARK: QLPreviewItem
+        
+        var previewItemURL: URL? {
+            // Falling back to a clear image allows the presentation animation to work when
+            // the item is in the event cache and just needs to be loaded from the store.
+            fileHandle?.url ?? Bundle.main.url(forResource: "clear", withExtension: "png")
+        }
+        
+        var previewItemTitle: String? {
+            filename
+        }
+        
+        // MARK: Event details
+        
+        var sender: TimelineItemSender {
+            timelineItem.sender
+        }
+        
+        var timestamp: Date {
+            timelineItem.timestamp
+        }
+        
+        // MARK: Media details
+        
+        var mediaSource: MediaSourceProxy? {
+            switch timelineItem {
+            case let audioItem as AudioRoomTimelineItem:
+                audioItem.content.source
+            case let fileItem as FileRoomTimelineItem:
+                fileItem.content.source
+            case let imageItem as ImageRoomTimelineItem:
+                imageItem.content.imageInfo.source
+            case let videoItem as VideoRoomTimelineItem:
+                videoItem.content.videoInfo.source
+            default:
+                nil
+            }
+        }
+        
+        var thumbnailMediaSource: MediaSourceProxy? {
+            switch timelineItem {
+            case let fileItem as FileRoomTimelineItem:
+                fileItem.content.thumbnailSource
+            case let imageItem as ImageRoomTimelineItem:
+                imageItem.content.thumbnailInfo?.source
+            case let videoItem as VideoRoomTimelineItem:
+                videoItem.content.thumbnailInfo?.source
+            default:
+                nil
+            }
+        }
+        
+        var filename: String? {
+            switch timelineItem {
+            case let audioItem as AudioRoomTimelineItem:
+                audioItem.content.filename
+            case let fileItem as FileRoomTimelineItem:
+                fileItem.content.filename
+            case let imageItem as ImageRoomTimelineItem:
+                imageItem.content.filename
+            case let videoItem as VideoRoomTimelineItem:
+                videoItem.content.filename
+            default:
+                nil
+            }
+        }
+        
+        var fileSize: Double? {
+            previewItemURL.flatMap { try? FileManager.default.sizeForItem(at: $0) } ?? expectedFileSize
+        }
+        
+        private var expectedFileSize: Double? {
+            let fileSize: UInt? = switch timelineItem {
+            case let audioItem as AudioRoomTimelineItem:
+                audioItem.content.fileSize
+            case let fileItem as FileRoomTimelineItem:
+                fileItem.content.fileSize
+            case let imageItem as ImageRoomTimelineItem:
+                imageItem.content.imageInfo.fileSize
+            case let videoItem as VideoRoomTimelineItem:
+                videoItem.content.videoInfo.fileSize
+            default:
+                nil
+            }
+            
+            return fileSize.map(Double.init)
+        }
+        
+        var caption: String? {
+            timelineItem.mediaCaption
+        }
+        
+        var contentType: String? {
+            switch timelineItem {
+            case let audioItem as AudioRoomTimelineItem:
+                audioItem.content.contentType?.localizedDescription
+            case let fileItem as FileRoomTimelineItem:
+                fileItem.content.contentType?.localizedDescription
+            case let imageItem as ImageRoomTimelineItem:
+                imageItem.content.contentType?.localizedDescription
+            case let videoItem as VideoRoomTimelineItem:
+                videoItem.content.contentType?.localizedDescription
+            default:
+                nil
+            }
+        }
+        
+        var blurhash: String? {
+            switch timelineItem {
+            case let imageItem as ImageRoomTimelineItem:
+                imageItem.content.blurhash
+            case let videoItem as VideoRoomTimelineItem:
+                videoItem.content.blurhash
+            default:
+                nil
+            }
         }
     }
     
-    var blurhash: String? {
-        switch timelineItem {
-        case let imageItem as ImageRoomTimelineItem:
-            imageItem.content.blurhash
-        case let videoItem as VideoRoomTimelineItem:
-            videoItem.content.blurhash
-        default:
-            nil
+    class Loading: NSObject, QLPreviewItem {
+        static let paginating = Loading(state: .paginating)
+        static let timelineStart = Loading(state: .timelineStart)
+        static let timelineEnd = Loading(state: .timelineEnd)
+        
+        enum State { case paginating, timelineStart, timelineEnd }
+        let state: State
+        
+        let previewItemURL: URL? = nil
+        let previewItemTitle: String? = "" // Empty to force QLPreviewController to not show any text.
+        
+        init(state: State) {
+            self.state = state
         }
     }
-}
-
-class TimelineMediaPreviewLoadingItem: NSObject, QLPreviewItem {
-    static let shared = TimelineMediaPreviewLoadingItem()
-    
-    let previewItemURL: URL? = nil
-    let previewItemTitle: String? = "" // Empty to force QLPreviewController to not show any text.
 }

--- a/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewModels.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewModels.swift
@@ -18,7 +18,7 @@ struct TimelineMediaPreviewViewState: BindableState {
     var dataSource: TimelineMediaPreviewDataSource
     
     /// The media item that is currently being previewed.
-    var currentItem: TimelineMediaPreviewItem? { dataSource.currentItem }
+    var currentItem: TimelineMediaPreviewItem { dataSource.currentItem }
     /// All of the available actions for the current item.
     var currentItemActions: TimelineItemMenuActions?
     
@@ -32,9 +32,9 @@ struct TimelineMediaPreviewViewState: BindableState {
 
 struct TimelineMediaPreviewViewStateBindings {
     /// A binding that will present the Details view for the specified item.
-    var mediaDetailsItem: TimelineMediaPreviewItem?
+    var mediaDetailsItem: TimelineMediaPreviewItem.Media?
     /// A binding that will present a confirmation to redact the specified item.
-    var redactConfirmationItem: TimelineMediaPreviewItem?
+    var redactConfirmationItem: TimelineMediaPreviewItem.Media?
     /// A binding that will present a document picker to export the specified file.
     var fileToExport: TimelineMediaPreviewFileExportPicker.File?
     
@@ -46,9 +46,10 @@ enum TimelineMediaPreviewAlertType {
 }
 
 enum TimelineMediaPreviewViewAction {
-    case updateCurrentItem(TimelineMediaPreviewItem?)
-    case showCurrentItemDetails
-    case menuAction(TimelineItemMenuAction, item: TimelineMediaPreviewItem)
-    case redactConfirmation(item: TimelineMediaPreviewItem)
+    case updateCurrentItem(TimelineMediaPreviewItem)
+    case showItemDetails(TimelineMediaPreviewItem.Media)
+    case menuAction(TimelineItemMenuAction, item: TimelineMediaPreviewItem.Media)
+    case redactConfirmation(item: TimelineMediaPreviewItem.Media)
+    case timelineEndReached
     case dismiss
 }

--- a/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewViewModel.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewViewModel.swift
@@ -35,8 +35,11 @@ class TimelineMediaPreviewViewModel: TimelineMediaPreviewViewModelType {
         self.userIndicatorController = userIndicatorController
         self.appMediator = appMediator
         
-        super.init(initialViewState: TimelineMediaPreviewViewState(dataSource: .init(itemViewStates: timelineViewModel.context.viewState.timelineState.itemViewStates,
-                                                                                     initialItem: context.item),
+        let timelineState = timelineViewModel.context.viewState.timelineState
+        
+        super.init(initialViewState: TimelineMediaPreviewViewState(dataSource: .init(itemViewStates: timelineState.itemViewStates,
+                                                                                     initialItem: context.item,
+                                                                                     paginationState: timelineState.paginationState),
                                                                    transitionNamespace: context.namespace),
                    mediaProvider: mediaProvider)
         
@@ -57,14 +60,19 @@ class TimelineMediaPreviewViewModel: TimelineMediaPreviewViewModelType {
                 self?.state.dataSource.updatePreviewItems(itemViewStates: itemViewStates)
             }
             .store(in: &cancellables)
+        
+        timelineViewModel.context.$viewState.map(\.timelineState.paginationState)
+            .removeDuplicates()
+            .weakAssign(to: \.state.dataSource.paginationState, on: self)
+            .store(in: &cancellables)
     }
     
     override func process(viewAction: TimelineMediaPreviewViewAction) {
         switch viewAction {
         case .updateCurrentItem(let item):
             Task { await updateCurrentItem(item) }
-        case .showCurrentItemDetails:
-            state.bindings.mediaDetailsItem = state.currentItem
+        case .showItemDetails(let mediaItem):
+            state.bindings.mediaDetailsItem = mediaItem
         case .menuAction(let action, let item):
             switch action {
             case .viewInRoomTimeline:
@@ -78,28 +86,32 @@ class TimelineMediaPreviewViewModel: TimelineMediaPreviewViewModelType {
             }
         case .redactConfirmation(let item):
             redactItem(item)
+        case .timelineEndReached:
+            showTimelineEndIndicator()
         case .dismiss:
             actionsSubject.send(.dismiss)
         }
     }
     
-    private func updateCurrentItem(_ previewItem: TimelineMediaPreviewItem?) async {
-        previewItem?.downloadError = nil // Clear any existing error.
+    private func updateCurrentItem(_ previewItem: TimelineMediaPreviewItem) async {
+        if case let .media(item) = previewItem {
+            item.downloadError = nil // Clear any existing error.
+        }
         state.dataSource.updateCurrentItem(previewItem)
         rebuildCurrentItemActions()
         
-        if let previewItem {
-            currentItemIDHandler?(previewItem.id)
+        if case let .media(mediaItem) = previewItem {
+            currentItemIDHandler?(mediaItem.id)
             
-            if previewItem.fileHandle == nil, let source = previewItem.mediaSource {
-                switch await mediaProvider.loadFileFromSource(source, filename: previewItem.filename) {
+            if mediaItem.fileHandle == nil, let source = mediaItem.mediaSource {
+                switch await mediaProvider.loadFileFromSource(source, filename: mediaItem.filename) {
                 case .success(let handle):
-                    previewItem.fileHandle = handle
-                    state.fileLoadedPublisher.send(previewItem.id)
+                    mediaItem.fileHandle = handle
+                    state.fileLoadedPublisher.send(mediaItem.id)
                 case .failure(let error):
                     MXLog.error("Failed loading media: \(error)")
                     context.objectWillChange.send() // Manually trigger the SwiftUI view update.
-                    previewItem.downloadError = error
+                    mediaItem.downloadError = error
                 }
             }
         }
@@ -107,8 +119,9 @@ class TimelineMediaPreviewViewModel: TimelineMediaPreviewViewModelType {
     
     private func rebuildCurrentItemActions() {
         let timelineContext = timelineViewModel.context
-        state.currentItemActions = if let currentItem = state.currentItem {
-            TimelineItemMenuActionProvider(timelineItem: currentItem.timelineItem,
+        state.currentItemActions = switch state.currentItem {
+        case .media(let mediaItem):
+            TimelineItemMenuActionProvider(timelineItem: mediaItem.timelineItem,
                                            canCurrentUserRedactSelf: timelineContext.viewState.canCurrentUserRedactSelf,
                                            canCurrentUserRedactOthers: timelineContext.viewState.canCurrentUserRedactOthers,
                                            canCurrentUserPin: timelineContext.viewState.canCurrentUserPin,
@@ -118,13 +131,13 @@ class TimelineMediaPreviewViewModel: TimelineMediaPreviewViewModelType {
                                            timelineKind: timelineContext.viewState.timelineKind,
                                            emojiProvider: timelineContext.viewState.emojiProvider)
                 .makeActions()
-        } else {
+        case .loading:
             nil
         }
     }
     
     private func saveCurrentItem() async {
-        guard let currentItem = state.currentItem, let fileURL = currentItem.fileHandle?.url else {
+        guard case let .media(mediaItem) = state.currentItem, let fileURL = mediaItem.fileHandle?.url else {
             MXLog.error("Unable to save an item without a URL, the button shouldn't be visible.")
             return
         }
@@ -133,7 +146,7 @@ class TimelineMediaPreviewViewModel: TimelineMediaPreviewViewModelType {
         state.bindings.mediaDetailsItem = nil
         
         do {
-            switch currentItem.timelineItem {
+            switch mediaItem.timelineItem {
             case is AudioRoomTimelineItem, is FileRoomTimelineItem:
                 state.bindings.fileToExport = .init(url: fileURL)
                 return // Don't show the indicator.
@@ -158,7 +171,7 @@ class TimelineMediaPreviewViewModel: TimelineMediaPreviewViewModelType {
         }
     }
     
-    private func redactItem(_ item: TimelineMediaPreviewItem) {
+    private func redactItem(_ item: TimelineMediaPreviewItem.Media) {
         timelineViewModel.context.send(viewAction: .handleTimelineItemMenuAction(itemID: item.id, action: .redact))
         state.bindings.redactConfirmationItem = nil
         state.bindings.mediaDetailsItem = nil
@@ -187,6 +200,12 @@ class TimelineMediaPreviewViewModel: TimelineMediaPreviewViewModelType {
                                                               type: .toast,
                                                               title: L10n.errorUnknown,
                                                               iconName: "xmark"))
+    }
+    
+    private func showTimelineEndIndicator() {
+        userIndicatorController.submitIndicator(UserIndicator(id: statusIndicatorID,
+                                                              type: .toast,
+                                                              title: L10n.screenMediaDetailsNoMoreMediaToShow))
     }
     
     private var statusIndicatorID: String { "\(Self.self)-Status" }

--- a/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewDetailsView.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewDetailsView.swift
@@ -9,7 +9,7 @@ import Compound
 import SwiftUI
 
 struct TimelineMediaPreviewDetailsView: View {
-    let item: TimelineMediaPreviewItem
+    let item: TimelineMediaPreviewItem.Media
     @ObservedObject var context: TimelineMediaPreviewViewModel.Context
     
     @State private var sheetHeight: CGFloat = .zero
@@ -132,7 +132,7 @@ struct TimelineMediaPreviewDetailsView: View {
     }
     
     private struct ActionButton: View {
-        let item: TimelineMediaPreviewItem
+        let item: TimelineMediaPreviewItem.Media
         let action: TimelineItemMenuAction
         let context: TimelineMediaPreviewViewModel.Context
         
@@ -177,29 +177,31 @@ struct TimelineMediaPreviewDetailsView_Previews: PreviewProvider, TestablePrevie
     static let presentedOnRoomViewModel = makeViewModel(isPresentedOnRoomScreen: true)
     
     static var previews: some View {
-        // swiftlint:disable force_unwrapping
-        TimelineMediaPreviewDetailsView(item: viewModel.state.currentItem!,
-                                        context: viewModel.context)
-            .previewDisplayName("Image")
-            .snapshotPreferences(expect: viewModel.context.$viewState.map { state in
-                state.currentItemActions?.secondaryActions.contains(.redact) ?? false
-            })
+        if case let .media(mediaItem) = viewModel.state.currentItem {
+            TimelineMediaPreviewDetailsView(item: mediaItem, context: viewModel.context)
+                .previewDisplayName("Image")
+                .snapshotPreferences(expect: viewModel.context.$viewState.map { state in
+                    state.currentItemActions?.secondaryActions.contains(.redact) ?? false
+                })
+        }
         
-        TimelineMediaPreviewDetailsView(item: loadingViewModel.state.currentItem!,
-                                        context: loadingViewModel.context)
-            .previewDisplayName("Loading")
-            .snapshotPreferences(expect: loadingViewModel.context.$viewState.map { state in
-                state.currentItemActions?.secondaryActions.contains(.redact) ?? false
-            })
+        if case let .media(mediaItem) = loadingViewModel.state.currentItem {
+            TimelineMediaPreviewDetailsView(item: mediaItem, context: loadingViewModel.context)
+                .previewDisplayName("Loading")
+                .snapshotPreferences(expect: loadingViewModel.context.$viewState.map { state in
+                    state.currentItemActions?.secondaryActions.contains(.redact) ?? false
+                })
+        }
         
-        TimelineMediaPreviewDetailsView(item: unknownTypeViewModel.state.currentItem!,
-                                        context: unknownTypeViewModel.context)
-            .previewDisplayName("Unknown type")
+        if case let .media(mediaItem) = unknownTypeViewModel.state.currentItem {
+            TimelineMediaPreviewDetailsView(item: mediaItem, context: unknownTypeViewModel.context)
+                .previewDisplayName("Unknown type")
+        }
         
-        TimelineMediaPreviewDetailsView(item: presentedOnRoomViewModel.state.currentItem!,
-                                        context: presentedOnRoomViewModel.context)
-            .previewDisplayName("Incoming on Room")
-        // swiftlint:enable force_unwrapping
+        if case let .media(mediaItem) = presentedOnRoomViewModel.state.currentItem {
+            TimelineMediaPreviewDetailsView(item: mediaItem, context: presentedOnRoomViewModel.context)
+                .previewDisplayName("Incoming on Room")
+        }
     }
     
     static func makeViewModel(contentType: UTType? = nil,

--- a/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewRedactConfirmationView.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewRedactConfirmationView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct TimelineMediaPreviewRedactConfirmationView: View {
     @Environment(\.dismiss) private var dismiss
     
-    let item: TimelineMediaPreviewItem
+    let item: TimelineMediaPreviewItem.Media
     @ObservedObject var context: TimelineMediaPreviewViewModel.Context
     
     @State private var sheetHeight: CGFloat = .zero
@@ -125,8 +125,9 @@ struct TimelineMediaPreviewRedactConfirmationView_Previews: PreviewProvider, Tes
     static let viewModel = makeViewModel(contentType: .jpeg)
     
     static var previews: some View {
-        // swiftlint:disable:next force_unwrapping
-        TimelineMediaPreviewRedactConfirmationView(item: viewModel.state.currentItem!, context: viewModel.context)
+        if case let .media(mediaItem) = viewModel.state.currentItem {
+            TimelineMediaPreviewRedactConfirmationView(item: mediaItem, context: viewModel.context)
+        }
     }
     
     static func makeViewModel(contentType: UTType? = nil) -> TimelineMediaPreviewViewModel {

--- a/ElementX/Sources/Services/Timeline/TimelineProxy.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineProxy.swift
@@ -586,10 +586,13 @@ final class TimelineProxy: TimelineProxyProtocol {
                 MXLog.error("Failed to subscribe to back pagination status with error: \(error)")
             }
             forwardPaginationStatusSubject.send(.timelineEndReached)
-        case .detached, .media:
+        case .detached:
             // Detached timelines don't support observation, set the initial state ourself.
             backPaginationStatusSubject.send(.idle)
             forwardPaginationStatusSubject.send(.idle)
+        case .media(let presentation):
+            backPaginationStatusSubject.send(.idle)
+            forwardPaginationStatusSubject.send(presentation == .mediaFilesScreen ? .timelineEndReached : .idle)
         case .pinned:
             backPaginationStatusSubject.send(.timelineEndReached)
             forwardPaginationStatusSubject.send(.timelineEndReached)

--- a/UnitTests/Sources/TimelineMediaPreviewViewModelTests.swift
+++ b/UnitTests/Sources/TimelineMediaPreviewViewModelTests.swift
@@ -25,7 +25,7 @@ class TimelineMediaPreviewViewModelTests: XCTestCase {
         // Given a fresh view model.
         setupViewModel()
         XCTAssertFalse(mediaProvider.loadFileFromSourceFilenameCalled)
-        XCTAssertEqual(context.viewState.currentItem, context.viewState.dataSource.previewItems[0])
+        XCTAssertEqual(context.viewState.currentItem, .media(context.viewState.dataSource.previewItems[0]))
         XCTAssertNotNil(context.viewState.currentItemActions)
         
         // When the preview controller sets the current item.
@@ -33,32 +33,32 @@ class TimelineMediaPreviewViewModelTests: XCTestCase {
         
         // Then the view model should load the item and update its view state.
         XCTAssertTrue(mediaProvider.loadFileFromSourceFilenameCalled)
-        XCTAssertEqual(context.viewState.currentItem, context.viewState.dataSource.previewItems[0])
+        XCTAssertEqual(context.viewState.currentItem, .media(context.viewState.dataSource.previewItems[0]))
         XCTAssertNotNil(context.viewState.currentItemActions)
     }
     
     func testLoadingItemFailure() async throws {
         // Given a fresh view model.
         setupViewModel()
-        guard let currentItem = context.viewState.currentItem else {
+        guard case let .media(mediaItem) = context.viewState.currentItem else {
             XCTFail("There should be a current item")
             return
         }
         
         XCTAssertFalse(mediaProvider.loadFileFromSourceFilenameCalled)
-        XCTAssertEqual(currentItem, context.viewState.dataSource.previewItems[0])
-        XCTAssertNil(currentItem.downloadError)
+        XCTAssertEqual(mediaItem, context.viewState.dataSource.previewItems[0])
+        XCTAssertNil(mediaItem.downloadError)
         
         // When the preview controller sets an item that fails to load.
         mediaProvider.loadFileFromSourceFilenameClosure = { _, _ in .failure(.failedRetrievingFile) }
         let failure = deferFailure(viewModel.state.fileLoadedPublisher, timeout: 1) { _ in true }
-        context.send(viewAction: .updateCurrentItem(context.viewState.dataSource.previewItems[0]))
+        context.send(viewAction: .updateCurrentItem(.media(context.viewState.dataSource.previewItems[0])))
         try await failure.fulfill()
         
         // Then the view model should load the item and update its view state.
         XCTAssertTrue(mediaProvider.loadFileFromSourceFilenameCalled)
-        XCTAssertEqual(currentItem, context.viewState.dataSource.previewItems[0])
-        XCTAssertNotNil(currentItem.downloadError)
+        XCTAssertEqual(mediaItem, context.viewState.dataSource.previewItems[0])
+        XCTAssertNotNil(mediaItem.downloadError)
     }
     
     func testSwipingBetweenItems() async throws {
@@ -67,21 +67,21 @@ class TimelineMediaPreviewViewModelTests: XCTestCase {
         
         // When swiping to another item.
         let deferred = deferFulfillment(viewModel.state.fileLoadedPublisher) { _ in true }
-        context.send(viewAction: .updateCurrentItem(context.viewState.dataSource.previewItems[1]))
+        context.send(viewAction: .updateCurrentItem(.media(context.viewState.dataSource.previewItems[1])))
         try await deferred.fulfill()
         
         // Then the view model should load the item and update its view state.
         XCTAssertEqual(mediaProvider.loadFileFromSourceFilenameCallsCount, 2)
-        XCTAssertEqual(context.viewState.currentItem, context.viewState.dataSource.previewItems[1])
+        XCTAssertEqual(context.viewState.currentItem, .media(context.viewState.dataSource.previewItems[1]))
         
         // When swiping back to the first item.
         let failure = deferFailure(viewModel.state.fileLoadedPublisher, timeout: 1) { _ in true }
-        context.send(viewAction: .updateCurrentItem(context.viewState.dataSource.previewItems[0]))
+        context.send(viewAction: .updateCurrentItem(.media(context.viewState.dataSource.previewItems[0])))
         try await failure.fulfill()
         
         // Then the view model should not need to load the item, but should still update its view state.
         XCTAssertEqual(mediaProvider.loadFileFromSourceFilenameCallsCount, 2)
-        XCTAssertEqual(context.viewState.currentItem, context.viewState.dataSource.previewItems[0])
+        XCTAssertEqual(context.viewState.currentItem, .media(context.viewState.dataSource.previewItems[0]))
     }
     
     func testLoadingMoreItem() async throws {
@@ -90,12 +90,12 @@ class TimelineMediaPreviewViewModelTests: XCTestCase {
         
         // When swiping to a "loading more" item.
         let deferred = deferFailure(viewModel.state.fileLoadedPublisher, timeout: 1) { _ in true }
-        context.send(viewAction: .updateCurrentItem(nil))
+        context.send(viewAction: .updateCurrentItem(.loading(.paginating)))
         try await deferred.fulfill()
         
         // Then there should no longer be a media preview and no attempt should be made to load one.
         XCTAssertEqual(mediaProvider.loadFileFromSourceFilenameCallsCount, 1)
-        XCTAssertNil(context.viewState.currentItem)
+        XCTAssertEqual(context.viewState.currentItem, .loading(.paginating))
     }
     
     func testPagination() async throws {
@@ -112,7 +112,7 @@ class TimelineMediaPreviewViewModelTests: XCTestCase {
         // And the preview controller attempts to update the current item (now at a new index in the array but it hasn't changed in the data source).
         mediaProvider.loadFileFromSourceFilenameClosure = { _, _ in .failure(.failedRetrievingFile) }
         let failure = deferFailure(viewModel.state.fileLoadedPublisher, timeout: 1) { _ in true }
-        context.send(viewAction: .updateCurrentItem(context.viewState.dataSource.previewItems[3]))
+        context.send(viewAction: .updateCurrentItem(.media(context.viewState.dataSource.previewItems[3])))
         try await failure.fulfill()
         
         // Then the current item shouldn't need to be reloaded.
@@ -125,13 +125,13 @@ class TimelineMediaPreviewViewModelTests: XCTestCase {
         try await testLoadingItem()
         
         // When choosing to view the current item in the timeline.
-        guard let item = context.viewState.currentItem else {
+        guard case let .media(mediaItem) = context.viewState.currentItem else {
             XCTFail("There should be a current item.")
             return
         }
         
-        let deferred = deferFulfillment(viewModel.actions) { $0 == .viewInRoomTimeline(item.id) }
-        context.send(viewAction: .menuAction(.viewInRoomTimeline, item: item))
+        let deferred = deferFulfillment(viewModel.actions) { $0 == .viewInRoomTimeline(mediaItem.id) }
+        context.send(viewAction: .menuAction(.viewInRoomTimeline, item: mediaItem))
         
         // Then the action should be sent upwards to make this happen.
         try await deferred.fulfill()
@@ -142,27 +142,31 @@ class TimelineMediaPreviewViewModelTests: XCTestCase {
         try await testLoadingItem()
         XCTAssertNil(context.redactConfirmationItem)
         XCTAssertFalse(timelineController.redactCalled)
+        guard case let .media(mediaItem) = context.viewState.currentItem else {
+            XCTFail("There should be a current item.")
+            return
+        }
         
         // When choosing to show the item details.
-        context.send(viewAction: .showCurrentItemDetails)
+        context.send(viewAction: .showItemDetails(mediaItem))
         
         // Then the details sheet should be presented.
-        guard let item = context.mediaDetailsItem else {
+        guard let mediaDetailsItem = context.mediaDetailsItem else {
             XCTFail("The default of the current item should be presented")
             return
         }
-        XCTAssertEqual(context.mediaDetailsItem, context.viewState.currentItem)
+        XCTAssertEqual(.media(mediaDetailsItem), context.viewState.currentItem)
         
         // When choosing to redact the item.
-        context.send(viewAction: .menuAction(.redact, item: item))
+        context.send(viewAction: .menuAction(.redact, item: mediaDetailsItem))
         
         // Then the confirmation sheet should be presented.
-        XCTAssertEqual(context.redactConfirmationItem, item)
+        XCTAssertEqual(context.redactConfirmationItem, mediaDetailsItem)
         XCTAssertFalse(timelineController.redactCalled)
         
         // When confirming the redaction.
         let deferred = deferFulfillment(viewModel.actions) { $0 == .dismiss }
-        context.send(viewAction: .redactConfirmation(item: item))
+        context.send(viewAction: .redactConfirmation(item: mediaDetailsItem))
         
         // Then the item should be redacted and the view should be dismissed.
         try await deferred.fulfill()
@@ -172,35 +176,35 @@ class TimelineMediaPreviewViewModelTests: XCTestCase {
     func testSaveImage() async throws {
         // Given a view model with a loaded image.
         try await testLoadingItem()
-        guard let currentItem = context.viewState.currentItem else {
+        guard case let .media(mediaItem) = context.viewState.currentItem else {
             XCTFail("There should be a current item")
             return
         }
-        XCTAssertEqual(currentItem.contentType, "JPEG image")
+        XCTAssertEqual(mediaItem.contentType, "JPEG image")
         
         // When choosing to save the image.
-        context.send(viewAction: .menuAction(.save, item: currentItem))
+        context.send(viewAction: .menuAction(.save, item: mediaItem))
         try await Task.sleep(for: .seconds(0.5))
         
         // Then the image should be saved as a photo to the user's photo library.
         XCTAssertTrue(photoLibraryManager.addResourceAtCalled)
         XCTAssertEqual(photoLibraryManager.addResourceAtReceivedArguments?.type, .photo)
-        XCTAssertEqual(photoLibraryManager.addResourceAtReceivedArguments?.url, currentItem.fileHandle?.url)
+        XCTAssertEqual(photoLibraryManager.addResourceAtReceivedArguments?.url, mediaItem.fileHandle?.url)
     }
     
     func testSaveImageWithoutAuthorization() async throws {
         // Given a view model with a loaded image where the user has denied access to the photo library.
         setupViewModel(photoLibraryAuthorizationDenied: true)
         try await loadInitialItem()
-        guard let currentItem = context.viewState.currentItem else {
+        guard case let .media(mediaItem) = context.viewState.currentItem else {
             XCTFail("There should be a current item")
             return
         }
-        XCTAssertEqual(currentItem.contentType, "JPEG image")
+        XCTAssertEqual(mediaItem.contentType, "JPEG image")
         
         // When choosing to save the image.
         let deferred = deferFulfillment(context.$viewState) { $0.bindings.alertInfo != nil }
-        context.send(viewAction: .menuAction(.save, item: currentItem))
+        context.send(viewAction: .menuAction(.save, item: mediaItem))
         try await deferred.fulfill()
         
         // Then the user should be prompted to allow access.
@@ -212,40 +216,40 @@ class TimelineMediaPreviewViewModelTests: XCTestCase {
         // Given a view model with a loaded video.
         setupViewModel(initialItemIndex: 1)
         try await loadInitialItem()
-        guard let currentItem = context.viewState.currentItem else {
+        guard case let .media(mediaItem) = context.viewState.currentItem else {
             XCTFail("There should be a current item")
             return
         }
-        XCTAssertEqual(currentItem.contentType, "MPEG-4 movie")
+        XCTAssertEqual(mediaItem.contentType, "MPEG-4 movie")
         
         // When choosing to save the video.
-        context.send(viewAction: .menuAction(.save, item: currentItem))
+        context.send(viewAction: .menuAction(.save, item: mediaItem))
         try await Task.sleep(for: .seconds(0.5))
         
         // Then the video should be saved as a video in the user's photo library.
         XCTAssertTrue(photoLibraryManager.addResourceAtCalled)
         XCTAssertEqual(photoLibraryManager.addResourceAtReceivedArguments?.type, .video)
-        XCTAssertEqual(photoLibraryManager.addResourceAtReceivedArguments?.url, currentItem.fileHandle?.url)
+        XCTAssertEqual(photoLibraryManager.addResourceAtReceivedArguments?.url, mediaItem.fileHandle?.url)
     }
     
     func testSaveFile() async throws {
         // Given a view model with a loaded file.
         setupViewModel(initialItemIndex: 2)
         try await loadInitialItem()
-        guard let currentItem = context.viewState.currentItem else {
+        guard case let .media(mediaItem) = context.viewState.currentItem else {
             XCTFail("There should be a current item")
             return
         }
-        XCTAssertEqual(currentItem.contentType, "PDF document")
+        XCTAssertEqual(mediaItem.contentType, "PDF document")
         
         // When choosing to save the file.
-        context.send(viewAction: .menuAction(.save, item: currentItem))
+        context.send(viewAction: .menuAction(.save, item: mediaItem))
         try await Task.sleep(for: .seconds(0.5))
         
         // Then the binding should be set for the user to export the file to their specified location.
         XCTAssertFalse(photoLibraryManager.addResourceAtCalled)
         XCTAssertNotNil(context.fileToExport)
-        XCTAssertEqual(context.fileToExport?.url, currentItem.fileHandle?.url)
+        XCTAssertEqual(context.fileToExport?.url, mediaItem.fileHandle?.url)
     }
     
     func testDismiss() async throws {
@@ -266,11 +270,11 @@ class TimelineMediaPreviewViewModelTests: XCTestCase {
         let deferred = deferFulfillment(viewModel.state.fileLoadedPublisher) { _ in true }
         let initialItem = context.viewState.dataSource.previewController(QLPreviewController(),
                                                                          previewItemAt: context.viewState.dataSource.initialItemIndex)
-        guard let initialPreviewItem = initialItem as? TimelineMediaPreviewItem else {
-            XCTFail("1234")
+        guard let initialPreviewItem = initialItem as? TimelineMediaPreviewItem.Media else {
+            XCTFail("The initial item should be a media preview.")
             return
         }
-        context.send(viewAction: .updateCurrentItem(initialPreviewItem))
+        context.send(viewAction: .updateCurrentItem(.media(initialPreviewItem)))
         try await deferred.fulfill()
     }
     


### PR DESCRIPTION
This PR makes the following changes:

- Make `TimelineMediaPreviewItem` an enum with `.loading` and `.media` cases to remove all the optionals.
    - I started the refactor whilst doing everything below and twigging that it makes more sense but I'm afraid that means it is mixed in to the same commit.
- Add the pagination state to the media preview data source and use it to vend loading items that indicate the timeline start/end.
- Automatically jump back to the first/last item when hitting the timeline start/end and show a user indicator that there are no more items to load.
- Bug fix: Configure the initial timeline proxy pagination state on the media browser like a live timeline so it knows it has already hit the end.

Note: This PR doesn't include detection of the start/end when loading more items and none are found.

https://github.com/user-attachments/assets/069e9a80-1cf0-4e47-88c1-6aafcabdc5f7
