### PR TITLE
Embed element call

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,7 +9,7 @@ then
   exit 1
 fi
 
-swift-package-list ElementX.xcodeproj --requires-license --ignore-package compound-ios --ignore-package compound-design-tokens --ignore-package matrix-rich-text-editor-swift --output-type settings-bundle --output-path ElementX/SupportingFiles
+swift-package-list ElementX.xcodeproj --requires-license --ignore-package compound-ios --ignore-package compound-design-tokens --ignore-package matrix-rich-text-editor-swift --ignore-package element-call-swift --output-type settings-bundle --output-path ElementX/SupportingFiles
 if ! git diff --quiet -- ./ElementX/SupportingFiles/Settings.bundle || [ -n "$(git ls-files --others --exclude-standard -- ./ElementX/SupportingFiles/Settings.bundle)" ]; then
   echo "pre-commit: Commit aborted due to unstaged changes to the package Acknowledgements."
   exit 1

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -8585,7 +8585,7 @@
 			repositoryURL = "https://github.com/element-hq/element-call-swift";
 			requirement = {
 				kind = exactVersion;
-				version = "0.9.0-release-test.3";
+				version = "0.9.0-rc.3";
 			};
 		};
 		821C67C9A7F8CC3FD41B28B4 /* XCRemoteSwiftPackageReference "emojibase-bindings" */ = {

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -276,13 +276,13 @@
 		36926D795D6D19177C7812F8 /* EncryptionResetPasswordScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6935A55AB3B0C94BC566DD6 /* EncryptionResetPasswordScreenCoordinator.swift */; };
 		369BF960E52BBEE61F8A5BD1 /* BlockedUsersScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED60E4D2CD678E1EBF16F77A /* BlockedUsersScreen.swift */; };
 		36AC963F2F04069B7FF1AA0C /* UIConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6D88E8AFFBF2C1D589C0FA /* UIConstants.swift */; };
-		36AD4DD4C798E22584ED3200 /* SentrySwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 75361A9D8A3C5501EADB225D /* SentrySwiftUI */; };
-		36CD6E11B37396E14F032CB6 /* Version in Frameworks */ = {isa = PBXBuildFile; productRef = A05AF81DDD14AD58CB0E1B9B /* Version */; };
+		36AD4DD4C798E22584ED3200 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 7731767AE437BA3BD2CC14A8 /* Sentry */; };
+		36CD6E11B37396E14F032CB6 /* SentrySwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 75361A9D8A3C5501EADB225D /* SentrySwiftUI */; };
 		36DE961B784087D5E18EF9BA /* LogViewerScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A07692536D66E3DA32C4964 /* LogViewerScreen.swift */; };
 		370AF5BFCD4384DD455479B6 /* ElementCallWidgetDriverProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C11AD9813045E44F950410 /* ElementCallWidgetDriverProtocol.swift */; };
 		37906355E207DB5703754675 /* AppLockSetupBiometricsScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F893F4A111CB7BA5C96949 /* AppLockSetupBiometricsScreenViewModel.swift */; };
 		37D789F24199B32E3FD1AA7B /* FileRoomTimelineItemContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216F0DDC98F2A2C162D09C28 /* FileRoomTimelineItemContent.swift */; };
-		37E47F5101C0C036289D3807 /* DSWaveformImageViews in Frameworks */ = {isa = PBXBuildFile; productRef = 2A4106A0A96DC4C273128AA5 /* DSWaveformImageViews */; };
+		37E47F5101C0C036289D3807 /* SwiftOGG in Frameworks */ = {isa = PBXBuildFile; productRef = 391D11F92DFC91666AA1503F /* SwiftOGG */; };
 		384D6B9A7DFD7260139D6852 /* UITestsNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBEB8D9F4940E161B18FE4BC /* UITestsNotificationCenter.swift */; };
 		38546A6010A2CF240EC9AF73 /* BindableState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA1D2CBAEA5D0BD00B90D1B /* BindableState.swift */; };
 		386720B603F87D156DB01FB2 /* VoiceMessageMediaManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40076C770A5FB83325252973 /* VoiceMessageMediaManager.swift */; };
@@ -304,7 +304,7 @@
 		3B98049F56025726FB646ABD /* SwipeToReplyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B0E0B55E2EE75AF67029924 /* SwipeToReplyView.swift */; };
 		3C312A3AEDE58BB1C9BBB07C /* preview_avatar_room.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 12FD5280AF55AB7F50F8E47D /* preview_avatar_room.jpg */; };
 		3C31E1A65EEB61E72E1113B4 /* AudioRecorderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBEC57C204D77908E355EF42 /* AudioRecorderProtocol.swift */; };
-		3C549A0BF39F8A854D45D9FD /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 0DD568A494247444A4B56031 /* Kingfisher */; };
+		3C549A0BF39F8A854D45D9FD /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = 020597E28A4BC8E1BE8EDF6E /* KeychainAccess */; };
 		3C73442084BF8A6939F0F80B /* AnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5445FCE0CE15E634FDC1A2E2 /* AnalyticsService.swift */; };
 		3CE4C5071B6D2576E2473989 /* OrderedSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62B07B296D7A9D2F09120853 /* OrderedSet.swift */; };
 		3D72F5F9109AAA257542456B /* CallInviteRoomTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664ABD745A746C45CB842158 /* CallInviteRoomTimelineView.swift */; };
@@ -320,12 +320,12 @@
 		3F70E237CE4C3FAB02FC227F /* NotificationConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C830A64609CBD152F06E0457 /* NotificationConstants.swift */; };
 		3F997171C3C79A45E92BF9EF /* ElementWellKnown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79FAC366FF299BCC555D756E /* ElementWellKnown.swift */; };
 		401BB28CD6B7DD6B4E7863E7 /* ServerConfirmationScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9342F5D6729627B6393AF853 /* ServerConfirmationScreenModels.swift */; };
