### PR TITLE
Stop CI from uploading Codecov results when a PR comes from a fork.

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -60,6 +60,7 @@ jobs:
           xcresultparser -q -o cobertura -t ElementX -p $(pwd) fastlane/test_output/PreviewTests.xcresult > fastlane/test_output/preview-cobertura.xml
       
       - name: Upload coverage to Codecov
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }} # Skip in forks
         uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3.1.6
         with:
           fail_ci_if_error: true
@@ -73,7 +74,7 @@ jobs:
           xcresultparser -q -o junit -p $(pwd) fastlane/test_output/PreviewTests.xcresult > fastlane/test_output/preview-junit.xml
 
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: codecov/test-results-action@f2dba722c67b86c6caa034178c6e4d35335f6706 #v1.1.0
         continue-on-error: true
         with:

--- a/.github/workflows/unit_tests_enterprise.yml
+++ b/.github/workflows/unit_tests_enterprise.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-15
     
     # Skip in forks
-    if: github.repository == 'element-hq/element-x-ios'
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
 
     concurrency:
       # Only allow a single run of this workflow on each branch, automatically cancelling older runs.


### PR DESCRIPTION
Looking at #3914, unit tests failed because the codecov upload failed. Also the enterprise tests were being run (which obviously then failed).
- The condition for the latter has been updated to actually work.
    - It was checking `'element-hq/element-x-ios' == 'element-hq/element-x-ios'` regardless of whether the PR came from our repo or a fork 🙈
- The same condition has been added to the codecov steps in the former.