### PR TITLE
Run the UI & Integration tests once a day instead of twice with a 6 hour offset.

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,7 +2,7 @@ name: Integration tests
 
 on:
   schedule:
-    - cron:  '0 6,18 * * *'
+    - cron:  '0 2 * * 1-5'
     
   workflow_dispatch:
 

--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -8,7 +8,7 @@ on:
         required: false
 
   schedule:
-    - cron:  '0 0,12 * * 1-5'
+    - cron:  '0 2 * * 1-5'
 
 jobs:
   tests:


### PR DESCRIPTION
Simpler, less annoying, just as good in practice.