-		407DCE030E0F9B7C9861D38A /* LRUCache in Frameworks */ = {isa = PBXBuildFile; productRef = 1081D3630AAD3ACEDDEC3A98 /* LRUCache */; };
+		407DCE030E0F9B7C9861D38A /* LoremSwiftum in Frameworks */ = {isa = PBXBuildFile; productRef = 1A6B622CCFDEFB92D9CF1CA5 /* LoremSwiftum */; };
 		40B79D20A873620F7F128A2C /* UserPreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35FA991289149D31F4286747 /* UserPreference.swift */; };
 		414F50CFCFEEE2611127DCFB /* RestorationToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3558A15CFB934F9229301527 /* RestorationToken.swift */; };
 		41C5DA0C06F30311A221E85B /* ClientSDKMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EAF4A49F3ACD8BB8B0D2371 /* ClientSDKMock.swift */; };
 		41CE5E1289C8768FC5B6490C /* RoomTimelineItemViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C2D52E36AD614B3C003EF6 /* RoomTimelineItemViewState.swift */; };
-		41DFDD212D1BE57CA50D783B /* KZFileWatchers in Frameworks */ = {isa = PBXBuildFile; productRef = 81DB3AB6CE996AB3954F4F03 /* KZFileWatchers */; };
+		41DFDD212D1BE57CA50D783B /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 0DD568A494247444A4B56031 /* Kingfisher */; };
 		41F553349AF44567184822D8 /* APNSPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D670124FC3E84F23A62CCF /* APNSPayload.swift */; };
 		4219391CD2351E410554B3E8 /* AggregratedReaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B858A61F2A570DFB8DE570A7 /* AggregratedReaction.swift */; };
 		422E8D182CA688D4565CD1E1 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B21E611DADDEF00307E7AC /* String.swift */; };
@@ -339,11 +339,12 @@
 		440123E29E2F9B001A775BBE /* TimelineItemProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D505843AB66822EB91F0DF0 /* TimelineItemProxy.swift */; };
 		446BCD2D0AE27E0CFD1BDC8F /* ImageMediaEventsTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF584D757E768EA7776A532 /* ImageMediaEventsTimelineView.swift */; };
 		44BDD670FF9095ACE240A3A2 /* VoiceMessageMediaManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC4F10BDD56FA77FEC742333 /* VoiceMessageMediaManagerTests.swift */; };
-		44F0E1B576C7599DF8022071 /* WysiwygComposer in Frameworks */ = {isa = PBXBuildFile; productRef = CA07D57389DACE18AEB6A5E2 /* WysiwygComposer */; };
+		44F0E1B576C7599DF8022071 /* Emojibase in Frameworks */ = {isa = PBXBuildFile; productRef = C05729B1684C331F5FFE9232 /* Emojibase */; };
 		454311EAC17D778E19F46592 /* NotificationPermissionsScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91868EB98818044E6FEBE532 /* NotificationPermissionsScreenCoordinator.swift */; };
 		454F8DDC4442C0DE54094902 /* LABiometryType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F219838588C62198E726E3 /* LABiometryType.swift */; };
 		4557192F5B15A8D9BB920232 /* AdvancedSettingsScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E492690C8B27A892C194CC4 /* AdvancedSettingsScreenCoordinator.swift */; };
 		45D6DC594816288983627484 /* UITestsScreenIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CEBE5EA91E8691EDF364EC2 /* UITestsScreenIdentifier.swift */; };
+		4610C57A4785FFF5E67F0C6D /* DSWaveformImageViews in Frameworks */ = {isa = PBXBuildFile; productRef = 2A4106A0A96DC4C273128AA5 /* DSWaveformImageViews */; };
 		46562110EE202E580A5FFD9C /* RoomScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CF7B19FFCF8EFBE0A8696A /* RoomScreenViewModelTests.swift */; };
 		4681820102DAC8BA586357D4 /* VoiceMessageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAB8D7926A5684E18196B538 /* VoiceMessageCache.swift */; };
 		46A183C6125A669AEB005699 /* UserProfileScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = F134D2D91DFF732FB75B2CB7 /* UserProfileScreenViewModelProtocol.swift */; };
@@ -489,7 +490,7 @@
 		62684AECDFC5C7DC989CBD9E /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 7B6BC3219ADD8AA0311D2B86 /* SnapshotTesting */; };
 		627139A3D79F032BA81E3A53 /* UserSessionFlowCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA29BAE9B0F2D90E57B261C /* UserSessionFlowCoordinatorTests.swift */; };
 		62910B515BCB4B455E24D7C1 /* AdvancedSettingsScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D086854995173E897F993C26 /* AdvancedSettingsScreenViewModelProtocol.swift */; };
-		6298AB0906DDD3525CD78C6B /* LoremSwiftum in Frameworks */ = {isa = PBXBuildFile; productRef = 1A6B622CCFDEFB92D9CF1CA5 /* LoremSwiftum */; };
+		6298AB0906DDD3525CD78C6B /* KZFileWatchers in Frameworks */ = {isa = PBXBuildFile; productRef = 81DB3AB6CE996AB3954F4F03 /* KZFileWatchers */; };
 		62A7FC3A0191BC7181AA432B /* AudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907FA4DE17DEA1A3738EFB83 /* AudioRecorder.swift */; };
 		62C5876C4254C58C2086F0DE /* HomeScreenContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B4B58B79A6FA250B24A1EC /* HomeScreenContent.swift */; };
 		63780F9DA06573E38A471ECA /* GenericCallLinkWidgetDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C202C1C7E330F124981A31 /* GenericCallLinkWidgetDriver.swift */; };
@@ -581,7 +582,7 @@
 		743790BF6A5B0577EA74AF14 /* ReadMarkerRoomTimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF3D25B3EDB283B5807EADCF /* ReadMarkerRoomTimelineItem.swift */; };
 		748F482FEF4E04D61C39AAD7 /* EmojiPickerScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = F174A5627CDB3CAF280D1880 /* EmojiPickerScreenModels.swift */; };
 		7501442D52A65F73DF79FFD4 /* PaginationIndicatorRoomTimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B987FC3FDBAA0E1C5AA235C /* PaginationIndicatorRoomTimelineItem.swift */; };
