### PR TITLE
Pin all 3rd party github actions to their full length commit SHA

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -73,7 +73,7 @@ jobs:
         run: xcresultparser -q -o cobertura -t ElementX -p $(pwd) fastlane/test_output/IntegrationTests.xcresult > fastlane/test_output/integration-cobertura.xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d #v3.1.4
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -86,7 +86,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@f2dba722c67b86c6caa034178c6e4d35335f6706 #v1.1.0
         continue-on-error: true
         with:
           fail_ci_if_error: false

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -35,7 +35,7 @@ jobs:
           source ci_scripts/ci_common.sh && setup_github_actions_environment
 
       - name: Import signing certificate
-        uses: apple-actions/import-codesign-certs@v3
+        uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d #v3
         with:
           p12-file-base64: ${{ secrets.ALPHA_CERTIFICATES_P12 }}
           p12-password: ${{ secrets.ALPHA_CERTIFICATES_P12_PASSWORD }}
@@ -52,7 +52,7 @@ jobs:
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
 
       - name: Add release notes and Diawi info
-        uses: NejcZdovc/comment-pr@v2
+        uses: NejcZdovc/comment-pr@a423635d183a8259308e80593c96fecf31539c26 #v2.1.0
         with:
           message: |
             :iphone: Scan the QR code below to install the build for this PR. 

--- a/.github/workflows/translations-pr.yml
+++ b/.github/workflows/translations-pr.yml
@@ -28,7 +28,7 @@ jobs:
         run: swift run tools generate-sas
 
       - name: Create PR for Translations
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e #v7.0.8
         with:
           token: ${{ secrets.ELEMENT_BOT_TOKEN }}
           commit-message: Translations update

--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -21,7 +21,7 @@ jobs:
       cancel-in-progress: true
 
     steps:
-      - uses: nschloe/action-cached-lfs-checkout@v1
+      - uses: nschloe/action-cached-lfs-checkout@f46300cd8952454b9f0a21a3d133d4bd5684cfc2 #v1.2.3
 
       - uses: actions/cache@v4
         with:
@@ -59,7 +59,7 @@ jobs:
         run: xcresultparser -q -o cobertura -t ElementX -p $(pwd) fastlane/test_output/UITests.xcresult > fastlane/test_output/ui-cobertura.xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d #v3.1.4
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -72,7 +72,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@f2dba722c67b86c6caa034178c6e4d35335f6706 #v1.1.0
         continue-on-error: true
         with:
           fail_ci_if_error: false

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -19,7 +19,7 @@ jobs:
       cancel-in-progress: true
 
     steps:
-      - uses: nschloe/action-cached-lfs-checkout@v1
+      - uses: nschloe/action-cached-lfs-checkout@f46300cd8952454b9f0a21a3d133d4bd5684cfc2 #v1.2.3
 
       - uses: actions/cache@v4
         with:
@@ -60,7 +60,7 @@ jobs:
           xcresultparser -q -o cobertura -t ElementX -p $(pwd) fastlane/test_output/PreviewTests.xcresult > fastlane/test_output/preview-cobertura.xml
       
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d #v3.1.4
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -74,7 +74,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@f2dba722c67b86c6caa034178c6e4d35335f6706 #v1.1.0
         continue-on-error: true
         with:
           fail_ci_if_error: false

--- a/.github/workflows/unit_tests_enterprise.yml
+++ b/.github/workflows/unit_tests_enterprise.yml
@@ -22,7 +22,7 @@ jobs:
       cancel-in-progress: true
 
     steps:
-      - uses: nschloe/action-cached-lfs-checkout@v1
+      - uses: nschloe/action-cached-lfs-checkout@f46300cd8952454b9f0a21a3d133d4bd5684cfc2 #v1.2.3
         with:
           submodules: recursive
           token: ${{ secrets.ELEMENT_BOT_TOKEN }}


### PR DESCRIPTION
- this is the recommended security practice as per https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions