### PR TITLE
Increase the time before we show loading indicators when processing user session and flow coordinators routes

### DIFF
--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -230,8 +230,9 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
     private func handleRoomRoute(roomID: String, via: [String], presentationAction: PresentationAction? = nil, animated: Bool) async {
         guard roomID == self.roomID else { fatalError("Navigation route doesn't belong to this room flow.") }
         
-        showLoadingIndicator(delay: .milliseconds(250))
+        showLoadingIndicator(delay: .seconds(0.5))
         defer { hideLoadingIndicator() }
+        
         guard let room = await userSession.clientProxy.roomForIdentifier(roomID) else {
             stateMachine.tryEvent(.presentJoinRoomScreen(via: via), userInfo: EventUserInfo(animated: animated))
             return

--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -146,10 +146,8 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
     // MARK: - Private
     
     func asyncHandleAppRoute(_ appRoute: AppRoute, animated: Bool) async {
-        showLoadingIndicator(delay: .seconds(0.25))
-        defer {
-            hideLoadingIndicator()
-        }
+        showLoadingIndicator(delay: .seconds(0.5))
+        defer { hideLoadingIndicator() }
         
         await clearPresentedSheets(animated: animated)
         


### PR DESCRIPTION
We've been getting reports that loading indicators show up too often when opening rooms. Having investigated the underlying stack there's nothign that jumps out so it might be that we're just too aggressive on the timings.

This PR increases the time before we show loading indicators when processing user session and flow coordinators routes, taking them up from 0.25s to 0.5.