-		754602A7B2AAD443C4228ED4 /* GZIP in Frameworks */ = {isa = PBXBuildFile; productRef = 997C7385E1A07E061D7E2100 /* GZIP */; };
+		754602A7B2AAD443C4228ED4 /* SwiftState in Frameworks */ = {isa = PBXBuildFile; productRef = 9573B94B1C86C6DF751AF3FD /* SwiftState */; };
 		755395927DDD6EBDDA5E217A /* SettingsFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28F7A6CEEA4A2815B0F0F55 /* SettingsFlowCoordinator.swift */; };
 		755727E0B756430DFFEC4732 /* SessionVerificationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF05DA24F71B455E8EFEBC3B /* SessionVerificationViewModelTests.swift */; };
 		756EA0D663261889EF64E6D4 /* VoiceMessageRecordingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E9CBF577B9711CFBB4FA40D /* VoiceMessageRecordingView.swift */; };
@@ -732,7 +733,7 @@
 		8E650379587C31D7912ED67B /* UNNotification+Creator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0AEA686E425F86F6BA0404 /* UNNotification+Creator.swift */; };
 		8E7A902CA16E24928F83646C /* ElementCallServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E321E840DCC63790049984F4 /* ElementCallServiceMock.swift */; };
 		8ED8AF57A06F5EE9978ED23F /* AuthenticationStartScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FB89DC7F9A4A91020037001 /* AuthenticationStartScreenViewModelTests.swift */; };
-		8F2FAA98457750D9D664136F /* Mapbox in Frameworks */ = {isa = PBXBuildFile; productRef = C1BF15833233CD3BDB7E2B1D /* Mapbox */; };
+		8F2FAA98457750D9D664136F /* LRUCache in Frameworks */ = {isa = PBXBuildFile; productRef = 1081D3630AAD3ACEDDEC3A98 /* LRUCache */; };
 		8F3AD08F2E706AA60F1A1D4D /* portrait_test_image.jpg in Resources */ = {isa = PBXBuildFile; fileRef = BC51BF90469412ABDE658CDD /* portrait_test_image.jpg */; };
 		904F06C9C1AEF884C2077542 /* RoomDirectorySearchScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E4EF80DFB8FE7C4469B15D /* RoomDirectorySearchScreen.swift */; };
 		90733645AE76FB33DAD28C2B /* URLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE40D4A5DD857AC16EED945A /* URLSession.swift */; };
@@ -816,7 +817,7 @@
 		A0601810597769B81C2358AF /* EncryptionResetPasswordScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2B5274C1D3D2999D643786 /* EncryptionResetPasswordScreenViewModelProtocol.swift */; };
 		A0861B727B273B5B3DD7FBF6 /* KnockRequestsListScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09227E671DB30795C43FFFD /* KnockRequestsListScreenViewModel.swift */; };
 		A0868BDE84D2140A885BE3C9 /* EncryptionResetScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8562F4D7DE073BC32902AB /* EncryptionResetScreenViewModelProtocol.swift */; };
-		A0D7E5BD0298A97DCBDCE40B /* Emojibase in Frameworks */ = {isa = PBXBuildFile; productRef = C05729B1684C331F5FFE9232 /* Emojibase */; };
+		A0D7E5BD0298A97DCBDCE40B /* Version in Frameworks */ = {isa = PBXBuildFile; productRef = A05AF81DDD14AD58CB0E1B9B /* Version */; };
 		A10D6CCDE2010C09EEA1A593 /* HomeScreenRoomList.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7661EFFCAA307A97D71132A /* HomeScreenRoomList.swift */; };
 		A14A9419105A1CD42F0511C4 /* UserIndicatorModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43005941B3A2C9671E23C85 /* UserIndicatorModalView.swift */; };
 		A1672EF491FE6F3BBF7878BE /* test_apple_image.heic in Resources */ = {isa = PBXBuildFile; fileRef = BB576F4118C35E6B5124FA22 /* test_apple_image.heic */; };
@@ -863,7 +864,7 @@
 		A851635B3255C6DC07034A12 /* RoomScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8108C8F0ACF6A7EB72D0117 /* RoomScreenCoordinator.swift */; };
 		A87DC550659C5176AC1829DE /* ElementTextFieldStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7673F2B0B038FAB2A8D16AD /* ElementTextFieldStyle.swift */; };
 		A8FA7671948E3DF27F320026 /* BugReportFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7367B3B9A8CAF902220F31D1 /* BugReportFlowCoordinator.swift */; };
-		A93661C962B12942C08864B6 /* SwiftOGG in Frameworks */ = {isa = PBXBuildFile; productRef = 391D11F92DFC91666AA1503F /* SwiftOGG */; };
+		A93661C962B12942C08864B6 /* WysiwygComposer in Frameworks */ = {isa = PBXBuildFile; productRef = CA07D57389DACE18AEB6A5E2 /* WysiwygComposer */; };
 		A950C95855C474F75B30CA7B /* PollFormScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDAB580109C09A6AA97AF7E /* PollFormScreenTests.swift */; };
 		A969147E0EEE0E27EE226570 /* MediaUploadPreviewScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47F29139BC2A804CE5E0757E /* MediaUploadPreviewScreenViewModel.swift */; };
 		A975D60EA49F6AF73308809F /* RoomMembersListScreenMemberCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC03209FDE8CE0810617BFFF /* RoomMembersListScreenMemberCell.swift */; };
@@ -893,7 +894,7 @@
 		AF8BFA37791E1756EE243E08 /* SettingsScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B8F0ED874DF8C9A51B0AB6F /* SettingsScreenCoordinator.swift */; };
 		AFE2AB612A1460E49578D746 /* JoinRoomScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BDCCD2F6B405C14B9BCE94E /* JoinRoomScreenCoordinator.swift */; };
 		B04E9EB589CE99C3929E817A /* HomeScreenRecoveryKeyConfirmationBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05512FB13987D221B7205DE0 /* HomeScreenRecoveryKeyConfirmationBanner.swift */; };
-		B0CB16349B96262AA65A04AF /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 7731767AE437BA3BD2CC14A8 /* Sentry */; };
+		B0CB16349B96262AA65A04AF /* GZIP in Frameworks */ = {isa = PBXBuildFile; productRef = 997C7385E1A07E061D7E2100 /* GZIP */; };
 		B1069F361E604D5436AE9FFD /* StaticLocationScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B06663F7858E45882E63471 /* StaticLocationScreen.swift */; };
 		B10F7D5C237417DA160F4603 /* LongPressWithFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9F148717D74F73BE724434 /* LongPressWithFeedback.swift */; };
 		B13774779EA19FDD7A35A4A8 /* RoomRolesAndPermissionsScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C28B70BEFD3676F11D5D51F /* RoomRolesAndPermissionsScreenCoordinator.swift */; };
