### PR TITLE
EC: Native switch for audio outputs/inputs and earpiece

### DIFF
--- a/ElementX/Sources/Screens/CallScreen/CallScreenModels.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenModels.swift
@@ -25,7 +25,6 @@ struct CallScreenViewState: BindableState {
 }
 
 struct Bindings {
-    var javaScriptMessageHandler: ((Any) -> Void)?
     var javaScriptEvaluator: ((String) async throws -> Any)?
     var requestPictureInPictureHandler: (() async -> Result<Void, CallScreenError>)?
     
@@ -40,6 +39,7 @@ enum CallScreenViewAction {
     case endCall
     case mediaCapturePermissionGranted
     case outputDeviceSelected(deviceID: String)
+    case widgetAction(message: String)
 }
 
 enum CallScreenError: Error {
@@ -49,7 +49,7 @@ enum CallScreenError: Error {
 /// Identifies each event handler used by the CallScreen webview
 ///
 /// The names of the enum need to always match the name of the handlers on the webview.
-enum CallScreenJavascriptMessageName: String, CaseIterable {
+enum CallScreenJavaScriptMessageName: String, CaseIterable {
     /// Widget actions's handler.
     case widgetAction
     /// Used to show the native AVRoutePickerView.
@@ -90,7 +90,7 @@ enum CallScreenJavascriptMessageName: String, CaseIterable {
         }
     }
     
-    static func makeFullInjectionScript() -> String {
+    static var allCasesInjectionScript: String {
         allCases.map(\.postMessageScript).joined(separator: "\n")
     }
 }

--- a/ElementX/Sources/Screens/CallScreen/CallScreenModels.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenModels.swift
@@ -38,7 +38,7 @@ enum CallScreenViewAction {
     case navigateBack
     case pictureInPictureWillStop
     case endCall
-    case ready
+    case mediaCapturePermissionGranted
     case outputDeviceSelected(deviceID: String)
 }
 
@@ -49,7 +49,7 @@ enum CallScreenError: Error {
 /// Identifies each event handler used by the CallScreen webview
 ///
 /// The names of the enum need to always match the name of the handlers on the webview.
-enum CallScreenEventJSHandler: String, CaseIterable {
+enum CallScreenJavascriptMessageName: String, CaseIterable {
     /// Widget actions's handler.
     case widgetAction
     /// Used to show the native AVRoutePickerView.
@@ -57,7 +57,7 @@ enum CallScreenEventJSHandler: String, CaseIterable {
     /// Used to determine if the webview has selected the earpiece or not.
     case onOutputDeviceSelect
     
-    private var script: String {
+    private var postMessageScript: String {
         switch self {
         case .widgetAction:
             """
@@ -90,7 +90,7 @@ enum CallScreenEventJSHandler: String, CaseIterable {
         }
     }
     
-    static var fullScript: String {
-        allCases.map(\.script).joined(separator: "\n")
+    static func makeFullInjectionScript() -> String {
+        allCases.map(\.postMessageScript).joined(separator: "\n")
     }
 }

--- a/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
@@ -273,9 +273,15 @@ class CallScreenViewModel: CallScreenViewModelType, CallScreenViewModelProtocol 
             "{id: 'dummy', name: 'dummy'}"
         }
         
+        let disableAudio = "window.controls.setAudioEnabled(false)"
+        let enableAudio = "window.controls.setAudioEnabled(true)"
         let javaScript = "window.controls.setAvailableOutputDevices([\(deviceList)])"
         do {
-            let result = try await state.bindings.javaScriptEvaluator?(javaScript)
+            var result = try await state.bindings.javaScriptEvaluator?(disableAudio)
+            MXLog.debug("Evaluated  with result: \(String(describing: result))")
+            result = try await state.bindings.javaScriptEvaluator?(javaScript)
+            MXLog.debug("Evaluated  with result: \(String(describing: result))")
+            result = try await state.bindings.javaScriptEvaluator?(enableAudio)
             MXLog.debug("Evaluated  with result: \(String(describing: result))")
         } catch {
             MXLog.error("Received javascript evaluation error: \(error)")

--- a/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
@@ -273,15 +273,9 @@ class CallScreenViewModel: CallScreenViewModelType, CallScreenViewModelProtocol 
             "{id: 'dummy', name: 'dummy'}"
         }
         
-        let disableAudio = "window.controls.setAudioEnabled(false)"
-        let enableAudio = "window.controls.setAudioEnabled(true)"
         let javaScript = "window.controls.setAvailableOutputDevices([\(deviceList)])"
         do {
-            var result = try await state.bindings.javaScriptEvaluator?(disableAudio)
-            MXLog.debug("Evaluated  with result: \(String(describing: result))")
-            result = try await state.bindings.javaScriptEvaluator?(javaScript)
-            MXLog.debug("Evaluated  with result: \(String(describing: result))")
-            result = try await state.bindings.javaScriptEvaluator?(enableAudio)
+            let result = try await state.bindings.javaScriptEvaluator?(javaScript)
             MXLog.debug("Evaluated  with result: \(String(describing: result))")
         } catch {
             MXLog.error("Received javascript evaluation error: \(error)")

--- a/ElementX/Sources/Services/ElementCall/ElementCallWidgetDriver.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallWidgetDriver.swift
@@ -97,7 +97,8 @@ class ElementCallWidgetDriver: WidgetCapabilitiesProvider, ElementCallWidgetDriv
                                                                           rageshakeSubmitUrl: rageshakeURL,
                                                                           sentryDsn: analyticsConfiguration?.sentryDSN,
                                                                           sentryEnvironment: nil,
-                                                                          controlledMediaDevices: !ProcessInfo.processInfo.isiOSAppOnMac))
+                                                                          // Set this to false until we have the full implementation otherwise should be false only on macOS
+                                                                          controlledMediaDevices: false))
         } catch {
             MXLog.error("Failed to build widget settings: \(error)")
             return .failure(.failedBuildingWidgetSettings)

--- a/ElementX/Sources/Services/ElementCall/ElementCallWidgetDriver.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallWidgetDriver.swift
@@ -97,8 +97,7 @@ class ElementCallWidgetDriver: WidgetCapabilitiesProvider, ElementCallWidgetDriv
                                                                           rageshakeSubmitUrl: rageshakeURL,
                                                                           sentryDsn: analyticsConfiguration?.sentryDSN,
                                                                           sentryEnvironment: nil,
-                                                                          // Set this to false until we have the full implementation otherwise should be false only on macOS
-                                                                          controlledMediaDevices: false))
+                                                                          controlledMediaDevices: !ProcessInfo.processInfo.isiOSAppOnMac))
         } catch {
             MXLog.error("Failed to build widget settings: \(error)")
             return .failure(.failedBuildingWidgetSettings)


### PR DESCRIPTION
WIP: We need a new version of EC for this to work properly, in the meantime this can only be tested by using specific development branches using the Element Call link override in the Developer options.

This includes:
- Support for the earpiece.
- Support for switching audio output and inputs from a webview button (by opening the native `AVRoutePicker`).
- Support for the proximity monitor when the earpiece mode is enabled.