### PR TITLE
updated the SDK to 25.05.19

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -8665,7 +8665,7 @@
 			repositoryURL = "https://github.com/element-hq/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 25.05.15;
+				version = 25.05.19;
 			};
 		};
 		701C7BEF8F70F7A83E852DCC /* XCRemoteSwiftPackageReference "GZIP" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/matrix-rust-components-swift",
       "state" : {
-        "revision" : "e84fa0642d90ed123520fd458d920945becf6ba8",
-        "version" : "25.5.15"
+        "revision" : "a290a27931a75db67b93f27329b09f5110553415",
+        "version" : "25.5.19"
       }
     },
     {

--- a/ElementX/Sources/Services/ElementCall/ElementCallWidgetDriver.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallWidgetDriver.swift
@@ -96,7 +96,8 @@ class ElementCallWidgetDriver: WidgetCapabilitiesProvider, ElementCallWidgetDriv
                                                                           posthogApiKey: analyticsConfiguration?.posthogAPIKey,
                                                                           rageshakeSubmitUrl: rageshakeURL,
                                                                           sentryDsn: analyticsConfiguration?.sentryDSN,
-                                                                          sentryEnvironment: nil))
+                                                                          sentryEnvironment: nil,
+                                                                          controlledMediaDevices: !ProcessInfo.processInfo.isiOSAppOnMac))
         } catch {
             MXLog.error("Failed to build widget settings: \(error)")
             return .failure(.failedBuildingWidgetSettings)

--- a/project.yml
+++ b/project.yml
@@ -65,7 +65,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/element-hq/matrix-rust-components-swift
-    exactVersion: 25.05.15
+    exactVersion: 25.05.19
     # path: ../matrix-rust-sdk
   Compound:
     url: https://github.com/element-hq/compound-ios


### PR DESCRIPTION
This will be used for some experimentation with EC (the new flag won't affect the new version but will affect the next one), and for opening another PR to allow for account data based media preview controls