@@ -1018,7 +1019,7 @@
 		C9F5B48D15B9BCAE1F8D564E /* RoomNotificationModeProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1511766C534367700C8DD75 /* RoomNotificationModeProxy.swift */; };
 		CA12AE0DCD57D49CD96C699A /* WaveformCursorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB9EABCA9348DFA27439A809 /* WaveformCursorView.swift */; };
 		CB07184D37D5D65327A5A693 /* AuthenticationFlowCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F46CC4FD89ECF4CF26391A /* AuthenticationFlowCoordinatorTests.swift */; };
-		CB137BFB3E083C33E398A6CB /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = 020597E28A4BC8E1BE8EDF6E /* KeychainAccess */; };
+		CB137BFB3E083C33E398A6CB /* EmbeddedElementCall in Frameworks */ = {isa = PBXBuildFile; productRef = 424B603C07AEA6FCA7C8E7C9 /* EmbeddedElementCall */; };
 		CB498F4E27AA0545DCEF0F6F /* DTCoreText in Frameworks */ = {isa = PBXBuildFile; productRef = 36B7FC232711031AA2B0D188 /* DTCoreText */; };
 		CB6956565D858C523E3E3B16 /* ComposerDraftServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7E37072597F67C4DD8CC2DB /* ComposerDraftServiceProtocol.swift */; };
 		CB6BCBF28E4B76EA08C2926D /* StateRoomTimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B16048D30F0438731C41F775 /* StateRoomTimelineItem.swift */; };
@@ -1165,7 +1166,7 @@
 		EA8D941771E762A5D3D7FA0D /* FileMediaEventsTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 430C73079A84654BF46A7FF5 /* FileMediaEventsTimelineView.swift */; };
 		EA974337FA7D040E7C74FE6E /* RoomDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EFE1922F39398ABFB36DF3F /* RoomDetailsViewModelTests.swift */; };
 		EAB3C1F0BC7F671ED8BDF82D /* CompletionSuggestionServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ECF11669EF253E98AA2977A /* CompletionSuggestionServiceProtocol.swift */; };
-		EAC6FE2CD4F50A43068ADCD8 /* SwiftState in Frameworks */ = {isa = PBXBuildFile; productRef = 9573B94B1C86C6DF751AF3FD /* SwiftState */; };
+		EAC6FE2CD4F50A43068ADCD8 /* PostHog in Frameworks */ = {isa = PBXBuildFile; productRef = 4278261E147DB2DE5CFB7FC5 /* PostHog */; };
 		EAF2B3E6C6AEC4AD3A8BD454 /* RoomMemberDetailsScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A87D0471D438A233C2CF4A /* RoomMemberDetailsScreenViewModel.swift */; };
 		EB87DF90CF6F8D5D12404C6E /* SecureBackupLogoutConfirmationScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848F69921527D31CAACB93AF /* SecureBackupLogoutConfirmationScreenViewModelTests.swift */; };
 		EB88DBD77221E2CFE463018C /* NSE.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 0D8F620C8B314840D8602E3F /* NSE.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -1257,7 +1258,7 @@
 		FBD402E3170EB1ED0D1AA672 /* EncryptionKeyProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2355398E4A55DA5A89128AD1 /* EncryptionKeyProvider.swift */; };
 		FBF09B6C900415800DDF2A21 /* EmojiProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C113E0CB7E15E9765B1817A /* EmojiProvider.swift */; };
 		FC0EEFF630F34899953BB950 /* BigIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01FD1171FF40E34D707FD00 /* BigIcon.swift */; };
-		FC10228E73323BDC09526F97 /* PostHog in Frameworks */ = {isa = PBXBuildFile; productRef = 4278261E147DB2DE5CFB7FC5 /* PostHog */; };
+		FC10228E73323BDC09526F97 /* Mapbox in Frameworks */ = {isa = PBXBuildFile; productRef = C1BF15833233CD3BDB7E2B1D /* Mapbox */; };
 		FC8B95EC506E6BB5793D81CE /* ClientProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E34685D186453E429ADEE58E /* ClientProtocolTests.swift */; };
 		FCD3F2B82CAB29A07887A127 /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = 2B43F2AF7456567FE37270A7 /* KeychainAccess */; };
 		FCDA202B246F75BA28E10C5F /* MapTilerAuthorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = E062C1750EFC8627DE4CAB8E /* MapTilerAuthorization.swift */; };
@@ -2659,22 +2660,23 @@
 				6F2AB43A1EFAD8A97AF41A15 /* Collections in Frameworks */,
 				93BA4A81B6D893271101F9F0 /* DeviceKit in Frameworks */,
 				9AC5F8142413862A9E3A2D98 /* DTCoreText in Frameworks */,
