### PR TITLE
Fix bubble animations overshooting in the timeline when SR/RRs are removed from an event

### DIFF
--- a/ElementX/Sources/Screens/Timeline/TimelineTableViewController.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineTableViewController.swift
@@ -292,7 +292,7 @@ class TimelineTableViewController: UIViewController {
             }
         }
         
-        // We only animate when there's a new last message, so its safe
+        // We only animate when there's a new last message, so it's safe
         // to animate from the bottom (which is the top as we're flipped).
         dataSource?.defaultRowAnimation = (UIAccessibility.isReduceMotionEnabled ? .none : .top)
         tableView.delegate = self

--- a/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemBubbledStylerView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemBubbledStylerView.swift
@@ -45,7 +45,10 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
                         .zIndex(1)
                 }
 
-                VStack(alignment: alignment, spacing: 0) {
+                VStack(alignment: alignment, spacing: -4) {
+                    // -4 spacing to compensate for the Spacer we have to add to stop
+                    // animation oversteer - see below.
+
                     HStack(spacing: 0) {
                         if timelineItem.isOutgoing {
                             Spacer()
@@ -64,6 +67,11 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
                             .padding(.top, 8)
                             .padding(.bottom, 3)
                     }
+
+                    // we need a Spacer here to top-align the bubble within the VStack, so that
+                    // when the the animation doesn't drift around and overshoot when the SR is hidden
+                    // see https://github.com/element-hq/element-x-ios/issues/4127
+                    Spacer()
                 }
                 .padding(.horizontal, bubbleHorizontalPadding)
                 .padding(.leading, bubbleAvatarPadding)


### PR DESCRIPTION
Top-align message bubbles within their VStack of `TimelineItemBubbledStylerView` by adding a Spacer, so that the bubble doesn't drift around as the row shrinks when the `TimelineItemStatusView` empties due to the message no longer having SR/RRs.  This causes the appearance of the "bubble animation overshoots its target" bug in https://github.com/element-hq/element-x-ios/issues/4127.

The addition of the Spacer empirically adds a gap between the bubbles, which we compensate for with some negative spacing on the VStack. 

Empirically this seems to work okay, although I did see some intermittent weirdness with the row at the top of the UITableView vanishing as the new row gets added at the bottom - feeling a bit like a cell reuse bug of some kind.  However, this seems very intermittent, and less distracting than the previous mangled animation (given you're not looking at the top of the screen when you hit send on a message).

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).

**UI changes have been tested with:**
- [x] iPhone and iPad simulators in portrait and landscape orientations.
- [x] Dark mode enabled and disabled.
- [x] Various sizes of dynamic type.
- [ ] Voiceover enabled.
