### PR TITLE
Load single rooms in the notification service extension

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -8549,7 +8549,7 @@
 			repositoryURL = "https://github.com/element-hq/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 25.03.31;
+				version = 25.04.02;
 			};
 		};
 		701C7BEF8F70F7A83E852DCC /* XCRemoteSwiftPackageReference "GZIP" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/matrix-rust-components-swift",
       "state" : {
-        "revision" : "271f8e34dd754ff6873350576d601442fe18b1d8",
-        "version" : "25.3.31"
+        "revision" : "1bc2c0b021107332e0691e288780e8a3adb87905",
+        "version" : "25.4.2"
       }
     },
     {

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -19,7 +19,6 @@ protocol CommonSettingsProtocol {
     var enableOnlySignedDeviceIsolationMode: Bool { get }
     var hideInviteAvatars: Bool { get }
     var hideTimelineMedia: Bool { get }
-    var eventCacheEnabled: Bool { get }
 }
 
 /// Store Element specific app settings.
@@ -57,7 +56,6 @@ final class AppSettings {
         case fuzzyRoomListSearchEnabled
         case enableOnlySignedDeviceIsolationMode
         case knockingEnabled
-        case eventCacheEnabledV2
     }
     
     private static var suiteName: String = InfoPlistReader.main.appGroupIdentifier
@@ -340,9 +338,6 @@ final class AppSettings {
     
     @UserPreference(key: UserDefaultsKeys.hideTimelineMedia, defaultValue: false, storageType: .userDefaults(store))
     var hideTimelineMedia
-    
-    @UserPreference(key: UserDefaultsKeys.eventCacheEnabledV2, defaultValue: true, storageType: .userDefaults(store))
-    var eventCacheEnabled
 }
 
 extension AppSettings: CommonSettingsProtocol { }

--- a/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
@@ -2927,6 +2927,52 @@ open class ClientSDKMock: MatrixRustSDK.Client, @unchecked Sendable {
         try await restoreSessionSessionClosure?(session)
     }
 
+    //MARK: - restoreSessionWith
+
+    open var restoreSessionWithSessionRoomLoadSettingsThrowableError: Error?
+    var restoreSessionWithSessionRoomLoadSettingsUnderlyingCallsCount = 0
+    open var restoreSessionWithSessionRoomLoadSettingsCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return restoreSessionWithSessionRoomLoadSettingsUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = restoreSessionWithSessionRoomLoadSettingsUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                restoreSessionWithSessionRoomLoadSettingsUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    restoreSessionWithSessionRoomLoadSettingsUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var restoreSessionWithSessionRoomLoadSettingsCalled: Bool {
+        return restoreSessionWithSessionRoomLoadSettingsCallsCount > 0
+    }
+    open var restoreSessionWithSessionRoomLoadSettingsReceivedArguments: (session: Session, roomLoadSettings: RoomLoadSettings)?
+    open var restoreSessionWithSessionRoomLoadSettingsReceivedInvocations: [(session: Session, roomLoadSettings: RoomLoadSettings)] = []
+    open var restoreSessionWithSessionRoomLoadSettingsClosure: ((Session, RoomLoadSettings) async throws -> Void)?
+
+    open override func restoreSessionWith(session: Session, roomLoadSettings: RoomLoadSettings) async throws {
+        if let error = restoreSessionWithSessionRoomLoadSettingsThrowableError {
+            throw error
+        }
+        restoreSessionWithSessionRoomLoadSettingsCallsCount += 1
+        restoreSessionWithSessionRoomLoadSettingsReceivedArguments = (session: session, roomLoadSettings: roomLoadSettings)
+        DispatchQueue.main.async {
+            self.restoreSessionWithSessionRoomLoadSettingsReceivedInvocations.append((session: session, roomLoadSettings: roomLoadSettings))
+        }
+        try await restoreSessionWithSessionRoomLoadSettingsClosure?(session, roomLoadSettings)
+    }
+
     //MARK: - roomAliasExists
 
     open var roomAliasExistsRoomAliasThrowableError: Error?
@@ -5210,77 +5256,6 @@ open class ClientBuilderSDKMock: MatrixRustSDK.ClientBuilder, @unchecked Sendabl
         }
     }
 
-    //MARK: - passphrase
-
-    var passphrasePassphraseUnderlyingCallsCount = 0
-    open var passphrasePassphraseCallsCount: Int {
-        get {
-            if Thread.isMainThread {
-                return passphrasePassphraseUnderlyingCallsCount
-            } else {
-                var returnValue: Int? = nil
-                DispatchQueue.main.sync {
-                    returnValue = passphrasePassphraseUnderlyingCallsCount
-                }
-
-                return returnValue!
-            }
-        }
-        set {
-            if Thread.isMainThread {
-                passphrasePassphraseUnderlyingCallsCount = newValue
-            } else {
-                DispatchQueue.main.sync {
-                    passphrasePassphraseUnderlyingCallsCount = newValue
-                }
-            }
-        }
-    }
-    open var passphrasePassphraseCalled: Bool {
-        return passphrasePassphraseCallsCount > 0
-    }
-    open var passphrasePassphraseReceivedPassphrase: String?
-    open var passphrasePassphraseReceivedInvocations: [String?] = []
-
-    var passphrasePassphraseUnderlyingReturnValue: ClientBuilder!
-    open var passphrasePassphraseReturnValue: ClientBuilder! {
-        get {
-            if Thread.isMainThread {
-                return passphrasePassphraseUnderlyingReturnValue
-            } else {
-                var returnValue: ClientBuilder? = nil
-                DispatchQueue.main.sync {
-                    returnValue = passphrasePassphraseUnderlyingReturnValue
-                }
-
-                return returnValue!
-            }
-        }
-        set {
-            if Thread.isMainThread {
-                passphrasePassphraseUnderlyingReturnValue = newValue
-            } else {
-                DispatchQueue.main.sync {
-                    passphrasePassphraseUnderlyingReturnValue = newValue
-                }
-            }
-        }
-    }
-    open var passphrasePassphraseClosure: ((String?) -> ClientBuilder)?
-
-    open override func passphrase(passphrase: String?) -> ClientBuilder {
-        passphrasePassphraseCallsCount += 1
-        passphrasePassphraseReceivedPassphrase = passphrase
-        DispatchQueue.main.async {
-            self.passphrasePassphraseReceivedInvocations.append(passphrase)
-        }
-        if let passphrasePassphraseClosure = passphrasePassphraseClosure {
-            return passphrasePassphraseClosure(passphrase)
-        } else {
-            return passphrasePassphraseReturnValue
-        }
-    }
-
     //MARK: - proxy
 
     var proxyUrlUnderlyingCallsCount = 0
@@ -5707,6 +5682,219 @@ open class ClientBuilderSDKMock: MatrixRustSDK.ClientBuilder, @unchecked Sendabl
         }
     }
 
+    //MARK: - sessionCacheSize
+
+    var sessionCacheSizeCacheSizeUnderlyingCallsCount = 0
+    open var sessionCacheSizeCacheSizeCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return sessionCacheSizeCacheSizeUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = sessionCacheSizeCacheSizeUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                sessionCacheSizeCacheSizeUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    sessionCacheSizeCacheSizeUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var sessionCacheSizeCacheSizeCalled: Bool {
+        return sessionCacheSizeCacheSizeCallsCount > 0
+    }
+    open var sessionCacheSizeCacheSizeReceivedCacheSize: UInt32?
+    open var sessionCacheSizeCacheSizeReceivedInvocations: [UInt32?] = []
+
+    var sessionCacheSizeCacheSizeUnderlyingReturnValue: ClientBuilder!
+    open var sessionCacheSizeCacheSizeReturnValue: ClientBuilder! {
+        get {
+            if Thread.isMainThread {
+                return sessionCacheSizeCacheSizeUnderlyingReturnValue
+            } else {
+                var returnValue: ClientBuilder? = nil
+                DispatchQueue.main.sync {
+                    returnValue = sessionCacheSizeCacheSizeUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                sessionCacheSizeCacheSizeUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    sessionCacheSizeCacheSizeUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    open var sessionCacheSizeCacheSizeClosure: ((UInt32?) -> ClientBuilder)?
+
+    open override func sessionCacheSize(cacheSize: UInt32?) -> ClientBuilder {
+        sessionCacheSizeCacheSizeCallsCount += 1
+        sessionCacheSizeCacheSizeReceivedCacheSize = cacheSize
+        DispatchQueue.main.async {
+            self.sessionCacheSizeCacheSizeReceivedInvocations.append(cacheSize)
+        }
+        if let sessionCacheSizeCacheSizeClosure = sessionCacheSizeCacheSizeClosure {
+            return sessionCacheSizeCacheSizeClosure(cacheSize)
+        } else {
+            return sessionCacheSizeCacheSizeReturnValue
+        }
+    }
+
+    //MARK: - sessionJournalSizeLimit
+
+    var sessionJournalSizeLimitLimitUnderlyingCallsCount = 0
+    open var sessionJournalSizeLimitLimitCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return sessionJournalSizeLimitLimitUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = sessionJournalSizeLimitLimitUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                sessionJournalSizeLimitLimitUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    sessionJournalSizeLimitLimitUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var sessionJournalSizeLimitLimitCalled: Bool {
+        return sessionJournalSizeLimitLimitCallsCount > 0
+    }
+    open var sessionJournalSizeLimitLimitReceivedLimit: UInt32?
+    open var sessionJournalSizeLimitLimitReceivedInvocations: [UInt32?] = []
+
+    var sessionJournalSizeLimitLimitUnderlyingReturnValue: ClientBuilder!
+    open var sessionJournalSizeLimitLimitReturnValue: ClientBuilder! {
+        get {
+            if Thread.isMainThread {
+                return sessionJournalSizeLimitLimitUnderlyingReturnValue
+            } else {
+                var returnValue: ClientBuilder? = nil
+                DispatchQueue.main.sync {
+                    returnValue = sessionJournalSizeLimitLimitUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                sessionJournalSizeLimitLimitUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    sessionJournalSizeLimitLimitUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    open var sessionJournalSizeLimitLimitClosure: ((UInt32?) -> ClientBuilder)?
+
+    open override func sessionJournalSizeLimit(limit: UInt32?) -> ClientBuilder {
+        sessionJournalSizeLimitLimitCallsCount += 1
+        sessionJournalSizeLimitLimitReceivedLimit = limit
+        DispatchQueue.main.async {
+            self.sessionJournalSizeLimitLimitReceivedInvocations.append(limit)
+        }
+        if let sessionJournalSizeLimitLimitClosure = sessionJournalSizeLimitLimitClosure {
+            return sessionJournalSizeLimitLimitClosure(limit)
+        } else {
+            return sessionJournalSizeLimitLimitReturnValue
+        }
+    }
+
+    //MARK: - sessionPassphrase
+
+    var sessionPassphrasePassphraseUnderlyingCallsCount = 0
+    open var sessionPassphrasePassphraseCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return sessionPassphrasePassphraseUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = sessionPassphrasePassphraseUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                sessionPassphrasePassphraseUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    sessionPassphrasePassphraseUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var sessionPassphrasePassphraseCalled: Bool {
+        return sessionPassphrasePassphraseCallsCount > 0
+    }
+    open var sessionPassphrasePassphraseReceivedPassphrase: String?
+    open var sessionPassphrasePassphraseReceivedInvocations: [String?] = []
+
+    var sessionPassphrasePassphraseUnderlyingReturnValue: ClientBuilder!
+    open var sessionPassphrasePassphraseReturnValue: ClientBuilder! {
+        get {
+            if Thread.isMainThread {
+                return sessionPassphrasePassphraseUnderlyingReturnValue
+            } else {
+                var returnValue: ClientBuilder? = nil
+                DispatchQueue.main.sync {
+                    returnValue = sessionPassphrasePassphraseUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                sessionPassphrasePassphraseUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    sessionPassphrasePassphraseUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    open var sessionPassphrasePassphraseClosure: ((String?) -> ClientBuilder)?
+
+    open override func sessionPassphrase(passphrase: String?) -> ClientBuilder {
+        sessionPassphrasePassphraseCallsCount += 1
+        sessionPassphrasePassphraseReceivedPassphrase = passphrase
+        DispatchQueue.main.async {
+            self.sessionPassphrasePassphraseReceivedInvocations.append(passphrase)
+        }
+        if let sessionPassphrasePassphraseClosure = sessionPassphrasePassphraseClosure {
+            return sessionPassphrasePassphraseClosure(passphrase)
+        } else {
+            return sessionPassphrasePassphraseReturnValue
+        }
+    }
+
     //MARK: - sessionPaths
 
     var sessionPathsDataPathCachePathUnderlyingCallsCount = 0
@@ -5775,6 +5963,77 @@ open class ClientBuilderSDKMock: MatrixRustSDK.ClientBuilder, @unchecked Sendabl
             return sessionPathsDataPathCachePathClosure(dataPath, cachePath)
         } else {
             return sessionPathsDataPathCachePathReturnValue
+        }
+    }
+
+    //MARK: - sessionPoolMaxSize
+
+    var sessionPoolMaxSizePoolMaxSizeUnderlyingCallsCount = 0
+    open var sessionPoolMaxSizePoolMaxSizeCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return sessionPoolMaxSizePoolMaxSizeUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = sessionPoolMaxSizePoolMaxSizeUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                sessionPoolMaxSizePoolMaxSizeUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    sessionPoolMaxSizePoolMaxSizeUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var sessionPoolMaxSizePoolMaxSizeCalled: Bool {
+        return sessionPoolMaxSizePoolMaxSizeCallsCount > 0
+    }
+    open var sessionPoolMaxSizePoolMaxSizeReceivedPoolMaxSize: UInt32?
+    open var sessionPoolMaxSizePoolMaxSizeReceivedInvocations: [UInt32?] = []
+
+    var sessionPoolMaxSizePoolMaxSizeUnderlyingReturnValue: ClientBuilder!
+    open var sessionPoolMaxSizePoolMaxSizeReturnValue: ClientBuilder! {
+        get {
+            if Thread.isMainThread {
+                return sessionPoolMaxSizePoolMaxSizeUnderlyingReturnValue
+            } else {
+                var returnValue: ClientBuilder? = nil
+                DispatchQueue.main.sync {
+                    returnValue = sessionPoolMaxSizePoolMaxSizeUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                sessionPoolMaxSizePoolMaxSizeUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    sessionPoolMaxSizePoolMaxSizeUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    open var sessionPoolMaxSizePoolMaxSizeClosure: ((UInt32?) -> ClientBuilder)?
+
+    open override func sessionPoolMaxSize(poolMaxSize: UInt32?) -> ClientBuilder {
+        sessionPoolMaxSizePoolMaxSizeCallsCount += 1
+        sessionPoolMaxSizePoolMaxSizeReceivedPoolMaxSize = poolMaxSize
+        DispatchQueue.main.async {
+            self.sessionPoolMaxSizePoolMaxSizeReceivedInvocations.append(poolMaxSize)
+        }
+        if let sessionPoolMaxSizePoolMaxSizeClosure = sessionPoolMaxSizePoolMaxSizeClosure {
+            return sessionPoolMaxSizePoolMaxSizeClosure(poolMaxSize)
+        } else {
+            return sessionPoolMaxSizePoolMaxSizeReturnValue
         }
     }
 

--- a/ElementX/Sources/Other/Extensions/ClientBuilder.swift
+++ b/ElementX/Sources/Other/Extensions/ClientBuilder.swift
@@ -15,15 +15,13 @@ extension ClientBuilder {
                             slidingSync: ClientBuilderSlidingSync,
                             sessionDelegate: ClientSessionDelegate,
                             appHooks: AppHooks,
-                            enableOnlySignedDeviceIsolationMode: Bool,
-                            eventCacheEnabled: Bool) -> ClientBuilder {
+                            enableOnlySignedDeviceIsolationMode: Bool) -> ClientBuilder {
         var builder = ClientBuilder()
             .crossProcessStoreLocksHolderName(holderName: InfoPlistReader.main.bundleIdentifier)
             .enableOidcRefreshLock()
             .setSessionDelegate(sessionDelegate: sessionDelegate)
             .userAgent(userAgent: UserAgentBuilder.makeASCIIUserAgent())
             .requestConfig(config: .init(retryLimit: 0, timeout: 30000, maxConcurrentRequests: nil, retryTimeout: nil))
-            .useEventCachePersistentStorage(value: eventCacheEnabled)
         
         builder = switch slidingSync {
         case .restored: builder

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
@@ -44,7 +44,6 @@ protocol DeveloperOptionsProtocol: AnyObject {
     var enableOnlySignedDeviceIsolationMode: Bool { get set }
     var elementCallBaseURLOverride: URL? { get set }
     var knockingEnabled: Bool { get set }
-    var eventCacheEnabled: Bool { get set }
 }
 
 extension AppSettings: DeveloperOptionsProtocol { }

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
@@ -30,16 +30,7 @@ struct DeveloperOptionsScreen: View {
                     }
                 }
             }
-            
-            Section("General") {
-                Toggle(isOn: $context.eventCacheEnabled) {
-                    Text("Event cache")
-                }
-                .onChange(of: context.eventCacheEnabled) {
-                    context.send(viewAction: .clearCache)
-                }
-            }
-            
+                        
             Section("Room List") {
                 Toggle(isOn: $context.publicSearchEnabled) {
                     Text("Public search")

--- a/ElementX/Sources/Services/Authentication/AuthenticationClientBuilder.swift
+++ b/ElementX/Sources/Services/Authentication/AuthenticationClientBuilder.swift
@@ -48,8 +48,7 @@ struct AuthenticationClientBuilder: AuthenticationClientBuilderProtocol {
                          slidingSync: .discover,
                          sessionDelegate: clientSessionDelegate,
                          appHooks: appHooks,
-                         enableOnlySignedDeviceIsolationMode: appSettings.enableOnlySignedDeviceIsolationMode,
-                         eventCacheEnabled: appSettings.eventCacheEnabled)
+                         enableOnlySignedDeviceIsolationMode: appSettings.enableOnlySignedDeviceIsolationMode)
             .sessionPaths(dataPath: sessionDirectories.dataPath,
                           cachePath: sessionDirectories.cachePath)
             .sessionPassphrase(passphrase: passphrase)

--- a/ElementX/Sources/Services/Authentication/AuthenticationClientBuilder.swift
+++ b/ElementX/Sources/Services/Authentication/AuthenticationClientBuilder.swift
@@ -52,6 +52,6 @@ struct AuthenticationClientBuilder: AuthenticationClientBuilderProtocol {
                          eventCacheEnabled: appSettings.eventCacheEnabled)
             .sessionPaths(dataPath: sessionDirectories.dataPath,
                           cachePath: sessionDirectories.cachePath)
-            .passphrase(passphrase: passphrase)
+            .sessionPassphrase(passphrase: passphrase)
     }
 }

--- a/ElementX/Sources/Services/Timeline/TimelineProxy.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineProxy.swift
@@ -236,6 +236,7 @@ final class TimelineProxy: TimelineProxyProtocol {
                                                               caption: caption,
                                                               formattedCaption: nil, // Rust will build this from the caption's markdown.
                                                               mentions: nil,
+                                                              replyParams: nil,
                                                               useSendQueue: true),
                                                 audioInfo: audioInfo,
                                                 progressWatcher: nil)
@@ -263,6 +264,7 @@ final class TimelineProxy: TimelineProxyProtocol {
                                                              caption: caption,
                                                              formattedCaption: nil, // Rust will build this from the caption's markdown.
                                                              mentions: nil,
+                                                             replyParams: nil,
                                                              useSendQueue: true),
                                                fileInfo: fileInfo,
                                                progressWatcher: nil)
@@ -291,6 +293,7 @@ final class TimelineProxy: TimelineProxyProtocol {
                                                               caption: caption,
                                                               formattedCaption: nil, // Rust will build this from the caption's markdown.
                                                               mentions: nil,
+                                                              replyParams: nil,
                                                               useSendQueue: true),
                                                 thumbnailPath: thumbnailURL.path(percentEncoded: false),
                                                 imageInfo: imageInfo,
@@ -338,6 +341,7 @@ final class TimelineProxy: TimelineProxyProtocol {
                                                               caption: caption,
                                                               formattedCaption: nil,
                                                               mentions: nil,
+                                                              replyParams: nil,
                                                               useSendQueue: true),
                                                 thumbnailPath: thumbnailURL.path(percentEncoded: false),
                                                 videoInfo: videoInfo,
@@ -366,6 +370,7 @@ final class TimelineProxy: TimelineProxyProtocol {
                                                                      caption: nil,
                                                                      formattedCaption: nil,
                                                                      mentions: nil,
+                                                                     replyParams: nil,
                                                                      useSendQueue: true),
                                                        audioInfo: audioInfo,
                                                        waveform: waveform,

--- a/ElementX/Sources/Services/UserSession/UserSessionStore.swift
+++ b/ElementX/Sources/Services/UserSession/UserSessionStore.swift
@@ -129,7 +129,7 @@ class UserSessionStore: UserSessionStoreProtocol {
                           cachePath: credentials.restorationToken.sessionDirectories.cachePath)
             .username(username: credentials.userID)
             .homeserverUrl(url: homeserverURL)
-            .passphrase(passphrase: credentials.restorationToken.passphrase)
+            .sessionPassphrase(passphrase: credentials.restorationToken.passphrase)
         
         do {
             let client = try await builder.build()

--- a/ElementX/Sources/Services/UserSession/UserSessionStore.swift
+++ b/ElementX/Sources/Services/UserSession/UserSessionStore.swift
@@ -123,8 +123,7 @@ class UserSessionStore: UserSessionStoreProtocol {
                          slidingSync: .restored,
                          sessionDelegate: keychainController,
                          appHooks: appHooks,
-                         enableOnlySignedDeviceIsolationMode: appSettings.enableOnlySignedDeviceIsolationMode,
-                         eventCacheEnabled: appSettings.eventCacheEnabled)
+                         enableOnlySignedDeviceIsolationMode: appSettings.enableOnlySignedDeviceIsolationMode)
             .sessionPaths(dataPath: credentials.restorationToken.sessionDirectories.dataPath,
                           cachePath: credentials.restorationToken.sessionDirectories.cachePath)
             .username(username: credentials.userID)

--- a/NSE/Sources/NotificationServiceExtension.swift
+++ b/NSE/Sources/NotificationServiceExtension.swift
@@ -47,17 +47,6 @@ class NotificationServiceExtension: UNNotificationServiceExtension {
     // Used to create one single UserSession across process/instances/runs
     private static let serialQueue = DispatchQueue(label: "io.element.elementx.nse")
     
-    // Temporary. We need to make sure the NSE and the main app pass in the same value.
-    // The NSE has a tendency of staying alive for longer so use this to manually kill it
-    // when the feature flag doesn't match.
-    private static var eventCacheEnabled = false
-    
-    private static var userSession: NSEUserSession? {
-        didSet {
-            eventCacheEnabled = settings.eventCacheEnabled
-        }
-    }
-    
     deinit {
         cleanUp()
         ExtensionLogger.logMemory(with: tag)
@@ -111,11 +100,6 @@ class NotificationServiceExtension: UNNotificationServiceExtension {
             }
         }
         
-        guard Self.eventCacheEnabled == settings.eventCacheEnabled else {
-            MXLog.error("Found missmatch `eventCacheEnabled` feature flag missmatch, restarting the NSE.")
-            exit(0)
-        }
-
         Task {
             await run(with: credentials,
                       roomID: roomID,

--- a/NSE/Sources/Other/NSEUserSession.swift
+++ b/NSE/Sources/Other/NSEUserSession.swift
@@ -40,7 +40,7 @@ final class NSEUserSession {
                           cachePath: credentials.restorationToken.sessionDirectories.cachePath)
             .username(username: credentials.userID)
             .homeserverUrl(url: homeserverURL)
-            .passphrase(passphrase: credentials.restorationToken.passphrase)
+            .sessionPassphrase(passphrase: credentials.restorationToken.passphrase)
         
         baseClient = try await clientBuilder.build()
         delegateHandle = baseClient.setDelegate(delegate: ClientDelegateWrapper())

--- a/NSE/Sources/Other/NSEUserSession.swift
+++ b/NSE/Sources/Other/NSEUserSession.swift
@@ -19,7 +19,11 @@ final class NSEUserSession {
                                                                                networkMonitor: nil)
     private let delegateHandle: TaskHandle?
 
-    init(credentials: KeychainCredentials, clientSessionDelegate: ClientSessionDelegate, appHooks: AppHooks, appSettings: CommonSettingsProtocol) async throws {
+    init(credentials: KeychainCredentials,
+         roomID: String,
+         clientSessionDelegate: ClientSessionDelegate,
+         appHooks: AppHooks,
+         appSettings: CommonSettingsProtocol) async throws {
         sessionDirectories = credentials.restorationToken.sessionDirectories
         
         userID = credentials.userID
@@ -34,8 +38,7 @@ final class NSEUserSession {
                          slidingSync: .restored,
                          sessionDelegate: clientSessionDelegate,
                          appHooks: appHooks,
-                         enableOnlySignedDeviceIsolationMode: appSettings.enableOnlySignedDeviceIsolationMode,
-                         eventCacheEnabled: appSettings.eventCacheEnabled)
+                         enableOnlySignedDeviceIsolationMode: appSettings.enableOnlySignedDeviceIsolationMode)
             .sessionPaths(dataPath: credentials.restorationToken.sessionDirectories.dataPath,
                           cachePath: credentials.restorationToken.sessionDirectories.cachePath)
             .username(username: credentials.userID)
@@ -44,7 +47,9 @@ final class NSEUserSession {
         
         baseClient = try await clientBuilder.build()
         delegateHandle = baseClient.setDelegate(delegate: ClientDelegateWrapper())
-        try await baseClient.restoreSession(session: credentials.restorationToken.session)
+        
+        try await baseClient.restoreSessionWith(session: credentials.restorationToken.session,
+                                                roomLoadSettings: .one(roomId: roomID))
         
         notificationClient = try await baseClient.notificationClient(processSetup: .multipleProcesses)
     }

--- a/project.yml
+++ b/project.yml
@@ -59,7 +59,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/element-hq/matrix-rust-components-swift
-    exactVersion: 25.03.31
+    exactVersion: 25.04.02
     # path: ../matrix-rust-sdk
   Compound:
     url: https://github.com/element-hq/compound-ios


### PR DESCRIPTION
This patch refactors the NSE to create a new UserSession every time a payload comes in and pass the room down to the SDK so it can optimize how many rooms it loads from the store and how much memory it's using.

It will:
- undo creating at most one user session pe process as that shoulnd't be a problem anymore
- rename some methods and improve the logging
- remove the event cache feature flag (as it was synced in the NSE)
- bump the RustSDK to v25.04.02