### PR TITLE
Fix the post-release workflow.

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -15,15 +15,14 @@ jobs:
       - name: Trigger pipeline
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.ENTERPRISE_ACTIONS_TOKEN }}
           script: |
             const tag = context.ref.replace('refs/tags/', '');
             const inputs = { git_tag: tag };
-            await github.actions.createWorkflowDispatch({
+            await github.rest.actions.createWorkflowDispatch({
               owner: 'element-hq',
               repo: 'element-enterprise',
               workflow_id: 'ios-pipeline.yml',
               ref: 'main',
               inputs: inputs
             });
-        env:
-          GITHUB_TOKEN: ${{ secrets.ELEMENT_BOT_TOKEN }}


### PR DESCRIPTION
This works properly now (tested by temporarily adding `on:pull_request` to it and hard-coding a tag).