### PR TITLE
Rely on the room's info to decide whether a call ringing notification is outdated

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		066A1E9B94723EE9F3038044 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47EBB5D698CE9A25BB553A2D /* Strings.swift */; };
 		06B31F84CE52A7A7C271267C /* SecureBackupRecoveryKeyScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FF08D0BD7D0B4B6877AB7D /* SecureBackupRecoveryKeyScreenViewModelTests.swift */; };
 		06B55882911B4BF5B14E9851 /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 227AC5D71A4CE43512062243 /* URL.swift */; };
+		06D17F7813AA931FF18FD5D0 /* SDKListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5CD2993048222B64C45006 /* SDKListener.swift */; };
 		06D3942496E9E0E655F14D21 /* NotificationManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A057F2FDC14866C3026A89A4 /* NotificationManagerProtocol.swift */; };
 		06F8EDF52E33A2D36BCC1161 /* AppLockScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D6F88FE35A0979D2821E06 /* AppLockScreen.swift */; };
 		071A017E415AD378F2961B11 /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 227AC5D71A4CE43512062243 /* URL.swift */; };
@@ -6725,6 +6726,7 @@
 				76C874243A8C440D6CF7B344 /* ProcessInfo.swift in Sources */,
 				414F50CFCFEEE2611127DCFB /* RestorationToken.swift in Sources */,
 				17BC15DA08A52587466698C5 /* RoomMessageEventStringBuilder.swift in Sources */,
+				06D17F7813AA931FF18FD5D0 /* SDKListener.swift in Sources */,
 				7573D682F089205F7F1D96CF /* SessionDirectories.swift in Sources */,
 				422E8D182CA688D4565CD1E1 /* String.swift in Sources */,
 				6EC7A40A537CFB3D526A111C /* Strings.swift in Sources */,

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -16,8 +16,6 @@
 			dependencies = (
 			);
 			name = Periphery;
-			packageProductDependencies = (
-			);
 			productName = Periphery;
 		};
 /* End PBXAggregateTarget section */
@@ -765,6 +763,7 @@
 		93AC1E8418D8C827671FB3A9 /* IdentityConfirmedScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 595EC503DA5517BBE6D39406 /* IdentityConfirmedScreenCoordinator.swift */; };
 		93BA4A81B6D893271101F9F0 /* DeviceKit in Frameworks */ = {isa = PBXBuildFile; productRef = A7CA6F33C553805035C3B114 /* DeviceKit */; };
 		93BAF04D9CCBC0A8841414D0 /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D67E616BCA82D8A1258D488 /* NetworkMonitor.swift */; };
+		93DC8297B8287B50B2A4B57D /* ExpiringTaskRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B25F959A434BB9923A3223F /* ExpiringTaskRunner.swift */; };
 		9408CE8B8865C0C8DD4C9869 /* NoticeRoomTimelineItemContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD51B4D5173F7FC886F5360 /* NoticeRoomTimelineItemContent.swift */; };
 		9462C62798F47E39DCC182D2 /* Application.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA89A2DD51B6BBE1DA55E263 /* Application.swift */; };
 		94A65DD8A353DF112EBEF67A /* SessionVerificationControllerProxyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D56469A9EE0CFA2B7BA9760 /* SessionVerificationControllerProxyProtocol.swift */; };
@@ -6411,7 +6410,6 @@
 				"zh-Hant-TW",
 			);
 			mainGroup = 405B00F139AEE3994601B36A;
-			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				E025F19D013D9BA6C58B37F4 /* XCRemoteSwiftPackageReference "swift-algorithms" */,
 				AC3475112CA40C2C6E78D1EB /* XCRemoteSwiftPackageReference "matrix-analytics-events" */,
@@ -6438,7 +6436,6 @@
 				EC6D0C817B1C21D9D096505A /* XCRemoteSwiftPackageReference "Version" */,
 				EE40B0E16A55BD23ECBFFD22 /* XCRemoteSwiftPackageReference "matrix-rich-text-editor-swift" */,
 			);
