### PR TITLE
Ensure multiple mandatory verification flows can be ran consecutively (e.g. following encryption resets)

### DIFF
--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -220,6 +220,8 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
     }
     
     func attemptStartingOnboarding() {
+        MXLog.info("Attempting to start onboarding")
+        
         if onboardingFlowCoordinator.shouldStart {
             clearRoute(animated: false)
             onboardingFlowCoordinator.start()
@@ -340,7 +342,6 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
         userSession.sessionSecurityStatePublisher
             .map(\.verificationState)
             .filter { $0 != .unknown }
-            .removeDuplicates()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 guard let self else { return }

--- a/ElementX/Sources/Screens/Onboarding/SessionVerificationScreen/View/SessionVerificationScreen.swift
+++ b/ElementX/Sources/Screens/Onboarding/SessionVerificationScreen/View/SessionVerificationScreen.swift
@@ -24,7 +24,7 @@ struct SessionVerificationScreen: View {
         .background()
         .backgroundStyle(.compound.bgCanvasDefault)
         .interactiveDismissDisabled()
-        .navigationBarBackButtonHidden(context.viewState.verificationState != .initial)
+        .navigationBarBackButtonHidden(context.viewState.verificationState == .verified)
     }
     
     // MARK: - Private

--- a/ElementX/Sources/Screens/Onboarding/SessionVerificationScreen/View/SessionVerificationScreen.swift
+++ b/ElementX/Sources/Screens/Onboarding/SessionVerificationScreen/View/SessionVerificationScreen.swift
@@ -24,6 +24,7 @@ struct SessionVerificationScreen: View {
         .background()
         .backgroundStyle(.compound.bgCanvasDefault)
         .interactiveDismissDisabled()
+        .navigationBarBackButtonHidden(context.viewState.verificationState != .initial)
     }
     
     // MARK: - Private

--- a/ElementX/Sources/Services/Session/UserSession.swift
+++ b/ElementX/Sources/Services/Session/UserSession.swift
@@ -47,7 +47,6 @@ class UserSession: UserSessionProtocol {
                 MXLog.info("Session security state changed, verificationState: \($0), recoveryState: \($1)")
                 return SessionSecurityState(verificationState: $0, recoveryState: $1)
             }
-            .removeDuplicates()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] value in
                 self?.sessionSecurityStateSubject.send(value)


### PR DESCRIPTION
* running multiple remote resets would find the onboarding flow coordinator in a finished state and prevent showing the mandatory verification again. Fixed that by transitioning from finished to initial automatically
* added onboarding flow coordinator state machine logs
* removed security state deduplication and added extra main queue dispatches
