### PR TITLE
Private rooms are now created with the `.invited` room history visibility

### DIFF
--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -396,6 +396,7 @@ class ClientProxy: ClientProxyProtocol {
                                                   avatar: avatarURL?.absoluteString,
                                                   powerLevelContentOverride: isKnockingOnly ? Self.knockingRoomCreationPowerLevelOverrides : Self.roomCreationPowerLevelOverrides,
                                                   joinRuleOverride: isKnockingOnly ? .knock : nil,
+                                                  historyVisibilityOverride: isRoomPrivate ? .invited : nil,
                                                   // This is an FFI naming mistake, what is required is the `aliasLocalPart` not the whole alias
                                                   canonicalAlias: aliasLocalPart)
             let roomID = try await client.createRoom(request: parameters)


### PR DESCRIPTION
fixes #3843

We want to always have private rooms to always start their room history with the .invited override
