### PR TITLE
Prevent various room subscription task from blocking opening rooms

### DIFF
--- a/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
@@ -135,15 +135,17 @@ class JoinedRoomProxy: JoinedRoomProxyProtocol {
         
         await timeline.subscribeForUpdates()
         
-        subscribeToRoomInfoUpdates()
-        
-        if isEncrypted {
-            subscribeToIdentityStatusChanges()
+        Task {
+            subscribeToRoomInfoUpdates()
+            
+            subscribeToTypingNotifications()
+            
+            await subscribeToKnockRequests()
+            
+            if isEncrypted { // This is actually blocking on the rust side and might make network requests
+                subscribeToIdentityStatusChanges()
+            }
         }
-        
-        subscribeToTypingNotifications()
-        
-        await subscribeToKnockRequests()
     }
     
     func subscribeToRoomInfoUpdates() {


### PR DESCRIPTION
- this came from having seen the opening room modal show up too often which was caused by `isEncrypted` being block_on on the rust side and sometimes making network requests
- we aggreed that the `block_on`s should go, which is handled in https://github.com/matrix-org/matrix-rust-sdk/pull/4756 and https://github.com/matrix-org/matrix-rust-sdk/pull/4757