### PR TITLE
Remove the Learn More URL for the sliding sync proxy.

### DIFF
--- a/ElementX/Resources/Localizations/be.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/be.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "Змяніць правайдара ўліковага запісу";
 "screen_change_server_error_invalid_homeserver" = "Нам не ўдалося звязацца з гэтым хатнім серверам. Упэўніцеся, што вы правільна ўвялі URL-адрас хатняга сервера. Калі URL-адрас пазначаны правільна, звярніцеся да адміністратара хатняга сервера за дадатковай дапамогай.";
 "screen_change_server_error_invalid_well_known" = "Sliding sync недаступны з-за праблемы ў вядомым файле:\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "Выбачце, гэты сервер не падтрымлівае sliding sync.";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "URL хатняга сервера";
-"screen_change_server_form_notice" = "Вы можаце падключыцца толькі да існуючага сервера, які падтрымлівае sliding sync. Адміністратару хатняга сервера запатрабуецца наладзіць яго. %1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "Які адрас вашага сервера?";
 "screen_change_server_title" = "Выберыце свой сервер";
 "screen_chat_backup_key_backup_action_disable" = "Выключыць рэзервовае капіраванне";

--- a/ElementX/Resources/Localizations/bg.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/bg.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "Промяна на доставчика на акаунт";
 "screen_change_server_error_invalid_homeserver" = "We couldn't reach this homeserver. Please check that you have entered the homeserver URL correctly. If the URL is correct, contact your homeserver administrator for further help.";
 "screen_change_server_error_invalid_well_known" = "Sliding sync isn't available due to an issue in the well-known file:\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "This server currently doesn’t support sliding sync.";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "Homeserver URL";
-"screen_change_server_form_notice" = "You can only connect to an existing server that supports sliding sync. Your homeserver admin will need to configure it. %1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "Какъв е адресът на вашия сървър?";
 "screen_change_server_title" = "Select your server";
 "screen_chat_backup_key_backup_action_disable" = "Изключване на резервните копия";

--- a/ElementX/Resources/Localizations/cs.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/cs.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "Změnit poskytovatele účtu";
 "screen_change_server_error_invalid_homeserver" = "Nepodařilo se nám připojit k tomuto domovskému serveru. Zkontrolujte prosím, zda jste správně zadali adresu URL domovského serveru. Pokud je adresa URL správná, obraťte se na správce domovského serveru, který vám poskytne další pomoc.";
 "screen_change_server_error_invalid_well_known" = "Klouzavá synchronizace není k dispozici kvůli problému se souborem well-known:\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "Tento server v současné době nepodporuje klouzavou synchronizaci.";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "Adresa URL domovského serveru";
-"screen_change_server_form_notice" = "Můžete se připojit pouze k serveru, který podporuje klouzavou synchronizaci. Správce vašeho domovského serveru jej bude muset nakonfigurovat. %1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "Jaká je adresa vašeho serveru?";
 "screen_change_server_title" = "Vyberte váš server";
 "screen_chat_backup_key_backup_action_disable" = "Vypnout zálohování";

--- a/ElementX/Resources/Localizations/cy.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/cy.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "Newid darparwr cyfrif";
 "screen_change_server_error_invalid_homeserver" = "Doedd dim modd i ni gyrraedd y gweinydd cartref hwn. Gwiriwch eich bod wedi rhoi URL y gweinydd cartref yn gywir. Os yw'r URL yn gywir, cysylltwch â gweinyddwr eich gweinydd cartref am ragor o help.";
 "screen_change_server_error_invalid_well_known" = "Nid yw cydweddu llithrig ar gael oherwydd problem yn y ffeil adnabyddus:\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "Nid yw'r gweinydd hwn yn cefnogi cydweddu llithrig ar hyn o bryd.";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "URL y Gweinydd Cartref";
-"screen_change_server_form_notice" = "Dim ond i weinydd presennol sy'n cefnogi cydweddu llithrig y gallwch chi gysylltu. Bydd angen i weinyddwr eich gweinydd cartref ei ffurfweddu. %1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "Beth yw cyfeiriad eich gweinydd?";
 "screen_change_server_title" = "Dewiswch eich gweinydd";
 "screen_chat_backup_key_backup_action_disable" = "Dileu storfa allweddi";

--- a/ElementX/Resources/Localizations/de.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/de.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "Kontoanbieter wechseln";
 "screen_change_server_error_invalid_homeserver" = "Wir konnten diesen Homeserver nicht erreichen. Bitte überprüfe, ob du die Homeserver-URL korrekt eingegeben hast. Wenn die URL korrekt ist, wende dich an deinen Homeserver-Administrator, um weitere Hilfe zu erhalten.";
 "screen_change_server_error_invalid_well_known" = "Sliding Sync ist aufgrund eines Problems im \"well-known file\" nicht verfügbar:\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "Dieser Server unterstützt derzeit kein Sliding Sync.";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "Homeserver-URL";
-"screen_change_server_form_notice" = "Du kannst nur eine Verbindung zu einem vorhandenen Server herstellen, der Sliding Sync unterstützt. Dein Homeserver-Administrator muss das konfigurieren. %1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "Wie lautet die Adresse deines Servers?";
 "screen_change_server_title" = "Wähle deinen Server aus";
 "screen_chat_backup_key_backup_action_disable" = "Backup deaktivieren";

--- a/ElementX/Resources/Localizations/el.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/el.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "Αλλαγή παρόχου λογαριασμού";
 "screen_change_server_error_invalid_homeserver" = "Δεν μπορούσαμε να επικοινωνήσουμε με αυτόν τον οικιακό διακομιστή. Βεβαιώσου ότι έχεις εισαγάγει σωστά τη διεύθυνση URL του αρχικού διακομιστή. Εάν η διεύθυνση URL είναι σωστή, επικοινώνησε με τον διαχειριστή του κεντρικού διακομιστή για περαιτέρω βοήθεια.";
 "screen_change_server_error_invalid_well_known" = "Το Sliding sync δεν είναι διαθέσιμο εξαιτίας ενός ζητήματος σε ένα πολύ γνωστό αρχείο:\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "Αυτός ο διακομιστής προς το παρόν δεν υποστηρίζει Sliding sync.";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "URL οικιακού διακομιστή";
-"screen_change_server_form_notice" = "Μπορείτε να συνδεθείς μόνο σε υπάρχοντα διακομιστή που υποστηρίζει Sliding sync. Ο διαχειριστής του οικιακού διακομιστή σου θα πρέπει να το ρυθμίσει. %1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "Ποια είναι η διεύθυνση του διακομιστή σου;";
 "screen_change_server_title" = "Επέλεξε το διακομιστή σου";
 "screen_chat_backup_key_backup_action_disable" = "Απενεργοποίηση αντιγράφων ασφαλείας";

--- a/ElementX/Resources/Localizations/en-US.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en-US.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "Change account provider";
 "screen_change_server_error_invalid_homeserver" = "We couldn't reach this homeserver. Please check that you have entered the homeserver URL correctly. If the URL is correct, contact your homeserver administrator for further help.";
 "screen_change_server_error_invalid_well_known" = "Sliding sync isn't available due to an issue in the well-known file:\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "This server currently doesn’t support sliding sync.";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "Homeserver URL";
-"screen_change_server_form_notice" = "You can only connect to an existing server that supports sliding sync. Your homeserver admin will need to configure it. %1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "What is the address of your server?";
 "screen_change_server_title" = "Select your server";
 "screen_chat_backup_key_backup_action_disable" = "Delete key storage";

