### PR TITLE
Update the template screen to use the new(ish) Observation framework.

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -1054,6 +1054,7 @@
 		CEB8FB1269DE20536608B957 /* LoginMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B41FABA2B0AEF4389986495 /* LoginMode.swift */; };
 		CF38B70D8C6DD42C00A56A27 /* LogViewerScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A84D413BF49F0E980F010A6B /* LogViewerScreenCoordinator.swift */; };
 		CF4044A8EED5C41BC0ED6ABE /* SoftLogoutScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D316BB02636AF2174F2580E6 /* SoftLogoutScreenViewModelProtocol.swift */; };
+		CF638B8C6FDCE920AE061FAE /* StateStoreViewModelV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A106D76741914F82664959 /* StateStoreViewModelV2.swift */; };
 		CFEC53440C572CEEABC4A6A0 /* ElementXAttributeScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = C024C151639C4E1B91FCC68B /* ElementXAttributeScope.swift */; };
 		D02AA6208C7ACB9BE6332394 /* UNNotificationContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE148A4FFEE853C5A281500C /* UNNotificationContent.swift */; };
 		D02DEB36D32A72A1B365E452 /* SessionVerificationScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 796CBD0C56FA0D3AEDAB255B /* SessionVerificationScreenCoordinator.swift */; };
@@ -1940,6 +1941,7 @@
 		7893780A1FD6E3F38B3E9049 /* UserIndicatorControllerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserIndicatorControllerMock.swift; sourceTree = "<group>"; };
 		78BBDF7A05CF53B5CDC13682 /* landscape_test_video.mov */ = {isa = PBXFileReference; lastKnownFileType = video.quicktime; path = landscape_test_video.mov; sourceTree = "<group>"; };
 		796CBD0C56FA0D3AEDAB255B /* SessionVerificationScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionVerificationScreenCoordinator.swift; sourceTree = "<group>"; };
+		79A106D76741914F82664959 /* StateStoreViewModelV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateStoreViewModelV2.swift; sourceTree = "<group>"; };
 		7A03E073077D92AA19C43DCF /* IdentityConfirmationScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityConfirmationScreenCoordinator.swift; sourceTree = "<group>"; };
 		7AAD8C633AA57948B34EDCF7 /* RoomChangeRolesScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomChangeRolesScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		7AC0CD1CAFD3F8B057F9AEA5 /* ClientBuilderHook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientBuilderHook.swift; sourceTree = "<group>"; };
@@ -2868,6 +2870,7 @@
 			children = (
 				6EA1D2CBAEA5D0BD00B90D1B /* BindableState.swift */,
 				6F3DFE5B444F131648066F05 /* StateStoreViewModel.swift */,
+				79A106D76741914F82664959 /* StateStoreViewModelV2.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -7662,6 +7665,7 @@
 				CB6BCBF28E4B76EA08C2926D /* StateRoomTimelineItem.swift in Sources */,
 				3B277D9538090766DA6C4566 /* StateRoomTimelineView.swift in Sources */,
 				B4AAB3257A83B73F53FB2689 /* StateStoreViewModel.swift in Sources */,
+				CF638B8C6FDCE920AE061FAE /* StateStoreViewModelV2.swift in Sources */,
 				B1069F361E604D5436AE9FFD /* StaticLocationScreen.swift in Sources */,
 				1AB3D8563AB12635250A6A6E /* StaticLocationScreenCoordinator.swift in Sources */,
 				DFD5AA8688A34C72D48AF3B1 /* StaticLocationScreenViewModel.swift in Sources */,

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -1276,6 +1276,7 @@
 		FCD3F2B82CAB29A07887A127 /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = 2B43F2AF7456567FE37270A7 /* KeychainAccess */; };
 		FD29471C72872F8B7580E3E1 /* KeychainControllerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C0D861FC397AC34BCF089E /* KeychainControllerMock.swift */; };
 		FD4C21F8DA1E273DE94FCD1A /* NotificationItemProxyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B927CF5EF7FCCDA5EDC474B /* NotificationItemProxyProtocol.swift */; };
