### PR TITLE
Stop sending call notifications

### DIFF
--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -200,7 +200,7 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
         case .userProfile(let userID):
             stateMachine.processEvent(.showUserProfileScreen(userID: userID), userInfo: .init(animated: animated))
         case .call(let roomID):
-            Task { await presentCallScreen(roomID: roomID, notifyOtherParticipants: false) }
+            Task { await presentCallScreen(roomID: roomID) }
         case .genericCallLink(let url):
             presentCallScreen(genericCallLink: url)
         case .settings, .chatBackupSettings:
@@ -683,8 +683,7 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
             
             switch action {
             case .presentCallScreen(let roomProxy):
-                // Here we assume that the app is running and the call state is already up to date
-                presentCallScreen(roomProxy: roomProxy, notifyOtherParticipants: !roomProxy.infoPublisher.value.hasRoomCall)
+                presentCallScreen(roomProxy: roomProxy)
             case .verifyUser(let userID):
                 presentSessionVerificationScreen(flow: .userIntiator(userID: userID))
             case .finished:
@@ -765,23 +764,22 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
         presentCallScreen(configuration: .init(genericCallLink: url))
     }
     
-    private func presentCallScreen(roomID: String, notifyOtherParticipants: Bool) async {
+    private func presentCallScreen(roomID: String) async {
         guard case let .joined(roomProxy) = await userSession.clientProxy.roomForIdentifier(roomID) else {
             return
         }
         
-        presentCallScreen(roomProxy: roomProxy, notifyOtherParticipants: notifyOtherParticipants)
+        presentCallScreen(roomProxy: roomProxy)
     }
     
-    private func presentCallScreen(roomProxy: JoinedRoomProxyProtocol, notifyOtherParticipants: Bool) {
+    private func presentCallScreen(roomProxy: JoinedRoomProxyProtocol) {
         let colorScheme: ColorScheme = appMediator.windowManager.mainWindow.traitCollection.userInterfaceStyle == .light ? .light : .dark
         presentCallScreen(configuration: .init(roomProxy: roomProxy,
                                                clientProxy: userSession.clientProxy,
                                                clientID: InfoPlistReader.main.bundleIdentifier,
                                                elementCallBaseURL: appSettings.elementCallBaseURL,
                                                elementCallBaseURLOverride: appSettings.elementCallBaseURLOverride,
-                                               colorScheme: colorScheme,
-                                               notifyOtherParticipants: notifyOtherParticipants))
+                                               colorScheme: colorScheme))
     }
     
     private var callScreenPictureInPictureController: AVPictureInPictureController?
@@ -1006,7 +1004,7 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
                 navigationSplitCoordinator.setSheetCoordinator(nil)
                 stateMachine.processEvent(.selectRoom(roomID: roomID, via: [], entryPoint: .room))
             case .startCall(let roomID):
-                Task { await self.presentCallScreen(roomID: roomID, notifyOtherParticipants: false) }
+                Task { await self.presentCallScreen(roomID: roomID) }
             case .dismiss:
                 navigationSplitCoordinator.setSheetCoordinator(nil)
             }

--- a/ElementX/Sources/Mocks/JoinedRoomProxyMock.swift
+++ b/ElementX/Sources/Mocks/JoinedRoomProxyMock.swift
@@ -127,7 +127,6 @@ extension JoinedRoomProxyMock {
         widgetDriver.startBaseURLClientIDColorSchemeRageshakeURLAnalyticsConfigurationReturnValue = .success(url)
         
         elementCallWidgetDriverDeviceIDReturnValue = widgetDriver
-        sendCallNotificationIfNeededReturnValue = .success(())
         
         matrixToPermalinkReturnValue = .success(.homeDirectory)
         matrixToEventPermalinkReturnValue = .success(.homeDirectory)

--- a/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
@@ -142,7 +142,7 @@ class CallScreenViewModel: CallScreenViewModelType, CallScreenViewModelProtocol 
             state.url = url
             // We need widget messaging to work before enabling CallKit, otherwise mute, hangup etc do nothing.
             
-        case .roomCall(let roomProxy, _, let clientID, let elementCallBaseURL, let elementCallBaseURLOverride, let colorScheme, let notifyOtherParticipants):
+        case .roomCall(let roomProxy, _, let clientID, let elementCallBaseURL, let elementCallBaseURLOverride, let colorScheme):
             Task { [weak self] in
                 guard let self else { return }
                 
@@ -175,10 +175,6 @@ class CallScreenViewModel: CallScreenViewModelType, CallScreenViewModelProtocol 
                 
                 await elementCallService.setupCallSession(roomID: roomProxy.id,
                                                           roomDisplayName: roomProxy.infoPublisher.value.displayName ?? roomProxy.id)
-                
-                if notifyOtherParticipants {
-                    _ = await roomProxy.sendCallNotificationIfNeeded()
-                }
             }
         }
     }

