### PR TITLE
Make the secrets optional.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,3 @@ build
 ## macOS Files
 .DS_Store
 ._*
-
-# This is a temporary file that is used to generate Secrets.swift
-# That file doesn't need to be ignored, as it we assumed-unchanged it post-checkout.
-Secrets/secrets.yml

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -17,6 +17,7 @@ included:
 excluded:
   - "*/Sources/Generated/*"
   - Tools/Sources # Our command-line tools use a lot of print commands.
+  - Secrets
 
 line_length:
   warning: 250

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -223,8 +223,8 @@ final class AppSettings {
         
     // MARK: - Bug report
 
-    let bugReportServiceBaseURL: URL? = URL(string: Secrets.rageshakeServerURL)! // swiftlint:disable:this force_unwrapping
-    let bugReportSentryURL: URL? = URL(string: Secrets.sentryDSN)! // swiftlint:disable:this force_unwrapping
+    let bugReportServiceBaseURL: URL? = Secrets.rageshakeServerURL.map { URL(string: $0)! } // swiftlint:disable:this force_unwrapping
+    let bugReportSentryURL: URL? = Secrets.sentryDSN.map { URL(string: $0)! } // swiftlint:disable:this force_unwrapping
     /// The name allocated by the bug report server
     let bugReportApplicationID = "element-x-ios"
     /// The maximum size of the upload request. Default value is just below CloudFlare's max request size.
@@ -233,11 +233,16 @@ final class AppSettings {
     // MARK: - Analytics
     
     /// The configuration to use for analytics. Set to `nil` to disable analytics.
-    let analyticsConfiguration: AnalyticsConfiguration? = AnalyticsConfiguration(host: Secrets.postHogHost, apiKey: Secrets.postHogAPIKey)
+    let analyticsConfiguration: AnalyticsConfiguration? = AppSettings.makeAnalyticsConfiguration()
     /// The URL to open with more information about analytics terms. When this is `nil` the "Learn more" link will be hidden.
     private(set) var analyticsTermsURL: URL? = "https://element.io/cookie-policy"
     /// Whether or not there the app is able ask for user consent to enable analytics or sentry reporting.
     var canPromptForAnalytics: Bool { analyticsConfiguration != nil || bugReportSentryURL != nil }
+    
+    private static func makeAnalyticsConfiguration() -> AnalyticsConfiguration? {
+        guard let host = Secrets.postHogHost, let apiKey = Secrets.postHogAPIKey else { return nil }
+        return AnalyticsConfiguration(host: host, apiKey: apiKey)
+    }
     
     /// Whether the user has opted in to send analytics.
     @UserPreference(key: UserDefaultsKeys.analyticsConsentState, defaultValue: AnalyticsConsentState.unknown, storageType: .userDefaults(store))

--- a/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
@@ -159,7 +159,7 @@ class CallScreenViewModel: CallScreenViewModelType, CallScreenViewModelProtocol 
                 switch await widgetDriver.start(baseURL: baseURL,
                                                 clientID: clientID,
                                                 colorScheme: colorScheme,
-                                                rageshakeURL: Secrets.rageshakeServerURL,
+                                                rageshakeURL: appSettings.bugReportServiceBaseURL?.absoluteString,
                                                 analyticsConfiguration: analyticsConfiguration) {
                 case .success(let url):
                     state.url = url

--- a/Secrets/Secrets.pkl
+++ b/Secrets/Secrets.pkl
@@ -7,11 +7,17 @@
 
 // Analytics and Diagnostics
 
-sentryDSN = read("env:SENTRY_DSN")
-postHogHost = read("env:POSTHOG_HOST")
-postHogAPIKey = read("env:POSTHOG_API_KEY")
-rageshakeServerURL = read("env:RAGESHAKE_SERVER_URL")
+import "package://pkg.pkl-lang.org/github.com/element-hq/pkl-tools/staticcode@1.0.0#/StaticCode.pkl"
 
-// Maps
+sentryDSN: String? = read?("env:SENTRY_DSN")
+postHogHost: String? = read?("env:POSTHOG_HOST")
+postHogAPIKey: String? = read?("env:POSTHOG_API_KEY")
+rageshakeServerURL: String? = read?("env:RAGESHAKE_SERVER_URL")
+mapLibreAPIKey: String? = read?("env:MAPLIBRE_API_KEY")
 
-mapLibreAPIKey = read("env:MAPLIBRE_API_KEY")
+output {
+  renderer = new StaticCode.Renderer {
+    language = "Swift"
+    objectName = "Secrets"
+  }
+}

--- a/Secrets/Secrets.swift
+++ b/Secrets/Secrets.swift
@@ -1,19 +1,8 @@
-// swiftlint:disable all
-// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+enum Secrets {
+    static let sentryDSN: String? = "https://sentry.localhost"
+    static let postHogHost: String? = "https://posthog.localhost"
+    static let postHogAPIKey: String? = "your_key"
+    static let rageshakeServerURL: String? = "https://rageshake.localhost"
+    static let mapLibreAPIKey: String? = "your_key"
 
-import Foundation
-
-// swiftlint:disable superfluous_disable_command
-// swiftlint:disable file_length
-
-// MARK: - YAML Files
-
-// swiftlint:disable identifier_name line_length number_separator type_body_length
-internal enum Secrets {
-  internal static let mapLibreAPIKey: String = "your_key"
-  internal static let postHogAPIKey: String = "your_key"
-  internal static let postHogHost: String = "https://posthog.localhost"
-  internal static let rageshakeServerURL: String = "https://rageshake.localhost"
-  internal static let sentryDSN: String = "https://sentry.localhost"
 }
-// swiftlint:enable identifier_name line_length number_separator type_body_length

--- a/ci_scripts/ci_common.sh
+++ b/ci_scripts/ci_common.sh
@@ -30,14 +30,14 @@ setup_xcode_cloud_environment () {
 }
 
 install_xcode_cloud_brew_dependencies () {
-    brew update && brew install xcodegen swiftgen pkl
+    brew update && brew install xcodegen pkl
 }
 
 setup_github_actions_environment() {
     unset HOMEBREW_NO_INSTALL_FROM_API
     export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
     
-    brew update && brew install xcodegen swiftlint swiftformat swiftgen git-lfs pkl a7ex/homebrew-formulae/xcresultparser
+    brew update && brew install xcodegen swiftlint swiftformat git-lfs pkl a7ex/homebrew-formulae/xcresultparser
 
     bundle config path vendor/bundle
     bundle install --jobs 4 --retry 3

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -429,7 +429,6 @@ end
 
 lane :config_secrets do
   Dir.chdir "../Secrets" do
-    sh("pkl eval -f yaml -o secrets.yml Secrets.pkl")
-    sh("swiftgen run yaml -n inline-swift5 --param enumName=Secrets -o Secrets.swift secrets.yml")
+    sh("pkl eval -o Secrets.swift Secrets.pkl")
   end
 end


### PR DESCRIPTION
Following on from #3961, this PR goes ahead and makes all of the secrets optional by:
- Using Pkl's optional `read?` method to allow null environment values.
- Using our [StaticCode](https://github.com/element-hq/pkl-tools/releases/tag/staticcode%401.0.0) Pkl renderer to skip the SwiftGen YAML step so that the secrets are properly typed as `String?`.