### PR TITLE
Fix sharing from in-app QuickLook to itself

### DIFF
--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -307,9 +307,15 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
             case (.userProfileScreen, .dismissedUserProfileScreen, .roomList):
                 break
                 
-            case (.roomList, .showShareExtensionRoomList, .shareExtensionRoomList(let sharePayload)):
-                clearRoute(animated: animated)
-                presentRoomSelectionScreen(sharePayload: sharePayload, animated: animated)
+            case (.roomList(let selectedRoomID), .showShareExtensionRoomList, .shareExtensionRoomList(let sharePayload)):
+                Task {
+                    if selectedRoomID != nil {
+                        self.clearRoute(animated: animated)
+                        try? await Task.sleep(for: .seconds(1.5))
+                    }
+                    
+                    self.presentRoomSelectionScreen(sharePayload: sharePayload, animated: animated)
+                }
             case (.shareExtensionRoomList, .dismissedShareExtensionRoomList, .roomList):
                 dismissRoomSelectionScreen()
                 


### PR DESCRIPTION
Delay the presentation of the share extension room selection screen until the currently presented room is correctly torn down

If QuickLook is presented (e.g. a timeline media is being viewed in full screen) then its animated dismissal will interfere with presenting other screens and break the state machine. Unfortunately I wasn't able to find any reasonable way to have the QuickLook dismiss itself without an animation

On the other hand, we can fix both this issue and improve #3893 by just delaying the presentation of the room selection list, which is what this patch does.