### PR TITLE
Don't group timeline items if more than 5 minutes has passed.

### DIFF
--- a/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
@@ -840,8 +840,9 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
             return false
         }
         
-        //  can be improved by adding a date threshold
-        return eventTimelineItem.properties.reactions.isEmpty && eventTimelineItem.sender == otherEventTimelineItem.sender
+        return eventTimelineItem.sender == otherEventTimelineItem.sender
+            && eventTimelineItem.properties.reactions.isEmpty // Reactions break the grouping.
+            && otherEventTimelineItem.timestamp.timeIntervalSince(eventTimelineItem.timestamp) < 5 * 60 // As does the passage of time.
     }
 
     // MARK: - Direct chats logics


### PR DESCRIPTION
This PR slightly tweaks the grouping algorithm so that we split up the bubble groups if more than 5-minutes has passed between messages from the same sender. I'm sure there could be lots more done here (such as splitting up groups if they span a long continuous time) but this seems like a simple start to make it easy to visualise the passage of time (and frankly fix something that really bothers me day to day).

The behaviour appears to match Element Web from my testing.

| DM incoming | DM outgoing | Room incoming | Room outgoing |
| - | - | - | - |
| ![Simulator Screenshot - iPhone 16 Plus - 2025-05-20 at 16 59 06](https://github.com/user-attachments/assets/2ccb26c8-c855-42fb-9ee9-30ea323b2000) | ![Simulator Screenshot - iPhone 16 Pro - 2025-05-20 at 16 59 08](https://github.com/user-attachments/assets/1e3f2180-df2b-465a-95ed-cbdbff31a81a) | ![Simulator Screenshot - iPhone 16 Pro - 2025-05-20 at 16 59 01](https://github.com/user-attachments/assets/7e53b23b-a9e8-4f0f-a08e-1d4b8148da48) | ![Simulator Screenshot - iPhone 16 Plus - 2025-05-20 at 16 59 00](https://github.com/user-attachments/assets/ddb6689f-c77b-477c-a77d-6e4194e968e6) |

| DM on EW | Room on EW |
| - | - |
| <img width="1132" alt="Screenshot 2025-05-20 at 5 28 09 pm" src="https://github.com/user-attachments/assets/9911960c-fc93-471b-a270-7eb7f97affeb" /> | <img width="1132" alt="Screenshot 2025-05-20 at 4 59 16 pm" src="https://github.com/user-attachments/assets/c8477d8b-26b9-4299-833d-bee0949c9303" /> |
