### PR TITLE
Stop showing the canonical alias for invites in the room list.

### DIFF
--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreenInviteCell.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreenInviteCell.swift
@@ -138,7 +138,7 @@ struct HomeScreenInviteCell: View {
     }
     
     private var subtitle: String? {
-        room.isDirect ? room.inviter?.id : room.canonicalAlias
+        room.isDirect ? room.inviter?.id : nil
     }
     
     @ViewBuilder

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/homeScreenInviteCell.iPad-en-GB-0.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/homeScreenInviteCell.iPad-en-GB-0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f4387db87d7aad30904305e7016faf2c9f75ac69156f10ae021b28688d48cdfd
-size 312302
+oid sha256:ea2cc7d91e41d0aec0eed3d3eab224f34dc6db9d720acf545bdeacadb5f8617c
+size 285651

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/homeScreenInviteCell.iPad-pseudo-0.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/homeScreenInviteCell.iPad-pseudo-0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:35cc053864bc1d96f644e54cbb7a7e02e7b9c6975aac298af01e09c1edc67a9b
-size 331781
+oid sha256:bab250389d2d96e64b972c46d753d74e805240f2401d30a87d8b01405c564350
+size 305385

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/homeScreenInviteCell.iPhone-16-en-GB-0.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/homeScreenInviteCell.iPhone-16-en-GB-0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9ff286a3d014c8bbb0cf64c06ffa958c6bb69d3278d56f8979d8ef0250f1d746
-size 255703
+oid sha256:1b39b3589ba23ed88fb44da76536f17b882040c87ed5597b8be273329cd1aa6d
+size 229692

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/homeScreenInviteCell.iPhone-16-pseudo-0.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/homeScreenInviteCell.iPhone-16-pseudo-0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f126924a6f6c7cff01354f59aa5710a238c8a2e8a4a971f315f07e6cd96b4f57
-size 339880
+oid sha256:38e079eaac4b2c91f988e2fe3f72ba263b412d7baa88ec3c262e75336fa013c1
+size 314011


### PR DESCRIPTION
Closes #3974.