### PR TITLE
Use the new preview screen when tapping media on the room and pinned events screens.

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Setup environment
         run: 
-          brew install danger/tap/danger-swift
+          brew install danger/tap/danger-swift swiftlint
 
       - name: Danger
         run: 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -41,6 +41,10 @@ function_body_length:
   warning: 100
   error: 100
 
+function_parameter_count:
+  warning: 10
+  error: 10
+
 cyclomatic_complexity:
   ignores_case_statements: true
 

--- a/ElementX/Sources/FlowCoordinators/MediaEventsTimelineFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/MediaEventsTimelineFlowCoordinator.swift
@@ -64,7 +64,8 @@ class MediaEventsTimelineFlowCoordinator: FlowCoordinatorProtocol {
                                                           attributedStringBuilder: AttributedStringBuilder(mentionBuilder: MentionBuilder()),
                                                           stateEventStringBuilder: RoomStateEventStringBuilder(userID: userSession.clientProxy.userID))
         
-        guard case let .success(mediaTimelineController) = await timelineControllerFactory.buildMessageFilteredTimelineController(allowedMessageTypes: [.image, .video],
+        guard case let .success(mediaTimelineController) = await timelineControllerFactory.buildMessageFilteredTimelineController(focus: .live,
+                                                                                                                                  allowedMessageTypes: [.image, .video],
                                                                                                                                   presentation: .mediaFilesScreen,
                                                                                                                                   roomProxy: roomProxy,
                                                                                                                                   timelineItemFactory: timelineItemFactory,
@@ -73,7 +74,8 @@ class MediaEventsTimelineFlowCoordinator: FlowCoordinatorProtocol {
             return
         }
         
-        guard case let .success(filesTimelineController) = await timelineControllerFactory.buildMessageFilteredTimelineController(allowedMessageTypes: [.file, .audio],
+        guard case let .success(filesTimelineController) = await timelineControllerFactory.buildMessageFilteredTimelineController(focus: .live,
+                                                                                                                                  allowedMessageTypes: [.file, .audio],
                                                                                                                                   presentation: .mediaFilesScreen,
                                                                                                                                   roomProxy: roomProxy,
                                                                                                                                   timelineItemFactory: timelineItemFactory,

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -6158,15 +6158,15 @@ class JoinedRoomProxyMock: JoinedRoomProxyProtocol, @unchecked Sendable {
     }
     //MARK: - messageFilteredTimeline
 
-    var messageFilteredTimelineAllowedMessageTypesPresentationUnderlyingCallsCount = 0
-    var messageFilteredTimelineAllowedMessageTypesPresentationCallsCount: Int {
+    var messageFilteredTimelineFocusAllowedMessageTypesPresentationUnderlyingCallsCount = 0
+    var messageFilteredTimelineFocusAllowedMessageTypesPresentationCallsCount: Int {
         get {
             if Thread.isMainThread {
-                return messageFilteredTimelineAllowedMessageTypesPresentationUnderlyingCallsCount
+                return messageFilteredTimelineFocusAllowedMessageTypesPresentationUnderlyingCallsCount
             } else {
                 var returnValue: Int? = nil
                 DispatchQueue.main.sync {
-                    returnValue = messageFilteredTimelineAllowedMessageTypesPresentationUnderlyingCallsCount
+                    returnValue = messageFilteredTimelineFocusAllowedMessageTypesPresentationUnderlyingCallsCount
                 }
 
                 return returnValue!
@@ -6174,29 +6174,29 @@ class JoinedRoomProxyMock: JoinedRoomProxyProtocol, @unchecked Sendable {
         }
         set {
             if Thread.isMainThread {
-                messageFilteredTimelineAllowedMessageTypesPresentationUnderlyingCallsCount = newValue
+                messageFilteredTimelineFocusAllowedMessageTypesPresentationUnderlyingCallsCount = newValue
             } else {
                 DispatchQueue.main.sync {
-                    messageFilteredTimelineAllowedMessageTypesPresentationUnderlyingCallsCount = newValue
+                    messageFilteredTimelineFocusAllowedMessageTypesPresentationUnderlyingCallsCount = newValue
                 }
             }
         }
     }
-    var messageFilteredTimelineAllowedMessageTypesPresentationCalled: Bool {
-        return messageFilteredTimelineAllowedMessageTypesPresentationCallsCount > 0
+    var messageFilteredTimelineFocusAllowedMessageTypesPresentationCalled: Bool {
+        return messageFilteredTimelineFocusAllowedMessageTypesPresentationCallsCount > 0
     }
-    var messageFilteredTimelineAllowedMessageTypesPresentationReceivedArguments: (allowedMessageTypes: [RoomMessageEventMessageType], presentation: TimelineKind.MediaPresentation)?
-    var messageFilteredTimelineAllowedMessageTypesPresentationReceivedInvocations: [(allowedMessageTypes: [RoomMessageEventMessageType], presentation: TimelineKind.MediaPresentation)] = []
+    var messageFilteredTimelineFocusAllowedMessageTypesPresentationReceivedArguments: (focus: TimelineFocus, allowedMessageTypes: [TimelineAllowedMessageType], presentation: TimelineKind.MediaPresentation)?
+    var messageFilteredTimelineFocusAllowedMessageTypesPresentationReceivedInvocations: [(focus: TimelineFocus, allowedMessageTypes: [TimelineAllowedMessageType], presentation: TimelineKind.MediaPresentation)] = []
 
-    var messageFilteredTimelineAllowedMessageTypesPresentationUnderlyingReturnValue: Result<TimelineProxyProtocol, RoomProxyError>!
-    var messageFilteredTimelineAllowedMessageTypesPresentationReturnValue: Result<TimelineProxyProtocol, RoomProxyError>! {
+    var messageFilteredTimelineFocusAllowedMessageTypesPresentationUnderlyingReturnValue: Result<TimelineProxyProtocol, RoomProxyError>!
+    var messageFilteredTimelineFocusAllowedMessageTypesPresentationReturnValue: Result<TimelineProxyProtocol, RoomProxyError>! {
         get {
             if Thread.isMainThread {
-                return messageFilteredTimelineAllowedMessageTypesPresentationUnderlyingReturnValue
+                return messageFilteredTimelineFocusAllowedMessageTypesPresentationUnderlyingReturnValue
             } else {
                 var returnValue: Result<TimelineProxyProtocol, RoomProxyError>? = nil
                 DispatchQueue.main.sync {
-                    returnValue = messageFilteredTimelineAllowedMessageTypesPresentationUnderlyingReturnValue
+                    returnValue = messageFilteredTimelineFocusAllowedMessageTypesPresentationUnderlyingReturnValue
                 }
 
                 return returnValue!
@@ -6204,26 +6204,26 @@ class JoinedRoomProxyMock: JoinedRoomProxyProtocol, @unchecked Sendable {
         }
         set {
             if Thread.isMainThread {
-                messageFilteredTimelineAllowedMessageTypesPresentationUnderlyingReturnValue = newValue
+                messageFilteredTimelineFocusAllowedMessageTypesPresentationUnderlyingReturnValue = newValue
             } else {
                 DispatchQueue.main.sync {
-                    messageFilteredTimelineAllowedMessageTypesPresentationUnderlyingReturnValue = newValue
+                    messageFilteredTimelineFocusAllowedMessageTypesPresentationUnderlyingReturnValue = newValue
                 }
             }
         }
     }
-    var messageFilteredTimelineAllowedMessageTypesPresentationClosure: (([RoomMessageEventMessageType], TimelineKind.MediaPresentation) async -> Result<TimelineProxyProtocol, RoomProxyError>)?
+    var messageFilteredTimelineFocusAllowedMessageTypesPresentationClosure: ((TimelineFocus, [TimelineAllowedMessageType], TimelineKind.MediaPresentation) async -> Result<TimelineProxyProtocol, RoomProxyError>)?
 
-    func messageFilteredTimeline(allowedMessageTypes: [RoomMessageEventMessageType], presentation: TimelineKind.MediaPresentation) async -> Result<TimelineProxyProtocol, RoomProxyError> {
-        messageFilteredTimelineAllowedMessageTypesPresentationCallsCount += 1
-        messageFilteredTimelineAllowedMessageTypesPresentationReceivedArguments = (allowedMessageTypes: allowedMessageTypes, presentation: presentation)
+    func messageFilteredTimeline(focus: TimelineFocus, allowedMessageTypes: [TimelineAllowedMessageType], presentation: TimelineKind.MediaPresentation) async -> Result<TimelineProxyProtocol, RoomProxyError> {
+        messageFilteredTimelineFocusAllowedMessageTypesPresentationCallsCount += 1
+        messageFilteredTimelineFocusAllowedMessageTypesPresentationReceivedArguments = (focus: focus, allowedMessageTypes: allowedMessageTypes, presentation: presentation)
         DispatchQueue.main.async {
-            self.messageFilteredTimelineAllowedMessageTypesPresentationReceivedInvocations.append((allowedMessageTypes: allowedMessageTypes, presentation: presentation))
+            self.messageFilteredTimelineFocusAllowedMessageTypesPresentationReceivedInvocations.append((focus: focus, allowedMessageTypes: allowedMessageTypes, presentation: presentation))
         }
-        if let messageFilteredTimelineAllowedMessageTypesPresentationClosure = messageFilteredTimelineAllowedMessageTypesPresentationClosure {
-            return await messageFilteredTimelineAllowedMessageTypesPresentationClosure(allowedMessageTypes, presentation)
+        if let messageFilteredTimelineFocusAllowedMessageTypesPresentationClosure = messageFilteredTimelineFocusAllowedMessageTypesPresentationClosure {
+            return await messageFilteredTimelineFocusAllowedMessageTypesPresentationClosure(focus, allowedMessageTypes, presentation)
         } else {
-            return messageFilteredTimelineAllowedMessageTypesPresentationReturnValue
+            return messageFilteredTimelineFocusAllowedMessageTypesPresentationReturnValue
         }
     }
     //MARK: - enableEncryption
@@ -14488,15 +14488,15 @@ class TimelineControllerFactoryMock: TimelineControllerFactoryProtocol, @uncheck
     }
     //MARK: - buildMessageFilteredTimelineController
 
-    var buildMessageFilteredTimelineControllerAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderUnderlyingCallsCount = 0
-    var buildMessageFilteredTimelineControllerAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderCallsCount: Int {
+    var buildMessageFilteredTimelineControllerFocusAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderUnderlyingCallsCount = 0
+    var buildMessageFilteredTimelineControllerFocusAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderCallsCount: Int {
         get {
             if Thread.isMainThread {
-                return buildMessageFilteredTimelineControllerAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderUnderlyingCallsCount
+                return buildMessageFilteredTimelineControllerFocusAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderUnderlyingCallsCount
             } else {
                 var returnValue: Int? = nil
                 DispatchQueue.main.sync {
-                    returnValue = buildMessageFilteredTimelineControllerAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderUnderlyingCallsCount
+                    returnValue = buildMessageFilteredTimelineControllerFocusAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderUnderlyingCallsCount
                 }
 
                 return returnValue!
@@ -14504,29 +14504,29 @@ class TimelineControllerFactoryMock: TimelineControllerFactoryProtocol, @uncheck
         }
         set {
             if Thread.isMainThread {
-                buildMessageFilteredTimelineControllerAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderUnderlyingCallsCount = newValue
+                buildMessageFilteredTimelineControllerFocusAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderUnderlyingCallsCount = newValue
             } else {
                 DispatchQueue.main.sync {
-                    buildMessageFilteredTimelineControllerAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderUnderlyingCallsCount = newValue
+                    buildMessageFilteredTimelineControllerFocusAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderUnderlyingCallsCount = newValue
                 }
             }
         }
     }
-    var buildMessageFilteredTimelineControllerAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderCalled: Bool {
-        return buildMessageFilteredTimelineControllerAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderCallsCount > 0
+    var buildMessageFilteredTimelineControllerFocusAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderCalled: Bool {
+        return buildMessageFilteredTimelineControllerFocusAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderCallsCount > 0
     }
-    var buildMessageFilteredTimelineControllerAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderReceivedArguments: (allowedMessageTypes: [RoomMessageEventMessageType], presentation: TimelineKind.MediaPresentation, roomProxy: JoinedRoomProxyProtocol, timelineItemFactory: RoomTimelineItemFactoryProtocol, mediaProvider: MediaProviderProtocol)?
-    var buildMessageFilteredTimelineControllerAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderReceivedInvocations: [(allowedMessageTypes: [RoomMessageEventMessageType], presentation: TimelineKind.MediaPresentation, roomProxy: JoinedRoomProxyProtocol, timelineItemFactory: RoomTimelineItemFactoryProtocol, mediaProvider: MediaProviderProtocol)] = []
+    var buildMessageFilteredTimelineControllerFocusAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderReceivedArguments: (focus: TimelineFocus, allowedMessageTypes: [TimelineAllowedMessageType], presentation: TimelineKind.MediaPresentation, roomProxy: JoinedRoomProxyProtocol, timelineItemFactory: RoomTimelineItemFactoryProtocol, mediaProvider: MediaProviderProtocol)?
+    var buildMessageFilteredTimelineControllerFocusAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderReceivedInvocations: [(focus: TimelineFocus, allowedMessageTypes: [TimelineAllowedMessageType], presentation: TimelineKind.MediaPresentation, roomProxy: JoinedRoomProxyProtocol, timelineItemFactory: RoomTimelineItemFactoryProtocol, mediaProvider: MediaProviderProtocol)] = []
 
-    var buildMessageFilteredTimelineControllerAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderUnderlyingReturnValue: Result<TimelineControllerProtocol, TimelineFactoryControllerError>!
-    var buildMessageFilteredTimelineControllerAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderReturnValue: Result<TimelineControllerProtocol, TimelineFactoryControllerError>! {
+    var buildMessageFilteredTimelineControllerFocusAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderUnderlyingReturnValue: Result<TimelineControllerProtocol, TimelineFactoryControllerError>!
+    var buildMessageFilteredTimelineControllerFocusAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderReturnValue: Result<TimelineControllerProtocol, TimelineFactoryControllerError>! {
         get {
             if Thread.isMainThread {
-                return buildMessageFilteredTimelineControllerAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderUnderlyingReturnValue
+                return buildMessageFilteredTimelineControllerFocusAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderUnderlyingReturnValue
             } else {
                 var returnValue: Result<TimelineControllerProtocol, TimelineFactoryControllerError>? = nil
                 DispatchQueue.main.sync {
-                    returnValue = buildMessageFilteredTimelineControllerAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderUnderlyingReturnValue
+                    returnValue = buildMessageFilteredTimelineControllerFocusAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderUnderlyingReturnValue
                 }
 
                 return returnValue!
@@ -14534,26 +14534,26 @@ class TimelineControllerFactoryMock: TimelineControllerFactoryProtocol, @uncheck
         }
         set {
             if Thread.isMainThread {
-                buildMessageFilteredTimelineControllerAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderUnderlyingReturnValue = newValue
+                buildMessageFilteredTimelineControllerFocusAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderUnderlyingReturnValue = newValue
             } else {
                 DispatchQueue.main.sync {
-                    buildMessageFilteredTimelineControllerAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderUnderlyingReturnValue = newValue
+                    buildMessageFilteredTimelineControllerFocusAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderUnderlyingReturnValue = newValue
                 }
             }
         }
     }
-    var buildMessageFilteredTimelineControllerAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderClosure: (([RoomMessageEventMessageType], TimelineKind.MediaPresentation, JoinedRoomProxyProtocol, RoomTimelineItemFactoryProtocol, MediaProviderProtocol) async -> Result<TimelineControllerProtocol, TimelineFactoryControllerError>)?
+    var buildMessageFilteredTimelineControllerFocusAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderClosure: ((TimelineFocus, [TimelineAllowedMessageType], TimelineKind.MediaPresentation, JoinedRoomProxyProtocol, RoomTimelineItemFactoryProtocol, MediaProviderProtocol) async -> Result<TimelineControllerProtocol, TimelineFactoryControllerError>)?
 
-    func buildMessageFilteredTimelineController(allowedMessageTypes: [RoomMessageEventMessageType], presentation: TimelineKind.MediaPresentation, roomProxy: JoinedRoomProxyProtocol, timelineItemFactory: RoomTimelineItemFactoryProtocol, mediaProvider: MediaProviderProtocol) async -> Result<TimelineControllerProtocol, TimelineFactoryControllerError> {
-        buildMessageFilteredTimelineControllerAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderCallsCount += 1
-        buildMessageFilteredTimelineControllerAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderReceivedArguments = (allowedMessageTypes: allowedMessageTypes, presentation: presentation, roomProxy: roomProxy, timelineItemFactory: timelineItemFactory, mediaProvider: mediaProvider)
+    func buildMessageFilteredTimelineController(focus: TimelineFocus, allowedMessageTypes: [TimelineAllowedMessageType], presentation: TimelineKind.MediaPresentation, roomProxy: JoinedRoomProxyProtocol, timelineItemFactory: RoomTimelineItemFactoryProtocol, mediaProvider: MediaProviderProtocol) async -> Result<TimelineControllerProtocol, TimelineFactoryControllerError> {
+        buildMessageFilteredTimelineControllerFocusAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderCallsCount += 1
+        buildMessageFilteredTimelineControllerFocusAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderReceivedArguments = (focus: focus, allowedMessageTypes: allowedMessageTypes, presentation: presentation, roomProxy: roomProxy, timelineItemFactory: timelineItemFactory, mediaProvider: mediaProvider)
         DispatchQueue.main.async {
-            self.buildMessageFilteredTimelineControllerAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderReceivedInvocations.append((allowedMessageTypes: allowedMessageTypes, presentation: presentation, roomProxy: roomProxy, timelineItemFactory: timelineItemFactory, mediaProvider: mediaProvider))
+            self.buildMessageFilteredTimelineControllerFocusAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderReceivedInvocations.append((focus: focus, allowedMessageTypes: allowedMessageTypes, presentation: presentation, roomProxy: roomProxy, timelineItemFactory: timelineItemFactory, mediaProvider: mediaProvider))
         }
-        if let buildMessageFilteredTimelineControllerAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderClosure = buildMessageFilteredTimelineControllerAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderClosure {
-            return await buildMessageFilteredTimelineControllerAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderClosure(allowedMessageTypes, presentation, roomProxy, timelineItemFactory, mediaProvider)
+        if let buildMessageFilteredTimelineControllerFocusAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderClosure = buildMessageFilteredTimelineControllerFocusAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderClosure {
+            return await buildMessageFilteredTimelineControllerFocusAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderClosure(focus, allowedMessageTypes, presentation, roomProxy, timelineItemFactory, mediaProvider)
         } else {
-            return buildMessageFilteredTimelineControllerAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderReturnValue
+            return buildMessageFilteredTimelineControllerFocusAllowedMessageTypesPresentationRoomProxyTimelineItemFactoryMediaProviderReturnValue
         }
     }
 }

--- a/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewDataSource.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewDataSource.swift
@@ -124,9 +124,9 @@ class TimelineMediaPreviewDataSource: NSObject, QLPreviewControllerDataSource {
         let arrayIndex = index - backwardPadding
         
         if index < firstPreviewItemIndex {
-            return paginationState.backward == .timelineEndReached ? TimelineMediaPreviewItem.Loading.timelineStart : .paginating
+            return paginationState.backward == .timelineEndReached ? TimelineMediaPreviewItem.Loading.timelineStart : .paginatingBackwards
         } else if index > lastPreviewItemIndex {
-            return paginationState.forward == .timelineEndReached ? TimelineMediaPreviewItem.Loading.timelineEnd : .paginating
+            return paginationState.forward == .timelineEndReached ? TimelineMediaPreviewItem.Loading.timelineEnd : .paginatingForwards
         } else {
             return previewItems[arrayIndex]
         }
@@ -297,11 +297,12 @@ enum TimelineMediaPreviewItem: Equatable {
     }
     
     class Loading: NSObject, QLPreviewItem {
-        static let paginating = Loading(state: .paginating)
+        static let paginatingBackwards = Loading(state: .paginating(.backwards))
+        static let paginatingForwards = Loading(state: .paginating(.forwards))
         static let timelineStart = Loading(state: .timelineStart)
         static let timelineEnd = Loading(state: .timelineEnd)
         
-        enum State { case paginating, timelineStart, timelineEnd }
+        enum State { case paginating(PaginationDirection), timelineStart, timelineEnd }
         let state: State
         
         let previewItemURL: URL? = nil

--- a/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewModels.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewModels.swift
@@ -14,7 +14,7 @@ enum TimelineMediaPreviewViewModelAction: Equatable {
 }
 
 enum TimelineMediaPreviewDriverAction {
-    case itemLoaded(TimelineItemIdentifier)
+    case itemLoaded(TimelineItemIdentifier.EventOrTransactionID)
     case showItemDetails(TimelineMediaPreviewItem.Media)
     case exportFile(TimelineMediaPreviewFileExportPicker.File)
     case authorizationRequired(appMediator: AppMediatorProtocol)

--- a/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewViewModel.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewViewModel.swift
@@ -77,7 +77,7 @@ class TimelineMediaPreviewViewModel: TimelineMediaPreviewViewModelType {
             switch action {
             case .viewInRoomTimeline:
                 state.previewControllerDriver.send(.dismissDetailsSheet)
-                actionsSubject.send(.viewInRoomTimeline(item.id))
+                actionsSubject.send(.viewInRoomTimeline(item.timelineItem.id))
             case .save:
                 Task { await saveCurrentItem() }
             case .redact:
@@ -166,7 +166,7 @@ class TimelineMediaPreviewViewModel: TimelineMediaPreviewViewModelType {
     }
     
     private func redactItem(_ item: TimelineMediaPreviewItem.Media) {
-        timelineViewModel.context.send(viewAction: .handleTimelineItemMenuAction(itemID: item.id, action: .redact))
+        timelineViewModel.context.send(viewAction: .handleTimelineItemMenuAction(itemID: item.timelineItem.id, action: .redact))
         state.bindings.redactConfirmationItem = nil
         state.previewControllerDriver.send(.dismissDetailsSheet)
         actionsSubject.send(.dismiss)

--- a/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewController.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewController.swift
@@ -301,7 +301,8 @@ private struct DownloadIndicatorView: View {
     private var shouldShowDownloadIndicator: Bool {
         switch currentItem {
         case .media(let mediaItem): mediaItem.fileHandle == nil
-        case .loading(let loadingItem): loadingItem.state == .paginating
+        case .loading(.paginatingBackwards), .loading(.paginatingForwards): true
+        case .loading: false
         }
     }
     

--- a/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewController.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewController.swift
@@ -182,7 +182,7 @@ class TimelineMediaPreviewController: QLPreviewController {
         }
     }
     
-    private func handleFileLoaded(itemID: TimelineItemIdentifier) {
+    private func handleFileLoaded(itemID: TimelineItemIdentifier.EventOrTransactionID) {
         guard (currentPreviewItem as? TimelineMediaPreviewItem.Media)?.id == itemID else { return }
         refreshCurrentPreviewItem()
     }

--- a/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewDetailsView.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewDetailsView.swift
@@ -222,7 +222,7 @@ struct TimelineMediaPreviewDetailsView_Previews: PreviewProvider, TestablePrevie
                                                         thumbnailInfo: .mockThumbnail,
                                                         contentType: contentType))
         
-        let timelineKind = TimelineKind.media(isPresentedOnRoomScreen ? .roomScreen : .mediaFilesScreen)
+        let timelineKind = TimelineKind.media(isPresentedOnRoomScreen ? .roomScreenLive : .mediaFilesScreen)
         let timelineController = MockTimelineController(timelineKind: timelineKind)
         timelineController.timelineItems = [item]
         

--- a/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewRedactConfirmationView.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewRedactConfirmationView.swift
@@ -63,7 +63,7 @@ struct TimelineMediaPreviewRedactConfirmationView: View {
                     .scaledFrame(size: 40)
                     .background {
                         LoadableImage(mediaSource: mediaSource,
-                                      mediaType: .timelineItem(uniqueID: item.id.uniqueID),
+                                      mediaType: .generic,
                                       blurhash: item.blurhash,
                                       mediaProvider: context.mediaProvider) {
                             Color.compound.bgSubtleSecondary

--- a/ElementX/Sources/Screens/MediaEventsTimelineScreen/MediaEventsTimelineScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/MediaEventsTimelineScreen/MediaEventsTimelineScreenCoordinator.swift
@@ -79,6 +79,10 @@ final class MediaEventsTimelineScreenCoordinator: CoordinatorProtocol {
             .store(in: &cancellables)
     }
     
+    func stop() {
+        viewModel.stop()
+    }
+    
     func toPresentable() -> AnyView {
         AnyView(MediaEventsTimelineScreen(context: viewModel.context))
     }

--- a/ElementX/Sources/Screens/MediaEventsTimelineScreen/MediaEventsTimelineScreenViewModel.swift
+++ b/ElementX/Sources/Screens/MediaEventsTimelineScreen/MediaEventsTimelineScreenViewModel.swift
@@ -120,6 +120,11 @@ class MediaEventsTimelineScreenViewModel: MediaEventsTimelineScreenViewModelType
         }
     }
     
+    func stop() {
+        // Work around QLPreviewController dismissal issues, see the InteractiveQuickLookModifier.
+        state.bindings.mediaPreviewViewModel = nil
+    }
+    
     // MARK: - Private
     
     private func updateWithTimelineViewState(_ timelineViewState: TimelineViewState) {

--- a/ElementX/Sources/Screens/MediaEventsTimelineScreen/MediaEventsTimelineScreenViewModelProtocol.swift
+++ b/ElementX/Sources/Screens/MediaEventsTimelineScreen/MediaEventsTimelineScreenViewModelProtocol.swift
@@ -11,4 +11,6 @@ import Combine
 protocol MediaEventsTimelineScreenViewModelProtocol {
     var actionsPublisher: AnyPublisher<MediaEventsTimelineScreenViewModelAction, Never> { get }
     var context: MediaEventsTimelineScreenViewModelType.Context { get }
+    
+    func stop()
 }

--- a/ElementX/Sources/Screens/PinnedEventsTimelineScreen/PinnedEventsTimelineScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/PinnedEventsTimelineScreen/PinnedEventsTimelineScreenCoordinator.swift
@@ -62,6 +62,9 @@ final class PinnedEventsTimelineScreenCoordinator: CoordinatorProtocol {
             
             guard let self else { return }
             switch action {
+            case .viewInRoomTimeline(let itemID):
+                guard let eventID = itemID.eventID else { fatalError("A pinned event must have an event ID.") }
+                actionsSubject.send(.displayRoomScreenWithFocussedPin(eventID: eventID))
             case .dismiss:
                 self.actionsSubject.send(.dismiss)
             }

--- a/ElementX/Sources/Screens/PinnedEventsTimelineScreen/PinnedEventsTimelineScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/PinnedEventsTimelineScreen/PinnedEventsTimelineScreenCoordinator.swift
@@ -77,6 +77,8 @@ final class PinnedEventsTimelineScreenCoordinator: CoordinatorProtocol {
                 actionsSubject.send(.displayUser(userID: userID))
             case .displayMessageForwarding(let forwardingItem):
                 actionsSubject.send(.displayMessageForwarding(forwardingItem: forwardingItem))
+            case .displayMediaPreview(let mediaPreviewViewModel):
+                viewModel.displayMediaPreview(mediaPreviewViewModel)
             case .displayLocation(_, let geoURI, let description):
                 actionsSubject.send(.presentLocationViewer(geoURI: geoURI, description: description))
             case .viewInRoomTimeline(let eventID):

--- a/ElementX/Sources/Screens/PinnedEventsTimelineScreen/PinnedEventsTimelineScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/PinnedEventsTimelineScreen/PinnedEventsTimelineScreenCoordinator.swift
@@ -93,6 +93,10 @@ final class PinnedEventsTimelineScreenCoordinator: CoordinatorProtocol {
         }
         .store(in: &cancellables)
     }
+    
+    func stop() {
+        viewModel.stop()
+    }
         
     func toPresentable() -> AnyView {
         AnyView(PinnedEventsTimelineScreen(context: viewModel.context, timelineContext: timelineViewModel.context))

--- a/ElementX/Sources/Screens/PinnedEventsTimelineScreen/PinnedEventsTimelineScreenModels.swift
+++ b/ElementX/Sources/Screens/PinnedEventsTimelineScreen/PinnedEventsTimelineScreenModels.swift
@@ -11,7 +11,14 @@ enum PinnedEventsTimelineScreenViewModelAction {
     case dismiss
 }
 
-struct PinnedEventsTimelineScreenViewState: BindableState { }
+struct PinnedEventsTimelineScreenViewState: BindableState {
+    var bindings = PinnedEventsTimelineScreenViewStateBindings()
+}
+
+struct PinnedEventsTimelineScreenViewStateBindings {
+    /// The view model used to present a QuickLook media preview.
+    var mediaPreviewViewModel: TimelineMediaPreviewViewModel?
+}
 
 enum PinnedEventsTimelineScreenViewAction {
     case close

--- a/ElementX/Sources/Screens/PinnedEventsTimelineScreen/PinnedEventsTimelineScreenModels.swift
+++ b/ElementX/Sources/Screens/PinnedEventsTimelineScreen/PinnedEventsTimelineScreenModels.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 enum PinnedEventsTimelineScreenViewModelAction {
+    case viewInRoomTimeline(itemID: TimelineItemIdentifier)
     case dismiss
 }
 

--- a/ElementX/Sources/Screens/PinnedEventsTimelineScreen/PinnedEventsTimelineScreenViewModel.swift
+++ b/ElementX/Sources/Screens/PinnedEventsTimelineScreen/PinnedEventsTimelineScreenViewModel.swift
@@ -35,6 +35,11 @@ class PinnedEventsTimelineScreenViewModel: PinnedEventsTimelineScreenViewModelTy
         }
     }
     
+    func stop() {
+        // Work around QLPreviewController dismissal issues, see the InteractiveQuickLookModifier.
+        state.bindings.mediaPreviewViewModel = nil
+    }
+    
     func displayMediaPreview(_ mediaPreviewViewModel: TimelineMediaPreviewViewModel) {
         mediaPreviewViewModel.actions.sink { [weak self] action in
             switch action {

--- a/ElementX/Sources/Screens/PinnedEventsTimelineScreen/PinnedEventsTimelineScreenViewModel.swift
+++ b/ElementX/Sources/Screens/PinnedEventsTimelineScreen/PinnedEventsTimelineScreenViewModel.swift
@@ -34,4 +34,18 @@ class PinnedEventsTimelineScreenViewModel: PinnedEventsTimelineScreenViewModelTy
             actionsSubject.send(.dismiss)
         }
     }
+    
+    func displayMediaPreview(_ mediaPreviewViewModel: TimelineMediaPreviewViewModel) {
+        mediaPreviewViewModel.actions.sink { [weak self] action in
+            switch action {
+            case .viewInRoomTimeline:
+                MXLog.error("Unexpected action: viewInRoomTimeline should not be visible on a room preview.")
+            case .dismiss:
+                self?.state.bindings.mediaPreviewViewModel = nil
+            }
+        }
+        .store(in: &cancellables)
+        
+        state.bindings.mediaPreviewViewModel = mediaPreviewViewModel
+    }
 }

--- a/ElementX/Sources/Screens/PinnedEventsTimelineScreen/PinnedEventsTimelineScreenViewModel.swift
+++ b/ElementX/Sources/Screens/PinnedEventsTimelineScreen/PinnedEventsTimelineScreenViewModel.swift
@@ -43,8 +43,8 @@ class PinnedEventsTimelineScreenViewModel: PinnedEventsTimelineScreenViewModelTy
     func displayMediaPreview(_ mediaPreviewViewModel: TimelineMediaPreviewViewModel) {
         mediaPreviewViewModel.actions.sink { [weak self] action in
             switch action {
-            case .viewInRoomTimeline:
-                MXLog.error("Unexpected action: viewInRoomTimeline should not be visible on a room preview.")
+            case .viewInRoomTimeline(let itemID):
+                self?.actionsSubject.send(.viewInRoomTimeline(itemID: itemID))
             case .dismiss:
                 self?.state.bindings.mediaPreviewViewModel = nil
             }

--- a/ElementX/Sources/Screens/PinnedEventsTimelineScreen/PinnedEventsTimelineScreenViewModelProtocol.swift
+++ b/ElementX/Sources/Screens/PinnedEventsTimelineScreen/PinnedEventsTimelineScreenViewModelProtocol.swift
@@ -11,4 +11,6 @@ import Combine
 protocol PinnedEventsTimelineScreenViewModelProtocol {
     var actionsPublisher: AnyPublisher<PinnedEventsTimelineScreenViewModelAction, Never> { get }
     var context: PinnedEventsTimelineScreenViewModelType.Context { get }
+    
+    func displayMediaPreview(_ mediaPreviewViewModel: TimelineMediaPreviewViewModel)
 }

--- a/ElementX/Sources/Screens/PinnedEventsTimelineScreen/PinnedEventsTimelineScreenViewModelProtocol.swift
+++ b/ElementX/Sources/Screens/PinnedEventsTimelineScreen/PinnedEventsTimelineScreenViewModelProtocol.swift
@@ -12,5 +12,7 @@ protocol PinnedEventsTimelineScreenViewModelProtocol {
     var actionsPublisher: AnyPublisher<PinnedEventsTimelineScreenViewModelAction, Never> { get }
     var context: PinnedEventsTimelineScreenViewModelType.Context { get }
     
+    func stop()
+    
     func displayMediaPreview(_ mediaPreviewViewModel: TimelineMediaPreviewViewModel)
 }

--- a/ElementX/Sources/Screens/PinnedEventsTimelineScreen/View/PinnedEventsTimelineScreen.swift
+++ b/ElementX/Sources/Screens/PinnedEventsTimelineScreen/View/PinnedEventsTimelineScreen.swift
@@ -27,7 +27,7 @@ struct PinnedEventsTimelineScreen: View {
             .toolbar { toolbar }
             .background(.compound.bgCanvasDefault)
             .interactiveDismissDisabled()
-            .interactiveQuickLook(item: $timelineContext.mediaPreviewItem)
+            .timelineMediaPreview(viewModel: $timelineContext.mediaPreviewViewModel)
             .sheet(item: $timelineContext.debugInfo) { TimelineItemDebugView(info: $0) }
             .sheet(item: $timelineContext.actionMenuInfo) { info in
                 let actions = TimelineItemMenuActionProvider(timelineItem: info.item,

--- a/ElementX/Sources/Screens/PinnedEventsTimelineScreen/View/PinnedEventsTimelineScreen.swift
+++ b/ElementX/Sources/Screens/PinnedEventsTimelineScreen/View/PinnedEventsTimelineScreen.swift
@@ -27,7 +27,7 @@ struct PinnedEventsTimelineScreen: View {
             .toolbar { toolbar }
             .background(.compound.bgCanvasDefault)
             .interactiveDismissDisabled()
-            .timelineMediaPreview(viewModel: $timelineContext.mediaPreviewViewModel)
+            .timelineMediaPreview(viewModel: $context.mediaPreviewViewModel)
             .sheet(item: $timelineContext.debugInfo) { TimelineItemDebugView(info: $0) }
             .sheet(item: $timelineContext.actionMenuInfo) { info in
                 let actions = TimelineItemMenuActionProvider(timelineItem: info.item,

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
@@ -126,6 +126,8 @@ final class RoomScreenCoordinator: CoordinatorProtocol {
                     actionsSubject.send(.presentMediaUploadPicker(.photoLibrary))
                 case .displayDocumentPicker:
                     actionsSubject.send(.presentMediaUploadPicker(.documents))
+                case .displayMediaPreview(let mediaPreviewViewModel):
+                    roomViewModel.displayMediaPreview(mediaPreviewViewModel)
                 case .displayLocationPicker:
                     actionsSubject.send(.presentLocationPicker)
                 case .displayPollForm(let mode):

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
@@ -201,7 +201,7 @@ final class RoomScreenCoordinator: CoordinatorProtocol {
     
     func stop() {
         composerViewModel.saveDraft()
-        timelineViewModel.stop()
+        roomViewModel.stop()
     }
     
     func toPresentable() -> AnyView {

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
@@ -67,7 +67,10 @@ struct RoomScreenViewState: BindableState {
     var bindings: RoomScreenViewStateBindings
 }
 
-struct RoomScreenViewStateBindings { }
+struct RoomScreenViewStateBindings {
+    /// The view model used to present a QuickLook media preview.
+    var mediaPreviewViewModel: TimelineMediaPreviewViewModel?
+}
 
 enum RoomScreenFooterViewAction {
     case resolvePinViolation(userID: String)

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -132,7 +132,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
         mediaPreviewViewModel.actions.sink { [weak self] action in
             switch action {
             case .viewInRoomTimeline:
-                MXLog.error("Unexpected action: viewInRoomTimeline should not be visible on a room preview.")
+                fatalError("viewInRoomTimeline should not be visible on a room preview.")
             case .dismiss:
                 self?.state.bindings.mediaPreviewViewModel = nil
             }

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -123,6 +123,20 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
         state.pinnedEventsBannerState.setSelectedPinnedEventID(eventID)
     }
     
+    func displayMediaPreview(_ mediaPreviewViewModel: TimelineMediaPreviewViewModel) {
+        mediaPreviewViewModel.actions.sink { [weak self] action in
+            switch action {
+            case .viewInRoomTimeline:
+                MXLog.error("Unexpected action: viewInRoomTimeline should not be visible on a room preview.")
+            case .dismiss:
+                self?.state.bindings.mediaPreviewViewModel = nil
+            }
+        }
+        .store(in: &cancellables)
+        
+        state.bindings.mediaPreviewViewModel = mediaPreviewViewModel
+    }
+    
     // MARK: - Private
     
     private func setupSubscriptions(ongoingCallRoomIDPublisher: CurrentValuePublisher<String?, Never>) {

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -115,6 +115,11 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
         }
     }
     
+    func stop() {
+        // Work around QLPreviewController dismissal issues, see the InteractiveQuickLookModifier.
+        state.bindings.mediaPreviewViewModel = nil
+    }
+    
     func timelineHasScrolled(direction: ScrollDirection) {
         state.lastScrollDirection = direction
     }

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModelProtocol.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModelProtocol.swift
@@ -12,6 +12,8 @@ protocol RoomScreenViewModelProtocol {
     var actions: AnyPublisher<RoomScreenViewModelAction, Never> { get }
     var context: RoomScreenViewModel.Context { get }
     
+    func stop()
+    
     func timelineHasScrolled(direction: ScrollDirection)
     func setSelectedPinnedEventID(_ eventID: String)
     func displayMediaPreview(_ mediaPreviewViewModel: TimelineMediaPreviewViewModel)

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModelProtocol.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModelProtocol.swift
@@ -14,4 +14,5 @@ protocol RoomScreenViewModelProtocol {
     
     func timelineHasScrolled(direction: ScrollDirection)
     func setSelectedPinnedEventID(_ eventID: String)
+    func displayMediaPreview(_ mediaPreviewViewModel: TimelineMediaPreviewViewModel)
 }

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
@@ -94,7 +94,7 @@ struct RoomScreen: View {
                 ReadReceiptsSummaryView(orderedReadReceipts: $0.orderedReceipts)
                     .environmentObject(timelineContext)
             }
-            .interactiveQuickLook(item: $timelineContext.mediaPreviewItem)
+            .timelineMediaPreview(viewModel: $timelineContext.mediaPreviewViewModel)
             .track(screen: .Room)
             .onDrop(of: ["public.item", "public.file-url"], isTargeted: $dragOver) { providers -> Bool in
                 guard let provider = providers.first,

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
@@ -94,7 +94,7 @@ struct RoomScreen: View {
                 ReadReceiptsSummaryView(orderedReadReceipts: $0.orderedReceipts)
                     .environmentObject(timelineContext)
             }
-            .timelineMediaPreview(viewModel: $timelineContext.mediaPreviewViewModel)
+            .timelineMediaPreview(viewModel: $roomContext.mediaPreviewViewModel)
             .track(screen: .Room)
             .onDrop(of: ["public.item", "public.file-url"], isTargeted: $dragOver) { providers -> Bool in
                 guard let provider = providers.first,

--- a/ElementX/Sources/Screens/Timeline/TimelineInteractionHandler.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineInteractionHandler.swift
@@ -536,29 +536,33 @@ class TimelineInteractionHandler {
     
     private func mediaPreviewAction(for item: EventBasedMessageTimelineItemProtocol, messageTypes: [TimelineAllowedMessageType]) async -> TimelineControllerAction {
         var newTimelineFocus: TimelineFocus?
+        var newTimelinePresentation: TimelineKind.MediaPresentation?
         switch timelineController.timelineKind {
         case .live:
             newTimelineFocus = .live
+            newTimelinePresentation = .roomScreenLive
         case .detached:
             guard case let .event(_, eventOrTransactionID: .eventID(eventID)) = item.id else {
                 MXLog.error("Unexpected event type on a detached timeline.")
                 return .none
             }
             newTimelineFocus = .eventID(eventID)
+            newTimelinePresentation = .roomScreenDetached
         case .pinned:
             newTimelineFocus = .pinned
+            newTimelinePresentation = .pinnedEventsScreen
         case .media:
             break // We don't need to create a new timeline as it is already filtered.
         }
         
-        if let newTimelineFocus {
+        if let newTimelineFocus, let newTimelinePresentation {
             let timelineItemFactory = RoomTimelineItemFactory(userID: roomProxy.ownUserID,
                                                               attributedStringBuilder: AttributedStringBuilder(mentionBuilder: MentionBuilder()),
                                                               stateEventStringBuilder: RoomStateEventStringBuilder(userID: roomProxy.ownUserID))
             
             guard case let .success(timelineController) = await timelineControllerFactory.buildMessageFilteredTimelineController(focus: newTimelineFocus,
                                                                                                                                  allowedMessageTypes: messageTypes,
-                                                                                                                                 presentation: .roomScreen,
+                                                                                                                                 presentation: newTimelinePresentation,
                                                                                                                                  roomProxy: roomProxy,
                                                                                                                                  timelineItemFactory: timelineItemFactory,
                                                                                                                                  mediaProvider: mediaProvider) else {

--- a/ElementX/Sources/Screens/Timeline/TimelineModels.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineModels.swift
@@ -123,8 +123,8 @@ struct TimelineViewStateBindings {
     /// Key is itemID, value is the collapsed state.
     var reactionsCollapsed: [TimelineItemIdentifier: Bool]
     
-    /// A media item that will be previewed with QuickLook.
-    var mediaPreviewItem: MediaPreviewItem?
+    /// The view model used to present a QuickLook media preview.
+    var mediaPreviewViewModel: TimelineMediaPreviewViewModel?
     
     var alertInfo: AlertInfo<RoomScreenAlertInfoType>?
     

--- a/ElementX/Sources/Screens/Timeline/TimelineModels.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineModels.swift
@@ -21,6 +21,7 @@ enum TimelineViewModelAction {
     case displayMediaUploadPreviewScreen(url: URL)
     case tappedOnSenderDetails(userID: String)
     case displayMessageForwarding(forwardingItem: MessageForwardingItem)
+    case displayMediaPreview(TimelineMediaPreviewViewModel)
     case displayLocation(body: String, geoURI: GeoURI, description: String?)
     case displayResolveSendFailure(failure: TimelineItemSendFailure.VerifiedUser, sendHandle: SendHandleProxy)
     case composer(action: TimelineComposerAction)
@@ -122,9 +123,6 @@ struct TimelineViewStateBindings {
     /// The state of wether reactions listed on the timeline are expanded/collapsed.
     /// Key is itemID, value is the collapsed state.
     var reactionsCollapsed: [TimelineItemIdentifier: Bool]
-    
-    /// The view model used to present a QuickLook media preview.
-    var mediaPreviewViewModel: TimelineMediaPreviewViewModel?
     
     var alertInfo: AlertInfo<RoomScreenAlertInfoType>?
     

--- a/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
@@ -125,11 +125,6 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
     
     // MARK: - Public
     
-    func stop() {
-        // Work around QLPreviewController dismissal issues, see the InteractiveQuickLookModifier.
-//        state.bindings.mediaPreviewViewModel = nil
-    }
-    
     override func process(viewAction: TimelineViewAction) {
         switch viewAction {
         case .itemAppeared(let id):

--- a/ElementX/Sources/Screens/Timeline/TimelineViewModelProtocol.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineViewModelProtocol.swift
@@ -13,8 +13,8 @@ import SwiftUI
 protocol TimelineViewModelProtocol {
     var actions: AnyPublisher<TimelineViewModelAction, Never> { get }
     var context: TimelineViewModel.Context { get }
+    
     func process(composerAction: ComposerToolbarViewModelAction)
     /// Updates the timeline to show and highlight the item with the corresponding event ID.
     func focusOnEvent(eventID: String) async
-    func stop()
 }

--- a/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenuActionProvider.swift
+++ b/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenuActionProvider.swift
@@ -38,7 +38,7 @@ struct TimelineItemMenuActionProvider {
         var actions: [TimelineItemMenuAction] = []
         var secondaryActions: [TimelineItemMenuAction] = []
         
-        if timelineKind == .pinned || timelineKind == .media(.mediaFilesScreen) {
+        if timelineKind == .pinned || timelineKind == .media(.mediaFilesScreen) || timelineKind == .media(.pinnedEventsScreen) {
             actions.append(.viewInRoomTimeline)
         }
         

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -375,7 +375,6 @@ class ClientProxy: ClientProxyProtocol {
         }
     }
     
-    // swiftlint:disable:next function_parameter_count
     func createRoom(name: String,
                     topic: String?,
                     isRoomPrivate: Bool,

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -117,7 +117,6 @@ protocol ClientProxyProtocol: AnyObject, MediaLoaderProtocol {
     
     func createDirectRoom(with userID: String, expectedRoomName: String?) async -> Result<String, ClientProxyError>
     
-    // swiftlint:disable:next function_parameter_count
     func createRoom(name: String,
                     topic: String?,
                     isRoomPrivate: Bool,

--- a/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
@@ -182,11 +182,27 @@ class JoinedRoomProxy: JoinedRoomProxyProtocol {
         }
     }
     
-    func messageFilteredTimeline(allowedMessageTypes: [RoomMessageEventMessageType],
+    func messageFilteredTimeline(focus: TimelineFocus,
+                                 allowedMessageTypes: [TimelineAllowedMessageType],
                                  presentation: TimelineKind.MediaPresentation) async -> Result<any TimelineProxyProtocol, RoomProxyError> {
         do {
-            let sdkTimeline = try await room.timelineWithConfiguration(configuration: .init(focus: .live,
-                                                                                            allowedMessageTypes: .only(types: allowedMessageTypes),
+            let rustFocus: MatrixRustSDK.TimelineFocus = switch focus {
+            case .live: .live
+            case .eventID(let eventID): .event(eventId: eventID, numContextEvents: 100)
+            case .pinned: .pinnedEvents(maxEventsToLoad: 100, maxConcurrentRequests: 10)
+            }
+            
+            let rustMessageTypes: [MatrixRustSDK.RoomMessageEventMessageType] = allowedMessageTypes.map {
+                switch $0 {
+                case .audio: .audio
+                case .file: .file
+                case .image: .image
+                case .video: .video
+                }
+            }
+            
+            let sdkTimeline = try await room.timelineWithConfiguration(configuration: .init(focus: rustFocus,
+                                                                                            allowedMessageTypes: .only(types: rustMessageTypes),
                                                                                             internalIdPrefix: nil,
                                                                                             dateDividerMode: .monthly))
             

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -78,7 +78,8 @@ protocol JoinedRoomProxyProtocol: RoomProxyProtocol {
     
     func timelineFocusedOnEvent(eventID: String, numberOfEvents: UInt16) async -> Result<TimelineProxyProtocol, RoomProxyError>
     
-    func messageFilteredTimeline(allowedMessageTypes: [RoomMessageEventMessageType],
+    func messageFilteredTimeline(focus: TimelineFocus,
+                                 allowedMessageTypes: [TimelineAllowedMessageType],
                                  presentation: TimelineKind.MediaPresentation) async -> Result<TimelineProxyProtocol, RoomProxyError>
     
     func enableEncryption() async -> Result<Void, RoomProxyError>

--- a/ElementX/Sources/Services/Timeline/TimelineController/MockTimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/MockTimelineController.swift
@@ -74,8 +74,11 @@ class MockTimelineController: TimelineControllerProtocol {
         focusLiveCallCount += 1
         callbacks.send(.isLive(true))
     }
-
+    
+    private(set) var paginateBackwardsCallCount = 0
     func paginateBackwards(requestSize: UInt16) async -> Result<Void, TimelineControllerError> {
+        paginateBackwardsCallCount += 1
+        
         paginationState = PaginationState(backward: .paginating, forward: .timelineEndReached)
         
         if client == nil {
@@ -85,9 +88,10 @@ class MockTimelineController: TimelineControllerProtocol {
         return .success(())
     }
     
+    private(set) var paginateForwardsCallCount = 0
     func paginateForwards(requestSize: UInt16) async -> Result<Void, TimelineControllerError> {
-        // try? await simulateForwardPagination()
-        .success(())
+        paginateForwardsCallCount += 1
+        return .success(())
     }
     
     func sendReadReceipt(for itemID: TimelineItemIdentifier) async {

--- a/ElementX/Sources/Services/Timeline/TimelineController/TimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/TimelineController.swift
@@ -42,7 +42,7 @@ class TimelineController: TimelineControllerProtocol {
     }
     
     var timelineKind: TimelineKind {
-        liveTimelineProvider.kind
+        activeTimelineProvider.kind
     }
     
     init(roomProxy: JoinedRoomProxyProtocol,

--- a/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerFactory.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerFactory.swift
@@ -36,12 +36,13 @@ struct TimelineControllerFactory: TimelineControllerFactoryProtocol {
                                   appSettings: ServiceLocator.shared.settings)
     }
     
-    func buildMessageFilteredTimelineController(allowedMessageTypes: [RoomMessageEventMessageType],
+    func buildMessageFilteredTimelineController(focus: TimelineFocus,
+                                                allowedMessageTypes: [TimelineAllowedMessageType],
                                                 presentation: TimelineKind.MediaPresentation,
                                                 roomProxy: JoinedRoomProxyProtocol,
                                                 timelineItemFactory: RoomTimelineItemFactoryProtocol,
                                                 mediaProvider: MediaProviderProtocol) async -> Result<TimelineControllerProtocol, TimelineFactoryControllerError> {
-        switch await roomProxy.messageFilteredTimeline(allowedMessageTypes: allowedMessageTypes, presentation: presentation) {
+        switch await roomProxy.messageFilteredTimeline(focus: focus, allowedMessageTypes: allowedMessageTypes, presentation: presentation) {
         case .success(let timelineProxy):
             return .success(TimelineController(roomProxy: roomProxy,
                                                timelineProxy: timelineProxy,

--- a/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerFactoryProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerFactoryProtocol.swift
@@ -23,7 +23,8 @@ protocol TimelineControllerFactoryProtocol {
                                              timelineItemFactory: RoomTimelineItemFactoryProtocol,
                                              mediaProvider: MediaProviderProtocol) async -> TimelineControllerProtocol?
     
-    func buildMessageFilteredTimelineController(allowedMessageTypes: [RoomMessageEventMessageType],
+    func buildMessageFilteredTimelineController(focus: TimelineFocus,
+                                                allowedMessageTypes: [TimelineAllowedMessageType],
                                                 presentation: TimelineKind.MediaPresentation,
                                                 roomProxy: JoinedRoomProxyProtocol,
                                                 timelineItemFactory: RoomTimelineItemFactoryProtocol,

--- a/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerProtocol.swift
@@ -16,7 +16,14 @@ enum TimelineControllerCallback {
 }
 
 enum TimelineControllerAction {
-    case displayMediaPreview(TimelineMediaPreviewViewModel)
+    enum TimelineViewModelKind {
+        /// Use the active timeline view model.
+        case active
+        /// Use the newly generated view model provided.
+        case new(TimelineViewModel)
+    }
+    
+    case displayMediaPreview(item: EventBasedMessageTimelineItemProtocol, timelineViewModel: TimelineViewModelKind)
     case displayLocation(body: String, geoURI: GeoURI, description: String?)
     case none
 }

--- a/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerProtocol.swift
@@ -16,7 +16,7 @@ enum TimelineControllerCallback {
 }
 
 enum TimelineControllerAction {
-    case displayMediaFile(file: MediaFileHandleProxy, title: String?)
+    case displayMediaPreview(TimelineMediaPreviewViewModel)
     case displayLocation(body: String, geoURI: GeoURI, description: String?)
     case none
 }

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomStateEventStringBuilder.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomStateEventStringBuilder.swift
@@ -76,7 +76,6 @@ struct RoomStateEventStringBuilder {
         }
     }
     
-    // swiftlint:disable:next function_parameter_count
     func buildProfileChangeString(displayName: String?, previousDisplayName: String?,
                                   avatarURLString: String?, previousAvatarURLString: String?,
                                   member: String, memberIsYou: Bool) -> String? {

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
@@ -379,8 +379,7 @@ struct RoomTimelineItemFactory: RoomTimelineItemFactoryProtocol {
                                                                         orderedReadReceipts: orderReadReceipts(eventItemProxy.readReceipts),
                                                                         encryptionAuthenticity: authenticity(eventItemProxy.shieldState)))
     }
-
-    // swiftlint:disable:next function_parameter_count
+    
     private func buildPollTimelineItem(_ question: String,
                                        _ pollKind: PollKind,
                                        _ maxSelections: UInt64,
@@ -645,7 +644,6 @@ struct RoomTimelineItemFactory: RoomTimelineItemFactoryProtocol {
         return buildStateTimelineItem(for: eventItemProxy, text: text, isOutgoing: isOutgoing)
     }
     
-    // swiftlint:disable:next function_parameter_count
     private func buildStateProfileChangeTimelineItem(for eventItemProxy: EventTimelineItemProxy,
                                                      displayName: String?,
                                                      previousDisplayName: String?,

--- a/ElementX/Sources/Services/Timeline/TimelineProxy.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineProxy.swift
@@ -591,8 +591,8 @@ final class TimelineProxy: TimelineProxyProtocol {
             backPaginationStatusSubject.send(.idle)
             forwardPaginationStatusSubject.send(.idle)
         case .media(let presentation):
-            backPaginationStatusSubject.send(.idle)
-            forwardPaginationStatusSubject.send(presentation == .mediaFilesScreen ? .timelineEndReached : .idle)
+            backPaginationStatusSubject.send(presentation == .pinnedEventsScreen ? .timelineEndReached : .idle)
+            forwardPaginationStatusSubject.send(presentation == .roomScreenDetached ? .idle : .timelineEndReached)
         case .pinned:
             backPaginationStatusSubject.send(.timelineEndReached)
             forwardPaginationStatusSubject.send(.timelineEndReached)

--- a/ElementX/Sources/Services/Timeline/TimelineProxyProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineProxyProtocol.swift
@@ -14,7 +14,7 @@ enum TimelineKind: Equatable {
     case detached
     case pinned
     
-    enum MediaPresentation { case roomScreen, mediaFilesScreen }
+    enum MediaPresentation { case roomScreenLive, roomScreenDetached, pinnedEventsScreen, mediaFilesScreen }
     case media(MediaPresentation)
 }
 

--- a/ElementX/Sources/Services/Timeline/TimelineProxyProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineProxyProtocol.swift
@@ -18,6 +18,16 @@ enum TimelineKind: Equatable {
     case media(MediaPresentation)
 }
 
+enum TimelineFocus {
+    case live
+    case eventID(String)
+    case pinned
+}
+
+enum TimelineAllowedMessageType {
+    case audio, file, image, video
+}
+
 enum TimelineProxyError: Error {
     case sdkError(Error)
     

--- a/UnitTests/Sources/HomeScreenRoomTests.swift
+++ b/UnitTests/Sources/HomeScreenRoomTests.swift
@@ -14,7 +14,6 @@ import XCTest
 class HomeScreenRoomTests: XCTestCase {
     var roomSummary: RoomSummary!
     
-    // swiftlint:disable:next function_parameter_count
     func setupRoomSummary(isMarkedUnread: Bool,
                           unreadMessagesCount: UInt,
                           unreadMentionsCount: UInt,

--- a/UnitTests/Sources/TimelineMediaPreviewViewModelTests.swift
+++ b/UnitTests/Sources/TimelineMediaPreviewViewModelTests.swift
@@ -90,12 +90,12 @@ class TimelineMediaPreviewViewModelTests: XCTestCase {
         
         // When swiping to a "loading more" item.
         let failure = deferFailure(viewModel.state.previewControllerDriver, timeout: 1) { $0.isItemLoaded }
-        context.send(viewAction: .updateCurrentItem(.loading(.paginating)))
+        context.send(viewAction: .updateCurrentItem(.loading(.paginatingBackwards)))
         try await failure.fulfill()
         
         // Then there should no longer be a media preview and no attempt should be made to load one.
         XCTAssertEqual(mediaProvider.loadFileFromSourceFilenameCallsCount, 1)
-        XCTAssertEqual(context.viewState.currentItem, .loading(.paginating))
+        XCTAssertEqual(context.viewState.currentItem, .loading(.paginatingBackwards))
     }
     
     func testPagination() async throws {

--- a/UnitTests/Sources/TimelineMediaPreviewViewModelTests.swift
+++ b/UnitTests/Sources/TimelineMediaPreviewViewModelTests.swift
@@ -84,18 +84,22 @@ class TimelineMediaPreviewViewModelTests: XCTestCase {
         XCTAssertEqual(context.viewState.currentItem, .media(context.viewState.dataSource.previewItems[0]))
     }
     
-    func testLoadingMoreItem() async throws {
+    func testLoadingMoreItems() async throws {
         // Given a view model with a loaded item.
         try await testLoadingItem()
+        XCTAssertEqual(timelineController.paginateBackwardsCallCount, 0)
         
-        // When swiping to a "loading more" item.
+        // When swiping to a "loading more" item and there are more media items to load.
+        timelineController.paginationState = .init(backward: .idle, forward: .timelineEndReached)
+        timelineController.backPaginationResponses.append(RoomTimelineItemFixtures.mediaChunk)
         let failure = deferFailure(viewModel.state.previewControllerDriver, timeout: 1) { $0.isItemLoaded }
         context.send(viewAction: .updateCurrentItem(.loading(.paginatingBackwards)))
         try await failure.fulfill()
         
-        // Then there should no longer be a media preview and no attempt should be made to load one.
+        // Then there should no longer be a media preview and instead of loading any media, a pagination request should be made.
         XCTAssertEqual(mediaProvider.loadFileFromSourceFilenameCallsCount, 1)
-        XCTAssertEqual(context.viewState.currentItem, .loading(.paginatingBackwards))
+        XCTAssertEqual(context.viewState.currentItem, .loading(.paginatingBackwards)) // Note: This item only changes when the preview controller handles the new items.
+        XCTAssertEqual(timelineController.paginateBackwardsCallCount, 1)
     }
     
     func testPagination() async throws {

--- a/UnitTests/Sources/TimelineMediaPreviewViewModelTests.swift
+++ b/UnitTests/Sources/TimelineMediaPreviewViewModelTests.swift
@@ -130,7 +130,7 @@ class TimelineMediaPreviewViewModelTests: XCTestCase {
             return
         }
         
-        let deferred = deferFulfillment(viewModel.actions) { $0 == .viewInRoomTimeline(mediaItem.id) }
+        let deferred = deferFulfillment(viewModel.actions) { $0 == .viewInRoomTimeline(mediaItem.timelineItem.id) }
         context.send(viewAction: .menuAction(.viewInRoomTimeline, item: mediaItem))
         
         // Then the action should be sent upwards to make this happen.

--- a/ci_scripts/ci_common.sh
+++ b/ci_scripts/ci_common.sh
@@ -37,9 +37,7 @@ setup_github_actions_environment() {
     unset HOMEBREW_NO_INSTALL_FROM_API
     export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
     
-    brew update && brew install xcodegen swiftformat git-lfs a7ex/homebrew-formulae/xcresultparser
-    
-    # brew "swiftlint" # Fails on the CI: `Target /usr/local/bin/swiftlint Target /usr/local/bin/swiftlint already exists`. Installed through https://github.com/actions/virtual-environments/blob/main/images/macos/macos-12-Readme.md#linters
+    brew update && brew install xcodegen swiftlint swiftformat git-lfs a7ex/homebrew-formulae/xcresultparser
 
     bundle config path vendor/bundle
     bundle install --jobs 4 --retry 3


### PR DESCRIPTION
This enables swiping between previews on both of those screens.

The second commit tidies up the presentation logic so that all of the screens use the same logic to present a media preview.

The last commit adds pagination requests.

https://github.com/user-attachments/assets/b71f9151-8d1e-4e51-ae22-d53d6c809f1c

Closes #3689
Closes #1520