### PR TITLE
Run integration tests on GH CI

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   integration_tests:
     name: Integration Tests
-    runs-on: perf-only
+    runs-on: macos-15
 
     concurrency:
       # Only allow a single run of this workflow on each branch, automatically cancelling older runs.
@@ -17,6 +17,10 @@ jobs:
       cancel-in-progress: false
 
     steps:
+        # While fastlane has its own way of selecting Xcode, will only work inside fastlane, so we need to set it globally to allow other actions like xcresultparser to use the same Xcode version.
+      - name: Select Xcode 16.3
+        run: sudo xcode-select -s /Applications/Xcode_16.3.app
+        
       - uses: actions/checkout@v4
 
       - uses: actions/cache@v4

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     # While fastlane has its own way of selecting Xcode, will only work inside fastlane, so we need to set it globally to allow other actions like xcresultparser to use the same Xcode version.
-      - name: Select XCode 16.3
+      - name: Select Xcode 16.3
         run: sudo xcode-select -s /Applications/Xcode_16.3.app
         
       - uses: nschloe/action-cached-lfs-checkout@f46300cd8952454b9f0a21a3d133d4bd5684cfc2 #v1.2.3


### PR DESCRIPTION
This will make integration tests run on GH CI, with the appropriate mac os and Xcode version