### PR TITLE
Delete dependabot.yml - it doesn't work for Xcode projects (or XcodeGen).

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "swift"
-    directories: 
-      - "/"
-      - "/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm"
-    schedule:
-      interval: "daily"


### PR DESCRIPTION
<img width="700" alt="Screenshot 2025-02-07 at 10 39 57 am" src="https://github.com/user-attachments/assets/153116d9-9348-41b4-a5ef-4d43ac9dfd8d" />

https://github.com/dependabot/dependabot-core/issues/7694