### PR TITLE
Stop the message composer from randomly changing the cursor position

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/MessageComposerTextField.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/MessageComposerTextField.swift
@@ -190,8 +190,8 @@ private struct UITextViewWrapper: UIViewRepresentable {
         }
         
         func textViewDidChangeSelection(_ textView: UITextView) {
-            if selectedRange.wrappedValue != textView.selectedRange {
-                DispatchQueue.main.async {
+            DispatchQueue.main.async {
+                if self.selectedRange.wrappedValue != textView.selectedRange {
                     self.selectedRange.wrappedValue = textView.selectedRange
                 }
             }


### PR DESCRIPTION
Check if the selection range is different at the same time as reading it not before being dispatched to the next main queue loop.