### PR TITLE
Add a tool (based on Periphery) that reports any unused strings.

### DIFF
--- a/.periphery.yml
+++ b/.periphery.yml
@@ -1,19 +1,19 @@
 project: ElementX.xcodeproj
 schemes:
 - ElementX
-- IntegrationTests
-- UITests
 - UnitTests
 - PreviewTests
+- UITests
+- IntegrationTests
 targets:
 - ElementX
-- IntegrationTests
 - NSE
+- ShareExtension
+- UnitTests
 - PreviewTests
 - UITests
-- UnitTests
+- IntegrationTests
 report_exclude:
   - ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
   - ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
-verbose: true
 retain_swift_ui_previews: true

--- a/ElementX/Resources/Localizations/en.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Localizable.strings
@@ -22,10 +22,10 @@
 "a11y_show_password" = "Show password";
 "a11y_start_call" = "Start a call";
 "a11y_user_menu" = "User menu";
+"a11y_view_details" = "View details";
 "a11y_voice_message" = "Voice message, duration: %1$@";
 "a11y_voice_message_record" = "Record voice message.";
 "a11y_voice_message_stop_recording" = "Stop recording";
-"a11y.view_details" = "View details";
 "action_accept" = "Accept";
 "action_add_caption" = "Add caption";
 "action_add_to_timeline" = "Add to timeline";
@@ -146,6 +146,7 @@
 "common_bubbles" = "Bubbles";
 "common_call_started" = "Call started";
 "common_chat_backup" = "Chat backup";
+"common_copied_to_clipboard" = "Copied to clipboard";
 "common_copyright" = "Copyright";
 "common_creating_room" = "Creating room…";
 "common_current_user_canceled_knock" = "Request canceled";
@@ -158,12 +159,14 @@
 "common_developer_options" = "Developer options";
 "common_device_id" = "Device ID";
 "common_direct_chat" = "Direct chat";
+"common_do_not_show_this_again" = "Do not show this again";
 "common_download_failed" = "Download failed";
 "common_downloading" = "Downloading";
 "common_edited_suffix" = "(edited)";
 "common_editing" = "Editing";
 "common_editing_caption" = "Editing caption";
 "common_emote" = "* %1$@ %2$@";
+"common_empty_file" = "Empty file";
 "common_encryption" = "Encryption";
 "common_encryption_enabled" = "Encryption enabled";
 "common_enter_your_pin" = "Enter your PIN";
@@ -184,6 +187,7 @@
 "common_invite_unknown_profile" = "This Matrix ID can't be found, so the invite might not be received.";
 "common_leaving_room" = "Leaving room";
 "common_light" = "Light";
+"common_line_copied_to_clipboard" = "Line copied to clipboard";
 "common_link_copied_to_clipboard" = "Link copied to clipboard";
 "common_loading" = "Loading…";
 "common_loading_more" = "Loading more…";
@@ -198,12 +202,14 @@
 "common_no_room_name" = "No room name";
 "common_not_encrypted" = "Not encrypted";
 "common_offline" = "Offline";
+"common_open_source_licenses" = "Open source licenses";
 "common_optic_id_ios" = "Optic ID";
 "common_or" = "or";
 "common_password" = "Password";
 "common_people" = "People";
 "common_permalink" = "Permalink";
 "common_permission" = "Permission";
+"common_pinned" = "Pinned";
 "common_please_check_internet_connection" = "Please check your internet connection";
 "common_please_wait" = "Please wait…";
 "common_poll_end_confirmation" = "Are you sure you want to end this poll?";
@@ -231,6 +237,7 @@
 "common_search_results" = "Search results";
 "common_security" = "Security";
 "common_seen_by" = "Seen by";
+"common_send_to" = "Send to";
 "common_sending" = "Sending…";
 "common_sending_failed" = "Sending failed";
 "common_sent" = "Sent";
@@ -274,13 +281,6 @@
 "common_waiting" = "Waiting…";
 "common_waiting_for_decryption_key" = "Waiting for this message";
 "common_you" = "You";
-"common.copied_to_clipboard" = "Copied to clipboard";
-"common.do_not_show_this_again" = "Do not show this again";
-"common.empty_file" = "Empty file";
-"common.line_copied_to_clipboard" = "Line copied to clipboard";
-"common.open_source_licenses" = "Open source licenses";
-"common.pinned" = "Pinned";
-"common.send_to" = "Send to";
 "common_unable_to_decrypt_insecure_device" = "Sent from an insecure device";
 "common_unable_to_decrypt_verification_violation" = "Sender's verified identity was reset";
 "confirm_recovery_key_banner_message" = "Confirm your recovery key to maintain access to your key storage and message history.";
