### PR TITLE
Update Localizable.strings (German | use casual "you" instead of formal version)

### DIFF
--- a/ElementX/Resources/Localizations/de.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/de.lproj/Localizable.strings
@@ -280,7 +280,7 @@
 "common_voice_message" = "Sprachnachricht";
 "common_waiting" = "Warten…";
 "common_waiting_for_decryption_key" = "Warte auf diese Nachricht";
-"common_you" = "Sie";
+"common_you" = "Du";
 "common_unable_to_decrypt_insecure_device" = "Von einem ungesicherten Gerät gesendet";
 "common_unable_to_decrypt_verification_violation" = "Die verifizierte Identität des Senders hat sich geändert";
 "confirm_recovery_key_banner_message" = "Bestätigen Sie die Validität Ihres Wiederherstellungsschlüssels, um weiterhin auf Ihren Schlüsselspeicher und den Nachrichtenverlauf zugreifen zu können.";


### PR DESCRIPTION
"Sie" is the formal way of referring to someone while "Du" is the personal/casual way of talking to someone.

For example, you would say "Du" when youre talking with a friend.  You would use "Sie" when you try to get a credit from the bank.

Since the new update where the users message is prefixed with the "common_you" in the chat preview, my messages are prefixed with the very formal way which feels cold and not really personal since these messages are my own.... It does feel ok to use the formal way when explaining settings but it feels off when referring to my own actions/content.

For reference, both signal and whatsapp use the casual "Du" in german.

### Pull Request Checklist

- [ ] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