-			preferredProjectObjectVersion = 54;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -6694,6 +6691,7 @@
 				24A75F72EEB7561B82D726FD /* Date.swift in Sources */,
 				9F11B9F347F9E2D236799FB3 /* ElementCallServiceConstants.swift in Sources */,
 				CFEC53440C572CEEABC4A6A0 /* ElementXAttributeScope.swift in Sources */,
+				93DC8297B8287B50B2A4B57D /* ExpiringTaskRunner.swift in Sources */,
 				89198AE2649DD77673D5793B /* ExtensionLogger.swift in Sources */,
 				A33784831AD880A670CAA9F9 /* FileManager.swift in Sources */,
 				59F940FCBE6BC343AECEF75E /* ImageCache.swift in Sources */,

--- a/ElementX/Sources/Other/Extensions/ClientBuilder.swift
+++ b/ElementX/Sources/Other/Extensions/ClientBuilder.swift
@@ -15,13 +15,14 @@ extension ClientBuilder {
                             slidingSync: ClientBuilderSlidingSync,
                             sessionDelegate: ClientSessionDelegate,
                             appHooks: AppHooks,
-                            enableOnlySignedDeviceIsolationMode: Bool) -> ClientBuilder {
+                            enableOnlySignedDeviceIsolationMode: Bool,
+                            requestTimeout: UInt64? = 30000) -> ClientBuilder {
         var builder = ClientBuilder()
             .crossProcessStoreLocksHolderName(holderName: InfoPlistReader.main.bundleIdentifier)
             .enableOidcRefreshLock()
             .setSessionDelegate(sessionDelegate: sessionDelegate)
             .userAgent(userAgent: UserAgentBuilder.makeASCIIUserAgent())
-            .requestConfig(config: .init(retryLimit: 0, timeout: 30000, maxConcurrentRequests: nil, maxRetryTime: nil))
+            .requestConfig(config: .init(retryLimit: 0, timeout: requestTimeout, maxConcurrentRequests: nil, maxRetryTime: nil))
             .useEventCachePersistentStorage(value: true)
         
         builder = switch slidingSync {

--- a/ElementX/Sources/Other/Extensions/ClientBuilder.swift
+++ b/ElementX/Sources/Other/Extensions/ClientBuilder.swift
@@ -16,13 +16,17 @@ extension ClientBuilder {
                             sessionDelegate: ClientSessionDelegate,
                             appHooks: AppHooks,
                             enableOnlySignedDeviceIsolationMode: Bool,
-                            requestTimeout: UInt64? = 30000) -> ClientBuilder {
+                            requestTimeout: UInt64? = 30000,
+                            maxRequestRetryTime: UInt64? = nil) -> ClientBuilder {
         var builder = ClientBuilder()
             .crossProcessStoreLocksHolderName(holderName: InfoPlistReader.main.bundleIdentifier)
             .enableOidcRefreshLock()
             .setSessionDelegate(sessionDelegate: sessionDelegate)
             .userAgent(userAgent: UserAgentBuilder.makeASCIIUserAgent())
-            .requestConfig(config: .init(retryLimit: 0, timeout: requestTimeout, maxConcurrentRequests: nil, maxRetryTime: nil))
+            .requestConfig(config: .init(retryLimit: 0,
+                                         timeout: requestTimeout,
+                                         maxConcurrentRequests: nil,
+                                         maxRetryTime: maxRequestRetryTime))
             .useEventCachePersistentStorage(value: true)
         
         builder = switch slidingSync {

--- a/ElementX/Sources/Other/SDKListener.swift
+++ b/ElementX/Sources/Other/SDKListener.swift
@@ -74,6 +74,12 @@ extension SDKListener: RoomListLoadingStateListener where T == RoomListLoadingSt
     func onUpdate(state: RoomListLoadingState) { onUpdateClosure(state) }
 }
 
+// MARK: Room
+
+extension SDKListener: RoomInfoListener where T == RoomInfo {
+    func call(roomInfo: RoomInfo) { onUpdateClosure(roomInfo) }
+}
+
 // MARK: TimelineProxy
 
 extension SDKListener: PaginationStatusListener where T == RoomPaginationStatus {

--- a/ElementX/Sources/Services/ElementCall/ElementCallServiceConstants.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallServiceConstants.swift
@@ -12,4 +12,4 @@ enum ElementCallServiceNotificationKey: String {
     case roomDisplayName
 }
 
-let ElementCallServiceNotificationDiscardDelta = 10.0
+let ElementCallServiceNotificationDiscardDelta = 15.0

--- a/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
@@ -157,7 +157,7 @@ class JoinedRoomProxy: JoinedRoomProxyProtocol {
             return
         }
         
-        roomInfoObservationToken = room.subscribeToRoomInfoUpdates(listener: RoomInfoUpdateListener { [weak self] roomInfo in
+        roomInfoObservationToken = room.subscribeToRoomInfoUpdates(listener: SDKListener { [weak self] roomInfo in
             MXLog.info("Received room info update")
             self?.infoSubject.send(.init(roomInfo: roomInfo))
         })
@@ -807,18 +807,6 @@ class JoinedRoomProxy: JoinedRoomProxyProtocol {
         } catch {
             MXLog.error("Failed observing requests to join with error: \(error)")
         }
-    }
-}
-
-private final class RoomInfoUpdateListener: RoomInfoListener {
-    private let onUpdateClosure: (RoomInfo) -> Void
-    
-    init(_ onUpdateClosure: @escaping (RoomInfo) -> Void) {
-        self.onUpdateClosure = onUpdateClosure
-    }
-    
-    func call(roomInfo: RoomInfo) {
-        onUpdateClosure(roomInfo)
     }
 }
 

--- a/NSE/Sources/NotificationServiceExtension.swift
+++ b/NSE/Sources/NotificationServiceExtension.swift
@@ -63,11 +63,6 @@ class NotificationServiceExtension: UNNotificationServiceExtension {
         
         Target.nse.configure(logLevel: settings.logLevel, traceLogPacks: settings.traceLogPacks)
         
-        notificationHandler = NotificationHandler(settings: settings,
-                                                  contentHandler: contentHandler,
-                                                  notificationContent: mutableContent,
-                                                  tag: tag)
-        
         MXLog.info("\(tag) #########################################")
         
         ExtensionLogger.logMemory(with: tag)
@@ -82,12 +77,16 @@ class NotificationServiceExtension: UNNotificationServiceExtension {
                                                            appHooks: appHooks,
                                                            appSettings: settings)
                 
+                notificationHandler = NotificationHandler(userSession: userSession,
+                                                          settings: settings,
+                                                          contentHandler: contentHandler,
+                                                          notificationContent: mutableContent,
+                                                          tag: tag)
+                
                 ExtensionLogger.logMemory(with: tag)
                 MXLog.info("\(tag) Configured user session")
                 
-                await notificationHandler?.processEvent(eventID,
-                                                        roomID: roomID,
-                                                        userSession: userSession)
+                await notificationHandler?.processEvent(eventID, roomID: roomID)
             } catch {
                 MXLog.error("Failed creating user session with error: \(error)")
             }

--- a/NSE/Sources/Other/NSEUserSession.swift
+++ b/NSE/Sources/Other/NSEUserSession.swift
@@ -68,8 +68,17 @@ final class NSEUserSession {
                                          receiverID: userID,
                                          roomID: roomID)
         } catch {
-            MXLog.error("NSE: Could not get notification's content creating an empty notification instead, error: \(error)")
+            MXLog.error("Could not get notification's content creating an empty notification instead, error: \(error)")
             return EmptyNotificationItemProxy(eventID: eventID, roomID: roomID, receiverID: userID)
+        }
+    }
+    
+    func roomForIdentifier(_ roomID: String) -> Room? {
+        do {
+            return try baseClient.getRoom(roomId: roomID)
+        } catch {
+            MXLog.error("Failed retrieving room with error: \(error)")
+            return nil
         }
     }
     

--- a/NSE/Sources/Other/NSEUserSession.swift
+++ b/NSE/Sources/Other/NSEUserSession.swift
@@ -38,7 +38,8 @@ final class NSEUserSession {
                          slidingSync: .restored,
                          sessionDelegate: clientSessionDelegate,
                          appHooks: appHooks,
-                         enableOnlySignedDeviceIsolationMode: appSettings.enableOnlySignedDeviceIsolationMode)
+                         enableOnlySignedDeviceIsolationMode: appSettings.enableOnlySignedDeviceIsolationMode,
+                         requestTimeout: 15000)
             .systemIsMemoryConstrained()
             .sessionPaths(dataPath: credentials.restorationToken.sessionDirectories.dataPath,
                           cachePath: credentials.restorationToken.sessionDirectories.cachePath)

--- a/NSE/Sources/Other/NSEUserSession.swift
+++ b/NSE/Sources/Other/NSEUserSession.swift
@@ -39,7 +39,8 @@ final class NSEUserSession {
                          sessionDelegate: clientSessionDelegate,
                          appHooks: appHooks,
                          enableOnlySignedDeviceIsolationMode: appSettings.enableOnlySignedDeviceIsolationMode,
-                         requestTimeout: 15000)
+                         requestTimeout: 15000,
+                         maxRequestRetryTime: 5000)
             .systemIsMemoryConstrained()
             .sessionPaths(dataPath: credentials.restorationToken.sessionDirectories.dataPath,
                           cachePath: credentials.restorationToken.sessionDirectories.cachePath)