+		FD573B5D665824EB79EABF06 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5327E3B3C58BEB0E65F4CF98 /* Observable.swift */; };
 		FD762761C5D0C30E6255C3D8 /* ServerConfirmationScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABA4CF2F5B4F68D02E412004 /* ServerConfirmationScreenViewModelProtocol.swift */; };
 		FD9777315A5D9CDC47458AD1 /* MediaEventsTimelineScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A175D0FDEDBFA44C47FE13AE /* MediaEventsTimelineScreenViewModelProtocol.swift */; };
 		FDC67E8C0EDCB00ABC66C859 /* landscape_test_video.mov in Resources */ = {isa = PBXBuildFile; fileRef = 78BBDF7A05CF53B5CDC13682 /* landscape_test_video.mov */; };
@@ -1785,6 +1786,7 @@
 		529513218340CC8419273165 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		52BD6ED18E2EB61E28C340AD /* AttributedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedString.swift; sourceTree = "<group>"; };
 		52F5EE5DE3B55D59299DB5BC /* AppLockSetupBiometricsScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockSetupBiometricsScreenViewModelTests.swift; sourceTree = "<group>"; };
+		5327E3B3C58BEB0E65F4CF98 /* Observable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
 		53482ECA4B6633961EC224F5 /* ScrollViewAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollViewAdapter.swift; sourceTree = "<group>"; };
 		5351EBD7A0B9610548E4B7B2 /* EncryptedRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptedRoomTimelineItem.swift; sourceTree = "<group>"; };
 		536C0E2178949B290776EA4E /* QRCodeLoginServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeLoginServiceProtocol.swift; sourceTree = "<group>"; };
@@ -3684,6 +3686,7 @@
 				C14D83B2B7CD5501A0089EFC /* LayoutDirection.swift */,
 				F72EFC8C634469F9262659C7 /* NSItemProvider.swift */,
 				95BAC0F6C9644336E9567EE6 /* NSRegularExpresion.swift */,
+				5327E3B3C58BEB0E65F4CF98 /* Observable.swift */,
 				62B07B296D7A9D2F09120853 /* OrderedSet.swift */,
 				D26813CCE39221FE30BF22CD /* PlatformViewVersionPredicate.swift */,
 				077B01C13BBA2996272C5FB5 /* ProcessInfo.swift */,
@@ -7377,6 +7380,7 @@
 				523C6800ED85D5810CF18C19 /* OIDCAccountSettingsPresenter.swift in Sources */,
 				9A4E3D5AA44B041DAC3A0D81 /* OIDCAuthenticationPresenter.swift in Sources */,
 				E362924A42934C9F0F97A956 /* OIDCConfigurationProxy.swift in Sources */,
+				FD573B5D665824EB79EABF06 /* Observable.swift in Sources */,
 				11A6B8E3CBDBF0A4107FF4CE /* OnboardingFlowCoordinator.swift in Sources */,
 				3CE4C5071B6D2576E2473989 /* OrderedSet.swift in Sources */,
 				AA5924D3B67F7ACD98BBEFDC /* OrientationManagerProtocol.swift in Sources */,

--- a/ElementX/Sources/Other/Extensions/AsyncSequence.swift
+++ b/ElementX/Sources/Other/Extensions/AsyncSequence.swift
@@ -9,4 +9,19 @@ extension AsyncSequence {
     func first() async rethrows -> Self.Element? {
         try await first { _ in true }
     }
+    
+    /// Type-erases the sequence into a newly constructed asynchronous stream. This is useful until
+    /// we drop support for iOS 17, at which point we can replace this with `any AsyncSequence`.
+    @available(iOS, deprecated: 18.0, message: "Use `any AsyncSequence` instead.")
+    func eraseToStream() -> AsyncStream<Element> {
+        var asyncIterator = makeAsyncIterator()
+        return AsyncStream<Element> {
+            do {
+                return try await asyncIterator.next()
+            } catch {
+                MXLog.warning("Stopping stream: \(error)")
+                return nil
+            }
+        }
+    }
 }