--- a/ElementX/Resources/Localizations/en.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "Change account provider";
 "screen_change_server_error_invalid_homeserver" = "We couldn't reach this homeserver. Please check that you have entered the homeserver URL correctly. If the URL is correct, contact your homeserver administrator for further help.";
 "screen_change_server_error_invalid_well_known" = "Sliding sync isn't available due to an issue in the well-known file:\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "This server currently doesn’t support sliding sync.";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "Homeserver URL";
-"screen_change_server_form_notice" = "You can only connect to an existing server that supports sliding sync. Your homeserver admin will need to configure it. %1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "What is the address of your server?";
 "screen_change_server_title" = "Select your server";
 "screen_chat_backup_key_backup_action_disable" = "Delete key storage";

--- a/ElementX/Resources/Localizations/es.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/es.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "Cambiar el proveedor de la cuenta";
 "screen_change_server_error_invalid_homeserver" = "No hemos podido acceder a este servidor. Comprueba que has introducido correctamente la dirección del servidor. Si la dirección es correcta, ponte en contacto con el administrador del servidor para obtener más ayuda.";
 "screen_change_server_error_invalid_well_known" = "Sliding sync no está disponible debido a un problema en el archivo well-known:\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "Este servidor no soporta sliding sync.";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "Dirección del homeserver";
-"screen_change_server_form_notice" = "Solo puedes conectarte a un servidor que soporte sliding sync. El administrador de tu servidor tendrá que configurarlo. %1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "¿Cuál es la dirección de tu servidor?";
 "screen_change_server_title" = "Selecciona tu servidor";
 "screen_chat_backup_key_backup_action_disable" = "Borrar almacén de claves";

--- a/ElementX/Resources/Localizations/et.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/et.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "Muuda teenusepakkujat";
 "screen_change_server_error_invalid_homeserver" = "Me ei suutnud luuaühendust selle koduserveriga. Palun kontrolli, kas koduserveri aadress on õige. Kui aadress on õige, siis täiendavat teavet oskab sulle anda koduserveri haldaja.";
 "screen_change_server_error_invalid_well_known" = "Sliding sync režiim pole saadaval vea tõttu well-known failis:\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "See koduserver hetkel ei toeta „Sliding sync“ režiimi";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "Koduserveri url";
-"screen_change_server_form_notice" = "Sa saad luua ühendust vaid olemasoleva serveriga, mis toetab Sliding sync režiimi. Sinu koduserveri haldur peaks selle seadistama. %1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "Mis on sinu koduserveri aadress?";
 "screen_change_server_title" = "Vali oma server";
 "screen_chat_backup_key_backup_action_disable" = "Lülita võtmete varundamine välja";

--- a/ElementX/Resources/Localizations/eu.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/eu.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "Aldatu kontu-hornitzailea";
 "screen_change_server_error_invalid_homeserver" = "We couldn't reach this homeserver. Please check that you have entered the homeserver URL correctly. If the URL is correct, contact your homeserver administrator for further help.";
 "screen_change_server_error_invalid_well_known" = "Sliding sync isn't available due to an issue in the well-known file:\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "Zerbitzari hau ez da gaur-gaurkoz sliding sync-ekin bateragarria.";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "Zerbitzariaren URLa";
-"screen_change_server_form_notice" = "You can only connect to an existing server that supports sliding sync. Your homeserver admin will need to configure it. %1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "Zein da zure zerbitzariaren helbidea?";
 "screen_change_server_title" = "Hautatu zure zerbitzaria";
 "screen_chat_backup_key_backup_action_disable" = "Ezabatu gakoen biltegia";

--- a/ElementX/Resources/Localizations/fa.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/fa.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "تغییر فراهم کنندهٔ حساب";
 "screen_change_server_error_invalid_homeserver" = "We couldn't reach this homeserver. Please check that you have entered the homeserver URL correctly. If the URL is correct, contact your homeserver administrator for further help.";
 "screen_change_server_error_invalid_well_known" = "Sliding sync isn't available due to an issue in the well-known file:\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "این کارساز در حال حاضر از هم‌گام سازی اسلایدی پشتیبانی نمی‌کند.";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "نشانی کارساز خانگی";
-"screen_change_server_form_notice" = "تنها می‌توانید به کارسازهای موجودی که از هم‌گام سازی اسلاید پشتیبانی می‌کنند وصل شود. مدیر کارساز خانگیتان باید پیکربندیش کند. %1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "نشانی کارسازتان چیست؟";
 "screen_change_server_title" = "کارسازتان را برگزینید";
 "screen_chat_backup_key_backup_action_disable" = "خاموش کردن پشتیبان";

--- a/ElementX/Resources/Localizations/fi.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/fi.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "Vaihda palveluntarjoajaa";
 "screen_change_server_error_invalid_homeserver" = "Kotipalvelimeen ei saatu yhteyttä. Varmista, että olet syöttänyt osoitteen oikein. Jos osoite on oikein, ota yhteyttä palvelimesi ylläpitäjään.";
 "screen_change_server_error_invalid_well_known" = "Sliding sync ei ole saatavilla well-known tiedostossa olevan ongelman vuoksi:\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "Tämä palvelin ei tällä hetkellä tue sliding syncia.";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "Kotipalvelimen osoite";
-"screen_change_server_form_notice" = "Voit yhdistää vain olemassa olevaan palvelimeen, joka tukee sliding syncia. Kotipalvelimesi ylläpitäjän on otettava se käyttöön. %1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "Mikä on palvelimesi osoite?";
 "screen_change_server_title" = "Valitse palvelimesi";
 "screen_chat_backup_key_backup_action_disable" = "Ota avainten säilytys pois käytöstä";

--- a/ElementX/Resources/Localizations/fr.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/fr.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "Changer de fournisseur de compte";
 "screen_change_server_error_invalid_homeserver" = "Nous n’avons pas pu atteindre ce serveur d’accueil. Vérifiez que vous avez correctement saisi l’URL du serveur d’accueil. Si l’URL est correcte, contactez l’administrateur de votre serveur d’accueil pour obtenir de l’aide.";
 "screen_change_server_error_invalid_well_known" = "Sliding sync n'est pas disponible en raison d'un problème dans le well-known file :\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "Ce serveur ne prend actuellement pas en charge la synchronisation glissante.";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "URL du serveur d’accueil";
-"screen_change_server_form_notice" = "Vous ne pouvez vous connecter qu’à un serveur existant qui prend en charge le sliding sync. L’administrateur de votre serveur d’accueil devra le configurer. %1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "Quelle est l’adresse de votre serveur ?";
 "screen_change_server_title" = "Choisissez votre serveur";
 "screen_chat_backup_key_backup_action_disable" = "Désactiver la sauvegarde";

--- a/ElementX/Resources/Localizations/hu.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/hu.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "Fiókszolgáltató módosítása";
 "screen_change_server_error_invalid_homeserver" = "Nem sikerült elérni ezt a Matrix-kiszolgálót. Ellenőrizze, hogy helyesen adta-e meg a Matrix-kiszolgáló webcímét. Ha a webcím helyes, akkor további segítségért lépjen kapcsolatba a Matrix-kiszolgáló adminisztrátorával.";
 "screen_change_server_error_invalid_well_known" = "A Sliding sync protokoll a well-known fájl problémája miatt nem érhető el:\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "A kiszolgáló jelenleg nem támogatja a Sliding sync protokollt.";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "Matrix-kiszolgáló webcíme";
-"screen_change_server_form_notice" = "Csak olyan meglévő kiszolgálóhoz csatlakozhat, amely támogatja a Sliding sync protokollt. Ezt a Matrix-kiszolgáló adminisztrátorának kell beállítania. %1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "Mi a kiszolgálója címe?";
 "screen_change_server_title" = "Válassza ki a kiszolgálóját";
 "screen_chat_backup_key_backup_action_disable" = "Biztonsági mentés kikapcsolása";

