### PR TITLE
Tweak the size of the new bloom to match Figma better.

### DIFF
--- a/ElementX/Sources/Screens/HomeScreen/View/BloomModifier.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/BloomModifier.swift
@@ -65,9 +65,9 @@ struct NewBloomModifier: ViewModifier {
     private var bloomGradient: some View {
         LinearGradient(colors: [.compound._bgOwnPill, .clear], // This isn't the final gradient.
                        startPoint: .top,
-                       endPoint: .bottom)
+                       endPoint: .init(x: 0.5, y: 0.7))
             .ignoresSafeArea(edges: .all)
-            .frame(width: 100, height: 100)
+            .frame(width: 256, height: 256)
     }
 }
 


### PR DESCRIPTION
This PR tweaks the size of the gradient to match the Figma a bit better (it shouldn't extend into the search bar when the title is big). Also increases the resolution to reduce banding that became apparent with less of the image containing the gradient (it  is now the same size that the old bloom used to be).

| Before | After |
| - | - |
| ![Screenshot 2025-04-17 at 12 54 57 pm](https://github.com/user-attachments/assets/1486281d-efe5-4501-a642-8234a30d63af) | ![Simulator Screenshot - iPhone 16 Pro - 2025-04-17 at 12 55 08](https://github.com/user-attachments/assets/ac691191-42d1-4665-a3c0-cff3fcb61f9a) |