-				CB137BFB3E083C33E398A6CB /* KeychainAccess in Frameworks */,
-				3C549A0BF39F8A854D45D9FD /* Kingfisher in Frameworks */,
-				41DFDD212D1BE57CA50D783B /* KZFileWatchers in Frameworks */,
-				6298AB0906DDD3525CD78C6B /* LoremSwiftum in Frameworks */,
-				407DCE030E0F9B7C9861D38A /* LRUCache in Frameworks */,
-				8F2FAA98457750D9D664136F /* Mapbox in Frameworks */,
-				FC10228E73323BDC09526F97 /* PostHog in Frameworks */,
-				EAC6FE2CD4F50A43068ADCD8 /* SwiftState in Frameworks */,
-				754602A7B2AAD443C4228ED4 /* GZIP in Frameworks */,
-				B0CB16349B96262AA65A04AF /* Sentry in Frameworks */,
-				36AD4DD4C798E22584ED3200 /* SentrySwiftUI in Frameworks */,
-				36CD6E11B37396E14F032CB6 /* Version in Frameworks */,
-				A0D7E5BD0298A97DCBDCE40B /* Emojibase in Frameworks */,
-				44F0E1B576C7599DF8022071 /* WysiwygComposer in Frameworks */,
-				A93661C962B12942C08864B6 /* SwiftOGG in Frameworks */,
-				37E47F5101C0C036289D3807 /* DSWaveformImageViews in Frameworks */,
+				CB137BFB3E083C33E398A6CB /* EmbeddedElementCall in Frameworks */,
+				3C549A0BF39F8A854D45D9FD /* KeychainAccess in Frameworks */,
+				41DFDD212D1BE57CA50D783B /* Kingfisher in Frameworks */,
+				6298AB0906DDD3525CD78C6B /* KZFileWatchers in Frameworks */,
+				407DCE030E0F9B7C9861D38A /* LoremSwiftum in Frameworks */,
+				8F2FAA98457750D9D664136F /* LRUCache in Frameworks */,
+				FC10228E73323BDC09526F97 /* Mapbox in Frameworks */,
+				EAC6FE2CD4F50A43068ADCD8 /* PostHog in Frameworks */,
+				754602A7B2AAD443C4228ED4 /* SwiftState in Frameworks */,
+				B0CB16349B96262AA65A04AF /* GZIP in Frameworks */,
+				36AD4DD4C798E22584ED3200 /* Sentry in Frameworks */,
+				36CD6E11B37396E14F032CB6 /* SentrySwiftUI in Frameworks */,
+				A0D7E5BD0298A97DCBDCE40B /* Version in Frameworks */,
+				44F0E1B576C7599DF8022071 /* Emojibase in Frameworks */,
+				A93661C962B12942C08864B6 /* WysiwygComposer in Frameworks */,
+				37E47F5101C0C036289D3807 /* SwiftOGG in Frameworks */,
+				4610C57A4785FFF5E67F0C6D /* DSWaveformImageViews in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3069,6 +3071,7 @@
 			isa = PBXGroup;
 			children = (
 				01C4C7DB37597D7D8379511A /* Assets.xcassets */,
+				D174C6E7DCA00AAFC0169925 /* ElementCall */,
 				A0C06C0F6A8621B22BFAEB56 /* Localizations */,
 				8AEA6A91159FA0D3EAFCCB0D /* Sounds */,
 			);
@@ -5505,6 +5508,13 @@
 			path = ShareExtension;
 			sourceTree = "<group>";
 		};
+		D174C6E7DCA00AAFC0169925 /* ElementCall */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = ElementCall;
+			sourceTree = "<group>";
+		};
 		D382E465AF067C1BF888BF8E /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -6178,6 +6188,7 @@
 				9C73F37731C9FDED1BB24C1C /* Collections */,
 				A7CA6F33C553805035C3B114 /* DeviceKit */,
 				531CE4334AC5CA8DFF6AEB84 /* DTCoreText */,
+				424B603C07AEA6FCA7C8E7C9 /* EmbeddedElementCall */,
 				020597E28A4BC8E1BE8EDF6E /* KeychainAccess */,
 				0DD568A494247444A4B56031 /* Kingfisher */,
 				81DB3AB6CE996AB3954F4F03 /* KZFileWatchers */,
@@ -6341,6 +6352,7 @@
 				4C34425923978C97409A3EF2 /* XCRemoteSwiftPackageReference "DSWaveformImage" */,
 				C13F55E4518415CB4C278E73 /* XCRemoteSwiftPackageReference "DTCoreText" */,
 				D5F7D47BBAAE0CF1DDEB3034 /* XCRemoteSwiftPackageReference "DeviceKit" */,
+				8213398B60F9B660D9216ADF /* XCRemoteSwiftPackageReference "element-call-swift" */,
 				821C67C9A7F8CC3FD41B28B4 /* XCRemoteSwiftPackageReference "emojibase-bindings" */,
 				701C7BEF8F70F7A83E852DCC /* XCRemoteSwiftPackageReference "GZIP" */,
 				395DE6AE429B7ACC7C7FE31D /* XCRemoteSwiftPackageReference "KZFileWatchers" */,
@@ -8576,6 +8588,14 @@
 				minimumVersion = 1.3.2;
 			};
 		};
+		8213398B60F9B660D9216ADF /* XCRemoteSwiftPackageReference "element-call-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/element-hq/element-call-swift";
+			requirement = {
+				kind = exactVersion;
+				version = "0.9.0-release-test.3";
+			};
+		};
 		821C67C9A7F8CC3FD41B28B4 /* XCRemoteSwiftPackageReference "emojibase-bindings" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/matrix-org/emojibase-bindings";
@@ -8803,6 +8823,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = D5F7D47BBAAE0CF1DDEB3034 /* XCRemoteSwiftPackageReference "DeviceKit" */;
 			productName = DeviceKit;
+		};
+		424B603C07AEA6FCA7C8E7C9 /* EmbeddedElementCall */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8213398B60F9B660D9216ADF /* XCRemoteSwiftPackageReference "element-call-swift" */;
+			productName = EmbeddedElementCall;
 		};
 		4278261E147DB2DE5CFB7FC5 /* PostHog */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -3071,7 +3071,6 @@
 			isa = PBXGroup;
 			children = (
 				01C4C7DB37597D7D8379511A /* Assets.xcassets */,
-				D174C6E7DCA00AAFC0169925 /* ElementCall */,
 				A0C06C0F6A8621B22BFAEB56 /* Localizations */,
 				8AEA6A91159FA0D3EAFCCB0D /* Sounds */,
 			);
@@ -5506,13 +5505,6 @@
 				40D9A816C45E0278C29DF883 /* SupportingFiles */,
 			);
 			path = ShareExtension;
-			sourceTree = "<group>";
-		};
-		D174C6E7DCA00AAFC0169925 /* ElementCall */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = ElementCall;
 			sourceTree = "<group>";
 		};
 		D382E465AF067C1BF888BF8E /* View */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f9011692b20e61e6f0df94b6e0946a4c8f4d58429a88998f249712bb1fee47f1",