--- a/ElementX/Resources/Localizations/id.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/id.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "Ubah penyedia akun";
 "screen_change_server_error_invalid_homeserver" = "Kami tidak dapat menjangkau server ini. Periksa apakah Anda telah memasukkan URL homeserver dengan benar. Jika URL sudah benar, hubungi administrator homeserver Anda untuk bantuan lebih lanjut.";
 "screen_change_server_error_invalid_well_known" = "Sliding sync tidak tersedia karena adanya masalah dalam berkas .well-known:\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "Server ini saat ini tidak mendukung sinkronisasi geser.";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "URL Homeserver";
-"screen_change_server_form_notice" = "Anda hanya dapat terhubung ke server yang ada yang mendukung sinkronisasi geser. Admin homeserver Anda perlu mengaturnya. %1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "Apa alamat server Anda?";
 "screen_change_server_title" = "Pilih server Anda";
 "screen_chat_backup_key_backup_action_disable" = "Matikan pencadangan";

--- a/ElementX/Resources/Localizations/it.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/it.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "Cambia fornitore dell'account";
 "screen_change_server_error_invalid_homeserver" = "Non siamo riusciti a raggiungere questo homeserver. Verifica di aver inserito correttamente l'URL. Se l'URL è corretto, contatta l'amministratore del homeserver per ulteriore assistenza.";
 "screen_change_server_error_invalid_well_known" = "La sliding sync non è disponibile per un problema nel file well-known:\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "Questo server attualmente non supporta la sliding sync.";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "URL dell'homeserver";
-"screen_change_server_form_notice" = "Puoi connetterti solo a un server esistente che supporta la sliding sync. L'amministratore del tuo homeserver dovrà configurarla. %1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "Qual è l'indirizzo del tuo server?";
 "screen_change_server_title" = "Seleziona il tuo server";
 "screen_chat_backup_key_backup_action_disable" = "Disattiva il backup";

--- a/ElementX/Resources/Localizations/ka.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/ka.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "შეცვალეთ ანგარიშის მომწოდებელი";
 "screen_change_server_error_invalid_homeserver" = "ჩვენ ვერ მივაღწიეთ ამ სახლის სერვერს. გთხოვთ, შეამოწმოთ, რომ სწორად შეიყვანეთ სახლის სერვერის URL. თუ URL სწორია, დაუკავშირდით თქვენი სახლის სერვერის ადმინისტრატორს დამატებითი დახმარებისთვის.";
 "screen_change_server_error_invalid_well_known" = "Sliding sync არ არის ხელმისაწვდომი well-known ფაილში პრობლემის გამო: %1$@";
-"screen_change_server_error_no_sliding_sync_message" = "ამჟამად ეს სერვერი მხარს არ უჭერს \"sliding sync\"-ს.";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "სახლის სერვერის URL";
-"screen_change_server_form_notice" = "თქვენ შეგიძლიათ დაუკავშირდეთ მხოლოდ იმ სერვერს, რომელიც მხარს უჭერს \"sliding sync\"-ს. თქვენი სახლის სერვერის ადმინისტრატორს დასჭირდება მისი კონფიგურაცია.%1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "რა არის თქვენი სერვერის მისამართი?";
 "screen_change_server_title" = "აირჩიეთ თქვენი სერვერი";
 "screen_chat_backup_key_backup_action_disable" = "სარეზერვო ასლის გამორთვა";

--- a/ElementX/Resources/Localizations/lt.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/lt.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "Keisti paskyros teikėją";
 "screen_change_server_error_invalid_homeserver" = "Nepavyko pasiekti šio serverio. Patikrinkite, ar teisingai įvedėte serverio URL. Jei URL yra teisingas, susisiekite su serverio administracija dėl tolimesnės pagalbos.";
 "screen_change_server_error_invalid_well_known" = "Sliding sync isn't available due to an issue in the well-known file:\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "Šiuo metu šis serveris nepalaiko slenkančios sinchronizacijos (sliding sync).";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "Serverio URL";
-"screen_change_server_form_notice" = "Galite prisijungti tik prie serverio, palaikančio slenkančią sinchronizaciją (sliding sync). Jūsų serverio administracija turėtų ją sukonfigūruoti. %1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "Koks yra Jūsų serverio adresas?";
 "screen_change_server_title" = "Select your server";
 "screen_chat_backup_key_backup_action_disable" = "Delete key storage";

--- a/ElementX/Resources/Localizations/nb.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/nb.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "Bytt kontotilbyder";
 "screen_change_server_error_invalid_homeserver" = "Vi kunne ikke nå denne hjemmeserveren. Kontroller at du har skrevet inn hjemmeserverens URL riktig. Hvis URL-en er riktig, kontakt administratoren for hjemmeserveren din for å få mer hjelp.";
 "screen_change_server_error_invalid_well_known" = "Glidende synkronisering er ikke tilgjengelig på grunn av et problem i den velkjente filen:\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "Denne serveren støtter for øyeblikket ikke sliding sync.";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "URL til hjemmeserver";
-"screen_change_server_form_notice" = "Du kan bare koble til en eksisterende server som støtter sliding sync. Administrator for din hjemmeserver må konfigurere det. %1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "Hva er adressen til serveren din?";
 "screen_change_server_title" = "Velg din server";
 "screen_chat_backup_key_backup_action_disable" = "Slett nøkkellagring";

--- a/ElementX/Resources/Localizations/nl.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/nl.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "Wijzig accountprovider";
 "screen_change_server_error_invalid_homeserver" = "We konden deze homeserver niet bereiken. Controleer of je de homeserver-URL juist hebt ingevoerd. Als de URL juist is, neem dan contact op met de beheerder van je homeserver voor verdere hulp.";
 "screen_change_server_error_invalid_well_known" = "Sliding sync is niet beschikbaar vanwege een probleem in het well-known bestand:\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "Deze server ondersteunt op dit moment geen sliding sync.";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "Homeserver-URL";
-"screen_change_server_form_notice" = "Je kunt alleen verbinding maken met een bestaande server die sliding sync ondersteunt. De beheerder van de homeserver moet dit configureren. %1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "Wat is het adres van je server?";
 "screen_change_server_title" = "Selecteer je server";
 "screen_chat_backup_key_backup_action_disable" = "Back-up uitschakelen";

--- a/ElementX/Resources/Localizations/pl.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/pl.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "Zmień dostawcę konta";
 "screen_change_server_error_invalid_homeserver" = "Nie mogliśmy połączyć się z tym serwerem domowym. Sprawdź, czy adres URL serwera został wprowadzony poprawnie. Jeśli adres URL jest poprawny, skontaktuj się z administratorem serwera w celu uzyskania dalszej pomocy.";
 "screen_change_server_error_invalid_well_known" = "Sliding sync nie jest dostępny z powodu problemu w znanym pliku:\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "Ten serwer obecnie nie obsługuje technologii Sliding Sync.";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "URL serwera domowego";
-"screen_change_server_form_notice" = "Możesz połączyć się tylko z serwerem, który obsługuje technologię Sliding Sync. Administrator serwera domowego będzie musiał ją skonfigurować. %1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "Jaki jest adres Twojego serwera?";
 "screen_change_server_title" = "Wybierz swój serwer";
 "screen_chat_backup_key_backup_action_disable" = "Wyłącz backup";

