### PR TITLE
feat(notifications): add toggle to show group chat start as incoming …

### DIFF
--- a/ElementX/Resources/Localizations/en.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Localizable.strings
@@ -708,6 +708,7 @@
 "screen_notification_settings_failed_fixing_configuration" = "The configuration has not been corrected, please try again.";
 "screen_notification_settings_group_chats" = "Group chats";
 "screen_notification_settings_invite_for_me_label" = "Invitations";
+"screen_notification_settings_ring_for_group_calls_label" = "Ring for group calls";
 "screen_notification_settings_mentions_only_disclaimer" = "Your homeserver does not support this option in encrypted rooms, you may not get notified in some rooms.";
 "screen_notification_settings_mode_all" = "All";
 "screen_notification_settings_mode_mentions" = "Mentions";

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -20,6 +20,7 @@ protocol CommonSettingsProtocol {
     var hideInviteAvatars: Bool { get }
     var hideTimelineMedia: Bool { get }
     var eventCacheEnabled: Bool { get }
+    var ringForGroupCallsEnabled: Bool { get }
 }
 
 /// Store Element specific app settings.
@@ -58,6 +59,7 @@ final class AppSettings {
         case enableOnlySignedDeviceIsolationMode
         case knockingEnabled
         case eventCacheEnabledV2
+        case ringForGroupCallsEnabled
     }
     
     private static var suiteName: String = InfoPlistReader.main.appGroupIdentifier
@@ -335,6 +337,9 @@ final class AppSettings {
     
     @UserPreference(key: UserDefaultsKeys.eventCacheEnabledV2, defaultValue: true, storageType: .userDefaults(store))
     var eventCacheEnabled
+    
+    @UserPreference(key: UserDefaultsKeys.ringForGroupCallsEnabled, defaultValue: false, storageType: .userDefaults(store))
+    var ringForGroupCallsEnabled
 }
 
 extension AppSettings: CommonSettingsProtocol { }

--- a/ElementX/Sources/Generated/Strings.swift
+++ b/ElementX/Sources/Generated/Strings.swift
@@ -1588,6 +1588,8 @@ internal enum L10n {
   internal static var screenNotificationSettingsModeMentions: String { return L10n.tr("Localizable", "screen_notification_settings_mode_mentions") }
   /// Notify me for
   internal static var screenNotificationSettingsNotificationSectionTitle: String { return L10n.tr("Localizable", "screen_notification_settings_notification_section_title") }
+  /// Ring for group calls
+  internal static var screenNotificationSettingsRingForGroupCallsLabel: String { return L10n.tr("Localizable", "screen_notification_settings_ring_for_group_calls_label") }
   /// Notify me on @room
   internal static var screenNotificationSettingsRoomMentionLabel: String { return L10n.tr("Localizable", "screen_notification_settings_room_mention_label") }
   /// To receive notifications, please change your %1$@.

--- a/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenModels.swift
@@ -35,6 +35,7 @@ struct NotificationSettingsScreenViewStateBindings {
     var roomMentionsEnabled = false
     var callsEnabled = false
     var invitationsEnabled = false
+    var ringForGroupCallsEnabled = false
     var alertInfo: AlertInfo<NotificationSettingsScreenErrorType>?
 }
 
@@ -44,6 +45,7 @@ struct NotificationSettingsScreenSettings {
     let roomMentionsEnabled: Bool?
     let callsEnabled: Bool?
     let invitationsEnabled: Bool?
+    let ringForGroupCallsEnabled: Bool?
     // Old clients were having specific settings for encrypted and unencrypted rooms,
     // so it's possible for `group chats` and `direct chats` settings to be inconsistent (e.g. encrypted `direct chats` can have a different mode that unencrypted `direct chats`)
     let inconsistentSettings: [NotificationSettingsScreenInvalidSetting]
@@ -86,6 +88,7 @@ enum NotificationSettingsScreenViewAction {
     case roomMentionChanged
     case callsChanged
     case invitationsChanged
+    case ringForGroupCallsChanged
     case close
     case fixConfigurationMismatchTapped
 }

--- a/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenViewModel.swift
@@ -35,6 +35,10 @@ class NotificationSettingsScreenViewModel: NotificationSettingsScreenViewModelTy
             .weakAssign(to: \.state.bindings.enableNotifications, on: self)
             .store(in: &cancellables)
         
+        appSettings.$ringForGroupCallsEnabled
+            .weakAssign(to: \.state.bindings.ringForGroupCallsEnabled, on: self)
+            .store(in: &cancellables)
+
         setupDidBecomeActiveSubscription()
         setupNotificationSettingsSubscription()
     }
@@ -68,6 +72,8 @@ class NotificationSettingsScreenViewModel: NotificationSettingsScreenViewModelTy
                 return
             }
             Task { await enableInvitations(state.bindings.invitationsEnabled) }