+  "originHash" : "cb4b4c28930e04929217c9570b7f82a1dc8e3dc51e3f956f11584dbae9bac079",
   "pins" : [
     {
       "identity" : "compound-design-tokens",
@@ -52,6 +52,15 @@
       "state" : {
         "revision" : "76062513434421cb6c8a1ae1d4f8368a7ebc2da3",
         "version" : "1.7.18"
+      }
+    },
+    {
+      "identity" : "element-call-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/element-hq/element-call-swift",
+      "state" : {
+        "revision" : "de604d1ee0e6c27744f10fa1696e1b48757ae458",
+        "version" : "0.9.0-release-test.3"
       }
     },
     {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/element-call-swift",
       "state" : {
-        "revision" : "de604d1ee0e6c27744f10fa1696e1b48757ae458",
-        "version" : "0.9.0-release-test.3"
+        "revision" : "101bdac7a5f9c53f702065bac7772e9dedb26c62",
+        "version" : "0.9.0-rc.3"
       }
     },
     {

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -5,8 +5,8 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
-#if canImport(EmbeddedWebApp)
-import EmbeddedWebApp
+#if canImport(EmbeddedElementCall)
+import EmbeddedElementCall
 #endif
 
 import Foundation
@@ -272,7 +272,7 @@ final class AppSettings {
     // MARK: - Element Call
     
     // swiftlint:disable:next force_unwrapping
-    let elementCallBaseURL: URL = EmbeddedWebApp.appURL!
+    let elementCallBaseURL: URL = EmbeddedElementCall.appURL!
     
     // These are publicly availble on https://call.element.io so we don't neeed to treat them as secrets
     let elementCallPosthogAPIHost = "https://posthog-element-call.element.io"

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -5,6 +5,10 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+#if canImport(EmbeddedWebApp)
+import EmbeddedWebApp
+#endif
+
 import Foundation
 import SwiftUI
 
@@ -267,7 +271,8 @@ final class AppSettings {
 
     // MARK: - Element Call
     
-    let elementCallBaseURL: URL = "https://call.element.io/room"
+    // swiftlint:disable:next force_unwrapping
+    let elementCallBaseURL: URL = EmbeddedWebApp.appURL!
     
     // These are publicly availble on https://call.element.io so we don't neeed to treat them as secrets
     let elementCallPosthogAPIHost = "https://posthog-element-call.element.io"

--- a/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
@@ -148,8 +148,6 @@ class CallScreenViewModel: CallScreenViewModelType, CallScreenViewModelProtocol 
                 
                 let baseURL = if let elementCallBaseURLOverride {
                     elementCallBaseURLOverride
-                } else if case .success(let wellKnown) = await clientProxy.getElementWellKnown(), let wellKnownCall = wellKnown?.call {
-                    wellKnownCall.widgetURL
                 } else {
                     elementCallBaseURL
                 }

--- a/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
@@ -164,8 +164,7 @@ class CallScreenViewModel: CallScreenViewModelType, CallScreenViewModelProtocol 
                                                 colorScheme: colorScheme,
                                                 analyticsConfiguration: analyticsConfiguration) {
                 case .success(let url):
-                    // TODO: Set back to url, for now we are just testing if the baseURL is able to load, the widget url still defaults to aboutblank
-                    state.url = baseURL
+                    state.url = url
                 case .failure(let error):
                     MXLog.error("Failed starting ElementCall Widget Driver with error: \(error)")
                     state.bindings.alertInfo = .init(id: UUID(),

--- a/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
@@ -164,7 +164,8 @@ class CallScreenViewModel: CallScreenViewModelType, CallScreenViewModelProtocol 
                                                 colorScheme: colorScheme,
                                                 analyticsConfiguration: analyticsConfiguration) {
                 case .success(let url):
-                    state.url = url
+                    // TODO: Set back to url, for now we are just testing if the baseURL is able to load, the widget url still defaults to aboutblank
+                    state.url = baseURL
                 case .failure(let error):
                     MXLog.error("Failed starting ElementCall Widget Driver with error: \(error)")
                     state.bindings.alertInfo = .init(id: UUID(),

--- a/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
+++ b/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
@@ -167,8 +167,8 @@ private struct CallView: UIViewRepresentable {
         // MARK: - WKUIDelegate
         
         func webView(_ webView: WKWebView, decideMediaCapturePermissionsFor origin: WKSecurityOrigin, initiatedBy frame: WKFrameInfo, type: WKMediaCaptureType) async -> WKPermissionDecision {
-            // Don't allow permissions for domains different than what the call was started on
-            guard origin.host == url.host else {
+            // If we are using the local url, we allow the camera and microphone, otherwise we need to verify that the host matches the one from the provided URL.
+            guard url.isFileURL || origin.host == url.host else {
                 return .deny
             }
             

--- a/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
+++ b/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
@@ -167,8 +167,8 @@ private struct CallView: UIViewRepresentable {
         // MARK: - WKUIDelegate
         
         func webView(_ webView: WKWebView, decideMediaCapturePermissionsFor origin: WKSecurityOrigin, initiatedBy frame: WKFrameInfo, type: WKMediaCaptureType) async -> WKPermissionDecision {
-            // If we are using the local url, we allow the camera and microphone, otherwise we need to verify that the host matches the one from the provided URL.
-            guard url.isFileURL || origin.host == url.host else {
+            // Allow if the origin is local, otherwise don't allow permissions for domains different than what the call was started on
+            guard origin.protocol == "file" || origin.host == url.host else {
                 return .deny
             }
             

--- a/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
+++ b/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
@@ -185,12 +185,12 @@ private struct CallView: UIViewRepresentable {
         func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction) async -> WKNavigationActionPolicy {
             if let navigationURL = navigationAction.request.url {
                 // Do not allow navigation to a different URL scheme.
-                if url.scheme != navigationURL.scheme {
+                if navigationURL.scheme != url.scheme {
                     return .cancel
                 }
                 
                 // Allow any content from the main URL.
-                if navigationAction.request.url?.host == url.host {
+                if navigationURL.host == url.host {
                     return .allow
                 }
             }

--- a/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
+++ b/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
@@ -100,6 +100,7 @@ private struct CallView: UIViewRepresentable {
             userContentController.add(WKScriptMessageHandlerWrapper(self), name: viewModelContext.viewState.messageHandler)
             
             configuration.setValue(true, forKey: "allowUniversalAccessFromFileURLs")
+            configuration.preferences.setValue(true, forKey: "allowFileAccessFromFileURLs")
             configuration.userContentController = userContentController
             configuration.allowsInlineMediaPlayback = true
             configuration.allowsPictureInPictureMediaPlayback = true
@@ -135,8 +136,7 @@ private struct CallView: UIViewRepresentable {
         
         func load(_ url: URL) {
             self.url = url
-            let request = URLRequest(url: url)
-            webView.loadFileRequest(request, allowingReadAccessTo: EmbeddedWebApp.bundle.bundleURL)
+            webView.loadFileURL(url, allowingReadAccessTo: EmbeddedWebApp.bundle.bundleURL)
         }
         
         func evaluateJavaScript(_ script: String) async throws -> Any? {

--- a/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
+++ b/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
@@ -7,6 +7,7 @@
 
 import AVKit
 import Combine
+import EmbeddedWebApp
 import SFSafeSymbols
 import SwiftUI
 import WebKit
@@ -98,6 +99,7 @@ private struct CallView: UIViewRepresentable {
             let userContentController = WKUserContentController()
             userContentController.add(WKScriptMessageHandlerWrapper(self), name: viewModelContext.viewState.messageHandler)
             
+            configuration.setValue(true, forKey: "allowUniversalAccessFromFileURLs")
             configuration.userContentController = userContentController
             configuration.allowsInlineMediaPlayback = true
             configuration.allowsPictureInPictureMediaPlayback = true
@@ -134,7 +136,7 @@ private struct CallView: UIViewRepresentable {
         func load(_ url: URL) {
             self.url = url
             let request = URLRequest(url: url)
-            webView.load(request)
+            webView.loadFileRequest(request, allowingReadAccessTo: EmbeddedWebApp.bundle.bundleURL)
         }
         
         func evaluateJavaScript(_ script: String) async throws -> Any? {

--- a/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
+++ b/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
@@ -99,8 +99,7 @@ private struct CallView: UIViewRepresentable {
             let userContentController = WKUserContentController()
             userContentController.add(WKScriptMessageHandlerWrapper(self), name: viewModelContext.viewState.messageHandler)
             
-            // These two lines are required to allow a webview that uses file URL to load its own assets
-            configuration.setValue(true, forKey: "allowUniversalAccessFromFileURLs")
+            // Required to allow a webview that uses file URL to load its own assets
             configuration.preferences.setValue(true, forKey: "allowFileAccessFromFileURLs")
             configuration.userContentController = userContentController
             configuration.allowsInlineMediaPlayback = true

--- a/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
+++ b/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
@@ -136,7 +136,13 @@ private struct CallView: UIViewRepresentable {
         
         func load(_ url: URL) {
             self.url = url
-            webView.loadFileURL(url, allowingReadAccessTo: EmbeddedElementCall.bundle.bundleURL)
+            // The only file URL we allow is the one coming from our own local ElementCall bundle, so it's okay to allow read permission only to our local EC bundle
+            if url.isFileURL {
+                webView.loadFileURL(url, allowingReadAccessTo: EmbeddedElementCall.bundle.bundleURL)
+            } else {
+                let request = URLRequest(url: url)
+                webView.load(request)
+            }
         }
         
         func evaluateJavaScript(_ script: String) async throws -> Any? {

--- a/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
+++ b/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
@@ -7,7 +7,7 @@
 
 import AVKit
 import Combine
-import EmbeddedWebApp
+import EmbeddedElementCall
 import SFSafeSymbols
 import SwiftUI
 import WebKit
@@ -136,7 +136,7 @@ private struct CallView: UIViewRepresentable {
         
         func load(_ url: URL) {
             self.url = url
-            webView.loadFileURL(url, allowingReadAccessTo: EmbeddedWebApp.bundle.bundleURL)
+            webView.loadFileURL(url, allowingReadAccessTo: EmbeddedElementCall.bundle.bundleURL)
         }
         
         func evaluateJavaScript(_ script: String) async throws -> Any? {

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
@@ -73,7 +73,7 @@ struct DeveloperOptionsScreen: View {
             }
 
             Section {
-                TextField(context.viewState.elementCallBaseURL.absoluteString, text: $elementCallURLOverrideString)
+                TextField("Leave empty to use EC locally", text: $elementCallURLOverrideString)
                     .autocorrectionDisabled(true)
                     .autocapitalization(.none)
                     .foregroundColor(URL(string: elementCallURLOverrideString) == nil ? .red : .primary)
@@ -86,11 +86,7 @@ struct DeveloperOptionsScreen: View {
                         }
                     }
             } header: {
-                Text("Element Call")
-            } footer: {
-                if context.elementCallBaseURLOverride == nil {
-                    Text("The call URL may be overridden by your homeserver.")
-                }
+                Text("Element Call remote URL override")
             }
             
             Section {

--- a/ElementX/Sources/Services/Client/ElementWellKnown.swift
+++ b/ElementX/Sources/Services/Client/ElementWellKnown.swift
@@ -9,20 +9,9 @@ import Foundation
 import MatrixRustSDK
 
 struct ElementWellKnown {
-    struct Call {
-        let widgetURL: URL
-        
-        init?(_ wellKnown: MatrixRustSDK.ElementCallWellKnown) {
-            guard let widgetURL = URL(string: wellKnown.widgetUrl) else { return nil }
-            self.widgetURL = widgetURL
-        }
-    }
-    
-    let call: Call?
     let registrationHelperURL: URL?
     
     init?(_ wellKnown: MatrixRustSDK.ElementWellKnown) {
-        call = wellKnown.call.flatMap(Call.init)
         registrationHelperURL = wellKnown.registrationHelperUrl.flatMap(URL.init)
     }
 }

--- a/ElementX/Sources/Services/ElementCall/ElementCallWidgetDriver.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallWidgetDriver.swift
@@ -112,6 +112,7 @@ class ElementCallWidgetDriver: WidgetCapabilitiesProvider, ElementCallWidgetDriv
             return .failure(.failedBuildingCallURL)
         }
         
+        // Required to make the embedded app work with the widget URL
         let correctedUrlString = urlString.replacingOccurrences(of: "/room#", with: "#")
         guard let url = URL(string: correctedUrlString) else {
             return .failure(.failedParsingCallURL)

--- a/ElementX/Sources/Services/ElementCall/ElementCallWidgetDriver.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallWidgetDriver.swift
@@ -112,9 +112,7 @@ class ElementCallWidgetDriver: WidgetCapabilitiesProvider, ElementCallWidgetDriv
             return .failure(.failedBuildingCallURL)
         }
         
-        // Required to make the embedded app work with the widget URL
-        let correctedUrlString = baseURL.isFileURL ? urlString.replacingOccurrences(of: "/room#", with: "#") : urlString
-        guard let url = URL(string: correctedUrlString) else {
+        guard let url = URL(string: urlString) else {
             return .failure(.failedParsingCallURL)
         }
         

--- a/ElementX/Sources/Services/ElementCall/ElementCallWidgetDriver.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallWidgetDriver.swift
@@ -112,7 +112,8 @@ class ElementCallWidgetDriver: WidgetCapabilitiesProvider, ElementCallWidgetDriv
             return .failure(.failedBuildingCallURL)
         }
         
-        guard let url = URL(string: urlString) else {
+        let correctedUrlString = urlString.replacingOccurrences(of: "/room#", with: "#")
+        guard let url = URL(string: correctedUrlString) else {
             return .failure(.failedParsingCallURL)
         }
         

--- a/ElementX/Sources/Services/ElementCall/ElementCallWidgetDriver.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallWidgetDriver.swift
@@ -113,7 +113,7 @@ class ElementCallWidgetDriver: WidgetCapabilitiesProvider, ElementCallWidgetDriv
         }
         
         // Required to make the embedded app work with the widget URL
-        let correctedUrlString = urlString.replacingOccurrences(of: "/room#", with: "#")
+        let correctedUrlString = baseURL.isFileURL ? urlString.replacingOccurrences(of: "/room#", with: "#") : urlString
         guard let url = URL(string: correctedUrlString) else {
             return .failure(.failedParsingCallURL)
         }

--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -214,6 +214,7 @@ targets:
     - package: Collections
     - package: DeviceKit
     - package: DTCoreText
+    - package: EmbeddedWebApp
     - package: KeychainAccess
     - package: Kingfisher
     - package: KZFileWatchers

--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -214,7 +214,7 @@ targets:
     - package: Collections
     - package: DeviceKit
     - package: DTCoreText
-    - package: EmbeddedWebApp
+    - package: EmbeddedElementCall
     - package: KeychainAccess
     - package: Kingfisher
     - package: KZFileWatchers

--- a/project.yml
+++ b/project.yml
@@ -81,6 +81,9 @@ packages:
     url: https://github.com/element-hq/matrix-rich-text-editor-swift
     exactVersion: 2.37.12
     # path: ../matrix-rich-text-editor/platforms/ios/lib/WysiwygComposer
+  EmbeddedElementCall:
+    url: https://github.com/element-hq/element-call-swift
+    exactVersion: 0.9.0-rc.3
   
   # External dependencies
   Algorithms:
@@ -134,9 +137,6 @@ packages:
   Version:
     url: https://github.com/mxcl/Version
     minorVersion: 2.1.0
-  EmbeddedElementCall:
-    url: https://github.com/element-hq/element-call-swift
-    exactVersion: 0.9.0-rc.3
 
 aggregateTargets:
   Periphery:

--- a/project.yml
+++ b/project.yml
@@ -136,7 +136,7 @@ packages:
     minorVersion: 2.1.0
   EmbeddedElementCall:
     url: https://github.com/element-hq/element-call-swift
-    exactVersion: 0.9.0-release-test.3
+    exactVersion: 0.9.0-rc.3
 
 aggregateTargets:
   Periphery:

--- a/project.yml
+++ b/project.yml
@@ -136,7 +136,7 @@ packages:
     minorVersion: 2.1.0
   EmbeddedElementCall:
     url: https://github.com/element-hq/element-call-swift
-    exactVersion: 1.1.37-rc.0
+    exactVersion: 1.1.37-rc.1
 
 aggregateTargets:
   Periphery:

--- a/project.yml
+++ b/project.yml
@@ -137,7 +137,7 @@ packages:
   EmbeddedWebApp:
     url: https://github.com/Velin92/EmbeddedWebApp
     branch: main
-    revision: 77d8a4fdd75e4baf75931c1a456bb8e9ec8c61ef
+    revision: 1e6918acc44ee6609d9070a07a2e358d81d788fe
 
 aggregateTargets:
   Periphery:

--- a/project.yml
+++ b/project.yml
@@ -136,7 +136,7 @@ packages:
     minorVersion: 2.1.0
   EmbeddedElementCall:
     url: https://github.com/element-hq/element-call-swift
-    exactVersion: 1.1.35
+    exactVersion: 1.1.37-rc.0
 
 aggregateTargets:
   Periphery:

--- a/project.yml
+++ b/project.yml
@@ -136,7 +136,7 @@ packages:
     minorVersion: 2.1.0
   EmbeddedElementCall:
     url: https://github.com/element-hq/element-call-swift
-    exactVersion: 1.1.37-rc.1
+    exactVersion: 1.1.39
 
 aggregateTargets:
   Periphery:

--- a/project.yml
+++ b/project.yml
@@ -134,6 +134,10 @@ packages:
   Version:
     url: https://github.com/mxcl/Version
     minorVersion: 2.1.0
+  EmbeddedWebApp:
+    url: https://github.com/Velin92/EmbeddedWebApp
+    branch: main
+    revision: 77d8a4fdd75e4baf75931c1a456bb8e9ec8c61ef
 
 aggregateTargets:
   Periphery:

--- a/project.yml
+++ b/project.yml
@@ -136,7 +136,7 @@ packages:
     minorVersion: 2.1.0
   EmbeddedElementCall:
     url: https://github.com/element-hq/element-call-swift
-    exactVersion: 1.1.39
+    exactVersion: 0.9.0-release-test.3
 
 aggregateTargets:
   Periphery:

--- a/project.yml
+++ b/project.yml
@@ -134,10 +134,9 @@ packages:
   Version:
     url: https://github.com/mxcl/Version
     minorVersion: 2.1.0
-  EmbeddedWebApp:
-    url: https://github.com/Velin92/EmbeddedWebApp
-    branch: main
-    revision: 1e6918acc44ee6609d9070a07a2e358d81d788fe
+  EmbeddedElementCall:
+    url: https://github.com/element-hq/element-call-swift
+    exactVersion: 1.1.35
 
 aggregateTargets:
   Periphery:


### PR DESCRIPTION
This PR includes a new Swift package that embeds element call into the app for security reasons. It's still however possible to override the file URL, with a custom URL to test out a remote implementation of EC through the developer options.