--- a/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
+++ b/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
@@ -295,7 +295,6 @@ struct CallScreen_Previews: PreviewProvider {
         clientProxy.deviceID = "call-device-id"
         
         let roomProxy = JoinedRoomProxyMock()
-        roomProxy.sendCallNotificationIfNeededReturnValue = .success(())
         
         let widgetDriver = ElementCallWidgetDriverMock()
         widgetDriver.underlyingMessagePublisher = .init()
@@ -310,8 +309,7 @@ struct CallScreen_Previews: PreviewProvider {
                                                         clientID: "io.element.elementx",
                                                         elementCallBaseURL: "https://call.element.io",
                                                         elementCallBaseURLOverride: nil,
-                                                        colorScheme: .light,
-                                                        notifyOtherParticipants: false),
+                                                        colorScheme: .light),
                                    allowPictureInPicture: false,
                                    appHooks: AppHooks(),
                                    appSettings: ServiceLocator.shared.settings,

--- a/ElementX/Sources/Services/ElementCall/ElementCallConfiguration.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallConfiguration.swift
@@ -21,8 +21,7 @@ struct ElementCallConfiguration {
                       clientID: String,
                       elementCallBaseURL: URL,
                       elementCallBaseURLOverride: URL?,
-                      colorScheme: ColorScheme,
-                      notifyOtherParticipants: Bool)
+                      colorScheme: ColorScheme)
     }
     
     /// The type of call being configured i.e. whether it's an external URL or an internal room call.
@@ -59,15 +58,13 @@ struct ElementCallConfiguration {
          clientID: String,
          elementCallBaseURL: URL,
          elementCallBaseURLOverride: URL?,
-         colorScheme: ColorScheme,
-         notifyOtherParticipants: Bool) {
+         colorScheme: ColorScheme) {
         kind = .roomCall(roomProxy: roomProxy,
                          clientProxy: clientProxy,
                          clientID: clientID,
                          elementCallBaseURL: elementCallBaseURL,
                          elementCallBaseURLOverride: elementCallBaseURLOverride,
-                         colorScheme: colorScheme,
-                         notifyOtherParticipants: notifyOtherParticipants)
+                         colorScheme: colorScheme)
     }
     
     /// A string representing the call being configured.

--- a/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
@@ -706,16 +706,6 @@ class JoinedRoomProxy: JoinedRoomProxyProtocol {
         ElementCallWidgetDriver(room: room, deviceID: deviceID)
     }
     
-    func sendCallNotificationIfNeeded() async -> Result<Void, RoomProxyError> {
-        do {
-            try await room.sendCallNotificationIfNeeded()
-            return .success(())
-        } catch {
-            MXLog.error("Failed room call notification with error: \(error)")
-            return .failure(.sdkError(error))
-        }
-    }
-    
     // MARK: - Permalinks
     
     func matrixToPermalink() async -> Result<URL, RoomProxyError> {

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -173,8 +173,6 @@ protocol JoinedRoomProxyProtocol: RoomProxyProtocol {
     func canUserJoinCall(userID: String) async -> Result<Bool, RoomProxyError>
     func elementCallWidgetDriver(deviceID: String) -> ElementCallWidgetDriverProtocol
     
-    func sendCallNotificationIfNeeded() async -> Result<Void, RoomProxyError>
-    
     // MARK: - Permalinks
     
     func matrixToPermalink() async -> Result<URL, RoomProxyError>


### PR DESCRIPTION
In an upcoming version of Element Call, the Element Call widget will assume responsibility for sending notification events when you start a call. So we no longer need to have the client application send them.

### Pull Request Checklist

- [ ] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