+        case .ringForGroupCallsChanged:
+            appSettings.ringForGroupCallsEnabled.toggle()
         case .close:
             actionsSubject.send(.close)
         case .fixConfigurationMismatchTapped:
@@ -150,12 +156,14 @@ class NotificationSettingsScreenViewModel: NotificationSettingsScreenViewModelTy
                                                                           roomMentionsEnabled: roomMentionsEnabled,
                                                                           callsEnabled: callEnabled,
                                                                           invitationsEnabled: invitationsEnabled,
+                                                                          ringForGroupCallsEnabled: appSettings.ringForGroupCallsEnabled,
                                                                           inconsistentSettings: inconsistentSettings)
 
             state.settings = notificationSettings
             state.bindings.roomMentionsEnabled = notificationSettings.roomMentionsEnabled ?? false
             state.bindings.callsEnabled = notificationSettings.callsEnabled ?? false
             state.bindings.invitationsEnabled = notificationSettings.invitationsEnabled ?? false
+            state.bindings.ringForGroupCallsEnabled = notificationSettings.ringForGroupCallsEnabled ?? false
         }
     }
     

--- a/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/View/NotificationSettingsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/View/NotificationSettingsScreen.swift
@@ -33,7 +33,8 @@ struct NotificationSettingsScreen: View {
                         callsSection
                     }
                     
-                    if context.viewState.settings?.invitationsEnabled != nil {
+                    if context.viewState.settings?.invitationsEnabled != nil ||
+                       context.viewState.settings?.ringForGroupCallsEnabled != nil {
                         additionalSettingsSection
                     }
                 }
@@ -154,12 +155,22 @@ struct NotificationSettingsScreen: View {
     
     private var additionalSettingsSection: some View {
         Section {
+            // Invitations
             ListRow(label: .plain(title: L10n.screenNotificationSettingsInviteForMeLabel),
                     kind: .toggle($context.invitationsEnabled))
                 .disabled(context.viewState.settings?.invitationsEnabled == nil)
                 .allowsHitTesting(!context.viewState.applyingChange)
                 .onChange(of: context.invitationsEnabled) {
                     context.send(viewAction: .invitationsChanged)
+                }
+
+            // CallKit for group incoming calls
+            ListRow(label: .plain(title: L10n.screenNotificationSettingsRingForGroupCallsLabel),
+                    kind: .toggle($context.ringForGroupCallsEnabled))
+                .disabled(context.viewState.settings?.ringForGroupCallsEnabled == nil)
+                .allowsHitTesting(!context.viewState.applyingChange)
+                .onChange(of: context.ringForGroupCallsEnabled) {
+                    context.send(viewAction: .ringForGroupCallsChanged)
                 }
         } header: {
             Text(L10n.screenNotificationSettingsAdditionalSettingsSectionTitle)

--- a/NSE/Sources/NotificationServiceExtension.swift
+++ b/NSE/Sources/NotificationServiceExtension.swift
@@ -254,7 +254,8 @@ class NotificationServiceExtension: UNNotificationServiceExtension {
                 
                 return .processedShouldDiscard
             case .callNotify(let notifyType):
-                return await handleCallNotification(notifyType: notifyType,
+                let notificationType = settings.ringForGroupCallsEnabled ? .ring : notifyType
+                return await handleCallNotification(notifyType: notificationType,
                                                     timestamp: event.timestamp(),
                                                     roomID: itemProxy.roomID,
                                                     roomDisplayName: itemProxy.roomDisplayName)


### PR DESCRIPTION
…call

- Added a new toggle in NotificationSettings to display group chat start notifications as incoming calls
- Updated notification handling logic to respect the new setting
- Added localization keys for the toggle label

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).

**UI changes have been tested with:**
- [x] iPhone and iPad simulators in portrait and landscape orientations.
- [x] Dark mode enabled and disabled.
- [x] Various sizes of dynamic type.
- [x] Voiceover enabled.

Signed-off-by: [hek4ek@gmail.com](mailto:hek4ek@gmail.com)

Enhancement  for: https://github.com/element-hq/element-meta/issues/2429