### PR TITLE
Add the push gateway to settings overrides and remove the endpoint path from it.

### DIFF
--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -92,6 +92,7 @@ final class AppSettings {
     
     // swiftlint:disable:next function_parameter_count
     func override(defaultHomeserverAddress: String,
+                  pushGatewayBaseURL: URL,
                   oidcRedirectURL: URL,
                   websiteURL: URL,
                   logoURL: URL,
@@ -103,6 +104,7 @@ final class AppSettings {
                   analyticsTermsURL: URL?,
                   mapTilerConfiguration: MapTilerConfiguration) {
         self.defaultHomeserverAddress = defaultHomeserverAddress
+        self.pushGatewayBaseURL = pushGatewayBaseURL
         self.oidcRedirectURL = oidcRedirectURL
         self.websiteURL = websiteURL
         self.logoURL = logoURL
@@ -206,7 +208,7 @@ final class AppSettings {
     
     // MARK: - Notifications
     
-    var pusherAppId: String {
+    var pusherAppID: String {
         #if DEBUG
         InfoPlistReader.main.baseBundleIdentifier + ".ios.dev"
         #else
@@ -214,7 +216,8 @@ final class AppSettings {
         #endif
     }
     
-    let pushGatewayBaseURL: URL = "https://matrix.org/_matrix/push/v1/notify"
+    private(set) var pushGatewayBaseURL: URL = "https://matrix.org"
+    var pushGatewayNotifyEndpoint: URL { pushGatewayBaseURL.appending(path: "_matrix/push/v1/notify") }
     
     @UserPreference(key: UserDefaultsKeys.enableNotifications, defaultValue: true, storageType: .userDefaults(store))
     var enableNotifications

--- a/ElementX/Sources/Services/Notification/Manager/NotificationManager.swift
+++ b/ElementX/Sources/Services/Notification/Manager/NotificationManager.swift
@@ -145,8 +145,8 @@ final class NotificationManager: NSObject, NotificationManagerProtocol {
                                              pusherNotificationClientIdentifier: clientProxy.pusherNotificationClientIdentifier)
 
             let configuration = try await PusherConfiguration(identifiers: .init(pushkey: deviceToken.base64EncodedString(),
-                                                                                 appId: appSettings.pusherAppId),
-                                                              kind: .http(data: .init(url: appSettings.pushGatewayBaseURL.absoluteString,
+                                                                                 appId: appSettings.pusherAppID),
+                                                              kind: .http(data: .init(url: appSettings.pushGatewayNotifyEndpoint.absoluteString,
                                                                                       format: .eventIdOnly,
                                                                                       defaultPayload: defaultPayload.toJsonString())),
                                                               appDisplayName: "\(InfoPlistReader.main.bundleDisplayName) (iOS)",

--- a/UnitTests/Sources/NotificationManager/NotificationManagerTests.swift
+++ b/UnitTests/Sources/NotificationManager/NotificationManagerTests.swift
@@ -73,7 +73,7 @@ final class NotificationManagerTests: XCTestCase {
         }
         
         XCTAssertEqual(configuration.identifiers.pushkey, pushkeyData.base64EncodedString())
-        XCTAssertEqual(configuration.identifiers.appId, appSettings.pusherAppId)
+        XCTAssertEqual(configuration.identifiers.appId, appSettings.pusherAppID)
         XCTAssertEqual(configuration.appDisplayName, "\(InfoPlistReader.main.bundleDisplayName) (iOS)")
         XCTAssertEqual(configuration.deviceDisplayName, UIDevice.current.name)
         XCTAssertNotNil(configuration.profileTag)
@@ -82,7 +82,7 @@ final class NotificationManagerTests: XCTestCase {
             XCTFail("Http kind expected")
             return
         }
-        XCTAssertEqual(data.url, appSettings.pushGatewayBaseURL.absoluteString)
+        XCTAssertEqual(data.url, appSettings.pushGatewayNotifyEndpoint.absoluteString)
         XCTAssertEqual(data.format, .eventIdOnly)
         let defaultPayload = APNSPayload(aps: APSInfo(mutableContent: 1,
                                                       alert: APSAlert(locKey: "Notification",


### PR DESCRIPTION
This PR makes 2 changes:
- Make the `pushGatewayBaseURL` overridable in app settings.
- Remove the endpoint path from it, introducing a new `pushGatewayNotifyEndpoint` URL.

Also updates the Enterprise submodule, please also check the diff on that 🙏