### PR TITLE
Add a Compound hook.

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -254,6 +254,7 @@
 		30CC4F796B27BE8B1DFDBF5A /* NSEUserSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEAA2832D93EC7D2608703FB /* NSEUserSession.swift */; };
 		30E5628F74AD3C27A061BF25 /* QRCodeLoginScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC1B7CB061C9865B2B91B56 /* QRCodeLoginScreenViewModel.swift */; };
 		3113065AABBC14CEAE6843FA /* UserSessionFlowCoordinatorStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8774CF614849664B5B3C2A1 /* UserSessionFlowCoordinatorStateMachine.swift */; };
+		311868F5E65BA61AFA6CCC2C /* CompoundHook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B89D6C760E8CAE29CA28FB1 /* CompoundHook.swift */; };
 		3118D9ABFD4BE5A3492FF88A /* ElementCallConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC437C491EA6996513B1CEAB /* ElementCallConfiguration.swift */; };
 		32B7891D937377A59606EDFC /* UserFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DD8599815136EFF5B73F38 /* UserFlowTests.swift */; };
 		32F47002A331817F0E6BD7EB /* RoomMembershipDetailsProxyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1434D5169F0EE319E226DA7F /* RoomMembershipDetailsProxyProtocol.swift */; };
@@ -2013,6 +2014,7 @@
 		8AE0C9653870803E4F91F474 /* RoomListFiltersStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomListFiltersStateTests.swift; sourceTree = "<group>"; };
 		8AE78FA0011E07920AE83135 /* PlainMentionBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlainMentionBuilder.swift; sourceTree = "<group>"; };
 		8AFCE895ECFFA53FEE64D62B /* MediaLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaLoader.swift; sourceTree = "<group>"; };
+		8B89D6C760E8CAE29CA28FB1 /* CompoundHook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompoundHook.swift; sourceTree = "<group>"; };
 		8BCCE3D12B0A9C6E559B5B5A /* EmojiProviderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiProviderProtocol.swift; sourceTree = "<group>"; };
 		8BD9C9A31D9AB3B6D8128E69 /* KnockRequestsListScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnockRequestsListScreenModels.swift; sourceTree = "<group>"; };
 		8BEBF0E59F25E842EDB6FD11 /* LocationSharingScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSharingScreenModels.swift; sourceTree = "<group>"; };
@@ -3160,6 +3162,7 @@
 				25586C0ADB814FEE9897DCAA /* BugReportHook.swift */,
 				3865AD7B7249C939D7C69C33 /* CertificateValidatorHook.swift */,
 				7AC0CD1CAFD3F8B057F9AEA5 /* ClientBuilderHook.swift */,
+				8B89D6C760E8CAE29CA28FB1 /* CompoundHook.swift */,
 			);
 			path = Hooks;
 			sourceTree = "<group>";
@@ -6989,6 +6992,7 @@
 				94E15D018D70563FA4AB4E5A /* ComposerToolbarModels.swift in Sources */,
 				71AC1CAAC23403FFE847F2C9 /* ComposerToolbarViewModel.swift in Sources */,
 				4A4110369DBB79E4A314F415 /* ComposerToolbarViewModelProtocol.swift in Sources */,
+				311868F5E65BA61AFA6CCC2C /* CompoundHook.swift in Sources */,
 				A6B83EB78F025D21B6EBA90C /* CompoundIcon.swift in Sources */,
 				EA6613B29BA671F39CE1B1D2 /* ConfirmationDialog.swift in Sources */,
 				AC7AA215D60FBC307F984028 /* Consumable.swift in Sources */,

--- a/ElementX/Sources/AppHooks/AppHooks.swift
+++ b/ElementX/Sources/AppHooks/AppHooks.swift
@@ -32,9 +32,9 @@ class AppHooks: AppHooksProtocol {
 }
 
 protocol AppHooksProtocol {
-    func configure()
+    func setUp()
 }
 
 extension AppHooksProtocol {
-    func configure() { }
+    func setUp() { }
 }

--- a/ElementX/Sources/AppHooks/AppHooks.swift
+++ b/ElementX/Sources/AppHooks/AppHooks.swift
@@ -14,6 +14,11 @@ class AppHooks: AppHooksProtocol {
         appSettingsHook = hook
     }
     
+    private(set) var compoundHook: CompoundHookProtocol = DefaultCompoundHook()
+    func registerCompoundHook(_ hook: CompoundHookProtocol) {
+        compoundHook = hook
+    }
+    
     private(set) var bugReportHook: BugReportHookProtocol = DefaultBugReportHook()
     func registerBugReportHook(_ hook: BugReportHookProtocol) {
         bugReportHook = hook

--- a/ElementX/Sources/AppHooks/Hooks/CompoundHook.swift
+++ b/ElementX/Sources/AppHooks/Hooks/CompoundHook.swift
@@ -1,0 +1,16 @@
+//
+// Copyright 2025 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Compound
+
+protocol CompoundHookProtocol {
+    func override(colors: CompoundColors, uiColors: CompoundUIColors)
+}
+
+struct DefaultCompoundHook: CompoundHookProtocol {
+    func override(colors: CompoundColors, uiColors: CompoundUIColors) { }
+}

--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -61,7 +61,7 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
 
     init(appDelegate: AppDelegate) {
         let appHooks = AppHooks()
-        appHooks.configure()
+        appHooks.setUp()
         
         windowManager = WindowManager(appDelegate: appDelegate)
         let networkMonitor = NetworkMonitor()

--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -63,6 +63,9 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
         let appHooks = AppHooks()
         appHooks.setUp()
         
+        // Override colours before we start building any UI components.
+        appHooks.compoundHook.override(colors: Color.compound, uiColors: UIColor.compound)
+        
         windowManager = WindowManager(appDelegate: appDelegate)
         let networkMonitor = NetworkMonitor()
         appMediator = AppMediator(windowManager: windowManager, networkMonitor: networkMonitor)


### PR DESCRIPTION
Adds a new Compound hook that allows for overriding colour tokens

This hook is slightly different to the others in that it can't return the mutated version given that CompoundColors and CompoundUIColors are defined as `static let` on (`UI`)`Color`, but that seems fine.

Also updates the Enterprise submodule, please check the diff for that too.