### PR TITLE
Fix flakey room member details screen snapshot test

### DIFF
--- a/ElementX/Sources/Screens/RoomMemberDetailsScreen/View/RoomMemberDetailsScreen.swift
+++ b/ElementX/Sources/Screens/RoomMemberDetailsScreen/View/RoomMemberDetailsScreen.swift
@@ -146,7 +146,7 @@ struct RoomMemberDetailsScreen_Previews: PreviewProvider, TestablePreview {
             
         RoomMemberDetailsScreen(context: otherUserViewModel.context)
             .snapshotPreferences(expect: otherUserViewModel.context.$viewState.map { state in
-                state.memberDetails?.role == .user
+                state.memberDetails?.role == .user && state.dmRoomID != nil
             })
             .previewDisplayName("Other User")
             


### PR DESCRIPTION
- needs to wait for the call button to appear i.e. dmRoomID

