### PR TITLE
Dismiss room invite notifications when rejecting them from the home screen.

### DIFF
--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -494,7 +494,11 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
     private func presentHomeScreen() {
         let parameters = HomeScreenCoordinatorParameters(userSession: userSession,
                                                          bugReportService: bugReportService,
-                                                         selectedRoomPublisher: selectedRoomSubject.asCurrentValuePublisher())
+                                                         selectedRoomPublisher: selectedRoomSubject.asCurrentValuePublisher(),
+                                                         appSettings: appSettings,
+                                                         analyticsService: analytics,
+                                                         notificationManager: notificationManager,
+                                                         userIndicatorController: ServiceLocator.shared.userIndicatorController)
         let coordinator = HomeScreenCoordinator(parameters: parameters)
         
         coordinator.actions

--- a/ElementX/Sources/Other/SwiftUI/Animation/ShimmerModifier.swift
+++ b/ElementX/Sources/Other/SwiftUI/Animation/ShimmerModifier.swift
@@ -8,6 +8,13 @@
 import Combine
 import SwiftUI
 
+extension View {
+    /// Applies a shimmering effect to the view.
+    func shimmer() -> some View {
+        modifier(ShimmerModifier())
+    }
+}
+
 /// A view modifier that applies a shimmering effect to the view.
 struct ShimmerModifier: ViewModifier {
     /// A boolean which is toggled to trigger the animation.
@@ -59,18 +66,12 @@ struct ShimmerModifier: ViewModifier {
     }
 }
 
