### PR TITLE
Revert "Show error screens in group calls"

### DIFF
--- a/ElementX/Sources/Services/ElementCall/ElementCallWidgetDriver.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallWidgetDriver.swift
@@ -17,7 +17,6 @@ struct ElementCallWidgetMessage: Codable {
     
     enum Action: String, Codable {
         case hangup = "im.vector.hangup"
-        case close = "io.element.close"
         case mediaState = "io.element.device_mute"
     }
     
@@ -182,8 +181,6 @@ class ElementCallWidgetDriver: WidgetCapabilitiesProvider, ElementCallWidgetDriv
             if widgetMessage.direction == .fromWidget {
                 switch widgetMessage.action {
                 case .hangup:
-                    break
-                case .close:
                     actionsSubject.send(.callEnded)
                 case .mediaState:
                     guard let audioEnabled = widgetMessage.data.audioEnabled,


### PR DESCRIPTION
Reverts element-hq/element-x-ios#3813

The original PR breaks UX on Element Call <=0.7.2 so we don't want to merge it yet.