### PR TITLE
Add the new emoji from iOS 18.4 to the reaction picker.

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -8641,7 +8641,7 @@
 			repositoryURL = "https://github.com/matrix-org/emojibase-bindings";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 1.3.3;
+				minimumVersion = 1.4.1;
 			};
 		};
 		96495DD8554E2F39D3954354 /* XCRemoteSwiftPackageReference "posthog-ios" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/emojibase-bindings",
       "state" : {
-        "revision" : "d4682a2ad5e68cfd2f41544c3c6c970b4d524bd1",
-        "version" : "1.3.3"
+        "revision" : "81e483cff9827fdbc8138b9ec9a409c20cd9850c",
+        "version" : "1.4.1"
       }
     },
     {

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/emojiPickerScreen.Screen-iPad-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/emojiPickerScreen.Screen-iPad-en-GB.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:54bbf2be960ebae83cf6eb21d7d428f3e1afe81e4c83c4724c6845d7da7ba989
-size 983177
+oid sha256:ebbc4777cdaecc426ff54260d1311a41bfb39d1e487f8568fd2b555f73e215f5
+size 978927

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/emojiPickerScreen.Screen-iPad-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/emojiPickerScreen.Screen-iPad-pseudo.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3fd1b1598d6166d0e50c03b9fb83eec32dbe498ecc84096ac38f9ffbff9189e7
-size 986603
+oid sha256:c5c47adfd987d40591e8ef3739ee762b4c452d66c108754b7928122c29d495f1
+size 982353

--- a/project.yml
+++ b/project.yml
@@ -71,7 +71,7 @@ packages:
     # path: ../matrix-analytics-events
   Emojibase:
     url: https://github.com/matrix-org/emojibase-bindings
-    minorVersion: 1.3.3
+    minorVersion: 1.4.1
     # path: ../emojibase-bindings
   SwiftOGG:
     url: https://github.com/element-hq/swift-ogg


### PR DESCRIPTION
This PR updates emojibase to include [#26](https://github.com/matrix-org/emojibase-bindings/pull/26) so we can react with the new emoji added in 18.4:

https://emojipedia.org/unicode-16.0

🪉