### PR TITLE
Fix the integration tests.

### DIFF
--- a/ElementX/Sources/Other/Extensions/XCUIElement.swift
+++ b/ElementX/Sources/Other/Extensions/XCUIElement.swift
@@ -5,11 +5,12 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+import SwiftUI
 import XCTest
 
 extension XCUIElement {
     func clearAndTypeText(_ text: String, app: XCUIApplication) {
-        tapCenter()
+        tap(.center)
         
         app.showKeyboardIfNeeded()
         
@@ -26,8 +27,8 @@ extension XCUIElement {
         }
     }
     
-    func tapCenter() {
-        let coordinate: XCUICoordinate = coordinate(withNormalizedOffset: .init(dx: 0.5, dy: 0.5))
+    func tap(_ point: UnitPoint) {
+        let coordinate = coordinate(withNormalizedOffset: .init(dx: point.x, dy: point.y))
         coordinate.tap()
     }
 }

--- a/IntegrationTests/Sources/Application.swift
+++ b/IntegrationTests/Sources/Application.swift
@@ -23,10 +23,10 @@ enum Application {
 }
 
 extension XCUIApplication {
-    var homeserver: String {
+    var homeserver: String? {
         guard let homeserver = ProcessInfo.processInfo.environment["INTEGRATION_TESTS_HOST"],
               homeserver.count > 0 else {
-            return "default"
+            return nil
         }
         
         return homeserver

--- a/IntegrationTests/Sources/Common.swift
+++ b/IntegrationTests/Sources/Common.swift
@@ -12,11 +12,11 @@ extension XCUIApplication {
         let getStartedButton = buttons[A11yIdentifiers.authenticationStartScreen.signIn]
         
         XCTAssertTrue(getStartedButton.waitForExistence(timeout: 10.0))
-        getStartedButton.tapCenter()
+        getStartedButton.tap(.center)
         
         let changeHomeserverButton = buttons[A11yIdentifiers.serverConfirmationScreen.changeServer]
         XCTAssertTrue(changeHomeserverButton.waitForExistence(timeout: 10.0))
-        changeHomeserverButton.tapCenter()
+        changeHomeserverButton.tap(.center)
         
         let homeserverTextField = textFields[A11yIdentifiers.changeServerScreen.server]
         XCTAssertTrue(homeserverTextField.waitForExistence(timeout: 10.0))
@@ -25,7 +25,7 @@ extension XCUIApplication {
         
         let confirmButton = buttons[A11yIdentifiers.changeServerScreen.continue]
         XCTAssertTrue(confirmButton.waitForExistence(timeout: 10.0))
-        confirmButton.tapCenter()
+        confirmButton.tap(.center)
         
         // Wait for server confirmation to finish
         let doesNotExistPredicate = NSPredicate(format: "exists == 0")
@@ -34,16 +34,16 @@ extension XCUIApplication {
         
         let continueButton = buttons[A11yIdentifiers.serverConfirmationScreen.continue]
         XCTAssertTrue(continueButton.waitForExistence(timeout: 30.0))
-        continueButton.tapCenter()
+        continueButton.tap(.center)
         
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
         let webAuthenticationSessionAlertContinueButton = springboard.buttons["Continue"].firstMatch
         XCTAssertTrue(webAuthenticationSessionAlertContinueButton.waitForExistence(timeout: 30.0))
-        webAuthenticationSessionAlertContinueButton.tapCenter()
+        webAuthenticationSessionAlertContinueButton.tap(.center)
         
         let webAuthenticationView = webViews.firstMatch
         XCTAssertTrue(webAuthenticationView.waitForExistence(timeout: 10.0))
-        webAuthenticationView.tap() // Tap the web view to properly focus the app again.
+        webAuthenticationView.tap(.top) // Tap the web view to properly focus the app again.
         
         let webUsernameTextField = textFields["Username or Email"]
         XCTAssertTrue(webUsernameTextField.waitForExistence(timeout: 10.0))
@@ -55,7 +55,7 @@ extension XCUIApplication {
         
         let webLoginButton = webAuthenticationView.buttons["Continue"]
         XCTAssertTrue(webLoginButton.waitForExistence(timeout: 10.0))
-        webLoginButton.tapCenter()
+        webLoginButton.tap(.center)
         
         // Handle the password saving dialog
         let savePasswordButton = buttons["Save Password"]
@@ -63,12 +63,12 @@ extension XCUIApplication {
             // Tapping the sheet button while animating upwards fails. Wait for it to settle
             sleep(1)
             
-            savePasswordButton.tapCenter()
+            buttons["Not Now"].tap(.center)
         }
         
         let webConsentButton = webAuthenticationView.buttons["Continue"]
         XCTAssertTrue(webConsentButton.waitForExistence(timeout: 10.0))
-        webConsentButton.tapCenter()
+        webConsentButton.tap(.center)
         
         // Wait for login to finish
         currentTestCase.expectation(for: doesNotExistPredicate, evaluatedWith: webUsernameTextField)
@@ -88,7 +88,7 @@ extension XCUIApplication {
         let profileButton = buttons[A11yIdentifiers.homeScreen.userAvatar]
                 
         // `Failed to scroll to visible (by AX action) Button` https://stackoverflow.com/a/33534187/730924
-        profileButton.tapCenter()
+        profileButton.tap(.center)
         
         // Make the logout button visible
         swipeUp()
@@ -96,12 +96,12 @@ extension XCUIApplication {
         // Logout
         let logoutButton = buttons[A11yIdentifiers.settingsScreen.logout]
         XCTAssertTrue(logoutButton.waitForExistence(timeout: 10.0))
-        logoutButton.tapCenter()
+        logoutButton.tap(.center)
         
         // Confirm logout
         let alertLogoutButton = alerts.firstMatch.buttons["Sign out"]
         XCTAssertTrue(alertLogoutButton.waitForExistence(timeout: 10.0))
-        alertLogoutButton.tapCenter()
+        alertLogoutButton.tap(.center)
         
         // Check that we're back on the login screen
         let getStartedButton = buttons[A11yIdentifiers.authenticationStartScreen.signIn]

--- a/IntegrationTests/Sources/Common.swift
+++ b/IntegrationTests/Sources/Common.swift
@@ -51,10 +51,12 @@ extension XCUIApplication {
         let webUsernameTextField = textFields["Username or Email"]
         XCTAssertTrue(webUsernameTextField.waitForExistence(timeout: 10.0))
         webUsernameTextField.clearAndTypeText(username, app: self)
+        buttons["Done"].tap() // Dismiss the keyboard so that the password text field is fully hittable.
         
         let webPasswordTextField = secureTextFields["Password"]
         XCTAssertTrue(webPasswordTextField.waitForExistence(timeout: 10.0))
         webPasswordTextField.clearAndTypeText(password, app: self)
+        buttons["Done"].tap() // Dismiss the keyboard so that the continue button is fully hittable.
         
         let webLoginButton = webAuthenticationView.buttons["Continue"]
         XCTAssertTrue(webLoginButton.waitForExistence(timeout: 10.0))

--- a/IntegrationTests/Sources/Common.swift
+++ b/IntegrationTests/Sources/Common.swift
@@ -8,29 +8,32 @@
 import XCTest
 
 extension XCUIApplication {
+    private var doesNotExistPredicate: NSPredicate { NSPredicate(format: "exists == 0") }
+    
     func login(currentTestCase: XCTestCase) {
         let getStartedButton = buttons[A11yIdentifiers.authenticationStartScreen.signIn]
         
         XCTAssertTrue(getStartedButton.waitForExistence(timeout: 10.0))
         getStartedButton.tap(.center)
         
-        let changeHomeserverButton = buttons[A11yIdentifiers.serverConfirmationScreen.changeServer]
-        XCTAssertTrue(changeHomeserverButton.waitForExistence(timeout: 10.0))
-        changeHomeserverButton.tap(.center)
-        
-        let homeserverTextField = textFields[A11yIdentifiers.changeServerScreen.server]
-        XCTAssertTrue(homeserverTextField.waitForExistence(timeout: 10.0))
-        
-        homeserverTextField.clearAndTypeText(homeserver, app: self)
-        
-        let confirmButton = buttons[A11yIdentifiers.changeServerScreen.continue]
-        XCTAssertTrue(confirmButton.waitForExistence(timeout: 10.0))
-        confirmButton.tap(.center)
-        
-        // Wait for server confirmation to finish
-        let doesNotExistPredicate = NSPredicate(format: "exists == 0")
-        currentTestCase.expectation(for: doesNotExistPredicate, evaluatedWith: confirmButton)
-        currentTestCase.waitForExpectations(timeout: 300.0)
+        if let homeserver {
+            let changeHomeserverButton = buttons[A11yIdentifiers.serverConfirmationScreen.changeServer]
+            XCTAssertTrue(changeHomeserverButton.waitForExistence(timeout: 10.0))
+            changeHomeserverButton.tap(.center)
+            
+            let homeserverTextField = textFields[A11yIdentifiers.changeServerScreen.server]
+            XCTAssertTrue(homeserverTextField.waitForExistence(timeout: 10.0))
+            
+            homeserverTextField.clearAndTypeText(homeserver, app: self)
+            
+            let confirmButton = buttons[A11yIdentifiers.changeServerScreen.continue]
+            XCTAssertTrue(confirmButton.waitForExistence(timeout: 10.0))
+            confirmButton.tap(.center)
+            
+            // Wait for server confirmation to finish
+            currentTestCase.expectation(for: doesNotExistPredicate, evaluatedWith: confirmButton)
+            currentTestCase.waitForExpectations(timeout: 300.0)
+        }
         
         let continueButton = buttons[A11yIdentifiers.serverConfirmationScreen.continue]
         XCTAssertTrue(continueButton.waitForExistence(timeout: 30.0))

--- a/IntegrationTests/Sources/UserFlowTests.swift
+++ b/IntegrationTests/Sources/UserFlowTests.swift
@@ -42,7 +42,7 @@ class UserFlowTests: XCTestCase {
         // And open it
         let firstRoom = app.buttons.matching(NSPredicate(format: "identifier CONTAINS %@", Self.integrationTestsRoomName)).firstMatch
         XCTAssertTrue(firstRoom.waitForExistence(timeout: 10.0))
-        firstRoom.tapCenter()
+        firstRoom.tap(.center)
         
         sendMessages()
         
@@ -62,7 +62,7 @@ class UserFlowTests: XCTestCase {
         // Cancel initial the room search
         let searchCancelButton = app.buttons["Cancel"].firstMatch
         XCTAssertTrue(searchCancelButton.waitForExistence(timeout: 10.0))
-        searchCancelButton.tapCenter()
+        searchCancelButton.tap(.center)
     }
     
     private func sendMessages() {
@@ -72,7 +72,7 @@ class UserFlowTests: XCTestCase {
         
         var sendButton = app.buttons[A11yIdentifiers.roomScreen.sendButton].firstMatch
         XCTAssertTrue(sendButton.waitForExistence(timeout: 10.0))
-        sendButton.tapCenter()
+        sendButton.tap(.center)
         
         sleep(10) // Wait for the message to be sent
         
@@ -86,12 +86,12 @@ class UserFlowTests: XCTestCase {
         
         sendButton = app.buttons[A11yIdentifiers.roomScreen.sendButton].firstMatch
         XCTAssertTrue(sendButton.waitForExistence(timeout: 10.0))
-        sendButton.tapCenter()
+        sendButton.tap(.center)
         
         sleep(5) // Wait for the message to be sent
         
         // Close the formatting options
-        app.buttons[A11yIdentifiers.roomScreen.composerToolbar.closeFormattingOptions].tapCenter()
+        app.buttons[A11yIdentifiers.roomScreen.composerToolbar.closeFormattingOptions].tap(.center)
     }
         
     private func checkPhotoSharing() {
@@ -103,7 +103,7 @@ class UserFlowTests: XCTestCase {
         // Tap on the second image. First one is always broken on simulators.
         let secondImage = app.scrollViews.images.element(boundBy: 1)
         XCTAssertTrue(secondImage.waitForExistence(timeout: 20.0)) // Photo library takes a bit to load
-        secondImage.tapCenter()
+        secondImage.tap(.center)
         
         // Wait for the image to be processed and the new screen to appear
         sleep(10)
@@ -134,7 +134,7 @@ class UserFlowTests: XCTestCase {
         // Handle map loading errors (missing credentials)
         let alertOkButton = app.alerts.firstMatch.buttons["OK"].firstMatch
         if alertOkButton.waitForExistence(timeout: 10.0) {
-            alertOkButton.tapCenter()
+            alertOkButton.tap(.center)
         }
         
         allowLocationPermissionOnce()
@@ -146,7 +146,7 @@ class UserFlowTests: XCTestCase {
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
         let notificationAlertAllowButton = springboard.buttons["Allow Once"].firstMatch
         if notificationAlertAllowButton.waitForExistence(timeout: 10.0) {
-            notificationAlertAllowButton.tapCenter()
+            notificationAlertAllowButton.tap(.center)
         }
     }
     
@@ -183,7 +183,7 @@ class UserFlowTests: XCTestCase {
         // Open the room details
         let roomHeader = app.staticTexts[A11yIdentifiers.roomScreen.name]
         XCTAssertTrue(roomHeader.waitForExistence(timeout: 10.0))
-        roomHeader.tapCenter()
+        roomHeader.tap(.center)
         
         // Open the room member details
         tapOnButton(A11yIdentifiers.roomDetailsScreen.people)
@@ -191,7 +191,7 @@ class UserFlowTests: XCTestCase {
         // Open the first member's details. Loading members for big rooms can take a while.
         let firstRoomMember = app.scrollViews.buttons.firstMatch
         XCTAssertTrue(firstRoomMember.waitForExistence(timeout: 1000.0))
-        firstRoomMember.tapCenter()
+        firstRoomMember.tap(.center)
         
         // Go back to the room member details
         tapOnBackButton("People")
@@ -211,7 +211,7 @@ class UserFlowTests: XCTestCase {
         let profileButton = app.buttons[A11yIdentifiers.homeScreen.userAvatar]
         
         // `Failed to scroll to visible (by AX action) Button` https://stackoverflow.com/a/33534187/730924
-        profileButton.tapCenter()
+        profileButton.tap(.center)
         
         // Open analytics
         tapOnButton(A11yIdentifiers.settingsScreen.analytics)
@@ -238,7 +238,7 @@ class UserFlowTests: XCTestCase {
     private func tapOnButton(_ identifier: String, waitForDisappearance: Bool = false) {
         let button = app.buttons[identifier]
         XCTAssertTrue(button.waitForExistence(timeout: 10.0))
-        button.tapCenter()
+        button.tap(.center)
         
         if waitForDisappearance {
             let doesNotExistPredicate = NSPredicate(format: "exists == 0")
@@ -250,7 +250,7 @@ class UserFlowTests: XCTestCase {
     private func tapOnMenu(_ identifier: String) {
         let button = app.buttons[identifier]
         XCTAssertTrue(button.waitForExistence(timeout: 10.0))
-        button.tapCenter()
+        button.tap(.center)
     }
     
     /// Taps on a back button that the system configured with a label but no identifier.
@@ -260,6 +260,6 @@ class UserFlowTests: XCTestCase {
     private func tapOnBackButton(_ label: String = "Back") {
         let button = app.buttons.matching(NSPredicate(format: "label == %@ && identifier == ''", label)).firstMatch
         XCTAssertTrue(button.waitForExistence(timeout: 10.0))
-        button.tapCenter()
+        button.tap(.center)
     }
 }


### PR DESCRIPTION
The issues were 2-fold:

- On a fresh simulator (reproducible locally by erasing an existing one) the Web Authentication Session is sometimes slow to pick up the webcredentials association with element.io (used for the call back). This is fixed by looping on the Continue button until the association is made.
- When the WAS does appear, the keyboard was getting in the way of tapping on the password field.
![Screen Recording 2025-05-01 at 11 36 44 am 2025-05-01 11_42_53 am](https://github.com/user-attachments/assets/5a992c5d-9138-48ad-b8ef-9bbd255bff15)
This is fixed by dismissing the keyboard before moving onto the next step.

A couple of extra tweaks:
- If the homeserver isn't set in the environment, don't change the default (makes local testing quicker).
- Refactor `tapCenter()` in to `tap(_ point: UnitPoint)` so you can `tap(.center)`, `tap(.top)` etc and uses this when tapping the web view to bring focus back to the app (so that it doesn't end up tapping the password field by mistake).
- Fixes the OIDC presenter to
    - not show an error when pressing Cancel *inside* the web view (a regression introduced in #4010).
    - show an error when the system cancels the web view (Apple weirdly uses the `canceledLogin` error code for this instead of a specific one).