### PR TITLE
Only use the appGroupTemporaryDirectory to access a file from the share extension.

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -409,7 +409,7 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
     
     /// Manually cleans up any files in the app group's `tmp` directory.
     ///
-    /// **Note:** If there is a single file we consider it to bar an active share payload and it is ignored.
+    /// **Note:** If there is a single file we consider it to be an active share payload and ignore it.
     private func cleanAppGroupTemporaryDirectory() {
         let fileURLs: [URL]
         do {

--- a/ElementX/Sources/Other/Extensions/FileManager.swift
+++ b/ElementX/Sources/Other/Extensions/FileManager.swift
@@ -37,8 +37,9 @@ extension FileManager {
     }
 
     @discardableResult
-    func writeDataToTemporaryDirectory(data: Data, fileName: String) throws -> URL {
-        let newURL = URL.appGroupTemporaryDirectory.appendingPathComponent(fileName)
+    func writeDataToTemporaryDirectory(data: Data, fileName: String, withinAppGroupContainer: Bool = false) throws -> URL {
+        let baseURL: URL = withinAppGroupContainer ? .appGroupTemporaryDirectory : .temporaryDirectory
+        let newURL = baseURL.appendingPathComponent(fileName)
         
         try data.write(to: newURL)
         

--- a/ElementX/Sources/Other/Extensions/URL.swift
+++ b/ElementX/Sources/Other/Extensions/URL.swift
@@ -75,7 +75,10 @@ extension URL: @retroactive ExpressibleByStringLiteral {
         return url
     }
     
-    /// The app group temporary directory
+    /// The app group temporary directory (useful for transferring files between different bundles).
+    ///
+    /// **Note:** This `tmp` directory doesn't appear to behave as expected as it isn't being tidied up by the system.
+    /// Make sure to manually tidy up any files you place in here once you've transferred them from one bundle to another.
     static var appGroupTemporaryDirectory: URL {
         let url = appGroupContainerDirectory
             .appendingPathComponent("tmp", isDirectory: true)

--- a/ShareExtension/Sources/ShareExtensionViewController.swift
+++ b/ShareExtension/Sources/ShareExtensionViewController.swift
@@ -44,7 +44,7 @@ class ShareExtensionViewController: UIViewController {
         
         let roomID = (extensionContext?.intent as? INSendMessageIntent)?.conversationIdentifier
         
-        if let fileURL = await itemProvider.storeData() {
+        if let fileURL = await itemProvider.storeData(withinAppGroupContainer: true) {
             return .mediaFile(roomID: roomID, mediaFile: .init(url: fileURL, suggestedName: fileURL.lastPathComponent))
         } else if let url = await itemProvider.loadTransferable(type: URL.self) {
             return .text(roomID: roomID, text: url.absoluteString)


### PR DESCRIPTION
This PR switches back to the plain `URL.temporaryDirectory` for everything other than when a file is sent from the share extension in to the main app. When the main app receives the file it immediately moves it into the `temporaryDirectory` and continues as before.

Also adds a step to clear out the `appGroupTemporaryDirectory` on every upgrade to tidy up anything that may already be in here or anything that may have been shared and resulted in the app crashing (and as such, was left orphaned in the appGroupTemporaryDirectory).