-extension View {
-    /// Applies a shimmering effect to the view.
-    func shimmer() -> some View {
-        modifier(ShimmerModifier())
-    }
-}
-
 struct ShimmerOverlay_Previews: PreviewProvider, TestablePreview {
     static let viewModel = HomeScreenViewModel(userSession: UserSessionMock(.init(clientProxy: ClientProxyMock(.init(userID: "")))),
-                                               analyticsService: ServiceLocator.shared.analytics,
-                                               appSettings: ServiceLocator.shared.settings,
                                                selectedRoomPublisher: CurrentValueSubject<String?, Never>(nil).asCurrentValuePublisher(),
+                                               appSettings: ServiceLocator.shared.settings,
+                                               analyticsService: ServiceLocator.shared.analytics,
+                                               notificationManager: NotificationManagerMock(),
                                                userIndicatorController: ServiceLocator.shared.userIndicatorController)
     
     static var previews: some View {

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenCoordinator.swift
@@ -12,6 +12,10 @@ struct HomeScreenCoordinatorParameters {
     let userSession: UserSessionProtocol
     let bugReportService: BugReportServiceProtocol
     let selectedRoomPublisher: CurrentValuePublisher<String?, Never>
+    let appSettings: AppSettings
+    let analyticsService: AnalyticsService
+    let notificationManager: NotificationManagerProtocol
+    let userIndicatorController: UserIndicatorControllerProtocol
 }
 
 enum HomeScreenCoordinatorAction {
@@ -45,10 +49,11 @@ final class HomeScreenCoordinator: CoordinatorProtocol {
     
     init(parameters: HomeScreenCoordinatorParameters) {
         viewModel = HomeScreenViewModel(userSession: parameters.userSession,
-                                        analyticsService: ServiceLocator.shared.analytics,
-                                        appSettings: ServiceLocator.shared.settings,
                                         selectedRoomPublisher: parameters.selectedRoomPublisher,
-                                        userIndicatorController: ServiceLocator.shared.userIndicatorController)
+                                        appSettings: parameters.appSettings,
+                                        analyticsService: parameters.analyticsService,
+                                        notificationManager: parameters.notificationManager,
+                                        userIndicatorController: parameters.userIndicatorController)
         bugReportService = parameters.bugReportService
         
         viewModel.actions

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -16,6 +16,7 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
     private let userSession: UserSessionProtocol
     private let analyticsService: AnalyticsService
     private let appSettings: AppSettings
+    private let notificationManager: NotificationManagerProtocol
     private let userIndicatorController: UserIndicatorControllerProtocol
     
     private let roomSummaryProvider: RoomSummaryProviderProtocol?
@@ -26,13 +27,15 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
     }
     
     init(userSession: UserSessionProtocol,
-         analyticsService: AnalyticsService,
-         appSettings: AppSettings,
          selectedRoomPublisher: CurrentValuePublisher<String?, Never>,
+         appSettings: AppSettings,
+         analyticsService: AnalyticsService,
+         notificationManager: NotificationManagerProtocol,
          userIndicatorController: UserIndicatorControllerProtocol) {
         self.userSession = userSession
         self.analyticsService = analyticsService
         self.appSettings = appSettings
+        self.notificationManager = notificationManager
         self.userIndicatorController = userIndicatorController
         
         roomSummaryProvider = userSession.clientProxy.roomSummaryProvider
@@ -462,6 +465,7 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
         
         switch result {
         case .success:
+            await notificationManager.removeDeliveredMessageNotifications(for: roomID) // Normally handled by the room flow, but that's never presented in this case.
             appSettings.seenInvites.remove(roomID)
         case .failure:
             displayError()

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
@@ -137,9 +137,10 @@ struct HomeScreen_Previews: PreviewProvider, TestablePreview {
         let userSession = UserSessionMock(.init(clientProxy: clientProxy))
         
         return HomeScreenViewModel(userSession: userSession,
-                                   analyticsService: ServiceLocator.shared.analytics,
-                                   appSettings: ServiceLocator.shared.settings,
                                    selectedRoomPublisher: CurrentValueSubject<String?, Never>(nil).asCurrentValuePublisher(),
+                                   appSettings: ServiceLocator.shared.settings,
+                                   analyticsService: ServiceLocator.shared.analytics,
+                                   notificationManager: NotificationManagerMock(),
                                    userIndicatorController: ServiceLocator.shared.userIndicatorController)
     }
 }

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreenEmptyStateView.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreenEmptyStateView.swift
@@ -144,9 +144,10 @@ struct HomeScreenEmptyStateView_Previews: PreviewProvider, TestablePreview {
                                                                                    roomSummaryProvider: RoomSummaryProviderMock(.init(state: .loaded([])))))))
         
         return HomeScreenViewModel(userSession: userSession,
-                                   analyticsService: ServiceLocator.shared.analytics,
-                                   appSettings: ServiceLocator.shared.settings,
                                    selectedRoomPublisher: CurrentValueSubject<String?, Never>(nil).asCurrentValuePublisher(),
+                                   appSettings: ServiceLocator.shared.settings,
+                                   analyticsService: ServiceLocator.shared.analytics,
+                                   notificationManager: NotificationManagerMock(),
                                    userIndicatorController: ServiceLocator.shared.userIndicatorController)
     }()
 }

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreenInviteCell.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreenInviteCell.swift
@@ -155,38 +155,39 @@ struct HomeScreenInviteCell_Previews: PreviewProvider, TestablePreview {
     static var previews: some View {
         VStack(spacing: 0) {
             HomeScreenInviteCell(room: .dmInvite,
-                                 context: viewModel().context, hideInviteAvatars: false)
+                                 context: makeViewModel().context, hideInviteAvatars: false)
             
             HomeScreenInviteCell(room: .dmInvite,
-                                 context: viewModel().context, hideInviteAvatars: false)
+                                 context: makeViewModel().context, hideInviteAvatars: false)
             
             HomeScreenInviteCell(room: .roomInvite(),
-                                 context: viewModel().context, hideInviteAvatars: false)
+                                 context: makeViewModel().context, hideInviteAvatars: false)
             
             HomeScreenInviteCell(room: .roomInvite(),
-                                 context: viewModel().context, hideInviteAvatars: false)
+                                 context: makeViewModel().context, hideInviteAvatars: false)
             
             HomeScreenInviteCell(room: .roomInvite(alias: "#footest:somewhere.org", avatarURL: .mockMXCAvatar),
-                                 context: viewModel().context, hideInviteAvatars: false)
+                                 context: makeViewModel().context, hideInviteAvatars: false)
             HomeScreenInviteCell(room: .roomInvite(alias: "#footest-hidden-avatars:somewhere.org", avatarURL: .mockMXCAvatar),
-                                 context: viewModel().context, hideInviteAvatars: true)
+                                 context: makeViewModel().context, hideInviteAvatars: true)
             HomeScreenInviteCell(room: .roomInvite(alias: "#footest:somewhere.org"),
-                                 context: viewModel().context, hideInviteAvatars: false)
+                                 context: makeViewModel().context, hideInviteAvatars: false)
                 .dynamicTypeSize(.accessibility1)
                 .previewDisplayName("Aliased room (AX1)")
         }
         .previewLayout(.sizeThatFits)
     }
     