--- a/ElementX/Resources/Localizations/pt-BR.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/pt-BR.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "Alterar provedor da conta";
 "screen_change_server_error_invalid_homeserver" = "Não conseguimos acessar esse servidor. Verifique se você inseriu a URL do servidor corretamente. Se a URL estiver correta, entre em contato com o administrador do servidor para obter mais ajuda.";
 "screen_change_server_error_invalid_well_known" = "Sliding sync isn't available due to an issue in the well-known file:\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "Este servidor atualmente não oferece suporte à tecnologia sliding sync.";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "URL do servidor";
-"screen_change_server_form_notice" = "Você só pode se conectar a um servidor existente que ofereça suporte à tecnologia sliding sync. O administrador do seu servidor precisará configurá-lo. %1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "Qual é o endereço do seu servidor?";
 "screen_change_server_title" = "Selecione seu servidor";
 "screen_chat_backup_key_backup_action_disable" = "Desativar o backup";

--- a/ElementX/Resources/Localizations/pt.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/pt.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "Alterar operador de conta";
 "screen_change_server_error_invalid_homeserver" = "Não foi possível comunicar com este servidor. Por favor, verifica se introduziste o seu URL corretamente. Se sim, contacta o administrador para obteres mais ajuda.";
 "screen_change_server_error_invalid_well_known" = "A sincronização deslizante (sliding sync) não está disponível devido a um problema no ficheiro \"well-known\":\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "Este servidor não suporta sincronização deslizante (sliding sync).";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "URL do servidor";
-"screen_change_server_form_notice" = "Só te podes ligar a um servidor existente que suporte a sincronização deslizante (sliding sync). O administrador do teu servidor terá de a configurar. %1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "Qual é o endereço do teu servidor?";
 "screen_change_server_title" = "Seleciona o teu servidor";
 "screen_chat_backup_key_backup_action_disable" = "Desativar a cópia de segurança";

--- a/ElementX/Resources/Localizations/ro.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/ro.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "Schimbați furnizorul contului";
 "screen_change_server_error_invalid_homeserver" = "Nu am putut accesa acest homeserver. Te rugăm să verifici că ai introdus corect adresa URL a homeserver-ului. Dacă adresa URL este corectă, contactează administratorul homeserver-ului pentru ajutor suplimentar.";
 "screen_change_server_error_invalid_well_known" = "Sliding sync nu este disponibil din cauza unei probleme în fișierul well-known:\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "Momentan acest server nu oferă suport pentru sliding sync.";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "Adresa URL a homeserver-ului";
-"screen_change_server_form_notice" = "Vă putețo conecta numai la un server existent care oferă suport pentru sliding sync. Administratorul homeserver-ului dumneavoastră va trebui să îl configureze. %1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "Care este adresa serverului dumneavoastră?";
 "screen_change_server_title" = "Selectați serverul dumneavoastra";
 "screen_chat_backup_key_backup_action_disable" = "Dezactivați backupul";

--- a/ElementX/Resources/Localizations/ru.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/ru.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "Сменить поставщика учетной записи";
 "screen_change_server_error_invalid_homeserver" = "Нам не удалось связаться с этим домашним сервером. Убедитесь, что вы правильно ввели URL-адрес домашнего сервера. Если URL-адрес указан правильно, обратитесь к администратору домашнего сервера за дополнительной помощью.";
 "screen_change_server_error_invalid_well_known" = "Sliding sync недоступен из-за проблемы в известном файле:\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "К сожалению данный сервер не поддерживает sliding sync.";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "URL-адрес домашнего сервера";
-"screen_change_server_form_notice" = "Вы можете подключиться только к существующему серверу, поддерживающему sliding sync. Администратору домашнего сервера потребуется настроить его. %1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "Какой адрес у вашего сервера?";
 "screen_change_server_title" = "Выберите свой сервер";
 "screen_chat_backup_key_backup_action_disable" = "Удалить хранилище ключей";

--- a/ElementX/Resources/Localizations/sk.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/sk.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "Zmeniť poskytovateľa účtu";
 "screen_change_server_error_invalid_homeserver" = "Nemohli sme sa spojiť s týmto domovským serverom. Skontrolujte prosím, či ste zadali URL adresu domovského servera správne. Ak je adresa URL správna, kontaktujte svoj domovský server pre ďalšiu pomoc.";
 "screen_change_server_error_invalid_well_known" = "Posuvná synchronizácia nie je k dispozícii z dôvodu problému v známom súbore:\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "Tento server momentálne nepodporuje kĺzavú synchronizáciu.";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "Adresa URL domovského servera";
-"screen_change_server_form_notice" = "Môžete sa pripojiť iba k existujúcemu serveru, ktorý podporuje kĺzavú synchronizáciu. Správca domovského servera ju bude musieť nakonfigurovať. %1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "Aká je adresa vášho servera?";
 "screen_change_server_title" = "Vyberte svoj server";
 "screen_chat_backup_key_backup_action_disable" = "Vypnúť zálohovanie";

--- a/ElementX/Resources/Localizations/sv.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/sv.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "Byt kontoleverantör";
 "screen_change_server_error_invalid_homeserver" = "Vi kunde inte nå den här hemservern. Kontrollera att du har angett hemserverns URL korrekt. Om URL:en är korrekt kontaktar du administratören för hemservern för ytterligare hjälp.";
 "screen_change_server_error_invalid_well_known" = "Sliding Sync är inte tillgängligt på grund av ett problem i well-known-filen:\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "Den här servern stöder för närvarande inte sliding sync.";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "Hemserverns URL";
-"screen_change_server_form_notice" = "Du kan bara ansluta till en befintlig server som stöder sliding sync. Din hemserveradministratör måste konfigurera det. %1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "Vad är adressen till din server?";
 "screen_change_server_title" = "Välj din server";
 "screen_chat_backup_key_backup_action_disable" = "Stäng av säkerhetskopiering";

--- a/ElementX/Resources/Localizations/tr.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/tr.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "Hesap sağlayıcısını değiştir";
 "screen_change_server_error_invalid_homeserver" = "Bu ana sunucuya ulaşamadık. Lütfen ana sunucu URL'sini doğru girip girmediğinizi kontrol edin. URL doğruysa, daha fazla yardım için ana sunucu yöneticinize başvurun.";
 "screen_change_server_error_invalid_well_known" = "Sliding sync, iyi bilinen dosyadaki bir sorun nedeniyle kullanılamıyor:\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "Bu sunucu şu anda sliding sync desteklemiyor.";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "Ana sunucu URL'si";
-"screen_change_server_form_notice" = "Yalnızca sliding sync destekleyen mevcut bir sunucuya bağlanabilirsiniz. Ana sunucu yöneticinizin bunu yapılandırması gerekecektir. %1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "Sunucunuzun adresi nedir?";
 "screen_change_server_title" = "Sunucunuzu seçin";
 "screen_chat_backup_key_backup_action_disable" = "Anahtar depolamasını sil";

--- a/ElementX/Resources/Localizations/uk.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/uk.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "Змінити провайдера облікового запису";
 "screen_change_server_error_invalid_homeserver" = "Не вдалося під'єднатися до цього домашнього сервера. Перевірте правильність введеної URL-адреси домашнього сервера. Якщо URL-адреса правильна, зверніться по додаткову допомогу до адміністратора домашнього сервера.";
 "screen_change_server_error_invalid_well_known" = "Sliding sync недоступний через проблему у файлі well-known:\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "Наразі цей сервер не підтримує sliding sync.";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "URL-адреса домашнього сервера";
