### PR TITLE
Rename a couple of missed isEncryptedOneToOneRoom properties.

### DIFF
--- a/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewViewModel.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewViewModel.swift
@@ -144,7 +144,7 @@ class TimelineMediaPreviewViewModel: TimelineMediaPreviewViewModelType {
                                            canCurrentUserRedactOthers: timelineContext.viewState.canCurrentUserRedactOthers,
                                            canCurrentUserPin: timelineContext.viewState.canCurrentUserPin,
                                            pinnedEventIDs: timelineContext.viewState.pinnedEventIDs,
-                                           isDM: timelineContext.viewState.isEncryptedOneToOneRoom,
+                                           isDM: timelineContext.viewState.isDirectOneToOneRoom,
                                            isViewSourceEnabled: timelineContext.viewState.isViewSourceEnabled,
                                            timelineKind: timelineContext.viewState.timelineKind,
                                            emojiProvider: timelineContext.viewState.emojiProvider)

--- a/ElementX/Sources/Screens/PinnedEventsTimelineScreen/View/PinnedEventsTimelineScreen.swift
+++ b/ElementX/Sources/Screens/PinnedEventsTimelineScreen/View/PinnedEventsTimelineScreen.swift
@@ -35,7 +35,7 @@ struct PinnedEventsTimelineScreen: View {
                                                              canCurrentUserRedactOthers: timelineContext.viewState.canCurrentUserRedactOthers,
                                                              canCurrentUserPin: timelineContext.viewState.canCurrentUserPin,
                                                              pinnedEventIDs: timelineContext.viewState.pinnedEventIDs,
-                                                             isDM: timelineContext.viewState.isEncryptedOneToOneRoom,
+                                                             isDM: timelineContext.viewState.isDirectOneToOneRoom,
                                                              isViewSourceEnabled: timelineContext.viewState.isViewSourceEnabled,
                                                              timelineKind: timelineContext.viewState.timelineKind,
                                                              emojiProvider: timelineContext.viewState.emojiProvider)

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
@@ -73,7 +73,7 @@ struct RoomScreen: View {
                                                              canCurrentUserRedactOthers: timelineContext.viewState.canCurrentUserRedactOthers,
                                                              canCurrentUserPin: timelineContext.viewState.canCurrentUserPin,
                                                              pinnedEventIDs: timelineContext.viewState.pinnedEventIDs,
-                                                             isDM: timelineContext.viewState.isEncryptedOneToOneRoom,
+                                                             isDM: timelineContext.viewState.isDirectOneToOneRoom,
                                                              isViewSourceEnabled: timelineContext.viewState.isViewSourceEnabled,
                                                              timelineKind: timelineContext.viewState.timelineKind,
                                                              emojiProvider: timelineContext.viewState.emojiProvider)

--- a/ElementX/Sources/Screens/Timeline/TimelineModels.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineModels.swift
@@ -92,7 +92,7 @@ struct TimelineViewState: BindableState {
     var typingMembers: [String] = []
     var showLoading = false
     var showReadReceipts = false
-    var isEncryptedOneToOneRoom = false
+    var isDirectOneToOneRoom = false
     var timelineState: TimelineState // check the doc before changing this
 
     var ownUserID: String

--- a/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
@@ -84,7 +84,7 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
         
         super.init(initialViewState: TimelineViewState(timelineKind: timelineController.timelineKind,
                                                        roomID: roomProxy.id,
-                                                       isEncryptedOneToOneRoom: roomProxy.isDirectOneToOneRoom,
+                                                       isDirectOneToOneRoom: roomProxy.isDirectOneToOneRoom,
                                                        timelineState: TimelineState(focussedEvent: focussedEventID.map { .init(eventID: $0, appearance: .immediate) }),
                                                        ownUserID: roomProxy.ownUserID,
                                                        isViewSourceEnabled: appSettings.viewSourceEnabled,

--- a/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemBubbledStylerView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemBubbledStylerView.swift
@@ -17,7 +17,7 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
     let adjustedDeliveryStatus: TimelineItemDeliveryStatus?
     @ViewBuilder let content: () -> Content
 
-    private var isEncryptedOneToOneRoom: Bool { context.viewState.isEncryptedOneToOneRoom }
+    private var isDirectOneToOneRoom: Bool { context.viewState.isDirectOneToOneRoom }
     private var isFocussed: Bool { focussedEventID != nil && timelineItem.id.eventID == focussedEventID }
     private var isPinned: Bool {
         guard context.viewState.timelineKind != .pinned,
@@ -33,14 +33,14 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
     private let bubbleHorizontalPadding: CGFloat = 8
     /// Additional padding applied to outgoing bubbles when the avatar is shown
     private var bubbleAvatarPadding: CGFloat {
-        guard !timelineItem.isOutgoing, !isEncryptedOneToOneRoom else { return 0 }
+        guard !timelineItem.isOutgoing, !isDirectOneToOneRoom else { return 0 }
         return 8
     }
     
     var body: some View {
         ZStack(alignment: .trailingFirstTextBaseline) {
             VStack(alignment: alignment, spacing: -12) {
-                if !timelineItem.isOutgoing, !isEncryptedOneToOneRoom {
+                if !timelineItem.isOutgoing, !isDirectOneToOneRoom {
                     header
                         .zIndex(1)
                 }
@@ -147,7 +147,7 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
                                                               canCurrentUserRedactOthers: context.viewState.canCurrentUserRedactOthers,
                                                               canCurrentUserPin: context.viewState.canCurrentUserPin,
                                                               pinnedEventIDs: context.viewState.pinnedEventIDs,
-                                                              isDM: context.viewState.isEncryptedOneToOneRoom,
+                                                              isDM: context.viewState.isDirectOneToOneRoom,
                                                               isViewSourceEnabled: context.viewState.isViewSourceEnabled,
                                                               timelineKind: context.viewState.timelineKind,
                                                               emojiProvider: context.viewState.emojiProvider)
@@ -208,7 +208,7 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
     }
     
     private var messageBubbleTopPadding: CGFloat {
-        guard timelineItem.isOutgoing || isEncryptedOneToOneRoom else { return 0 }
+        guard timelineItem.isOutgoing || isDirectOneToOneRoom else { return 0 }
         return timelineGroupStyle == .single || timelineGroupStyle == .first ? 8 : 0
     }
     


### PR DESCRIPTION
This was taken care of as part of knocking and these properties are all set by `roomProxy.isDirectOneToOneRoom`, they just appear to have been missed from the refactor.