### PR TITLE
Bump the RustSDK to v25.03.05

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -8534,7 +8534,7 @@
 			repositoryURL = "https://github.com/element-hq/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 25.02.28;
+				version = 25.03.05;
 			};
 		};
 		701C7BEF8F70F7A83E852DCC /* XCRemoteSwiftPackageReference "GZIP" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/matrix-rust-components-swift",
       "state" : {
-        "revision" : "f42b210c7edce2a58e55f94830d7c19eaec7215a",
-        "version" : "25.2.28"
+        "revision" : "72da14a8d8077a799561e9a37519feac8c872e19",
+        "version" : "25.3.5"
       }
     },
     {

--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -757,13 +757,12 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
         stopSync(isBackgroundTask: false)
         userSessionFlowCoordinator?.stop()
         
-        let userID = userSession.clientProxy.userID
         tearDownUserSession()
     
         // Allow for everything to deallocate properly
         Task {
             try? await Task.sleep(for: .seconds(2))
-            userSessionStore.clearCache(for: userID)
+            await userSession.clientProxy.clearCaches()
             stateMachine.processEvent(.startWithExistingSession)
             hideLoadingIndicator()
         }

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -4258,6 +4258,71 @@ class ClientProxyMock: ClientProxyProtocol, @unchecked Sendable {
             return getElementWellKnownReturnValue
         }
     }
+    //MARK: - clearCaches
+
+    var clearCachesUnderlyingCallsCount = 0
+    var clearCachesCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return clearCachesUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = clearCachesUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                clearCachesUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    clearCachesUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var clearCachesCalled: Bool {
+        return clearCachesCallsCount > 0
+    }
+
+    var clearCachesUnderlyingReturnValue: Result<Void, ClientProxyError>!
+    var clearCachesReturnValue: Result<Void, ClientProxyError>! {
+        get {
+            if Thread.isMainThread {
+                return clearCachesUnderlyingReturnValue
+            } else {
+                var returnValue: Result<Void, ClientProxyError>? = nil
+                DispatchQueue.main.sync {
+                    returnValue = clearCachesUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                clearCachesUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    clearCachesUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    var clearCachesClosure: (() async -> Result<Void, ClientProxyError>)?
+
+    @discardableResult
+    func clearCaches() async -> Result<Void, ClientProxyError> {
+        clearCachesCallsCount += 1
+        if let clearCachesClosure = clearCachesClosure {
+            return await clearCachesClosure()
+        } else {
+            return clearCachesReturnValue
+        }
+    }
     //MARK: - ignoreUser
 
     var ignoreUserUnderlyingCallsCount = 0
@@ -17571,47 +17636,6 @@ class UserSessionStoreMock: UserSessionStoreProtocol, @unchecked Sendable {
             self.logoutUserSessionReceivedInvocations.append(userSession)
         }
         logoutUserSessionClosure?(userSession)
-    }
-    //MARK: - clearCache
-
-    var clearCacheForUnderlyingCallsCount = 0
-    var clearCacheForCallsCount: Int {
-        get {
-            if Thread.isMainThread {
-                return clearCacheForUnderlyingCallsCount
-            } else {
-                var returnValue: Int? = nil
-                DispatchQueue.main.sync {
-                    returnValue = clearCacheForUnderlyingCallsCount
-                }
-
-                return returnValue!
-            }
-        }
-        set {
-            if Thread.isMainThread {
-                clearCacheForUnderlyingCallsCount = newValue
-            } else {
-                DispatchQueue.main.sync {
-                    clearCacheForUnderlyingCallsCount = newValue
-                }
-            }
-        }
-    }
-    var clearCacheForCalled: Bool {
-        return clearCacheForCallsCount > 0
-    }
-    var clearCacheForReceivedUserID: String?
-    var clearCacheForReceivedInvocations: [String] = []
-    var clearCacheForClosure: ((String) -> Void)?
-
-    func clearCache(for userID: String) {
-        clearCacheForCallsCount += 1
-        clearCacheForReceivedUserID = userID
-        DispatchQueue.main.async {
-            self.clearCacheForReceivedInvocations.append(userID)
-        }
-        clearCacheForClosure?(userID)
     }
 }
 class VoiceMessageCacheMock: VoiceMessageCacheProtocol, @unchecked Sendable {

--- a/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
@@ -552,6 +552,46 @@ open class ClientSDKMock: MatrixRustSDK.Client, @unchecked Sendable {
         }
     }
 
+    //MARK: - clearCaches
+
+    open var clearCachesThrowableError: Error?
+    var clearCachesUnderlyingCallsCount = 0
+    open var clearCachesCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return clearCachesUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = clearCachesUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                clearCachesUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    clearCachesUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var clearCachesCalled: Bool {
+        return clearCachesCallsCount > 0
+    }
+    open var clearCachesClosure: (() async throws -> Void)?
+
+    open override func clearCaches() async throws {
+        if let error = clearCachesThrowableError {
+            throw error
+        }
+        clearCachesCallsCount += 1
+        try await clearCachesClosure?()
+    }
+
     //MARK: - createRoom
 
     open var createRoomRequestThrowableError: Error?
@@ -3387,6 +3427,52 @@ open class ClientSDKMock: MatrixRustSDK.Client, @unchecked Sendable {
             self.setDisplayNameNameReceivedInvocations.append(name)
         }
         try await setDisplayNameNameClosure?(name)
+    }
+
+    //MARK: - setMediaRetentionPolicy
+
+    open var setMediaRetentionPolicyPolicyThrowableError: Error?
+    var setMediaRetentionPolicyPolicyUnderlyingCallsCount = 0
+    open var setMediaRetentionPolicyPolicyCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return setMediaRetentionPolicyPolicyUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = setMediaRetentionPolicyPolicyUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                setMediaRetentionPolicyPolicyUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    setMediaRetentionPolicyPolicyUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var setMediaRetentionPolicyPolicyCalled: Bool {
+        return setMediaRetentionPolicyPolicyCallsCount > 0
+    }
+    open var setMediaRetentionPolicyPolicyReceivedPolicy: MediaRetentionPolicy?
+    open var setMediaRetentionPolicyPolicyReceivedInvocations: [MediaRetentionPolicy] = []
+    open var setMediaRetentionPolicyPolicyClosure: ((MediaRetentionPolicy) async throws -> Void)?
+
+    open override func setMediaRetentionPolicy(policy: MediaRetentionPolicy) async throws {
+        if let error = setMediaRetentionPolicyPolicyThrowableError {
+            throw error
+        }
+        setMediaRetentionPolicyPolicyCallsCount += 1
+        setMediaRetentionPolicyPolicyReceivedPolicy = policy
+        DispatchQueue.main.async {
+            self.setMediaRetentionPolicyPolicyReceivedInvocations.append(policy)
+        }
+        try await setMediaRetentionPolicyPolicyClosure?(policy)
     }
 
     //MARK: - setPusher
@@ -13723,6 +13809,52 @@ open class RoomSDKMock: MatrixRustSDK.Room, @unchecked Sendable {
             self.reportContentEventIdScoreReasonReceivedInvocations.append((eventId: eventId, score: score, reason: reason))
         }
         try await reportContentEventIdScoreReasonClosure?(eventId, score, reason)
+    }
+
+    //MARK: - reportRoom
+
+    open var reportRoomReasonThrowableError: Error?
+    var reportRoomReasonUnderlyingCallsCount = 0
+    open var reportRoomReasonCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return reportRoomReasonUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = reportRoomReasonUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                reportRoomReasonUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    reportRoomReasonUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var reportRoomReasonCalled: Bool {
+        return reportRoomReasonCallsCount > 0
+    }
+    open var reportRoomReasonReceivedReason: String?
+    open var reportRoomReasonReceivedInvocations: [String?] = []
+    open var reportRoomReasonClosure: ((String?) async throws -> Void)?
+
+    open override func reportRoom(reason: String?) async throws {
+        if let error = reportRoomReasonThrowableError {
+            throw error
+        }
+        reportRoomReasonCallsCount += 1
+        reportRoomReasonReceivedReason = reason
+        DispatchQueue.main.async {
+            self.reportRoomReasonReceivedInvocations.append(reason)
+        }
+        try await reportRoomReasonClosure?(reason)
     }
 
     //MARK: - resetPowerLevels

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -702,6 +702,15 @@ class ClientProxy: ClientProxyProtocol {
     func getElementWellKnown() async -> Result<ElementWellKnown?, ClientProxyError> {
         await client.getElementWellKnown().map(ElementWellKnown.init)
     }
+    
+    func clearCaches() async -> Result<Void, ClientProxyError> {
+        do {
+            return try await .success(client.clearCaches())
+        } catch {
+            MXLog.error("Failed clearing client caches with error: \(error)")
+            return .failure(.sdkError(error))
+        }
+    }
         
     // MARK: Ignored users
     

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -179,6 +179,8 @@ protocol ClientProxyProtocol: AnyObject, MediaLoaderProtocol {
     func isAliasAvailable(_ alias: String) async -> Result<Bool, ClientProxyError>
     
     func getElementWellKnown() async -> Result<ElementWellKnown?, ClientProxyError>
+    
+    @discardableResult func clearCaches() async -> Result<Void, ClientProxyError>
 
     // MARK: - Ignored users
     

--- a/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
@@ -36,9 +36,10 @@ class JoinedRoomProxy: JoinedRoomProxyProtocol {
                     
                     do {
                         let sdkTimeline = try await room.timelineWithConfiguration(configuration: .init(focus: .pinnedEvents(maxEventsToLoad: 100, maxConcurrentRequests: 10),
-                                                                                                        allowedMessageTypes: .all,
+                                                                                                        filter: .all,
                                                                                                         internalIdPrefix: nil,
-                                                                                                        dateDividerMode: .daily))
+                                                                                                        dateDividerMode: .daily,
+                                                                                                        trackReadReceipts: false))
                         
                         let timeline = TimelineProxy(timeline: sdkTimeline, kind: .pinned)
                         
@@ -159,9 +160,10 @@ class JoinedRoomProxy: JoinedRoomProxyProtocol {
     func timelineFocusedOnEvent(eventID: String, numberOfEvents: UInt16) async -> Result<TimelineProxyProtocol, RoomProxyError> {
         do {
             let sdkTimeline = try await room.timelineWithConfiguration(configuration: .init(focus: .event(eventId: eventID, numContextEvents: numberOfEvents),
-                                                                                            allowedMessageTypes: .all,
+                                                                                            filter: .all,
                                                                                             internalIdPrefix: UUID().uuidString,
-                                                                                            dateDividerMode: .daily))
+                                                                                            dateDividerMode: .daily,
+                                                                                            trackReadReceipts: false))
             
             return .success(TimelineProxy(timeline: sdkTimeline, kind: .detached))
         } catch let error as FocusEventError {
@@ -202,9 +204,10 @@ class JoinedRoomProxy: JoinedRoomProxyProtocol {
             }
             
             let sdkTimeline = try await room.timelineWithConfiguration(configuration: .init(focus: rustFocus,
-                                                                                            allowedMessageTypes: .only(types: rustMessageTypes),
+                                                                                            filter: .onlyMessage(types: rustMessageTypes),
                                                                                             internalIdPrefix: nil,
-                                                                                            dateDividerMode: .monthly))
+                                                                                            dateDividerMode: .monthly,
+                                                                                            trackReadReceipts: false))
             
             let timeline = TimelineProxy(timeline: sdkTimeline, kind: .media(presentation))
             await timeline.subscribeForUpdates()

--- a/ElementX/Sources/Services/Room/RoomPreview/RoomPreviewProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomPreview/RoomPreviewProxyProtocol.swift
@@ -8,8 +8,10 @@
 import Foundation
 
 /// A preview object for the Room. useful to get all the possible info for rooms to which the user is not invited to
-// sourcery: AutoMockable
 protocol RoomPreviewProxyProtocol {
     var info: RoomPreviewInfoProxy { get }
     var ownMembershipDetails: RoomMembershipDetailsProxyProtocol? { get async }
 }
+
+// sourcery: AutoMockable
+extension RoomPreviewProxyProtocol { }

--- a/ElementX/Sources/Services/UserSession/UserSessionStore.swift
+++ b/ElementX/Sources/Services/UserSession/UserSessionStore.swift
@@ -91,15 +91,7 @@ class UserSessionStore: UserSessionStoreProtocol {
             credentials.restorationToken.sessionDirectories.delete()
         }
     }
-    
-    func clearCache(for userID: String) {
-        guard let credentials = keychainController.restorationTokens().first(where: { $0.userID == userID }) else {
-            MXLog.error("Failed to clearing caches: Credentials missing")
-            return
-        }
-        credentials.restorationToken.sessionDirectories.deleteTransientUserData()
-    }
-    
+        
     // MARK: - Private
     
     private func buildUserSessionWithClient(_ clientProxy: ClientProxyProtocol) -> UserSessionProtocol {

--- a/ElementX/Sources/Services/UserSession/UserSessionStoreProtocol.swift
+++ b/ElementX/Sources/Services/UserSession/UserSessionStoreProtocol.swift
@@ -36,7 +36,4 @@ protocol UserSessionStoreProtocol {
     
     /// Logs out of the specified session.
     func logout(userSession: UserSessionProtocol)
-    
-    /// Clears our all the matrix sdk state data for the specified session
-    func clearCache(for userID: String)
 }

--- a/project.yml
+++ b/project.yml
@@ -59,7 +59,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/element-hq/matrix-rust-components-swift
-    exactVersion: 25.02.28
+    exactVersion: 25.03.05
     # path: ../matrix-rust-sdk
   Compound:
     url: https://github.com/element-hq/compound-ios


### PR DESCRIPTION
- adopt the new timeline configuration which now exposes read receipst tracking. For now it should be set to false for all timelines except the live one which still gets configured properly on the rust side through init_timeline. Eventually we will converge on this configurationi API for all of them.
- also adopt the new rust side cache clearing method and remove our own