### PR TITLE
Run the 'prevent blocked' workflow even if PR has conflicts

### DIFF
--- a/.github/workflows/blocked.yml
+++ b/.github/workflows/blocked.yml
@@ -1,6 +1,6 @@
 name: Prevent blocked
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, labeled, unlabeled]
 jobs:
   prevent-blocked:


### PR DESCRIPTION
See the description of pull_request versus pull_request_target documented at https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request.