### PR TITLE
Updated Bottom Sheet message string

### DIFF
--- a/ElementX/Resources/Localizations/en-US.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en-US.lproj/Localizable.strings
@@ -181,6 +181,7 @@
 "common_message_removed" = "Message removed";
 "common_modern" = "Modern";
 "common_mute" = "Mute";
+"common_name_and_id" = "%1$@ (%2$@)";
 "common_no_results" = "No results";
 "common_no_room_name" = "No room name";
 "common_offline" = "Offline";
@@ -371,8 +372,7 @@
 "screen_advanced_settings_element_call_base_url_description" = "Set a custom base URL for Element Call.";
 "screen_advanced_settings_element_call_base_url_validation_error" = "Invalid URL, please make sure you include the protocol (http/https) and the correct address.";
 "screen_bottom_sheet_create_dm_confirmation_button_title" = "Send invite";
-"screen_bottom_sheet_create_dm_message" = "Would you like to start a chat with %1$@ (%2$@)?";
-"screen_bottom_sheet_create_dm_message_no_displayname" = "Would you like to start a chat with %1$@?";
+"screen_bottom_sheet_create_dm_message" = "Would you like to start a chat with %1$@?";
 "screen_bottom_sheet_create_dm_title" = "Send invite?";
 "screen_create_room_room_access_section_anyone_option_description" = "Anyone can join this room";
 "screen_create_room_room_access_section_anyone_option_title" = "Anyone";

--- a/ElementX/Resources/Localizations/en.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Localizable.strings
@@ -181,6 +181,7 @@
 "common_message_removed" = "Message removed";
 "common_modern" = "Modern";
 "common_mute" = "Mute";
+"common_name_and_id" = "%1$@ (%2$@)";
 "common_no_results" = "No results";
 "common_no_room_name" = "No room name";
 "common_offline" = "Offline";
@@ -371,8 +372,7 @@
 "screen_advanced_settings_element_call_base_url_description" = "Set a custom base URL for Element Call.";
 "screen_advanced_settings_element_call_base_url_validation_error" = "Invalid URL, please make sure you include the protocol (http/https) and the correct address.";
 "screen_bottom_sheet_create_dm_confirmation_button_title" = "Send invite";
-"screen_bottom_sheet_create_dm_message" = "Would you like to start a chat with %1$@ (%2$@)?";
-"screen_bottom_sheet_create_dm_message_no_displayname" = "Would you like to start a chat with %1$@?";
+"screen_bottom_sheet_create_dm_message" = "Would you like to start a chat with %1$@?";
 "screen_bottom_sheet_create_dm_title" = "Send invite?";
 "screen_create_room_room_access_section_anyone_option_description" = "Anyone can join this room";
 "screen_create_room_room_access_section_anyone_option_title" = "Anyone";

--- a/ElementX/Sources/Generated/Strings.swift
+++ b/ElementX/Sources/Generated/Strings.swift
@@ -408,6 +408,10 @@ internal enum L10n {
   internal static var commonModern: String { return L10n.tr("Localizable", "common_modern") }
   /// Mute
   internal static var commonMute: String { return L10n.tr("Localizable", "common_mute") }
+  /// %1$@ (%2$@)
+  internal static func commonNameAndId(_ p1: Any, _ p2: Any) -> String {
+    return L10n.tr("Localizable", "common_name_and_id", String(describing: p1), String(describing: p2))
+  }
   /// No results
   internal static var commonNoResults: String { return L10n.tr("Localizable", "common_no_results") }
   /// No room name
@@ -1016,13 +1020,9 @@ internal enum L10n {
   internal static var screenBlockedUsersUnblocking: String { return L10n.tr("Localizable", "screen_blocked_users_unblocking") }
   /// Send invite
   internal static var screenBottomSheetCreateDmConfirmationButtonTitle: String { return L10n.tr("Localizable", "screen_bottom_sheet_create_dm_confirmation_button_title") }
-  /// Would you like to start a chat with %1$@ (%2$@)?
-  internal static func screenBottomSheetCreateDmMessage(_ p1: Any, _ p2: Any) -> String {
-    return L10n.tr("Localizable", "screen_bottom_sheet_create_dm_message", String(describing: p1), String(describing: p2))
-  }
   /// Would you like to start a chat with %1$@?
-  internal static func screenBottomSheetCreateDmMessageNoDisplayname(_ p1: Any) -> String {
-    return L10n.tr("Localizable", "screen_bottom_sheet_create_dm_message_no_displayname", String(describing: p1))
+  internal static func screenBottomSheetCreateDmMessage(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "screen_bottom_sheet_create_dm_message", String(describing: p1))
   }
   /// Send invite?
   internal static var screenBottomSheetCreateDmTitle: String { return L10n.tr("Localizable", "screen_bottom_sheet_create_dm_title") }

--- a/ElementX/Sources/Screens/StartChatScreen/View/SendInviteConfirmationView.swift
+++ b/ElementX/Sources/Screens/StartChatScreen/View/SendInviteConfirmationView.swift
@@ -19,11 +19,13 @@ struct SendInviteConfirmationView: View {
     private let topPadding: CGFloat = 24
     
     private var subtitle: String {
+        let string: String
         if let displayName = userToInvite.displayName {
-            L10n.screenBottomSheetCreateDmMessage(displayName, userToInvite.userID)
+            string = L10n.commonNameAndId(displayName, userToInvite.userID)
         } else {
-            L10n.screenBottomSheetCreateDmMessageNoDisplayname(userToInvite.userID)
+            string = userToInvite.userID
         }
+        return L10n.screenBottomSheetCreateDmMessage(string)
     }
     
     var body: some View {

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_sendInviteConfirmationView-iPad-pseudo.1.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_sendInviteConfirmationView-iPad-pseudo.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:579816b346b4bd8a865ab3c787712ad7f69a96ea4bdb6175902ddb1d7ee32344
-size 102539
+oid sha256:0c6cfb2b199b8daf5d186ebfeb3e6aa5badf5195457ece011f61b3378566405c
+size 104184

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/test_sendInviteConfirmationView-iPhone-16-pseudo.1.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/test_sendInviteConfirmationView-iPhone-16-pseudo.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bd3dc048f39e113f12a396a25a607b156862583c3f54d580a212b0288c42e8f1
-size 64963
+oid sha256:dfedb2e52414e484cc465b6aa68324e2cef35a18ad024074373a21fe8f508abc
+size 66823


### PR DESCRIPTION
The display name and the id pair is now localised with its own string that is reusable, and we use it when the display name is available, otherwise we just replace it with the user id.