### PR TITLE
Show error screens in group calls

### DIFF
--- a/ElementX/Sources/Services/ElementCall/ElementCallWidgetDriver.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallWidgetDriver.swift
@@ -17,6 +17,7 @@ struct ElementCallWidgetMessage: Codable {
     
     enum Action: String, Codable {
         case hangup = "im.vector.hangup"
+        case close = "io.element.close"
         case mediaState = "io.element.device_mute"
     }
     
@@ -181,6 +182,8 @@ class ElementCallWidgetDriver: WidgetCapabilitiesProvider, ElementCallWidgetDriv
             if widgetMessage.direction == .fromWidget {
                 switch widgetMessage.action {
                 case .hangup:
+                    break
+                case .close:
                     actionsSubject.send(.callEnded)
                 case .mediaState:
                     guard let audioEnabled = widgetMessage.data.audioEnabled,


### PR DESCRIPTION
Element Call now sends a 'close' widget action when the widget is ready to close. Usually this will be sent immediately after the 'hangup' action, but it could be sent later if the widget wants to present an error screen before closing. So by listening to the 'close' action rather than the 'hangup' action, we get to see these error screens.

For https://github.com/element-hq/element-call/issues/2955
Depends on https://github.com/element-hq/element-call/pull/3011

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