@@ -406,7 +406,6 @@
 "screen_advanced_settings_show_media_timeline_private_rooms" = "In private rooms";
 "screen_advanced_settings_show_media_timeline_subtitle" = "A hidden media can always be shown by tapping on it";
 "screen_advanced_settings_show_media_timeline_title" = "Show media in timeline";
-"screen_bottom_sheet,manage_room_member_remove" = "Remove from room";
 "screen_bottom_sheet_create_dm_confirmation_button_title" = "Send invite";
 "screen_bottom_sheet_create_dm_message" = "Would you like to start a chat with %1$@?";
 "screen_bottom_sheet_create_dm_title" = "Send invite?";
@@ -419,6 +418,7 @@
 "screen_bottom_sheet_manage_room_member_kick_member_confirmation_description" = "They will be able to join this room again if invited.";
 "screen_bottom_sheet_manage_room_member_kick_member_confirmation_title" = "Are you sure you want to remove this member?";
 "screen_bottom_sheet_manage_room_member_member_user_info" = "View profile";
+"screen_bottom_sheet_manage_room_member_remove" = "Remove from room";
 "screen_bottom_sheet_manage_room_member_remove_confirmation_title" = "Remove member and ban from joining in the future?";
 "screen_bottom_sheet_manage_room_member_removing_user" = "Removing %1$@…";
 "screen_create_room_room_access_section_anyone_option_description" = "Anyone can join this room";

--- a/ElementX/Resources/Localizations/en.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Localizable.strings
@@ -610,7 +610,7 @@
 "screen_change_account_provider_subtitle" = "Use a different account provider, such as your own private server or a work account.";
 "screen_change_account_provider_title" = "Change account provider";
 "screen_change_server_error_invalid_homeserver" = "We couldn't reach this homeserver. Please check that you have entered the homeserver URL correctly. If the URL is correct, contact your homeserver administrator for further help.";
-"screen_change_server_error_invalid_well_known" = "Sliding sync isn't available due to an issue in the well-known file:\n%1$@";
+"screen_change_server_error_invalid_well_known" = "Server isn't available due to an issue in the well-known file:\n%1$@";
 "screen_change_server_error_no_sliding_sync_message" = "The selected account provider does not support sliding sync. An upgrade to the server is needed to use %1$@.";
 "screen_change_server_form_header" = "Homeserver URL";
 "screen_change_server_form_notice" = "Enter a domain address.";