-"screen_change_server_form_notice" = "Ви можете під'єднатися лише до наявного сервера, який підтримує sliding sync. Адміністратор вашого домашнього сервера повинен буде налаштувати його. %1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "Яка адреса вашого сервера?";
 "screen_change_server_title" = "Виберіть свій сервер";
 "screen_chat_backup_key_backup_action_disable" = "Вимкнути резервне копіювання";

--- a/ElementX/Resources/Localizations/uz.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/uz.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "Hisob provayderini o'zgartiring";
 "screen_change_server_error_invalid_homeserver" = "Bu uy serveriga kira olmadik. Iltimos, uy serverining URL manzilini to'ri kiritganingizni tekshiring. Agar URL toʻgʻri boʻlsa, qoʻshimcha yordam olish uchun uy serveri administratoriga murojaat qiling.";
 "screen_change_server_error_invalid_well_known" = "Sliding sync isn't available due to an issue in the well-known file:\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "Hozirda bu server siljish sinxronlashni qo‘llab-quvvatlamaydi.";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "Uy serverining URL manzili";
-"screen_change_server_form_notice" = "Siz faqat siljish sinxronlashni qo'llab-quvvatlaydigan mavjud serverga ulanishingiz mumkin. Uy serveringiz administratori uni sozlashi kerak.%1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "Serveringizning manzili nima?";
 "screen_change_server_title" = "Serveringizni tanlang";
 "screen_chat_backup_key_backup_action_disable" = "Zaxiralashni o'chirib qo'ying";

--- a/ElementX/Resources/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/zh-Hans.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "更改账户提供方";
 "screen_change_server_error_invalid_homeserver" = "我们无法访问此服务器。请检查您输入的服务器网址是否正确。如果 URL 正确，请联系您的服务器管理员寻求进一步帮助。";
 "screen_change_server_error_invalid_well_known" = "由于 Well Known 文件中的问题，Sliding Sync 不可用：\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "该服务器目前不支持 Sliding Sync。";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "服务器网址";
-"screen_change_server_form_notice" = "您只能连接到支持 Sliding Sync 的现有服务器。您的服务器管理员需要对其进行配置。%1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "您的服务器地址是什么？";
 "screen_change_server_title" = "选择服务器";
 "screen_chat_backup_key_backup_action_disable" = "关闭备份";

--- a/ElementX/Resources/Localizations/zh-Hant-TW.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/zh-Hant-TW.lproj/Localizable.strings
@@ -611,9 +611,9 @@
 "screen_change_account_provider_title" = "更改帳號提供者";
 "screen_change_server_error_invalid_homeserver" = "我們無法連線至此家伺服器。請檢查您是否已正確輸入家伺服器 URL。若 URL 正確，請聯絡您家伺服器的管理員以取得進一步協助。";
 "screen_change_server_error_invalid_well_known" = "因為 well-known 檔案的問題，無法使用 sliding sync：\n%1$@";