--- a/ElementX/Sources/Other/Extensions/Observable.swift
+++ b/ElementX/Sources/Other/Extensions/Observable.swift
@@ -8,7 +8,9 @@
 import Foundation
 
 extension Observable {
-    /// Creates an async stream for the specified property on this object.
+    /// Creates an async stream for the specified property on this object. We probably won't need this once SE-0475 is available:
+    /// https://github.com/swiftlang/swift-evolution/blob/main/proposals/0475-observed.md
+    ///
     /// - Parameter property: The key path to the property you would like to observe.
     func observe<Value>(_ property: KeyPath<Self, Value>) -> AsyncStream<Value> {
         AsyncStream { continuation in

--- a/ElementX/Sources/Other/Extensions/Observable.swift
+++ b/ElementX/Sources/Other/Extensions/Observable.swift
@@ -1,0 +1,35 @@
+//
+// Copyright 2025 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Foundation
+
+extension Observable {
+    /// Creates an async stream for the specified property on this object.
+    /// - Parameter property: The key path to the property you would like to observe.
+    func observe<Value>(_ property: KeyPath<Self, Value>) -> AsyncStream<Value> {
+        AsyncStream { continuation in
+            var isActive = true
+            
+            @Sendable func observe() {
+                let value = withObservationTracking {
+                    self[keyPath: property]
+                } onChange: {
+                    // Dispatch the update as this is willSet not didSet.
+                    DispatchQueue.main.async {
+                        guard isActive else { return }
+                        observe()
+                    }
+                }
+                continuation.yield(value)
+            }
+            
+            continuation.onTermination = { _ in isActive = false }
+            
+            observe()
+        }
+    }
+}

--- a/ElementX/Sources/Other/Extensions/XCTestCase.swift
+++ b/ElementX/Sources/Other/Extensions/XCTestCase.swift
@@ -48,6 +48,61 @@ extension XCTestCase {
         }
     }
     
+    /// XCTest utility that assists in observing an `Observable`'s property and deferring the fulfilment and results until some condition has been met.
+    /// - Parameters:
+    ///   - observable: The object to observe.
+    ///   - property: The object's property to wait on.
+    ///   - timeout: A timeout after which we give up.
+    ///   - message: An optional custom expectation message
+    ///   - until: callback that evaluates outputs until some condition is reached
+    /// - Returns: The deferred fulfilment to be executed after some actions and that returns the result of the publisher.
+    func deferFulfillment<Object: Observable, Value>(_ observable: Object,
+                                                     property: KeyPath<Object, Value> & Sendable,
+                                                     timeout: TimeInterval = 10,
+                                                     message: String? = nil,
+                                                     until condition: @escaping (Value) -> Bool) -> DeferredFulfillment<Value> {
+        var result: Result<Value, Error>?
+        let expectation = expectation(description: message ?? "Awaiting observable")
+        var hasFulfilled = false
+        
+        let task = Task {
+            func completion(_ value: Value) {
+                result = .success(value)
+                expectation.fulfill()
+                hasFulfilled = true
+            }
+            
+            @discardableResult
+            func startObservation() -> Value {
+                withObservationTracking {
+                    observable[keyPath: property]
+                } onChange: {
+                    guard !Task.isCancelled else { return }
+                    
+                    DispatchQueue.main.async {
+                        let value = observable[keyPath: property]
+                        if condition(value), !hasFulfilled {
+                            completion(value)
+                        } else {
+                            startObservation()
+                        }
+                    }
+                }
+            }
+            
+            if condition(startObservation()), !hasFulfilled {
+                completion(observable[keyPath: property])
+            }
+        }
+        
+        return DeferredFulfillment<Value> {
+            await self.fulfillment(of: [expectation], timeout: timeout)
+            task.cancel()
+            let unwrappedResult = try XCTUnwrap(result, "Awaited observable did not produce any output")
+            return try unwrappedResult.get()
+        }
+    }
+    
     /// XCTest utility that assists in subscribing to a publisher and deferring the fulfilment and results until some other actions have been performed.
     /// - Parameters:
     ///   - publisher: The publisher to wait on.

--- a/ElementX/Sources/Other/Extensions/XCTestCase.swift
+++ b/ElementX/Sources/Other/Extensions/XCTestCase.swift
@@ -60,7 +60,7 @@ extension XCTestCase {
                                  message: String? = nil,
                                  until condition: @escaping (Value) -> Bool) -> DeferredFulfillment<Value> {
         var result: Result<Value, Error>?
-        let expectation = expectation(description: message ?? "Awaiting observable")
+        let expectation = expectation(description: message ?? "Awaiting stream")
         var hasFulfilled = false
         
         let task = Task {
@@ -76,7 +76,7 @@ extension XCTestCase {
         return DeferredFulfillment<Value> {
             await self.fulfillment(of: [expectation], timeout: timeout)
             task.cancel()
-            let unwrappedResult = try XCTUnwrap(result, "Awaited observable did not produce any output")
+            let unwrappedResult = try XCTUnwrap(result, "Awaited stream did not produce any output")
             return try unwrappedResult.get()
         }
     }

--- a/Tools/Scripts/Templates/SimpleScreenExample/ElementX/TemplateScreenModels.swift
+++ b/Tools/Scripts/Templates/SimpleScreenExample/ElementX/TemplateScreenModels.swift
@@ -16,6 +16,8 @@ enum TemplateScreenViewModelAction {
 struct TemplateScreenViewState: BindableState {
     var title: String
     var placeholder: String
+    var counter = 0
+    
     var bindings: TemplateScreenViewStateBindings
 }
 
@@ -26,6 +28,9 @@ struct TemplateScreenViewStateBindings {
 enum TemplateScreenViewAction {
     case done
     case textChanged
+    
+    case incrementCounter
+    case decrementCounter
     
     // Consider adding CustomStringConvertible conformance if the actions contain PII
 }

--- a/Tools/Scripts/Templates/SimpleScreenExample/ElementX/TemplateScreenViewModel.swift
+++ b/Tools/Scripts/Templates/SimpleScreenExample/ElementX/TemplateScreenViewModel.swift
@@ -33,9 +33,15 @@ class TemplateScreenViewModel: TemplateScreenViewModelType, TemplateScreenViewMo
         case .textChanged:
             MXLog.info("View model: composer text changed to: \(state.bindings.composerText)")
         case .incrementCounter:
-            state.counter += 1
+            Task {
+                try await Task.sleep(for: .seconds(.random(in: 1.0...2.0)))
+                state.counter += 1
+            }
         case .decrementCounter:
-            state.counter -= 1
+            Task {
+                try await Task.sleep(for: .seconds(.random(in: 1.0...2.0)))
+                state.counter -= 1
+            }
         }
     }
 }

--- a/Tools/Scripts/Templates/SimpleScreenExample/ElementX/TemplateScreenViewModel.swift
+++ b/Tools/Scripts/Templates/SimpleScreenExample/ElementX/TemplateScreenViewModel.swift
@@ -8,7 +8,7 @@
 import Combine
 import SwiftUI
 
-typealias TemplateScreenViewModelType = StateStoreViewModel<TemplateScreenViewState, TemplateScreenViewAction>
+typealias TemplateScreenViewModelType = StateStoreViewModelV2<TemplateScreenViewState, TemplateScreenViewAction>
 
 class TemplateScreenViewModel: TemplateScreenViewModelType, TemplateScreenViewModelProtocol {
     private let actionsSubject: PassthroughSubject<TemplateScreenViewModelAction, Never> = .init()
@@ -32,6 +32,10 @@ class TemplateScreenViewModel: TemplateScreenViewModelType, TemplateScreenViewMo
             actionsSubject.send(.done)
         case .textChanged:
             MXLog.info("View model: composer text changed to: \(state.bindings.composerText)")
+        case .incrementCounter:
+            state.counter += 1
+        case .decrementCounter:
+            state.counter -= 1
         }
     }
 }

--- a/Tools/Scripts/Templates/SimpleScreenExample/ElementX/View/TemplateScreen.swift
+++ b/Tools/Scripts/Templates/SimpleScreenExample/ElementX/View/TemplateScreen.swift
@@ -9,7 +9,7 @@ import Compound
 import SwiftUI
 
 struct TemplateScreen: View {
-    @ObservedObject var context: TemplateScreenViewModel.Context
+    @Bindable var context: TemplateScreenViewModel.Context
     
     var body: some View {
         Form {
@@ -18,8 +18,18 @@ struct TemplateScreen: View {
                         kind: .textField(text: $context.composerText))
                 
                 ListRow(label: .centeredAction(title: L10n.actionDone,
-                                               systemIcon: .doorLeftHandClosed),
+                                               icon: \.leave),
                         kind: .button { context.send(viewAction: .done) })
+            }
+            
+            Section {
+                ListRow(label: .default(title: "Counter", icon: \.chart),
+                        details: .counter(context.viewState.counter),
+                        kind: .label)
+                ListRow(label: .default(title: "Increment", icon: \.plus),
+                        kind: .button { context.send(viewAction: .incrementCounter) })
+                ListRow(label: .default(title: "Decrement", icon: \.minus),
+                        kind: .button { context.send(viewAction: .decrementCounter) })
             }
         }
         .compoundList()

--- a/Tools/Scripts/Templates/SimpleScreenExample/ElementX/View/TemplateScreen.swift
+++ b/Tools/Scripts/Templates/SimpleScreenExample/ElementX/View/TemplateScreen.swift
@@ -43,10 +43,29 @@ struct TemplateScreen: View {
 // MARK: - Previews
 
 struct TemplateScreen_Previews: PreviewProvider, TestablePreview {
-    static let viewModel = TemplateScreenViewModel()
+    static let viewModel = makeViewModel()
+    static let incrementedViewModel = makeViewModel(counterValue: 1)
+    
     static var previews: some View {
         NavigationStack {
             TemplateScreen(context: viewModel.context)
         }
+        .previewDisplayName("Initial")
+        
+        NavigationStack {
+            TemplateScreen(context: incrementedViewModel.context)
+        }
+        .previewDisplayName("Incremented")
+        .snapshotPreferences(expect: incrementedViewModel.context.observe(\.viewState.counter).map { $0 == 1 }.eraseToStream())
+    }
+    
+    static func makeViewModel(counterValue: Int = 0) -> TemplateScreenViewModel {
+        let viewModel = TemplateScreenViewModel()
+        
+        for _ in 0..<counterValue {
+            viewModel.context.send(viewAction: .incrementCounter)
+        }
+        
+        return viewModel
     }
 }

--- a/Tools/Scripts/Templates/SimpleScreenExample/Tests/Unit/TemplateScreenViewModelTests.swift
+++ b/Tools/Scripts/Templates/SimpleScreenExample/Tests/Unit/TemplateScreenViewModelTests.swift
@@ -33,12 +33,20 @@ class TemplateScreenViewModelTests: XCTestCase {
     }
     
     func testCounter() async throws {
+        var deferred = deferFulfillment(context, property: \.viewState.counter) { $0 == 1 }
+        context.send(viewAction: .incrementCounter)
+        try await deferred.fulfill()
+        XCTAssertEqual(context.viewState.counter, 1)
+        
+        deferred = deferFulfillment(context, property: \.viewState.counter) { $0 == 3 }
         context.send(viewAction: .incrementCounter)
         context.send(viewAction: .incrementCounter)
-        context.send(viewAction: .incrementCounter)
+        try await deferred.fulfill()
         XCTAssertEqual(context.viewState.counter, 3)
         
+        deferred = deferFulfillment(context, property: \.viewState.counter) { $0 == 2 }
         context.send(viewAction: .decrementCounter)
+        try await deferred.fulfill()
         XCTAssertEqual(context.viewState.counter, 2)
     }
 }

--- a/Tools/Scripts/Templates/SimpleScreenExample/Tests/Unit/TemplateScreenViewModelTests.swift
+++ b/Tools/Scripts/Templates/SimpleScreenExample/Tests/Unit/TemplateScreenViewModelTests.swift
@@ -33,18 +33,18 @@ class TemplateScreenViewModelTests: XCTestCase {
     }
     
     func testCounter() async throws {
-        var deferred = deferFulfillment(context, property: \.viewState.counter) { $0 == 1 }
+        var deferred = deferFulfillment(context.observe(\.viewState.counter)) { $0 == 1 }
         context.send(viewAction: .incrementCounter)
         try await deferred.fulfill()
         XCTAssertEqual(context.viewState.counter, 1)
         
-        deferred = deferFulfillment(context, property: \.viewState.counter) { $0 == 3 }
+        deferred = deferFulfillment(context.observe(\.viewState.counter)) { $0 == 3 }
         context.send(viewAction: .incrementCounter)
         context.send(viewAction: .incrementCounter)
         try await deferred.fulfill()
         XCTAssertEqual(context.viewState.counter, 3)
         
-        deferred = deferFulfillment(context, property: \.viewState.counter) { $0 == 2 }
+        deferred = deferFulfillment(context.observe(\.viewState.counter)) { $0 == 2 }
         context.send(viewAction: .decrementCounter)
         try await deferred.fulfill()
         XCTAssertEqual(context.viewState.counter, 2)

--- a/Tools/Scripts/Templates/SimpleScreenExample/Tests/Unit/TemplateScreenViewModelTests.swift
+++ b/Tools/Scripts/Templates/SimpleScreenExample/Tests/Unit/TemplateScreenViewModelTests.swift
@@ -22,13 +22,23 @@ class TemplateScreenViewModelTests: XCTestCase {
     }
 
     func testInitialState() {
-        XCTAssertFalse(context.viewState.placeholder.isEmpty)
         XCTAssertFalse(context.composerText.isEmpty)
+        XCTAssertEqual(context.viewState.counter, 0)
     }
 
-    func testCounter() async throws {
+    func testTextField() async throws {
         context.composerText = "123"
         context.send(viewAction: .textChanged)
         XCTAssertEqual(context.composerText, "123")
+    }
+    
+    func testCounter() async throws {
+        context.send(viewAction: .incrementCounter)
+        context.send(viewAction: .incrementCounter)
+        context.send(viewAction: .incrementCounter)
+        XCTAssertEqual(context.viewState.counter, 3)
+        
+        context.send(viewAction: .decrementCounter)
+        XCTAssertEqual(context.viewState.counter, 2)
     }
 }


### PR DESCRIPTION
Initial step for #3883 this PR introduces a `StateStoreViewModelV2` who's `Context` is `@Observable` instead of conforming to `ObservableObject` and therefore doesn't need an `@Published` on it's `viewState` property. Other than that the template screen now uses this type and an `@Bindable` on the context to allow the bindable state to work.

The second commit adds a variant of `deferFulfillment` that works with `Observable`s.

What this PR doesn't solve:
- What to do about expecting published view state in preview snapshots (shouldn’t be too hard to make a similar solution as the `deferFulfillment` implementation though).