--- a/ElementX/Sources/Generated/Strings.swift
+++ b/ElementX/Sources/Generated/Strings.swift
@@ -1174,7 +1174,7 @@ internal enum L10n {
   internal static var screenChangeAccountProviderTitle: String { return L10n.tr("Localizable", "screen_change_account_provider_title") }
   /// We couldn't reach this homeserver. Please check that you have entered the homeserver URL correctly. If the URL is correct, contact your homeserver administrator for further help.
   internal static var screenChangeServerErrorInvalidHomeserver: String { return L10n.tr("Localizable", "screen_change_server_error_invalid_homeserver") }
-  /// Sliding sync isn't available due to an issue in the well-known file:
+  /// Server isn't available due to an issue in the well-known file:
   /// %1$@
   internal static func screenChangeServerErrorInvalidWellKnown(_ p1: Any) -> String {
     return L10n.tr("Localizable", "screen_change_server_error_invalid_well_known", String(describing: p1))

--- a/ElementX/Sources/Generated/Strings.swift
+++ b/ElementX/Sources/Generated/Strings.swift
@@ -78,6 +78,8 @@ internal enum L10n {
   internal static var a11yStartCall: String { return L10n.tr("Localizable", "a11y_start_call") }
   /// User menu
   internal static var a11yUserMenu: String { return L10n.tr("Localizable", "a11y_user_menu") }
+  /// View details
+  internal static var a11yViewDetails: String { return L10n.tr("Localizable", "a11y_view_details") }
   /// Voice message, duration: %1$@
   internal static func a11yVoiceMessage(_ p1: Any) -> String {
     return L10n.tr("Localizable", "a11y_voice_message", String(describing: p1))
@@ -334,6 +336,8 @@ internal enum L10n {
   internal static var commonCallStarted: String { return L10n.tr("Localizable", "common_call_started") }
   /// Chat backup
   internal static var commonChatBackup: String { return L10n.tr("Localizable", "common_chat_backup") }
+  /// Copied to clipboard
+  internal static var commonCopiedToClipboard: String { return L10n.tr("Localizable", "common_copied_to_clipboard") }
   /// Copyright
   internal static var commonCopyright: String { return L10n.tr("Localizable", "common_copyright") }
   /// Creating room…
@@ -360,6 +364,8 @@ internal enum L10n {
   internal static var commonDeviceId: String { return L10n.tr("Localizable", "common_device_id") }
   /// Direct chat
   internal static var commonDirectChat: String { return L10n.tr("Localizable", "common_direct_chat") }
+  /// Do not show this again
+  internal static var commonDoNotShowThisAgain: String { return L10n.tr("Localizable", "common_do_not_show_this_again") }
   /// Download failed
   internal static var commonDownloadFailed: String { return L10n.tr("Localizable", "common_download_failed") }
   /// Downloading
@@ -374,6 +380,8 @@ internal enum L10n {
   internal static func commonEmote(_ p1: Any, _ p2: Any) -> String {
     return L10n.tr("Localizable", "common_emote", String(describing: p1), String(describing: p2))
   }
+  /// Empty file
+  internal static var commonEmptyFile: String { return L10n.tr("Localizable", "common_empty_file") }
   /// Encryption
   internal static var commonEncryption: String { return L10n.tr("Localizable", "common_encryption") }
   /// Encryption enabled
@@ -416,6 +424,8 @@ internal enum L10n {
   internal static var commonLeavingRoom: String { return L10n.tr("Localizable", "common_leaving_room") }
   /// Light
   internal static var commonLight: String { return L10n.tr("Localizable", "common_light") }
+  /// Line copied to clipboard
+  internal static var commonLineCopiedToClipboard: String { return L10n.tr("Localizable", "common_line_copied_to_clipboard") }
   /// Link copied to clipboard
   internal static var commonLinkCopiedToClipboard: String { return L10n.tr("Localizable", "common_link_copied_to_clipboard") }
   /// Loading…
@@ -450,6 +460,8 @@ internal enum L10n {
   internal static var commonNotEncrypted: String { return L10n.tr("Localizable", "common_not_encrypted") }
   /// Offline
   internal static var commonOffline: String { return L10n.tr("Localizable", "common_offline") }
+  /// Open source licenses
+  internal static var commonOpenSourceLicenses: String { return L10n.tr("Localizable", "common_open_source_licenses") }
   /// Optic ID
   internal static var commonOpticIdIos: String { return L10n.tr("Localizable", "common_optic_id_ios") }
   /// or
@@ -462,6 +474,8 @@ internal enum L10n {
   internal static var commonPermalink: String { return L10n.tr("Localizable", "common_permalink") }
   /// Permission
   internal static var commonPermission: String { return L10n.tr("Localizable", "common_permission") }
+  /// Pinned
+  internal static var commonPinned: String { return L10n.tr("Localizable", "common_pinned") }
   /// Please check your internet connection
   internal static var commonPleaseCheckInternetConnection: String { return L10n.tr("Localizable", "common_please_check_internet_connection") }
   /// Please wait…
@@ -526,6 +540,8 @@ internal enum L10n {
   internal static var commonSecurity: String { return L10n.tr("Localizable", "common_security") }
   /// Seen by
   internal static var commonSeenBy: String { return L10n.tr("Localizable", "common_seen_by") }
+  /// Send to
+  internal static var commonSendTo: String { return L10n.tr("Localizable", "common_send_to") }
   /// Sending…
   internal static var commonSending: String { return L10n.tr("Localizable", "common_sending") }
   /// Sending failed
@@ -1098,8 +1114,6 @@ internal enum L10n {
   internal static var screenBlockedUsersUnblockAlertTitle: String { return L10n.tr("Localizable", "screen_blocked_users_unblock_alert_title") }
   /// Unblocking…
   internal static var screenBlockedUsersUnblocking: String { return L10n.tr("Localizable", "screen_blocked_users_unblocking") }
-  /// Remove from room
-  internal static var screenBottomSheetManageRoomMemberRemove: String { return L10n.tr("Localizable", "screen_bottom_sheet,manage_room_member_remove") }
   /// Send invite
   internal static var screenBottomSheetCreateDmConfirmationButtonTitle: String { return L10n.tr("Localizable", "screen_bottom_sheet_create_dm_confirmation_button_title") }
   /// Would you like to start a chat with %1$@?
@@ -1128,6 +1142,8 @@ internal enum L10n {
   internal static var screenBottomSheetManageRoomMemberKickMemberConfirmationTitle: String { return L10n.tr("Localizable", "screen_bottom_sheet_manage_room_member_kick_member_confirmation_title") }
   /// View profile
   internal static var screenBottomSheetManageRoomMemberMemberUserInfo: String { return L10n.tr("Localizable", "screen_bottom_sheet_manage_room_member_member_user_info") }
+  /// Remove from room
+  internal static var screenBottomSheetManageRoomMemberRemove: String { return L10n.tr("Localizable", "screen_bottom_sheet_manage_room_member_remove") }
   /// Remove member and ban from joining in the future?
   internal static var screenBottomSheetManageRoomMemberRemoveConfirmationTitle: String { return L10n.tr("Localizable", "screen_bottom_sheet_manage_room_member_remove_confirmation_title") }
   /// Removing %1$@…
@@ -2970,28 +2986,6 @@ internal enum L10n {
   }
   /// Check UnifiedPush
   internal static var troubleshootNotificationsTestUnifiedPushTitle: String { return L10n.tr("Localizable", "troubleshoot_notifications_test_unified_push_title") }
-
-  internal enum A11y {
-    /// View details
-    internal static var viewDetails: String { return L10n.tr("Localizable", "a11y.view_details") }
-  }
-
-  internal enum Common {
-    /// Copied to clipboard
-    internal static var copiedToClipboard: String { return L10n.tr("Localizable", "common.copied_to_clipboard") }
-    /// Do not show this again
-    internal static var doNotShowThisAgain: String { return L10n.tr("Localizable", "common.do_not_show_this_again") }
-    /// Empty file
-    internal static var emptyFile: String { return L10n.tr("Localizable", "common.empty_file") }
-    /// Line copied to clipboard
-    internal static var lineCopiedToClipboard: String { return L10n.tr("Localizable", "common.line_copied_to_clipboard") }
-    /// Open source licenses
-    internal static var openSourceLicenses: String { return L10n.tr("Localizable", "common.open_source_licenses") }
-    /// Pinned
-    internal static var pinned: String { return L10n.tr("Localizable", "common.pinned") }
-    /// Send to
-    internal static var sendTo: String { return L10n.tr("Localizable", "common.send_to") }
-  }
 }
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:enable nesting type_body_length type_name vertical_whitespace_opening_braces

--- a/Tools/Sources/Tools.swift
+++ b/Tools/Sources/Tools.swift
@@ -11,5 +11,6 @@ struct Tools: AsyncParsableCommand {
                                                                   Locheck.self,
                                                                   GenerateSDKMocks.self,
                                                                   GenerateSAS.self,
-                                                                  AppIconBanner.self])
+                                                                  AppIconBanner.self,
+                                                                  UnusedStrings.self])
 }

--- a/Tools/Sources/UnusedStrings.swift
+++ b/Tools/Sources/UnusedStrings.swift
@@ -1,0 +1,34 @@
+import ArgumentParser
+import CommandLineTools
+import Foundation
+
+struct UnusedStrings: ParsableCommand {
+    static var configuration = CommandConfiguration(abstract: "Generates a report showing which strings aren't used in the project.")
+    
+    @Flag(help: "Save the results to disk instead of printing them.")
+    var saveToFile = false
+
+    func run() throws {
+        try peripheryScan()
+    }
+
+    func peripheryScan() throws {
+        print("Analysing project, this may take a while…")
+        
+        // Uses the existing .periphery.yml with small tweaks to the output.
+        let command = "periphery scan --quiet --relative-results --report-include ElementX/Sources/Generated/Strings.swift"
+        let output = try Zsh.run(command: command)
+        
+        guard let output else {
+            print("Nothing reported.")
+            return
+        }
+        
+        if saveToFile {
+            try output.write(to: .projectDirectory.appending(component: "Unused Strings.txt"), atomically: true, encoding: .utf8)
+            print("Report saved: Unused Strings.txt")
+        } else {
+            print(output)
+        }
+    }
+}


### PR DESCRIPTION
Also updates an error string that was talking about using the well-known for Sliding Sync.

Output based on a run just now: [Unused Strings.txt](https://github.com/user-attachments/files/20015557/Unused.Strings.txt)