-"screen_change_server_error_no_sliding_sync_message" = "此伺服器目前不支援滑動同步（sliding sync）。";
+"screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "家伺服器 URL";
-"screen_change_server_form_notice" = "您僅能連線至支援 sliding sync 的既有伺服器。您的家伺服器管理員必須設定它。%1$@";
+"screen_change_server_form_notice" = "Enter a domain address.";
 "screen_change_server_subtitle" = "您的伺服器地址？";
 "screen_change_server_title" = "選擇您的伺服器";
 "screen_chat_backup_key_backup_action_disable" = "關閉備份功能";

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -191,9 +191,6 @@ final class AppSettings {
     
     // MARK: - Authentication
     
-    /// The URL that is opened when tapping the Learn more button on the sliding sync alert during authentication.
-    let slidingSyncLearnMoreURL: URL = "https://github.com/matrix-org/sliding-sync/blob/main/docs/Landing.md"
-    
     /// Any pre-defined static client registrations for OIDC issuers.
     let oidcStaticRegistrations: [URL: String] = ["https://id.thirdroom.io/realms/thirdroom": "elementx"]
     /// The redirect URL used for OIDC. This no longer uses universal links so we don't need the bundle ID to avoid conflicts between Element X, Nightly and PR builds.

--- a/ElementX/Sources/FlowCoordinators/AuthenticationFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/AuthenticationFlowCoordinator.swift
@@ -136,7 +136,6 @@ class AuthenticationFlowCoordinator: FlowCoordinatorProtocol {
         
         let parameters = ServerConfirmationScreenCoordinatorParameters(authenticationService: authenticationService,
                                                                        authenticationFlow: authenticationFlow,
-                                                                       slidingSyncLearnMoreURL: appSettings.slidingSyncLearnMoreURL,
                                                                        userIndicatorController: userIndicatorController)
         let coordinator = ServerConfirmationScreenCoordinator(parameters: parameters)
         
@@ -162,7 +161,6 @@ class AuthenticationFlowCoordinator: FlowCoordinatorProtocol {
         
         let parameters = ServerSelectionScreenCoordinatorParameters(authenticationService: authenticationService,
                                                                     authenticationFlow: authenticationFlow,
-                                                                    slidingSyncLearnMoreURL: appSettings.slidingSyncLearnMoreURL,
                                                                     userIndicatorController: userIndicatorController)
         let coordinator = ServerSelectionScreenCoordinator(parameters: parameters)
         
@@ -203,7 +201,6 @@ class AuthenticationFlowCoordinator: FlowCoordinatorProtocol {
     
     private func showLoginScreen() {
         let parameters = LoginScreenCoordinatorParameters(authenticationService: authenticationService,
-                                                          slidingSyncLearnMoreURL: appSettings.slidingSyncLearnMoreURL,
                                                           userIndicatorController: userIndicatorController,
                                                           analytics: analytics)
         let coordinator = LoginScreenCoordinator(parameters: parameters)

--- a/ElementX/Sources/Generated/Strings.swift
+++ b/ElementX/Sources/Generated/Strings.swift
@@ -1179,14 +1179,14 @@ internal enum L10n {
   internal static func screenChangeServerErrorInvalidWellKnown(_ p1: Any) -> String {
     return L10n.tr("Localizable", "screen_change_server_error_invalid_well_known", String(describing: p1))
   }
-  /// This server currently doesn’t support sliding sync.
-  internal static var screenChangeServerErrorNoSlidingSyncMessage: String { return L10n.tr("Localizable", "screen_change_server_error_no_sliding_sync_message") }
+  /// The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.
+  internal static func screenChangeServerErrorNoSlidingSyncMessage(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "screen_change_server_error_no_sliding_sync_message", String(describing: p1))
+  }
   /// Homeserver URL
   internal static var screenChangeServerFormHeader: String { return L10n.tr("Localizable", "screen_change_server_form_header") }
-  /// You can only connect to an existing server that supports sliding sync. Your homeserver admin will need to configure it. %1$@
-  internal static func screenChangeServerFormNotice(_ p1: Any) -> String {
-    return L10n.tr("Localizable", "screen_change_server_form_notice", String(describing: p1))
-  }
+  /// Enter a domain address.
+  internal static var screenChangeServerFormNotice: String { return L10n.tr("Localizable", "screen_change_server_form_notice") }
   /// What is the address of your server?
   internal static var screenChangeServerSubtitle: String { return L10n.tr("Localizable", "screen_change_server_subtitle") }
   /// Select your server

--- a/ElementX/Sources/Screens/Authentication/LoginScreen/LoginScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Authentication/LoginScreen/LoginScreenCoordinator.swift
@@ -11,7 +11,6 @@ import SwiftUI
 struct LoginScreenCoordinatorParameters {
     /// The service used to authenticate the user.
     let authenticationService: AuthenticationServiceProtocol
-    let slidingSyncLearnMoreURL: URL
     let userIndicatorController: UserIndicatorControllerProtocol
     let analytics: AnalyticsService
 }
@@ -43,7 +42,6 @@ final class LoginScreenCoordinator: CoordinatorProtocol {
         self.parameters = parameters
         
         viewModel = LoginScreenViewModel(authenticationService: parameters.authenticationService,
-                                         slidingSyncLearnMoreURL: parameters.slidingSyncLearnMoreURL,
                                          userIndicatorController: parameters.userIndicatorController,
                                          analytics: parameters.analytics)
     }

--- a/ElementX/Sources/Screens/Authentication/LoginScreen/LoginScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Authentication/LoginScreen/LoginScreenViewModel.swift
@@ -12,7 +12,6 @@ typealias LoginScreenViewModelType = StateStoreViewModel<LoginScreenViewState, L
 
 class LoginScreenViewModel: LoginScreenViewModelType, LoginScreenViewModelProtocol {
     private let authenticationService: AuthenticationServiceProtocol
-    private let slidingSyncLearnMoreURL: URL
     private let userIndicatorController: UserIndicatorControllerProtocol
     private let analytics: AnalyticsService
     
@@ -22,11 +21,9 @@ class LoginScreenViewModel: LoginScreenViewModelType, LoginScreenViewModelProtoc
     }
 
     init(authenticationService: AuthenticationServiceProtocol,
-         slidingSyncLearnMoreURL: URL,
          userIndicatorController: UserIndicatorControllerProtocol,
          analytics: AnalyticsService) {
         self.authenticationService = authenticationService
-        self.slidingSyncLearnMoreURL = slidingSyncLearnMoreURL
         self.userIndicatorController = userIndicatorController
         self.analytics = analytics
         
@@ -134,12 +131,10 @@ class LoginScreenViewModel: LoginScreenViewModelType, LoginScreenViewModelProtoc
                                                  title: L10n.commonServerNotSupported,
                                                  message: L10n.screenChangeServerErrorInvalidWellKnown(error))
         case .slidingSyncNotAvailable:
-            let openURL = { UIApplication.shared.open(self.slidingSyncLearnMoreURL) }
+            let nonBreakingAppName = InfoPlistReader.main.bundleDisplayName.replacingOccurrences(of: " ", with: "\u{00A0}")
             state.bindings.alertInfo = AlertInfo(id: .slidingSyncAlert,
                                                  title: L10n.commonServerNotSupported,
-                                                 message: L10n.screenChangeServerErrorNoSlidingSyncMessage,
-                                                 primaryButton: .init(title: L10n.actionLearnMore, role: .cancel, action: openURL),
-                                                 secondaryButton: .init(title: L10n.actionCancel, action: nil))
+                                                 message: L10n.screenChangeServerErrorNoSlidingSyncMessage(nonBreakingAppName))
             
             // Clear out the invalid username to avoid an attempted login to matrix.org
             state.bindings.username = ""

--- a/ElementX/Sources/Screens/Authentication/LoginScreen/View/LoginScreen.swift
+++ b/ElementX/Sources/Screens/Authentication/LoginScreen/View/LoginScreen.swift
@@ -161,7 +161,6 @@ struct LoginScreen_Previews: PreviewProvider, TestablePreview {
         Task { await authenticationService.configure(for: homeserverAddress, flow: .login) }
         
         let viewModel = LoginScreenViewModel(authenticationService: authenticationService,
-                                             slidingSyncLearnMoreURL: ServiceLocator.shared.settings.slidingSyncLearnMoreURL,
                                              userIndicatorController: UserIndicatorControllerMock(),
                                              analytics: ServiceLocator.shared.analytics)
         

--- a/ElementX/Sources/Screens/Authentication/ServerConfirmationScreen/ServerConfirmationScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerConfirmationScreen/ServerConfirmationScreenCoordinator.swift
@@ -11,7 +11,6 @@ import SwiftUI
 struct ServerConfirmationScreenCoordinatorParameters {
     let authenticationService: AuthenticationServiceProtocol
     let authenticationFlow: AuthenticationFlow
-    let slidingSyncLearnMoreURL: URL
     let userIndicatorController: UserIndicatorControllerProtocol
 }
 
@@ -33,7 +32,6 @@ final class ServerConfirmationScreenCoordinator: CoordinatorProtocol {
     init(parameters: ServerConfirmationScreenCoordinatorParameters) {
         viewModel = ServerConfirmationScreenViewModel(authenticationService: parameters.authenticationService,
                                                       authenticationFlow: parameters.authenticationFlow,
-                                                      slidingSyncLearnMoreURL: parameters.slidingSyncLearnMoreURL,
                                                       userIndicatorController: parameters.userIndicatorController)
     }
     

--- a/ElementX/Sources/Screens/Authentication/ServerConfirmationScreen/ServerConfirmationScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerConfirmationScreen/ServerConfirmationScreenViewModel.swift
@@ -13,7 +13,6 @@ typealias ServerConfirmationScreenViewModelType = StateStoreViewModel<ServerConf
 class ServerConfirmationScreenViewModel: ServerConfirmationScreenViewModelType, ServerConfirmationScreenViewModelProtocol {
     let authenticationService: AuthenticationServiceProtocol
     let authenticationFlow: AuthenticationFlow
-    let slidingSyncLearnMoreURL: URL
     let userIndicatorController: UserIndicatorControllerProtocol
     
     private var actionsSubject: PassthroughSubject<ServerConfirmationScreenViewModelAction, Never> = .init()
@@ -24,11 +23,9 @@ class ServerConfirmationScreenViewModel: ServerConfirmationScreenViewModelType, 
 
     init(authenticationService: AuthenticationServiceProtocol,
          authenticationFlow: AuthenticationFlow,
-         slidingSyncLearnMoreURL: URL,
          userIndicatorController: UserIndicatorControllerProtocol) {
         self.authenticationService = authenticationService
         self.authenticationFlow = authenticationFlow
-        self.slidingSyncLearnMoreURL = slidingSyncLearnMoreURL
         self.userIndicatorController = userIndicatorController
         
         let homeserver = authenticationService.homeserver.value
@@ -136,12 +133,10 @@ class ServerConfirmationScreenViewModel: ServerConfirmationScreenViewModelType, 
                                                  title: L10n.commonServerNotSupported,
                                                  message: L10n.screenChangeServerErrorInvalidWellKnown(error))
         case .slidingSync:
-            let openURL = { UIApplication.shared.open(self.slidingSyncLearnMoreURL) }
+            let nonBreakingAppName = InfoPlistReader.main.bundleDisplayName.replacingOccurrences(of: " ", with: "\u{00A0}")
             state.bindings.alertInfo = AlertInfo(id: .slidingSync,
                                                  title: L10n.commonServerNotSupported,
-                                                 message: L10n.screenChangeServerErrorNoSlidingSyncMessage,
-                                                 primaryButton: .init(title: L10n.actionLearnMore, role: .cancel, action: openURL),
-                                                 secondaryButton: .init(title: L10n.actionCancel, action: nil))
+                                                 message: L10n.screenChangeServerErrorNoSlidingSyncMessage(nonBreakingAppName))
         case .login:
             state.bindings.alertInfo = AlertInfo(id: .login,
                                                  title: L10n.commonServerNotSupported,

--- a/ElementX/Sources/Screens/Authentication/ServerConfirmationScreen/View/ServerConfirmationScreen.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerConfirmationScreen/View/ServerConfirmationScreen.swift
@@ -88,7 +88,6 @@ struct ServerConfirmationScreen_Previews: PreviewProvider, TestablePreview {
     static func makeViewModel(flow: AuthenticationFlow) -> ServerConfirmationScreenViewModel {
         ServerConfirmationScreenViewModel(authenticationService: AuthenticationService.mock,
                                           authenticationFlow: flow,
-                                          slidingSyncLearnMoreURL: ServiceLocator.shared.settings.slidingSyncLearnMoreURL,
                                           userIndicatorController: UserIndicatorControllerMock())
     }
 }

--- a/ElementX/Sources/Screens/Authentication/ServerSelectionScreen/ServerSelectionScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerSelectionScreen/ServerSelectionScreenCoordinator.swift
@@ -12,7 +12,6 @@ struct ServerSelectionScreenCoordinatorParameters {
     /// The service used to authenticate the user.
     let authenticationService: AuthenticationServiceProtocol
     let authenticationFlow: AuthenticationFlow
-    let slidingSyncLearnMoreURL: URL
     let userIndicatorController: UserIndicatorControllerProtocol
 }
 
@@ -39,7 +38,6 @@ final class ServerSelectionScreenCoordinator: CoordinatorProtocol {
         self.parameters = parameters
         viewModel = ServerSelectionScreenViewModel(authenticationService: parameters.authenticationService,
                                                    authenticationFlow: parameters.authenticationFlow,
-                                                   slidingSyncLearnMoreURL: parameters.slidingSyncLearnMoreURL,
                                                    userIndicatorController: parameters.userIndicatorController)
         userIndicatorController = parameters.userIndicatorController
     }

--- a/ElementX/Sources/Screens/Authentication/ServerSelectionScreen/ServerSelectionScreenModels.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerSelectionScreen/ServerSelectionScreenModels.swift
@@ -16,7 +16,7 @@ enum ServerSelectionScreenViewModelAction {
 
 struct ServerSelectionScreenViewState: BindableState {
     /// The message to be shown in the text field footer when no error has occurred.
-    private let regularFooterMessage: AttributedString
+    private let regularFooterMessage = L10n.screenChangeServerFormNotice
     
     /// View state that can be bound to from SwiftUI.
     var bindings: ServerSelectionScreenBindings
@@ -24,8 +24,8 @@ struct ServerSelectionScreenViewState: BindableState {
     var footerErrorMessage: String?
     
     /// The message to show in the text field footer.
-    var footerMessage: AttributedString {
-        footerErrorMessage.map(AttributedString.init) ?? regularFooterMessage
+    var footerMessage: String {
+        footerErrorMessage ?? regularFooterMessage
     }
     
     /// The text field is showing an error.
@@ -36,18 +36,6 @@ struct ServerSelectionScreenViewState: BindableState {
     /// Whether it is possible to continue when tapping the confirmation button.
     var hasValidationError: Bool {
         bindings.homeserverAddress.isEmpty || isShowingFooterError
-    }
-    
-    init(slidingSyncLearnMoreURL: URL, bindings: ServerSelectionScreenBindings, footerErrorMessage: String? = nil) {
-        self.bindings = bindings
-        self.footerErrorMessage = footerErrorMessage
-        
-        let linkPlaceholder = "{link}"
-        var message = AttributedString(L10n.screenChangeServerFormNotice(linkPlaceholder))
-        message.replace(linkPlaceholder,
-                        with: L10n.actionLearnMore,
-                        asLinkTo: slidingSyncLearnMoreURL)
-        regularFooterMessage = message
     }
 }
 

--- a/ElementX/Sources/Screens/Authentication/ServerSelectionScreen/ServerSelectionScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerSelectionScreen/ServerSelectionScreenViewModel.swift
@@ -13,7 +13,6 @@ typealias ServerSelectionScreenViewModelType = StateStoreViewModel<ServerSelecti
 class ServerSelectionScreenViewModel: ServerSelectionScreenViewModelType, ServerSelectionScreenViewModelProtocol {
     private let authenticationService: AuthenticationServiceProtocol
     private let authenticationFlow: AuthenticationFlow
-    private let slidingSyncLearnMoreURL: URL
     private let userIndicatorController: UserIndicatorControllerProtocol
     
     private var actionsSubject: PassthroughSubject<ServerSelectionScreenViewModelAction, Never> = .init()
@@ -24,15 +23,13 @@ class ServerSelectionScreenViewModel: ServerSelectionScreenViewModelType, Server
 
     init(authenticationService: AuthenticationServiceProtocol,
          authenticationFlow: AuthenticationFlow,
-         slidingSyncLearnMoreURL: URL,
          userIndicatorController: UserIndicatorControllerProtocol) {
         self.authenticationService = authenticationService
         self.authenticationFlow = authenticationFlow
-        self.slidingSyncLearnMoreURL = slidingSyncLearnMoreURL
         self.userIndicatorController = userIndicatorController
         
         let bindings = ServerSelectionScreenBindings(homeserverAddress: authenticationService.homeserver.value.address)
-        super.init(initialViewState: ServerSelectionScreenViewState(slidingSyncLearnMoreURL: slidingSyncLearnMoreURL, bindings: bindings))
+        super.init(initialViewState: ServerSelectionScreenViewState(bindings: bindings))
     }
     
     override func process(viewAction: ServerSelectionScreenViewAction) {
@@ -87,12 +84,10 @@ class ServerSelectionScreenViewModel: ServerSelectionScreenViewModelType, Server
                                                  title: L10n.commonServerNotSupported,
                                                  message: L10n.screenChangeServerErrorInvalidWellKnown(error))
         case .slidingSyncNotAvailable:
-            let openURL = { UIApplication.shared.open(self.slidingSyncLearnMoreURL) }
+            let nonBreakingAppName = InfoPlistReader.main.bundleDisplayName.replacingOccurrences(of: " ", with: "\u{00A0}")
             state.bindings.alertInfo = AlertInfo(id: .slidingSyncAlert,
                                                  title: L10n.commonServerNotSupported,
-                                                 message: L10n.screenChangeServerErrorNoSlidingSyncMessage,
-                                                 primaryButton: .init(title: L10n.actionLearnMore, role: .cancel, action: openURL),
-                                                 secondaryButton: .init(title: L10n.actionCancel, action: nil))
+                                                 message: L10n.screenChangeServerErrorNoSlidingSyncMessage(nonBreakingAppName))
         case .loginNotSupported:
             state.bindings.alertInfo = AlertInfo(id: .loginAlert,
                                                  title: L10n.commonServerNotSupported,

--- a/ElementX/Sources/Screens/Authentication/ServerSelectionScreen/View/ServerSelectionScreen.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerSelectionScreen/View/ServerSelectionScreen.swift
@@ -115,11 +115,8 @@ struct ServerSelection_Previews: PreviewProvider, TestablePreview {
     static func makeViewModel(for homeserverAddress: String) -> ServerSelectionScreenViewModel {
         let authenticationService = AuthenticationService.mock
         
-        let slidingSyncLearnMoreURL = ServiceLocator.shared.settings.slidingSyncLearnMoreURL
-        
         let viewModel = ServerSelectionScreenViewModel(authenticationService: authenticationService,
                                                        authenticationFlow: .login,
-                                                       slidingSyncLearnMoreURL: slidingSyncLearnMoreURL,
                                                        userIndicatorController: UserIndicatorControllerMock())
         viewModel.context.homeserverAddress = homeserverAddress
         if homeserverAddress == "thisisbad" {

--- a/ElementX/Sources/UITests/UITestsAppCoordinator.swift
+++ b/ElementX/Sources/UITests/UITestsAppCoordinator.swift
@@ -117,7 +117,6 @@ class MockScreen: Identifiable {
             let navigationStackCoordinator = NavigationStackCoordinator()
             let coordinator = ServerSelectionScreenCoordinator(parameters: .init(authenticationService: AuthenticationService.mock,
                                                                                  authenticationFlow: .login,
-                                                                                 slidingSyncLearnMoreURL: ServiceLocator.shared.settings.slidingSyncLearnMoreURL,
                                                                                  userIndicatorController: ServiceLocator.shared.userIndicatorController))
             navigationStackCoordinator.setRootCoordinator(coordinator)
             return navigationStackCoordinator

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/serverSelection.iPad-en-GB-0.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/serverSelection.iPad-en-GB-0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:111b41824f4397079dd2ac02ddbcb33e23f1edef67730ef43b23f8f4c46c6ac7
-size 117946
+oid sha256:91fad44e7f4156be3ac302bde23a2d4c2045e4243af4712e7d422ff5318e4814
+size 105276

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/serverSelection.iPad-en-GB-1.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/serverSelection.iPad-en-GB-1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d378ea07fed85fcfc7e43af8b8c31d6e9c5606a92a82a70c339a4939d4f8231d
-size 115702
+oid sha256:5b4ef513ec1efa9b66302c8748759a9b5871678bf2be368b590521b715383cf4
+size 102669

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/serverSelection.iPad-pseudo-0.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/serverSelection.iPad-pseudo-0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6b05329a6787cbb9637e4d51049ae0751ea08ad02363e8e391459474efb63e03
-size 139154
+oid sha256:269982e13659ac47e61229b2a9662ce5e9d3e9f71da54bbbdd01aa09ad18ee4a
+size 113980

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/serverSelection.iPad-pseudo-1.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/serverSelection.iPad-pseudo-1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dccd132d5ae4047053d4790668cc528a9b2f1168634e512fe25d853b715fc682
-size 136729
+oid sha256:0ff77c73693f717b6a67e2840af7c59c73cfcfb5693a30409f0fdd9a503f7072
+size 111453

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/serverSelection.iPhone-16-en-GB-0.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/serverSelection.iPhone-16-en-GB-0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:73225825f622bd3aa26052bb55400da19bd55f0a38ff5b0b8c9d0ee4d7b2b9be
-size 74384
+oid sha256:1b9ea475ec78bcadce063dfec67776c759fe2344d37e7a1ef55e326918fbf101
+size 60764

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/serverSelection.iPhone-16-en-GB-1.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/serverSelection.iPhone-16-en-GB-1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e6ee1ee7c4780e27db0ab72b6e8d908b5339ccb84b829dfc67a0756ba1e10ccb
-size 72185
+oid sha256:df9109a3e62b83ee6be295b6f07cf674a0668e46702ca32fb1626bb2a7d50955
+size 58559

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/serverSelection.iPhone-16-pseudo-0.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/serverSelection.iPhone-16-pseudo-0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a9910ff281692741af72a0ef63741b0125dd16c56a78a29c74e215bf1532a8ea
-size 100628
+oid sha256:0bd1517c9522bbe67ad85c39c9b6bb1224a2db70d49a56f716cff387c68c2020
+size 73399

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/serverSelection.iPhone-16-pseudo-1.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/serverSelection.iPhone-16-pseudo-1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e18e957714579290c95fe10fbe5e12b65c100f8ffb8fa5432e6fcb23c0e6ac1f
-size 98549
+oid sha256:afd6c97122695d38bf2cff97447903c6fb8b2d8d3278d9330f24f1add2152523
+size 71341

--- a/UnitTests/Sources/LoginScreenViewModelTests.swift
+++ b/UnitTests/Sources/LoginScreenViewModelTests.swift
@@ -31,7 +31,6 @@ class LoginScreenViewModelTests: XCTestCase {
         }
         
         viewModel = LoginScreenViewModel(authenticationService: service,
-                                         slidingSyncLearnMoreURL: ServiceLocator.shared.settings.slidingSyncLearnMoreURL,
                                          userIndicatorController: UserIndicatorControllerMock(),
                                          analytics: ServiceLocator.shared.analytics)
     }

--- a/UnitTests/Sources/ServerConfirmationScreenViewModelTests.swift
+++ b/UnitTests/Sources/ServerConfirmationScreenViewModelTests.swift
@@ -195,7 +195,6 @@ class ServerConfirmationScreenViewModelTests: XCTestCase {
         
         viewModel = ServerConfirmationScreenViewModel(authenticationService: service,
                                                       authenticationFlow: authenticationFlow,
-                                                      slidingSyncLearnMoreURL: ServiceLocator.shared.settings.slidingSyncLearnMoreURL,
                                                       userIndicatorController: UserIndicatorControllerMock())
         
         // Add a fake window in order for the OIDC flow to continue

--- a/UnitTests/Sources/ServerSelectionScreenViewModelTests.swift
+++ b/UnitTests/Sources/ServerSelectionScreenViewModelTests.swift
@@ -92,7 +92,7 @@ class ServerSelectionScreenViewModelTests: XCTestCase {
         setupViewModel(authenticationFlow: .login)
         XCTAssertFalse(context.viewState.isShowingFooterError, "There should not be an error message for a new view model.")
         XCTAssertNil(context.viewState.footerErrorMessage, "There should not be an error message for a new view model.")
-        XCTAssertEqual(String(context.viewState.footerMessage.characters), L10n.screenChangeServerFormNotice(L10n.actionLearnMore),
+        XCTAssertEqual(String(context.viewState.footerMessage), L10n.screenChangeServerFormNotice,
                        "The standard footer message should be shown.")
         
         // When attempting to discover an invalid server
@@ -104,7 +104,7 @@ class ServerSelectionScreenViewModelTests: XCTestCase {
         // Then the footer should now be showing an error.
         XCTAssertTrue(context.viewState.isShowingFooterError, "The error message should be stored.")
         XCTAssertNotNil(context.viewState.footerErrorMessage, "The error message should be stored.")
-        XCTAssertNotEqual(String(context.viewState.footerMessage.characters), L10n.screenChangeServerFormNotice(L10n.actionLearnMore),
+        XCTAssertNotEqual(String(context.viewState.footerMessage), L10n.screenChangeServerFormNotice,
                           "The error message should be shown.")
         
         // And when clearing the error.
@@ -115,7 +115,7 @@ class ServerSelectionScreenViewModelTests: XCTestCase {
         
         // Then the error message should now be removed.
         XCTAssertNil(context.viewState.footerErrorMessage, "The error message should have been cleared.")
-        XCTAssertEqual(String(context.viewState.footerMessage.characters), L10n.screenChangeServerFormNotice(L10n.actionLearnMore),
+        XCTAssertEqual(String(context.viewState.footerMessage), L10n.screenChangeServerFormNotice,
                        "The standard footer message should be shown again.")
     }
     

--- a/UnitTests/Sources/ServerSelectionScreenViewModelTests.swift
+++ b/UnitTests/Sources/ServerSelectionScreenViewModelTests.swift
@@ -131,7 +131,6 @@ class ServerSelectionScreenViewModelTests: XCTestCase {
         
         viewModel = ServerSelectionScreenViewModel(authenticationService: service,
                                                    authenticationFlow: authenticationFlow,
-                                                   slidingSyncLearnMoreURL: ServiceLocator.shared.settings.slidingSyncLearnMoreURL,
                                                    userIndicatorController: UserIndicatorControllerMock())
     }
 }


### PR DESCRIPTION
It linked to documentation about the old Sliding Sync proxy. Now that we're production ready, Sliding Sync is part of the spec and Synapse has native support, we don't need these docs anymore.