### PR TITLE
Adopt latest timeline API changes

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -8708,7 +8708,7 @@
 			repositoryURL = "https://github.com/element-hq/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 25.05.19;
+				version = 25.05.21;
 			};
 		};
 		701C7BEF8F70F7A83E852DCC /* XCRemoteSwiftPackageReference "GZIP" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/matrix-rust-components-swift",
       "state" : {
-        "revision" : "a290a27931a75db67b93f27329b09f5110553415",
-        "version" : "25.5.19"
+        "revision" : "ce4a5f25ada21246d62e4b54c26fb1414432fb77",
+        "version" : "25.5.21"
       }
     },
     {

--- a/ElementX/Sources/FlowCoordinators/PinnedEventsTimelineFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/PinnedEventsTimelineFlowCoordinator.swift
@@ -67,10 +67,10 @@ class PinnedEventsTimelineFlowCoordinator: FlowCoordinatorProtocol {
         let timelineItemFactory = RoomTimelineItemFactory(userID: userID,
                                                           attributedStringBuilder: AttributedStringBuilder(mentionBuilder: MentionBuilder()),
                                                           stateEventStringBuilder: RoomStateEventStringBuilder(userID: userID))
-                
-        guard let timelineController = await timelineControllerFactory.buildPinnedEventsTimelineController(roomProxy: roomProxy,
-                                                                                                           timelineItemFactory: timelineItemFactory,
-                                                                                                           mediaProvider: userSession.mediaProvider) else {
+        
+        guard case let .success(timelineController) = await timelineControllerFactory.buildPinnedEventsTimelineController(roomProxy: roomProxy,
+                                                                                                                          timelineItemFactory: timelineItemFactory,
+                                                                                                                          mediaProvider: userSession.mediaProvider) else {
             fatalError("This can never fail because we allow this view to be presented only when the timeline is fully loaded and not nil")
         }
         

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -6270,23 +6270,6 @@ class JoinedRoomProxyMock: JoinedRoomProxyProtocol, @unchecked Sendable {
         set(value) { underlyingTimeline = value }
     }
     var underlyingTimeline: TimelineProxyProtocol!
-    var pinnedEventsTimelineCallsCount = 0
-    var pinnedEventsTimelineCalled: Bool {
-        return pinnedEventsTimelineCallsCount > 0
-    }
-
-    var pinnedEventsTimeline: TimelineProxyProtocol? {
-        get async {
-            pinnedEventsTimelineCallsCount += 1
-            if let pinnedEventsTimelineClosure = pinnedEventsTimelineClosure {
-                return await pinnedEventsTimelineClosure()
-            } else {
-                return underlyingPinnedEventsTimeline
-            }
-        }
-    }
-    var underlyingPinnedEventsTimeline: TimelineProxyProtocol?
-    var pinnedEventsTimelineClosure: (() async -> TimelineProxyProtocol?)?
     var id: String {
         get { return underlyingId }
         set(value) { underlyingId = value }
@@ -6576,6 +6559,70 @@ class JoinedRoomProxyMock: JoinedRoomProxyProtocol, @unchecked Sendable {
             return await messageFilteredTimelineFocusAllowedMessageTypesPresentationClosure(focus, allowedMessageTypes, presentation)
         } else {
             return messageFilteredTimelineFocusAllowedMessageTypesPresentationReturnValue
+        }
+    }
+    //MARK: - pinnedEventsTimeline
+
+    var pinnedEventsTimelineUnderlyingCallsCount = 0
+    var pinnedEventsTimelineCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return pinnedEventsTimelineUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = pinnedEventsTimelineUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                pinnedEventsTimelineUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    pinnedEventsTimelineUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var pinnedEventsTimelineCalled: Bool {
+        return pinnedEventsTimelineCallsCount > 0
+    }
+
+    var pinnedEventsTimelineUnderlyingReturnValue: Result<TimelineProxyProtocol, RoomProxyError>!
+    var pinnedEventsTimelineReturnValue: Result<TimelineProxyProtocol, RoomProxyError>! {
+        get {
+            if Thread.isMainThread {
+                return pinnedEventsTimelineUnderlyingReturnValue
+            } else {
+                var returnValue: Result<TimelineProxyProtocol, RoomProxyError>? = nil
+                DispatchQueue.main.sync {
+                    returnValue = pinnedEventsTimelineUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                pinnedEventsTimelineUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    pinnedEventsTimelineUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    var pinnedEventsTimelineClosure: (() async -> Result<TimelineProxyProtocol, RoomProxyError>)?
+
+    func pinnedEventsTimeline() async -> Result<TimelineProxyProtocol, RoomProxyError> {
+        pinnedEventsTimelineCallsCount += 1
+        if let pinnedEventsTimelineClosure = pinnedEventsTimelineClosure {
+            return await pinnedEventsTimelineClosure()
+        } else {
+            return pinnedEventsTimelineReturnValue
         }
     }
     //MARK: - enableEncryption
@@ -15141,13 +15188,13 @@ class TimelineControllerFactoryMock: TimelineControllerFactoryProtocol, @uncheck
     var buildPinnedEventsTimelineControllerRoomProxyTimelineItemFactoryMediaProviderReceivedArguments: (roomProxy: JoinedRoomProxyProtocol, timelineItemFactory: RoomTimelineItemFactoryProtocol, mediaProvider: MediaProviderProtocol)?
     var buildPinnedEventsTimelineControllerRoomProxyTimelineItemFactoryMediaProviderReceivedInvocations: [(roomProxy: JoinedRoomProxyProtocol, timelineItemFactory: RoomTimelineItemFactoryProtocol, mediaProvider: MediaProviderProtocol)] = []
 
-    var buildPinnedEventsTimelineControllerRoomProxyTimelineItemFactoryMediaProviderUnderlyingReturnValue: TimelineControllerProtocol?
-    var buildPinnedEventsTimelineControllerRoomProxyTimelineItemFactoryMediaProviderReturnValue: TimelineControllerProtocol? {
+    var buildPinnedEventsTimelineControllerRoomProxyTimelineItemFactoryMediaProviderUnderlyingReturnValue: Result<TimelineControllerProtocol, TimelineFactoryControllerError>!
+    var buildPinnedEventsTimelineControllerRoomProxyTimelineItemFactoryMediaProviderReturnValue: Result<TimelineControllerProtocol, TimelineFactoryControllerError>! {
         get {
             if Thread.isMainThread {
                 return buildPinnedEventsTimelineControllerRoomProxyTimelineItemFactoryMediaProviderUnderlyingReturnValue
             } else {
-                var returnValue: TimelineControllerProtocol?? = nil
+                var returnValue: Result<TimelineControllerProtocol, TimelineFactoryControllerError>? = nil
                 DispatchQueue.main.sync {
                     returnValue = buildPinnedEventsTimelineControllerRoomProxyTimelineItemFactoryMediaProviderUnderlyingReturnValue
                 }
@@ -15165,9 +15212,9 @@ class TimelineControllerFactoryMock: TimelineControllerFactoryProtocol, @uncheck
             }
         }
     }
-    var buildPinnedEventsTimelineControllerRoomProxyTimelineItemFactoryMediaProviderClosure: ((JoinedRoomProxyProtocol, RoomTimelineItemFactoryProtocol, MediaProviderProtocol) async -> TimelineControllerProtocol?)?
+    var buildPinnedEventsTimelineControllerRoomProxyTimelineItemFactoryMediaProviderClosure: ((JoinedRoomProxyProtocol, RoomTimelineItemFactoryProtocol, MediaProviderProtocol) async -> Result<TimelineControllerProtocol, TimelineFactoryControllerError>)?
 
-    func buildPinnedEventsTimelineController(roomProxy: JoinedRoomProxyProtocol, timelineItemFactory: RoomTimelineItemFactoryProtocol, mediaProvider: MediaProviderProtocol) async -> TimelineControllerProtocol? {
+    func buildPinnedEventsTimelineController(roomProxy: JoinedRoomProxyProtocol, timelineItemFactory: RoomTimelineItemFactoryProtocol, mediaProvider: MediaProviderProtocol) async -> Result<TimelineControllerProtocol, TimelineFactoryControllerError> {
         buildPinnedEventsTimelineControllerRoomProxyTimelineItemFactoryMediaProviderCallsCount += 1
         buildPinnedEventsTimelineControllerRoomProxyTimelineItemFactoryMediaProviderReceivedArguments = (roomProxy: roomProxy, timelineItemFactory: timelineItemFactory, mediaProvider: mediaProvider)
         DispatchQueue.main.async {

--- a/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
@@ -1125,6 +1125,75 @@ open class ClientSDKMock: MatrixRustSDK.Client, @unchecked Sendable {
         }
     }
 
+    //MARK: - getInviteAvatarsDisplayPolicy
+
+    open var getInviteAvatarsDisplayPolicyThrowableError: Error?
+    var getInviteAvatarsDisplayPolicyUnderlyingCallsCount = 0
+    open var getInviteAvatarsDisplayPolicyCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return getInviteAvatarsDisplayPolicyUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = getInviteAvatarsDisplayPolicyUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                getInviteAvatarsDisplayPolicyUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    getInviteAvatarsDisplayPolicyUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var getInviteAvatarsDisplayPolicyCalled: Bool {
+        return getInviteAvatarsDisplayPolicyCallsCount > 0
+    }
+
+    var getInviteAvatarsDisplayPolicyUnderlyingReturnValue: InviteAvatars!
+    open var getInviteAvatarsDisplayPolicyReturnValue: InviteAvatars! {
+        get {
+            if Thread.isMainThread {
+                return getInviteAvatarsDisplayPolicyUnderlyingReturnValue
+            } else {
+                var returnValue: InviteAvatars? = nil
+                DispatchQueue.main.sync {
+                    returnValue = getInviteAvatarsDisplayPolicyUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                getInviteAvatarsDisplayPolicyUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    getInviteAvatarsDisplayPolicyUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    open var getInviteAvatarsDisplayPolicyClosure: (() async throws -> InviteAvatars)?
+
+    open override func getInviteAvatarsDisplayPolicy() async throws -> InviteAvatars {
+        if let error = getInviteAvatarsDisplayPolicyThrowableError {
+            throw error
+        }
+        getInviteAvatarsDisplayPolicyCallsCount += 1
+        if let getInviteAvatarsDisplayPolicyClosure = getInviteAvatarsDisplayPolicyClosure {
+            return try await getInviteAvatarsDisplayPolicyClosure()
+        } else {
+            return getInviteAvatarsDisplayPolicyReturnValue
+        }
+    }
+
     //MARK: - getMediaContent
 
     open var getMediaContentMediaSourceThrowableError: Error?
@@ -1272,6 +1341,75 @@ open class ClientSDKMock: MatrixRustSDK.Client, @unchecked Sendable {
             return try await getMediaFileMediaSourceFilenameMimeTypeUseCacheTempDirClosure(mediaSource, filename, mimeType, useCache, tempDir)
         } else {
             return getMediaFileMediaSourceFilenameMimeTypeUseCacheTempDirReturnValue
+        }
+    }
+
+    //MARK: - getMediaPreviewDisplayPolicy
+
+    open var getMediaPreviewDisplayPolicyThrowableError: Error?
+    var getMediaPreviewDisplayPolicyUnderlyingCallsCount = 0
+    open var getMediaPreviewDisplayPolicyCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return getMediaPreviewDisplayPolicyUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = getMediaPreviewDisplayPolicyUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                getMediaPreviewDisplayPolicyUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    getMediaPreviewDisplayPolicyUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var getMediaPreviewDisplayPolicyCalled: Bool {
+        return getMediaPreviewDisplayPolicyCallsCount > 0
+    }
+
+    var getMediaPreviewDisplayPolicyUnderlyingReturnValue: MediaPreviews!
+    open var getMediaPreviewDisplayPolicyReturnValue: MediaPreviews! {
+        get {
+            if Thread.isMainThread {
+                return getMediaPreviewDisplayPolicyUnderlyingReturnValue
+            } else {
+                var returnValue: MediaPreviews? = nil
+                DispatchQueue.main.sync {
+                    returnValue = getMediaPreviewDisplayPolicyUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                getMediaPreviewDisplayPolicyUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    getMediaPreviewDisplayPolicyUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    open var getMediaPreviewDisplayPolicyClosure: (() async throws -> MediaPreviews)?
+
+    open override func getMediaPreviewDisplayPolicy() async throws -> MediaPreviews {
+        if let error = getMediaPreviewDisplayPolicyThrowableError {
+            throw error
+        }
+        getMediaPreviewDisplayPolicyCallsCount += 1
+        if let getMediaPreviewDisplayPolicyClosure = getMediaPreviewDisplayPolicyClosure {
+            return try await getMediaPreviewDisplayPolicyClosure()
+        } else {
+            return getMediaPreviewDisplayPolicyReturnValue
         }
     }
 
@@ -3650,6 +3788,7 @@ open class ClientSDKMock: MatrixRustSDK.Client, @unchecked Sendable {
 
     //MARK: - setDelegate
 
+    open var setDelegateDelegateThrowableError: Error?
     var setDelegateDelegateUnderlyingCallsCount = 0
     open var setDelegateDelegateCallsCount: Int {
         get {
@@ -3704,16 +3843,19 @@ open class ClientSDKMock: MatrixRustSDK.Client, @unchecked Sendable {
             }
         }
     }
-    open var setDelegateDelegateClosure: ((ClientDelegate?) -> TaskHandle?)?
+    open var setDelegateDelegateClosure: ((ClientDelegate?) throws -> TaskHandle?)?
 
-    open override func setDelegate(delegate: ClientDelegate?) -> TaskHandle? {
+    open override func setDelegate(delegate: ClientDelegate?) throws -> TaskHandle? {
+        if let error = setDelegateDelegateThrowableError {
+            throw error
+        }
         setDelegateDelegateCallsCount += 1
         setDelegateDelegateReceivedDelegate = delegate
         DispatchQueue.main.async {
             self.setDelegateDelegateReceivedInvocations.append(delegate)
         }
         if let setDelegateDelegateClosure = setDelegateDelegateClosure {
-            return setDelegateDelegateClosure(delegate)
+            return try setDelegateDelegateClosure(delegate)
         } else {
             return setDelegateDelegateReturnValue
         }
@@ -3763,6 +3905,98 @@ open class ClientSDKMock: MatrixRustSDK.Client, @unchecked Sendable {
             self.setDisplayNameNameReceivedInvocations.append(name)
         }
         try await setDisplayNameNameClosure?(name)
+    }
+
+    //MARK: - setInviteAvatarsDisplayPolicy
+
+    open var setInviteAvatarsDisplayPolicyPolicyThrowableError: Error?
+    var setInviteAvatarsDisplayPolicyPolicyUnderlyingCallsCount = 0
+    open var setInviteAvatarsDisplayPolicyPolicyCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return setInviteAvatarsDisplayPolicyPolicyUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = setInviteAvatarsDisplayPolicyPolicyUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                setInviteAvatarsDisplayPolicyPolicyUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    setInviteAvatarsDisplayPolicyPolicyUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var setInviteAvatarsDisplayPolicyPolicyCalled: Bool {
+        return setInviteAvatarsDisplayPolicyPolicyCallsCount > 0
+    }
+    open var setInviteAvatarsDisplayPolicyPolicyReceivedPolicy: InviteAvatars?
+    open var setInviteAvatarsDisplayPolicyPolicyReceivedInvocations: [InviteAvatars] = []
+    open var setInviteAvatarsDisplayPolicyPolicyClosure: ((InviteAvatars) async throws -> Void)?
+
+    open override func setInviteAvatarsDisplayPolicy(policy: InviteAvatars) async throws {
+        if let error = setInviteAvatarsDisplayPolicyPolicyThrowableError {
+            throw error
+        }
+        setInviteAvatarsDisplayPolicyPolicyCallsCount += 1
+        setInviteAvatarsDisplayPolicyPolicyReceivedPolicy = policy
+        DispatchQueue.main.async {
+            self.setInviteAvatarsDisplayPolicyPolicyReceivedInvocations.append(policy)
+        }
+        try await setInviteAvatarsDisplayPolicyPolicyClosure?(policy)
+    }
+
+    //MARK: - setMediaPreviewDisplayPolicy
+
+    open var setMediaPreviewDisplayPolicyPolicyThrowableError: Error?
+    var setMediaPreviewDisplayPolicyPolicyUnderlyingCallsCount = 0
+    open var setMediaPreviewDisplayPolicyPolicyCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return setMediaPreviewDisplayPolicyPolicyUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = setMediaPreviewDisplayPolicyPolicyUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                setMediaPreviewDisplayPolicyPolicyUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    setMediaPreviewDisplayPolicyPolicyUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var setMediaPreviewDisplayPolicyPolicyCalled: Bool {
+        return setMediaPreviewDisplayPolicyPolicyCallsCount > 0
+    }
+    open var setMediaPreviewDisplayPolicyPolicyReceivedPolicy: MediaPreviews?
+    open var setMediaPreviewDisplayPolicyPolicyReceivedInvocations: [MediaPreviews] = []
+    open var setMediaPreviewDisplayPolicyPolicyClosure: ((MediaPreviews) async throws -> Void)?
+
+    open override func setMediaPreviewDisplayPolicy(policy: MediaPreviews) async throws {
+        if let error = setMediaPreviewDisplayPolicyPolicyThrowableError {
+            throw error
+        }
+        setMediaPreviewDisplayPolicyPolicyCallsCount += 1
+        setMediaPreviewDisplayPolicyPolicyReceivedPolicy = policy
+        DispatchQueue.main.async {
+            self.setMediaPreviewDisplayPolicyPolicyReceivedInvocations.append(policy)
+        }
+        try await setMediaPreviewDisplayPolicyPolicyClosure?(policy)
     }
 
     //MARK: - setMediaRetentionPolicy
@@ -3855,6 +4089,52 @@ open class ClientSDKMock: MatrixRustSDK.Client, @unchecked Sendable {
             self.setPusherIdentifiersKindAppDisplayNameDeviceDisplayNameProfileTagLangReceivedInvocations.append((identifiers: identifiers, kind: kind, appDisplayName: appDisplayName, deviceDisplayName: deviceDisplayName, profileTag: profileTag, lang: lang))
         }
         try await setPusherIdentifiersKindAppDisplayNameDeviceDisplayNameProfileTagLangClosure?(identifiers, kind, appDisplayName, deviceDisplayName, profileTag, lang)
+    }
+
+    //MARK: - setUtdDelegate
+
+    open var setUtdDelegateUtdDelegateThrowableError: Error?
+    var setUtdDelegateUtdDelegateUnderlyingCallsCount = 0
+    open var setUtdDelegateUtdDelegateCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return setUtdDelegateUtdDelegateUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = setUtdDelegateUtdDelegateUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                setUtdDelegateUtdDelegateUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    setUtdDelegateUtdDelegateUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var setUtdDelegateUtdDelegateCalled: Bool {
+        return setUtdDelegateUtdDelegateCallsCount > 0
+    }
+    open var setUtdDelegateUtdDelegateReceivedUtdDelegate: UnableToDecryptDelegate?
+    open var setUtdDelegateUtdDelegateReceivedInvocations: [UnableToDecryptDelegate] = []
+    open var setUtdDelegateUtdDelegateClosure: ((UnableToDecryptDelegate) async throws -> Void)?
+
+    open override func setUtdDelegate(utdDelegate: UnableToDecryptDelegate) async throws {
+        if let error = setUtdDelegateUtdDelegateThrowableError {
+            throw error
+        }
+        setUtdDelegateUtdDelegateCallsCount += 1
+        setUtdDelegateUtdDelegateReceivedUtdDelegate = utdDelegate
+        DispatchQueue.main.async {
+            self.setUtdDelegateUtdDelegateReceivedInvocations.append(utdDelegate)
+        }
+        try await setUtdDelegateUtdDelegateClosure?(utdDelegate)
     }
 
     //MARK: - slidingSyncVersion
@@ -4065,6 +4345,81 @@ open class ClientSDKMock: MatrixRustSDK.Client, @unchecked Sendable {
             return subscribeToIgnoredUsersListenerClosure(listener)
         } else {
             return subscribeToIgnoredUsersListenerReturnValue
+        }
+    }
+
+    //MARK: - subscribeToMediaPreviewConfig
+
+    open var subscribeToMediaPreviewConfigListenerThrowableError: Error?
+    var subscribeToMediaPreviewConfigListenerUnderlyingCallsCount = 0
+    open var subscribeToMediaPreviewConfigListenerCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return subscribeToMediaPreviewConfigListenerUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = subscribeToMediaPreviewConfigListenerUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                subscribeToMediaPreviewConfigListenerUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    subscribeToMediaPreviewConfigListenerUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var subscribeToMediaPreviewConfigListenerCalled: Bool {
+        return subscribeToMediaPreviewConfigListenerCallsCount > 0
+    }
+    open var subscribeToMediaPreviewConfigListenerReceivedListener: MediaPreviewConfigListener?
+    open var subscribeToMediaPreviewConfigListenerReceivedInvocations: [MediaPreviewConfigListener] = []
+
+    var subscribeToMediaPreviewConfigListenerUnderlyingReturnValue: TaskHandle!
+    open var subscribeToMediaPreviewConfigListenerReturnValue: TaskHandle! {
+        get {
+            if Thread.isMainThread {
+                return subscribeToMediaPreviewConfigListenerUnderlyingReturnValue
+            } else {
+                var returnValue: TaskHandle? = nil
+                DispatchQueue.main.sync {
+                    returnValue = subscribeToMediaPreviewConfigListenerUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                subscribeToMediaPreviewConfigListenerUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    subscribeToMediaPreviewConfigListenerUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    open var subscribeToMediaPreviewConfigListenerClosure: ((MediaPreviewConfigListener) async throws -> TaskHandle)?
+
+    open override func subscribeToMediaPreviewConfig(listener: MediaPreviewConfigListener) async throws -> TaskHandle {
+        if let error = subscribeToMediaPreviewConfigListenerThrowableError {
+            throw error
+        }
+        subscribeToMediaPreviewConfigListenerCallsCount += 1
+        subscribeToMediaPreviewConfigListenerReceivedListener = listener
+        DispatchQueue.main.async {
+            self.subscribeToMediaPreviewConfigListenerReceivedInvocations.append(listener)
+        }
+        if let subscribeToMediaPreviewConfigListenerClosure = subscribeToMediaPreviewConfigListenerClosure {
+            return try await subscribeToMediaPreviewConfigListenerClosure(listener)
+        } else {
+            return subscribeToMediaPreviewConfigListenerReturnValue
         }
     }
 
@@ -17583,75 +17938,6 @@ open class RoomListItemSDKMock: MatrixRustSDK.RoomListItem, @unchecked Sendable 
         }
     }
 
-    //MARK: - fullRoom
-
-    open var fullRoomThrowableError: Error?
-    var fullRoomUnderlyingCallsCount = 0
-    open var fullRoomCallsCount: Int {
-        get {
-            if Thread.isMainThread {
-                return fullRoomUnderlyingCallsCount
-            } else {
-                var returnValue: Int? = nil
-                DispatchQueue.main.sync {
-                    returnValue = fullRoomUnderlyingCallsCount
-                }
-
-                return returnValue!
-            }
-        }
-        set {
-            if Thread.isMainThread {
-                fullRoomUnderlyingCallsCount = newValue
-            } else {
-                DispatchQueue.main.sync {
-                    fullRoomUnderlyingCallsCount = newValue
-                }
-            }
-        }
-    }
-    open var fullRoomCalled: Bool {
-        return fullRoomCallsCount > 0
-    }
-
-    var fullRoomUnderlyingReturnValue: Room!
-    open var fullRoomReturnValue: Room! {
-        get {
-            if Thread.isMainThread {
-                return fullRoomUnderlyingReturnValue
-            } else {
-                var returnValue: Room? = nil
-                DispatchQueue.main.sync {
-                    returnValue = fullRoomUnderlyingReturnValue
-                }
-
-                return returnValue!
-            }
-        }
-        set {
-            if Thread.isMainThread {
-                fullRoomUnderlyingReturnValue = newValue
-            } else {
-                DispatchQueue.main.sync {
-                    fullRoomUnderlyingReturnValue = newValue
-                }
-            }
-        }
-    }
-    open var fullRoomClosure: (() throws -> Room)?
-
-    open override func fullRoom() throws -> Room {
-        if let error = fullRoomThrowableError {
-            throw error
-        }
-        fullRoomCallsCount += 1
-        if let fullRoomClosure = fullRoomClosure {
-            return try fullRoomClosure()
-        } else {
-            return fullRoomReturnValue
-        }
-    }
-
     //MARK: - id
 
     var idUnderlyingCallsCount = 0
@@ -17715,52 +18001,6 @@ open class RoomListItemSDKMock: MatrixRustSDK.RoomListItem, @unchecked Sendable 
         } else {
             return idReturnValue
         }
-    }
-
-    //MARK: - initTimeline
-
-    open var initTimelineEventTypeFilterInternalIdPrefixThrowableError: Error?
-    var initTimelineEventTypeFilterInternalIdPrefixUnderlyingCallsCount = 0
-    open var initTimelineEventTypeFilterInternalIdPrefixCallsCount: Int {
-        get {
-            if Thread.isMainThread {
-                return initTimelineEventTypeFilterInternalIdPrefixUnderlyingCallsCount
-            } else {
-                var returnValue: Int? = nil
-                DispatchQueue.main.sync {
-                    returnValue = initTimelineEventTypeFilterInternalIdPrefixUnderlyingCallsCount
-                }
-
-                return returnValue!
-            }
-        }
-        set {
-            if Thread.isMainThread {
-                initTimelineEventTypeFilterInternalIdPrefixUnderlyingCallsCount = newValue
-            } else {
-                DispatchQueue.main.sync {
-                    initTimelineEventTypeFilterInternalIdPrefixUnderlyingCallsCount = newValue
-                }
-            }
-        }
-    }
-    open var initTimelineEventTypeFilterInternalIdPrefixCalled: Bool {
-        return initTimelineEventTypeFilterInternalIdPrefixCallsCount > 0
-    }
-    open var initTimelineEventTypeFilterInternalIdPrefixReceivedArguments: (eventTypeFilter: TimelineEventTypeFilter?, internalIdPrefix: String?)?
-    open var initTimelineEventTypeFilterInternalIdPrefixReceivedInvocations: [(eventTypeFilter: TimelineEventTypeFilter?, internalIdPrefix: String?)] = []
-    open var initTimelineEventTypeFilterInternalIdPrefixClosure: ((TimelineEventTypeFilter?, String?) async throws -> Void)?
-
-    open override func initTimeline(eventTypeFilter: TimelineEventTypeFilter?, internalIdPrefix: String?) async throws {
-        if let error = initTimelineEventTypeFilterInternalIdPrefixThrowableError {
-            throw error
-        }
-        initTimelineEventTypeFilterInternalIdPrefixCallsCount += 1
-        initTimelineEventTypeFilterInternalIdPrefixReceivedArguments = (eventTypeFilter: eventTypeFilter, internalIdPrefix: internalIdPrefix)
-        DispatchQueue.main.async {
-            self.initTimelineEventTypeFilterInternalIdPrefixReceivedInvocations.append((eventTypeFilter: eventTypeFilter, internalIdPrefix: internalIdPrefix))
-        }
-        try await initTimelineEventTypeFilterInternalIdPrefixClosure?(eventTypeFilter, internalIdPrefix)
     }
 
     //MARK: - isDirect
@@ -17890,71 +18130,6 @@ open class RoomListItemSDKMock: MatrixRustSDK.RoomListItem, @unchecked Sendable 
             return await isEncryptedClosure()
         } else {
             return isEncryptedReturnValue
-        }
-    }
-
-    //MARK: - isTimelineInitialized
-
-    var isTimelineInitializedUnderlyingCallsCount = 0
-    open var isTimelineInitializedCallsCount: Int {
-        get {
-            if Thread.isMainThread {
-                return isTimelineInitializedUnderlyingCallsCount
-            } else {
-                var returnValue: Int? = nil
-                DispatchQueue.main.sync {
-                    returnValue = isTimelineInitializedUnderlyingCallsCount
-                }
-
-                return returnValue!
-            }
-        }
-        set {
-            if Thread.isMainThread {
-                isTimelineInitializedUnderlyingCallsCount = newValue
-            } else {
-                DispatchQueue.main.sync {
-                    isTimelineInitializedUnderlyingCallsCount = newValue
-                }
-            }
-        }
-    }
-    open var isTimelineInitializedCalled: Bool {
-        return isTimelineInitializedCallsCount > 0
-    }
-
-    var isTimelineInitializedUnderlyingReturnValue: Bool!
-    open var isTimelineInitializedReturnValue: Bool! {
-        get {
-            if Thread.isMainThread {
-                return isTimelineInitializedUnderlyingReturnValue
-            } else {
-                var returnValue: Bool? = nil
-                DispatchQueue.main.sync {
-                    returnValue = isTimelineInitializedUnderlyingReturnValue
-                }
-
-                return returnValue!
-            }
-        }
-        set {
-            if Thread.isMainThread {
-                isTimelineInitializedUnderlyingReturnValue = newValue
-            } else {
-                DispatchQueue.main.sync {
-                    isTimelineInitializedUnderlyingReturnValue = newValue
-                }
-            }
-        }
-    }
-    open var isTimelineInitializedClosure: (() -> Bool)?
-
-    open override func isTimelineInitialized() -> Bool {
-        isTimelineInitializedCallsCount += 1
-        if let isTimelineInitializedClosure = isTimelineInitializedClosure {
-            return isTimelineInitializedClosure()
-        } else {
-            return isTimelineInitializedReturnValue
         }
     }
 
@@ -20526,77 +20701,6 @@ open class SyncServiceBuilderSDKMock: MatrixRustSDK.SyncServiceBuilder, @uncheck
             return withOfflineModeClosure()
         } else {
             return withOfflineModeReturnValue
-        }
-    }
-
-    //MARK: - withUtdHook
-
-    var withUtdHookDelegateUnderlyingCallsCount = 0
-    open var withUtdHookDelegateCallsCount: Int {
-        get {
-            if Thread.isMainThread {
-                return withUtdHookDelegateUnderlyingCallsCount
-            } else {
-                var returnValue: Int? = nil
-                DispatchQueue.main.sync {
-                    returnValue = withUtdHookDelegateUnderlyingCallsCount
-                }
-
-                return returnValue!
-            }
-        }
-        set {
-            if Thread.isMainThread {
-                withUtdHookDelegateUnderlyingCallsCount = newValue
-            } else {
-                DispatchQueue.main.sync {
-                    withUtdHookDelegateUnderlyingCallsCount = newValue
-                }
-            }
-        }
-    }
-    open var withUtdHookDelegateCalled: Bool {
-        return withUtdHookDelegateCallsCount > 0
-    }
-    open var withUtdHookDelegateReceivedDelegate: UnableToDecryptDelegate?
-    open var withUtdHookDelegateReceivedInvocations: [UnableToDecryptDelegate] = []
-
-    var withUtdHookDelegateUnderlyingReturnValue: SyncServiceBuilder!
-    open var withUtdHookDelegateReturnValue: SyncServiceBuilder! {
-        get {
-            if Thread.isMainThread {
-                return withUtdHookDelegateUnderlyingReturnValue
-            } else {
-                var returnValue: SyncServiceBuilder? = nil
-                DispatchQueue.main.sync {
-                    returnValue = withUtdHookDelegateUnderlyingReturnValue
-                }
-
-                return returnValue!
-            }
-        }
-        set {
-            if Thread.isMainThread {
-                withUtdHookDelegateUnderlyingReturnValue = newValue
-            } else {
-                DispatchQueue.main.sync {
-                    withUtdHookDelegateUnderlyingReturnValue = newValue
-                }
-            }
-        }
-    }
-    open var withUtdHookDelegateClosure: ((UnableToDecryptDelegate) async -> SyncServiceBuilder)?
-
-    open override func withUtdHook(delegate: UnableToDecryptDelegate) async -> SyncServiceBuilder {
-        withUtdHookDelegateCallsCount += 1
-        withUtdHookDelegateReceivedDelegate = delegate
-        DispatchQueue.main.async {
-            self.withUtdHookDelegateReceivedInvocations.append(delegate)
-        }
-        if let withUtdHookDelegateClosure = withUtdHookDelegateClosure {
-            return await withUtdHookDelegateClosure(delegate)
-        } else {
-            return withUtdHookDelegateReturnValue
         }
     }
 }

--- a/ElementX/Sources/Mocks/JoinedRoomProxyMock.swift
+++ b/ElementX/Sources/Mocks/JoinedRoomProxyMock.swift
@@ -59,6 +59,8 @@ extension JoinedRoomProxyMock {
 
         timeline = TimelineProxyMock(.init(isAutoUpdating: configuration.shouldUseAutoUpdatingTimeline,
                                            timelineStartReached: configuration.timelineStartReached))
+        
+        pinnedEventsTimelineReturnValue = .failure(.failedCreatingPinnedTimeline)
 
         ownUserID = configuration.ownUserID
         

--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
@@ -445,12 +445,12 @@ class RoomDetailsScreenViewModel: RoomDetailsScreenViewModelType, RoomDetailsScr
         }
         
         Task {
-            guard let timelineProvider = await roomProxy.pinnedEventsTimeline?.timelineProvider else {
+            guard case let .success(pinnedEventsTimeline) = await roomProxy.pinnedEventsTimeline() else {
                 return
             }
             
             if pinnedEventsTimelineProvider == nil {
-                pinnedEventsTimelineProvider = timelineProvider
+                pinnedEventsTimelineProvider = pinnedEventsTimeline.timelineProvider
             }
         }
     }

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -353,12 +353,12 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
         }
         
         Task {
-            guard let timelineProvider = await roomProxy.pinnedEventsTimeline?.timelineProvider else {
+            guard case let .success(pinnedEventsTimeline) = await roomProxy.pinnedEventsTimeline() else {
                 return
             }
             
             if pinnedEventsTimelineProvider == nil {
-                pinnedEventsTimelineProvider = timelineProvider
+                pinnedEventsTimelineProvider = pinnedEventsTimeline.timelineProvider
             }
         }
     }

--- a/ElementX/Sources/Services/Room/BannedRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/BannedRoomProxy.swift
@@ -11,12 +11,14 @@ import MatrixRustSDK
 class BannedRoomProxy: BannedRoomProxyProtocol {
     private let roomListItem: RoomListItemProtocol
     private let roomPreview: RoomPreviewProtocol
-    let info: BaseRoomInfoProxyProtocol
-    let ownUserID: String
     
     // A room identifier is constant and lazy stops it from being fetched
     // multiple times over FFI
     lazy var id = info.id
+    
+    let ownUserID: String
+    
+    let info: BaseRoomInfoProxyProtocol
         
     init(roomListItem: RoomListItemProtocol,
          roomPreview: RoomPreviewProtocol,

--- a/ElementX/Sources/Services/Room/InvitedRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/InvitedRoomProxy.swift
@@ -12,13 +12,15 @@ import UIKit
 class InvitedRoomProxy: InvitedRoomProxyProtocol {
     private let roomListItem: RoomListItemProtocol
     private let roomPreview: RoomPreviewProtocol
-    let info: BaseRoomInfoProxyProtocol
-    let ownUserID: String
-    let inviter: RoomMemberProxyProtocol?
     
     // A room identifier is constant and lazy stops it from being fetched
     // multiple times over FFI
     lazy var id: String = info.id
+    
+    let ownUserID: String
+    
+    let info: BaseRoomInfoProxyProtocol
+    let inviter: RoomMemberProxyProtocol?
         
     init(roomListItem: RoomListItemProtocol,
          roomPreview: RoomPreviewProtocol,

--- a/ElementX/Sources/Services/Room/KnockedRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/KnockedRoomProxy.swift
@@ -11,12 +11,14 @@ import MatrixRustSDK
 class KnockedRoomProxy: KnockedRoomProxyProtocol {
     private let roomListItem: RoomListItemProtocol
     private let roomPreview: RoomPreviewProtocol
-    let info: BaseRoomInfoProxyProtocol
-    let ownUserID: String
     
     // A room identifier is constant and lazy stops it from being fetched
     // multiple times over FFI
     lazy var id = info.id
+    
+    let ownUserID: String
+    
+    let info: BaseRoomInfoProxyProtocol
         
     init(roomListItem: RoomListItemProtocol,
          roomPreview: RoomPreviewProtocol,

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -16,6 +16,7 @@ enum RoomProxyError: Error {
     case invalidMedia
     case eventNotFound
     case missingTransactionID
+    case failedCreatingPinnedTimeline
 }
 
 /// An enum that describes the relationship between the current user and the room, and contains a reference to the specific implementation of the `RoomProxy`.
@@ -75,8 +76,6 @@ protocol JoinedRoomProxyProtocol: RoomProxyProtocol {
     
     var timeline: TimelineProxyProtocol { get }
     
-    var pinnedEventsTimeline: TimelineProxyProtocol? { get async }
-    
     func subscribeForUpdates() async
     
     func subscribeToRoomInfoUpdates()
@@ -88,6 +87,8 @@ protocol JoinedRoomProxyProtocol: RoomProxyProtocol {
     func messageFilteredTimeline(focus: TimelineFocus,
                                  allowedMessageTypes: [TimelineAllowedMessageType],
                                  presentation: TimelineKind.MediaPresentation) async -> Result<TimelineProxyProtocol, RoomProxyError>
+    
+    func pinnedEventsTimeline() async -> Result<TimelineProxyProtocol, RoomProxyError>
     
     func enableEncryption() async -> Result<Void, RoomProxyError>
     

--- a/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerFactory.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerFactory.swift
@@ -40,17 +40,18 @@ struct TimelineControllerFactory: TimelineControllerFactoryProtocol {
     
     func buildPinnedEventsTimelineController(roomProxy: JoinedRoomProxyProtocol,
                                              timelineItemFactory: RoomTimelineItemFactoryProtocol,
-                                             mediaProvider: MediaProviderProtocol) async -> TimelineControllerProtocol? {
-        guard let pinnedEventsTimeline = await roomProxy.pinnedEventsTimeline else {
-            return nil
+                                             mediaProvider: MediaProviderProtocol) async -> Result<TimelineControllerProtocol, TimelineFactoryControllerError> {
+        switch await roomProxy.pinnedEventsTimeline() {
+        case .success(let timelineProxy):
+            return .success(TimelineController(roomProxy: roomProxy,
+                                               timelineProxy: timelineProxy,
+                                               initialFocussedEventID: nil,
+                                               timelineItemFactory: timelineItemFactory,
+                                               mediaProvider: mediaProvider,
+                                               appSettings: ServiceLocator.shared.settings))
+        case .failure(let error):
+            return .failure(.roomProxyError(error))
         }
-        
-        return TimelineController(roomProxy: roomProxy,
-                                  timelineProxy: pinnedEventsTimeline,
-                                  initialFocussedEventID: nil,
-                                  timelineItemFactory: timelineItemFactory,
-                                  mediaProvider: mediaProvider,
-                                  appSettings: ServiceLocator.shared.settings)
     }
     
     func buildMessageFilteredTimelineController(focus: TimelineFocus,

--- a/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerFactoryProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerFactoryProtocol.swift
@@ -26,7 +26,7 @@ protocol TimelineControllerFactoryProtocol {
     
     func buildPinnedEventsTimelineController(roomProxy: JoinedRoomProxyProtocol,
                                              timelineItemFactory: RoomTimelineItemFactoryProtocol,
-                                             mediaProvider: MediaProviderProtocol) async -> TimelineControllerProtocol?
+                                             mediaProvider: MediaProviderProtocol) async -> Result<TimelineControllerProtocol, TimelineFactoryControllerError>
     
     func buildMessageFilteredTimelineController(focus: TimelineFocus,
                                                 allowedMessageTypes: [TimelineAllowedMessageType],

--- a/NSE/Sources/NSEUserSession.swift
+++ b/NSE/Sources/NSEUserSession.swift
@@ -49,7 +49,7 @@ final class NSEUserSession {
             .sessionPassphrase(passphrase: credentials.restorationToken.passphrase)
         
         baseClient = try await clientBuilder.build()
-        delegateHandle = baseClient.setDelegate(delegate: ClientDelegateWrapper())
+        delegateHandle = try baseClient.setDelegate(delegate: ClientDelegateWrapper())
         
         try await baseClient.restoreSessionWith(session: credentials.restorationToken.session,
                                                 roomLoadSettings: .one(roomId: roomID))

--- a/UnitTests/Sources/RoomScreenViewModelTests.swift
+++ b/UnitTests/Sources/RoomScreenViewModelTests.swift
@@ -30,7 +30,11 @@ class RoomScreenViewModelTests: XCTestCase {
         let roomProxyMock = JoinedRoomProxyMock(configuration)
         // setup a way to inject the mock of the pinned events timeline
         roomProxyMock.pinnedEventsTimelineClosure = {
-            await timelineSubject.values.first()
+            guard let timeline = await timelineSubject.values.first() else {
+                fatalError()
+            }
+            
+            return .success(timeline)
         }
         // setup the room proxy actions publisher
         roomProxyMock.underlyingInfoPublisher = infoSubject.asCurrentValuePublisher()
@@ -113,7 +117,7 @@ class RoomScreenViewModelTests: XCTestCase {
         pinnedTimelineProviderMock.itemProxies = [.event(.init(item: EventTimelineItem(configuration: .init(eventID: "test1")), uniqueID: .init("1"))),
                                                   .event(.init(item: EventTimelineItem(configuration: .init(eventID: "test2")), uniqueID: .init("2"))),
                                                   .event(.init(item: EventTimelineItem(configuration: .init(eventID: "test3")), uniqueID: .init("3")))]
-        roomProxyMock.underlyingPinnedEventsTimeline = pinnedTimelineMock
+        roomProxyMock.pinnedEventsTimelineReturnValue = .success(pinnedTimelineMock)
         let viewModel = RoomScreenViewModel(clientProxy: ClientProxyMock(),
                                             roomProxy: roomProxyMock,
                                             initialSelectedPinnedEventID: "test1",

--- a/project.yml
+++ b/project.yml
@@ -65,7 +65,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/element-hq/matrix-rust-components-swift
-    exactVersion: 25.05.19
+    exactVersion: 25.05.21
     # path: ../matrix-rust-sdk
   Compound:
     url: https://github.com/element-hq/compound-ios


### PR DESCRIPTION
The room list items no longer hold any timeline instances and they can now be created through the normal `room.timelineWithConfiguration` mechanism.
This also means that we can move the UTD hook away from the sync service and into the client itself but setting it is now fallible as it can only be set once.

This patch also moves the pinned timeline inline with the other timeline creation methods and has it report errors just like the others.