-    static func viewModel() -> HomeScreenViewModel {
+    static func makeViewModel() -> HomeScreenViewModel {
         let clientProxy = ClientProxyMock(.init())
         
         let userSession = UserSessionMock(.init(clientProxy: clientProxy))
         
         return HomeScreenViewModel(userSession: userSession,
-                                   analyticsService: ServiceLocator.shared.analytics,
-                                   appSettings: ServiceLocator.shared.settings,
                                    selectedRoomPublisher: CurrentValueSubject<String?, Never>(nil).asCurrentValuePublisher(),
+                                   appSettings: ServiceLocator.shared.settings,
+                                   analyticsService: ServiceLocator.shared.analytics,
+                                   notificationManager: NotificationManagerMock(),
                                    userIndicatorController: ServiceLocator.shared.userIndicatorController)
     }
 }

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreenKnockedCell.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreenKnockedCell.swift
@@ -101,37 +101,38 @@ struct HomeScreenKnockedCell_Previews: PreviewProvider, TestablePreview {
         ScrollView {
             VStack(spacing: 0) {
                 HomeScreenKnockedCell(room: .dmInvite,
-                                      context: viewModel().context)
+                                      context: makeViewModel().context)
                 
                 HomeScreenKnockedCell(room: .dmInvite,
-                                      context: viewModel().context)
+                                      context: makeViewModel().context)
                 
                 HomeScreenKnockedCell(room: .roomKnocked(),
-                                      context: viewModel().context)
+                                      context: makeViewModel().context)
                 
                 HomeScreenKnockedCell(room: .roomKnocked(),
-                                      context: viewModel().context)
+                                      context: makeViewModel().context)
                 
                 HomeScreenKnockedCell(room: .roomKnocked(alias: "#footest:somewhere.org", avatarURL: .mockMXCAvatar),
-                                      context: viewModel().context)
+                                      context: makeViewModel().context)
                 
                 HomeScreenKnockedCell(room: .roomKnocked(alias: "#footest:somewhere.org"),
-                                      context: viewModel().context)
+                                      context: makeViewModel().context)
                     .dynamicTypeSize(.accessibility1)
                     .previewDisplayName("Aliased room (AX1)")
             }
         }
     }
     
-    static func viewModel() -> HomeScreenViewModel {
+    static func makeViewModel() -> HomeScreenViewModel {
         let clientProxy = ClientProxyMock(.init())
         
         let userSession = UserSessionMock(.init(clientProxy: clientProxy))
         
         return HomeScreenViewModel(userSession: userSession,
-                                   analyticsService: ServiceLocator.shared.analytics,
-                                   appSettings: ServiceLocator.shared.settings,
                                    selectedRoomPublisher: CurrentValueSubject<String?, Never>(nil).asCurrentValuePublisher(),
+                                   appSettings: ServiceLocator.shared.settings,
+                                   analyticsService: ServiceLocator.shared.analytics,
+                                   notificationManager: NotificationManagerMock(),
                                    userIndicatorController: ServiceLocator.shared.userIndicatorController)
     }
 }

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreenRecoveryKeyConfirmationBanner.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreenRecoveryKeyConfirmationBanner.swift
@@ -103,7 +103,7 @@ struct HomeScreenRecoveryKeyConfirmationBanner: View {
 }
 
 struct HomeScreenRecoveryKeyConfirmationBanner_Previews: PreviewProvider, TestablePreview {
-    static let viewModel = buildViewModel()
+    static let viewModel = makeViewModel()
     
     static var previews: some View {
         HomeScreenRecoveryKeyConfirmationBanner(state: .setUpRecovery,
@@ -114,16 +114,17 @@ struct HomeScreenRecoveryKeyConfirmationBanner_Previews: PreviewProvider, Testab
             .previewDisplayName("Out of sync")
     }
     
-    static func buildViewModel() -> HomeScreenViewModel {
+    static func makeViewModel() -> HomeScreenViewModel {
         let clientProxy = ClientProxyMock(.init(userID: "@alice:example.com",
                                                 roomSummaryProvider: RoomSummaryProviderMock(.init(state: .loading))))
         
         let userSession = UserSessionMock(.init(clientProxy: clientProxy))
         
         return HomeScreenViewModel(userSession: userSession,
-                                   analyticsService: ServiceLocator.shared.analytics,
-                                   appSettings: ServiceLocator.shared.settings,
                                    selectedRoomPublisher: CurrentValueSubject<String?, Never>(nil).asCurrentValuePublisher(),
+                                   appSettings: ServiceLocator.shared.settings,
+                                   analyticsService: ServiceLocator.shared.analytics,
+                                   notificationManager: NotificationManagerMock(),
                                    userIndicatorController: ServiceLocator.shared.userIndicatorController)
     }
 }


### PR DESCRIPTION
Normally we reject invitations when starting the room flow, but in the case of tapping reject on the home screen, these notifications would be left visible. 

Fixes #4069.