### PR TITLE
Support for experimental MSC4286 to not render external payment details

### DIFF
--- a/ElementX/Sources/Other/HTMLParsing/DTHTMLElement+AttributedStringBuilder.swift
+++ b/ElementX/Sources/Other/HTMLParsing/DTHTMLElement+AttributedStringBuilder.swift
@@ -18,6 +18,16 @@ public extension DTHTMLElement {
             // Remove any attachments to fix rendering.
             textAttachment = nil
             
+            // Handle special case for span with data-mx-external-payment-details
+            // This could be based on Storefront.current.countryCode to show the link
+            // content in unrestricted countries. e.g. currently USA
+            if name == "span",
+               let attributes = attributes as? [String: String],
+               attributes["data-msc4286-external-payment-details"] != nil {
+                parent.removeChildNode(self)
+                return
+            }
+            
             // If the element has plain text content show that,
             // otherwise prevent the tag from displaying.
             if let stringContent = attributedString()?.string,

--- a/UnitTests/Sources/AttributedStringBuilderTests.swift
+++ b/UnitTests/Sources/AttributedStringBuilderTests.swift
@@ -1020,7 +1020,23 @@ class AttributedStringBuilderTests: XCTestCase {
         XCTAssertEqual(link.confirmationParameters?.internalURL.absoluteString, "https://matrix.org")
         XCTAssertEqual(link.confirmationParameters?.displayString, "👉️ #room:matrix.org")
     }
-    
+
+    func testMxExternalPaymentDetailsRemoved() {
+        let htmlString = "This is visible<span data-msc4286-external-payment-details>. But text is hidden <a href=\"https://matrix.org\">and this link too</a></span>"
+        
+        guard let attributedString = attributedStringBuilder.fromHTML(htmlString) else {
+            XCTFail("Could not build the attributed string")
+            return
+        }
+        
+        XCTAssertEqual(String(attributedString.characters), "This is visible")
+        
+        for run in attributedString.runs where run.link != nil {
+            XCTFail("No link expected, but found one")
+            return
+        }
+    }
+
     // MARK: - Private
     
     private func checkLinkIn(attributedString: AttributedString?, expectedLink: String, expectedRuns: Int) {


### PR DESCRIPTION
Implementation of [MSC4286](https://github.com/matrix-org/matrix-spec-proposals/pull/4286)

Two parts to it:

- upgrade of matrix-rust-sdk so that the new `span` attribute is not stripped at that layer
- detect the new attribute and exclude the whole `span` from the rendering

Depends on https://github.com/matrix-org/matrix-rust-sdk/pull/5101 which was in https://github.com/element-hq/matrix-rust-components-swift/releases/tag/25.05.27 and is landed via https://github.com/element-hq/element-x-ios/pull/4151

| Before | After |
|-|-|
|![Screenshot 2025-05-28 at 16 36 57](https://github.com/user-attachments/assets/c2917a63-b28d-404a-a06f-d790697593e8)|![Screenshot 2025-05-28 at 16 27 28](https://github.com/user-attachments/assets/d6b8356b-c8fd-4974-8057-232ffcb604c9)|

In the above example the `formatted_body` of the event looks like this:

`Thanks for subscribing!<span data-msc4286-external-payment-details> You can manage your subscription and view your payment history <a href="https://account.example.com/account/plan">here</a> at any time</span>`

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).

**UI changes have been tested with:**
- [x] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