--- a/NSE/SupportingFiles/target.yml
+++ b/NSE/SupportingFiles/target.yml
@@ -88,6 +88,7 @@ targets:
     - path: ../../ElementX/Sources/Generated/Strings.swift
     - path: ../../ElementX/Sources/Other/Avatars.swift
     - path: ../../ElementX/Sources/Other/CurrentValuePublisher.swift
+    - path: ../../ElementX/Sources/Other/ExpiringTaskRunner.swift
     - path: ../../ElementX/Sources/Other/Extensions/AttributedString.swift
     - path: ../../ElementX/Sources/Other/Extensions/Bundle.swift
     - path: ../../ElementX/Sources/Other/Extensions/ClientBuilder.swift

--- a/NSE/SupportingFiles/target.yml
+++ b/NSE/SupportingFiles/target.yml
@@ -111,6 +111,7 @@ targets:
     - path: ../../ElementX/Sources/Other/NetworkMonitor
     - path: ../../ElementX/Sources/Other/Pills/PillUtilities.swift
     - path: ../../ElementX/Sources/Other/Pills/PlainMentionBuilder.swift
+    - path: ../../ElementX/Sources/Other/SDKListener.swift
     - path: ../../ElementX/Sources/Other/SwiftUI/Views/PlaceholderAvatarImage.swift
     - path: ../../ElementX/Sources/Other/TestablePreview.swift
     - path: ../../ElementX/Sources/Other/UserAgentBuilder.swift


### PR DESCRIPTION
This PR includes various tweaks for better handling call ring notifications:
* reduces the default client network request timeout from 30 to 15 seconds to avoid event requests blocking each other
* increases the duration after which a call notification is considered outdated for the legacy approach from 10 to 15 seconds (only applies if the room can't be retrieved from the client)
* starts relying on the room's info to decide whether a call ringing notification is outdated and should be ignored as opposed to the time based approach:
    * if the current info is that a call is ongoing then just go ahead and ring
    * if not try to wait for the next RoomInfo update or at least 5 seconds
    * check again and ring if necessary

The NSEUserSession creation has also been moved later in the flow and into the NotificationHandler constructor but it that's mostly cosmetical.
