### PR TITLE
Handle media previews and invite avatars through the account data

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -8836,7 +8836,7 @@
 			repositoryURL = "https://github.com/element-hq/compound-ios";
 			requirement = {
 				kind = revision;
-				revision = 81ba8bd8b3971beac252129c5466d7eac2f2ec31;
+				revision = acbe59727c8352c6768f8444acc6deb07e4b7563;
 			};
 		};
 		F76A08D0EA29A07A54F4EB4D /* XCRemoteSwiftPackageReference "swift-collections" */ = {

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -8836,7 +8836,7 @@
 			repositoryURL = "https://github.com/element-hq/compound-ios";
 			requirement = {
 				kind = revision;
-				revision = acbe59727c8352c6768f8444acc6deb07e4b7563;
+				revision = 139d4f3d1ed19cc513686e5e39750ecef54c8403;
 			};
 		};
 		F76A08D0EA29A07A54F4EB4D /* XCRemoteSwiftPackageReference "swift-collections" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/compound-ios",
       "state" : {
-        "revision" : "81ba8bd8b3971beac252129c5466d7eac2f2ec31"
+        "revision" : "acbe59727c8352c6768f8444acc6deb07e4b7563"
       }
     },
     {
@@ -203,8 +203,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SFSafeSymbols/SFSafeSymbols",
       "state" : {
-        "revision" : "e2e28f4e56e1769c2ec3c61c9355fc64eb7a535a",
-        "version" : "5.3.0"
+        "revision" : "3dd282d3269b061853a3b3bcd23a509d2aa166ce",
+        "version" : "6.2.0"
       }
     },
     {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/compound-ios",
       "state" : {
-        "revision" : "acbe59727c8352c6768f8444acc6deb07e4b7563"
+        "revision" : "139d4f3d1ed19cc513686e5e39750ecef54c8403"
       }
     },
     {

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -17,8 +17,6 @@ protocol CommonSettingsProtocol {
     var logLevel: LogLevel { get }
     var traceLogPacks: Set<TraceLogPack> { get }
     var enableOnlySignedDeviceIsolationMode: Bool { get }
-    var hideInviteAvatars: Bool { get }
-    var timelineMediaVisibility: TimelineMediaVisibility { get }
     var hideQuietNotificationAlerts: Bool { get }
 }
 
@@ -46,8 +44,7 @@ final class AppSettings {
         case optimizeMediaUploads
         case appAppearance
         case sharePresence
-        case hideInviteAvatars
-        case timelineMediaVisibility
+        case hideUnreadMessagesBadge
         case isNewBloomEnabled
         
         case elementCallBaseURLOverride
@@ -61,7 +58,6 @@ final class AppSettings {
         case developerOptionsEnabled
         
         // Doug's tweaks 🔧
-        case hideUnreadMessagesBadge
         case hideQuietNotificationAlerts
     }
     
@@ -368,20 +364,8 @@ final class AppSettings {
     @UserPreference(key: UserDefaultsKeys.enableOnlySignedDeviceIsolationMode, defaultValue: false, storageType: .userDefaults(store))
     var enableOnlySignedDeviceIsolationMode
     
-    @UserPreference(key: UserDefaultsKeys.hideInviteAvatars, defaultValue: false, storageType: .userDefaults(store))
-    var hideInviteAvatars
-    
-    @UserPreference(key: UserDefaultsKeys.timelineMediaVisibility, defaultValue: TimelineMediaVisibility.always, storageType: .userDefaults(store))
-    var timelineMediaVisibility
-    
     @UserPreference(key: UserDefaultsKeys.hideQuietNotificationAlerts, defaultValue: false, storageType: .userDefaults(store))
     var hideQuietNotificationAlerts
 }
 
 extension AppSettings: CommonSettingsProtocol { }
-
-enum TimelineMediaVisibility: Codable {
-    case always
-    case privateOnly
-    case never
-}

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -44,7 +44,6 @@ final class AppSettings {
         case optimizeMediaUploads
         case appAppearance
         case sharePresence
-        case hideUnreadMessagesBadge
         case isNewBloomEnabled
         
         case elementCallBaseURLOverride
@@ -58,6 +57,7 @@ final class AppSettings {
         case developerOptionsEnabled
         
         // Doug's tweaks 🔧
+        case hideUnreadMessagesBadge
         case hideQuietNotificationAlerts
     }
     

--- a/ElementX/Sources/FlowCoordinators/SettingsFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/SettingsFlowCoordinator.swift
@@ -226,7 +226,9 @@ class SettingsFlowCoordinator: FlowCoordinatorProtocol {
     
     private func presentAdvancedSettings() {
         let coordinator = AdvancedSettingsScreenCoordinator(parameters: .init(appSettings: parameters.appSettings,
-                                                                              analytics: parameters.analytics))
+                                                                              analytics: parameters.analytics,
+                                                                              clientProxy: parameters.userSession.clientProxy,
+                                                                              userIndicatorController: parameters.userIndicatorController))
         navigationStackCoordinator.push(coordinator)
     }
     

--- a/ElementX/Sources/Mocks/ClientProxyMock.swift
+++ b/ElementX/Sources/Mocks/ClientProxyMock.swift
@@ -17,6 +17,9 @@ struct ClientProxyMockConfiguration {
     var roomDirectorySearchProxy: RoomDirectorySearchProxyProtocol?
     
     var recoveryState: SecureBackupRecoveryState = .enabled
+    
+    var timelineMediaVisibility = TimelineMediaVisibility.always
+    var hideInviteAvatars = false
 }
 
 enum ClientProxyMockError: Error {
@@ -94,5 +97,8 @@ extension ClientProxyMock {
         userIdentityForReturnValue = .success(UserIdentityProxyMock(configuration: .init()))
         
         underlyingIsReportRoomSupported = true
+        
+        underlyingTimelineMediaVisibilityPublisher = CurrentValueSubject<TimelineMediaVisibility, Never>(configuration.timelineMediaVisibility).asCurrentValuePublisher()
+        underlyingHideInviteAvatarsPublisher = CurrentValueSubject<Bool, Never>(configuration.hideInviteAvatars).asCurrentValuePublisher()
     }
 }

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -4373,17 +4373,17 @@ class ClientProxyMock: ClientProxyProtocol, @unchecked Sendable {
             return clearCachesReturnValue
         }
     }
-    //MARK: - fetchMediaPreviewConfig
+    //MARK: - fetchMediaPreviewConfiguration
 
-    var fetchMediaPreviewConfigUnderlyingCallsCount = 0
-    var fetchMediaPreviewConfigCallsCount: Int {
+    var fetchMediaPreviewConfigurationUnderlyingCallsCount = 0
+    var fetchMediaPreviewConfigurationCallsCount: Int {
         get {
             if Thread.isMainThread {
-                return fetchMediaPreviewConfigUnderlyingCallsCount
+                return fetchMediaPreviewConfigurationUnderlyingCallsCount
             } else {
                 var returnValue: Int? = nil
                 DispatchQueue.main.sync {
-                    returnValue = fetchMediaPreviewConfigUnderlyingCallsCount
+                    returnValue = fetchMediaPreviewConfigurationUnderlyingCallsCount
                 }
 
                 return returnValue!
@@ -4391,27 +4391,27 @@ class ClientProxyMock: ClientProxyProtocol, @unchecked Sendable {
         }
         set {
             if Thread.isMainThread {
-                fetchMediaPreviewConfigUnderlyingCallsCount = newValue
+                fetchMediaPreviewConfigurationUnderlyingCallsCount = newValue
             } else {
                 DispatchQueue.main.sync {
-                    fetchMediaPreviewConfigUnderlyingCallsCount = newValue
+                    fetchMediaPreviewConfigurationUnderlyingCallsCount = newValue
                 }
             }
         }
     }
-    var fetchMediaPreviewConfigCalled: Bool {
-        return fetchMediaPreviewConfigCallsCount > 0
+    var fetchMediaPreviewConfigurationCalled: Bool {
+        return fetchMediaPreviewConfigurationCallsCount > 0
     }
 
-    var fetchMediaPreviewConfigUnderlyingReturnValue: Result<MediaPreviewConfig?, ClientProxyError>!
-    var fetchMediaPreviewConfigReturnValue: Result<MediaPreviewConfig?, ClientProxyError>! {
+    var fetchMediaPreviewConfigurationUnderlyingReturnValue: Result<MediaPreviewConfig?, ClientProxyError>!
+    var fetchMediaPreviewConfigurationReturnValue: Result<MediaPreviewConfig?, ClientProxyError>! {
         get {
             if Thread.isMainThread {
-                return fetchMediaPreviewConfigUnderlyingReturnValue
+                return fetchMediaPreviewConfigurationUnderlyingReturnValue
             } else {
                 var returnValue: Result<MediaPreviewConfig?, ClientProxyError>? = nil
                 DispatchQueue.main.sync {
-                    returnValue = fetchMediaPreviewConfigUnderlyingReturnValue
+                    returnValue = fetchMediaPreviewConfigurationUnderlyingReturnValue
                 }
 
                 return returnValue!
@@ -4419,22 +4419,22 @@ class ClientProxyMock: ClientProxyProtocol, @unchecked Sendable {
         }
         set {
             if Thread.isMainThread {
-                fetchMediaPreviewConfigUnderlyingReturnValue = newValue
+                fetchMediaPreviewConfigurationUnderlyingReturnValue = newValue
             } else {
                 DispatchQueue.main.sync {
-                    fetchMediaPreviewConfigUnderlyingReturnValue = newValue
+                    fetchMediaPreviewConfigurationUnderlyingReturnValue = newValue
                 }
             }
         }
     }
-    var fetchMediaPreviewConfigClosure: (() async -> Result<MediaPreviewConfig?, ClientProxyError>)?
+    var fetchMediaPreviewConfigurationClosure: (() async -> Result<MediaPreviewConfig?, ClientProxyError>)?
 
-    func fetchMediaPreviewConfig() async -> Result<MediaPreviewConfig?, ClientProxyError> {
-        fetchMediaPreviewConfigCallsCount += 1
-        if let fetchMediaPreviewConfigClosure = fetchMediaPreviewConfigClosure {
-            return await fetchMediaPreviewConfigClosure()
+    func fetchMediaPreviewConfiguration() async -> Result<MediaPreviewConfig?, ClientProxyError> {
+        fetchMediaPreviewConfigurationCallsCount += 1
+        if let fetchMediaPreviewConfigurationClosure = fetchMediaPreviewConfigurationClosure {
+            return await fetchMediaPreviewConfigurationClosure()
         } else {
-            return fetchMediaPreviewConfigReturnValue
+            return fetchMediaPreviewConfigurationReturnValue
         }
     }
     //MARK: - ignoreUser

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -2271,6 +2271,16 @@ class ClientProxyMock: ClientProxyProtocol, @unchecked Sendable {
         set(value) { underlyingIgnoredUsersPublisher = value }
     }
     var underlyingIgnoredUsersPublisher: CurrentValuePublisher<[String]?, Never>!
+    var timelineMediaVisibilityPublisher: CurrentValuePublisher<TimelineMediaVisibility, Never> {
+        get { return underlyingTimelineMediaVisibilityPublisher }
+        set(value) { underlyingTimelineMediaVisibilityPublisher = value }
+    }
+    var underlyingTimelineMediaVisibilityPublisher: CurrentValuePublisher<TimelineMediaVisibility, Never>!
+    var hideInviteAvatarsPublisher: CurrentValuePublisher<Bool, Never> {
+        get { return underlyingHideInviteAvatarsPublisher }
+        set(value) { underlyingHideInviteAvatarsPublisher = value }
+    }
+    var underlyingHideInviteAvatarsPublisher: CurrentValuePublisher<Bool, Never>!
     var pusherNotificationClientIdentifier: String?
     var roomSummaryProvider: RoomSummaryProviderProtocol {
         get { return underlyingRoomSummaryProvider }
@@ -4363,6 +4373,70 @@ class ClientProxyMock: ClientProxyProtocol, @unchecked Sendable {
             return clearCachesReturnValue
         }
     }
+    //MARK: - fetchMediaPreviewConfig
+
+    var fetchMediaPreviewConfigUnderlyingCallsCount = 0
+    var fetchMediaPreviewConfigCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return fetchMediaPreviewConfigUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = fetchMediaPreviewConfigUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                fetchMediaPreviewConfigUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    fetchMediaPreviewConfigUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var fetchMediaPreviewConfigCalled: Bool {
+        return fetchMediaPreviewConfigCallsCount > 0
+    }
+
+    var fetchMediaPreviewConfigUnderlyingReturnValue: Result<MediaPreviewConfig?, ClientProxyError>!
+    var fetchMediaPreviewConfigReturnValue: Result<MediaPreviewConfig?, ClientProxyError>! {
+        get {
+            if Thread.isMainThread {
+                return fetchMediaPreviewConfigUnderlyingReturnValue
+            } else {
+                var returnValue: Result<MediaPreviewConfig?, ClientProxyError>? = nil
+                DispatchQueue.main.sync {
+                    returnValue = fetchMediaPreviewConfigUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                fetchMediaPreviewConfigUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    fetchMediaPreviewConfigUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    var fetchMediaPreviewConfigClosure: (() async -> Result<MediaPreviewConfig?, ClientProxyError>)?
+
+    func fetchMediaPreviewConfig() async -> Result<MediaPreviewConfig?, ClientProxyError> {
+        fetchMediaPreviewConfigCallsCount += 1
+        if let fetchMediaPreviewConfigClosure = fetchMediaPreviewConfigClosure {
+            return await fetchMediaPreviewConfigClosure()
+        } else {
+            return fetchMediaPreviewConfigReturnValue
+        }
+    }
     //MARK: - ignoreUser
 
     var ignoreUserUnderlyingCallsCount = 0
@@ -5101,6 +5175,146 @@ class ClientProxyMock: ClientProxyProtocol, @unchecked Sendable {
             return await userIdentityForClosure(userID)
         } else {
             return userIdentityForReturnValue
+        }
+    }
+    //MARK: - setTimelineMediaVisibility
+
+    var setTimelineMediaVisibilityUnderlyingCallsCount = 0
+    var setTimelineMediaVisibilityCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return setTimelineMediaVisibilityUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = setTimelineMediaVisibilityUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                setTimelineMediaVisibilityUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    setTimelineMediaVisibilityUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var setTimelineMediaVisibilityCalled: Bool {
+        return setTimelineMediaVisibilityCallsCount > 0
+    }
+    var setTimelineMediaVisibilityReceivedValue: TimelineMediaVisibility?
+    var setTimelineMediaVisibilityReceivedInvocations: [TimelineMediaVisibility] = []
+
+    var setTimelineMediaVisibilityUnderlyingReturnValue: Result<Void, ClientProxyError>!
+    var setTimelineMediaVisibilityReturnValue: Result<Void, ClientProxyError>! {
+        get {
+            if Thread.isMainThread {
+                return setTimelineMediaVisibilityUnderlyingReturnValue
+            } else {
+                var returnValue: Result<Void, ClientProxyError>? = nil
+                DispatchQueue.main.sync {
+                    returnValue = setTimelineMediaVisibilityUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                setTimelineMediaVisibilityUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    setTimelineMediaVisibilityUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    var setTimelineMediaVisibilityClosure: ((TimelineMediaVisibility) async -> Result<Void, ClientProxyError>)?
+
+    func setTimelineMediaVisibility(_ value: TimelineMediaVisibility) async -> Result<Void, ClientProxyError> {
+        setTimelineMediaVisibilityCallsCount += 1
+        setTimelineMediaVisibilityReceivedValue = value
+        DispatchQueue.main.async {
+            self.setTimelineMediaVisibilityReceivedInvocations.append(value)
+        }
+        if let setTimelineMediaVisibilityClosure = setTimelineMediaVisibilityClosure {
+            return await setTimelineMediaVisibilityClosure(value)
+        } else {
+            return setTimelineMediaVisibilityReturnValue
+        }
+    }
+    //MARK: - setHideInviteAvatars
+
+    var setHideInviteAvatarsUnderlyingCallsCount = 0
+    var setHideInviteAvatarsCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return setHideInviteAvatarsUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = setHideInviteAvatarsUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                setHideInviteAvatarsUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    setHideInviteAvatarsUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var setHideInviteAvatarsCalled: Bool {
+        return setHideInviteAvatarsCallsCount > 0
+    }
+    var setHideInviteAvatarsReceivedValue: Bool?
+    var setHideInviteAvatarsReceivedInvocations: [Bool] = []
+
+    var setHideInviteAvatarsUnderlyingReturnValue: Result<Void, ClientProxyError>!
+    var setHideInviteAvatarsReturnValue: Result<Void, ClientProxyError>! {
+        get {
+            if Thread.isMainThread {
+                return setHideInviteAvatarsUnderlyingReturnValue
+            } else {
+                var returnValue: Result<Void, ClientProxyError>? = nil
+                DispatchQueue.main.sync {
+                    returnValue = setHideInviteAvatarsUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                setHideInviteAvatarsUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    setHideInviteAvatarsUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    var setHideInviteAvatarsClosure: ((Bool) async -> Result<Void, ClientProxyError>)?
+
+    func setHideInviteAvatars(_ value: Bool) async -> Result<Void, ClientProxyError> {
+        setHideInviteAvatarsCallsCount += 1
+        setHideInviteAvatarsReceivedValue = value
+        DispatchQueue.main.async {
+            self.setHideInviteAvatarsReceivedInvocations.append(value)
+        }
+        if let setHideInviteAvatarsClosure = setHideInviteAvatarsClosure {
+            return await setHideInviteAvatarsClosure(value)
+        } else {
+            return setHideInviteAvatarsReturnValue
         }
     }
     //MARK: - loadMediaContentForSource

--- a/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
@@ -1050,6 +1050,75 @@ open class ClientSDKMock: MatrixRustSDK.Client, @unchecked Sendable {
         }
     }
 
+    //MARK: - fetchMediaPreviewConfig
+
+    open var fetchMediaPreviewConfigThrowableError: Error?
+    var fetchMediaPreviewConfigUnderlyingCallsCount = 0
+    open var fetchMediaPreviewConfigCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return fetchMediaPreviewConfigUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = fetchMediaPreviewConfigUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                fetchMediaPreviewConfigUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    fetchMediaPreviewConfigUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var fetchMediaPreviewConfigCalled: Bool {
+        return fetchMediaPreviewConfigCallsCount > 0
+    }
+
+    var fetchMediaPreviewConfigUnderlyingReturnValue: MediaPreviewConfig?
+    open var fetchMediaPreviewConfigReturnValue: MediaPreviewConfig? {
+        get {
+            if Thread.isMainThread {
+                return fetchMediaPreviewConfigUnderlyingReturnValue
+            } else {
+                var returnValue: MediaPreviewConfig?? = nil
+                DispatchQueue.main.sync {
+                    returnValue = fetchMediaPreviewConfigUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                fetchMediaPreviewConfigUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    fetchMediaPreviewConfigUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    open var fetchMediaPreviewConfigClosure: (() async throws -> MediaPreviewConfig?)?
+
+    open override func fetchMediaPreviewConfig() async throws -> MediaPreviewConfig? {
+        if let error = fetchMediaPreviewConfigThrowableError {
+            throw error
+        }
+        fetchMediaPreviewConfigCallsCount += 1
+        if let fetchMediaPreviewConfigClosure = fetchMediaPreviewConfigClosure {
+            return try await fetchMediaPreviewConfigClosure()
+        } else {
+            return fetchMediaPreviewConfigReturnValue
+        }
+    }
+
     //MARK: - getDmRoom
 
     open var getDmRoomUserIdThrowableError: Error?
@@ -1156,13 +1225,13 @@ open class ClientSDKMock: MatrixRustSDK.Client, @unchecked Sendable {
         return getInviteAvatarsDisplayPolicyCallsCount > 0
     }
 
-    var getInviteAvatarsDisplayPolicyUnderlyingReturnValue: InviteAvatars!
-    open var getInviteAvatarsDisplayPolicyReturnValue: InviteAvatars! {
+    var getInviteAvatarsDisplayPolicyUnderlyingReturnValue: InviteAvatars?
+    open var getInviteAvatarsDisplayPolicyReturnValue: InviteAvatars? {
         get {
             if Thread.isMainThread {
                 return getInviteAvatarsDisplayPolicyUnderlyingReturnValue
             } else {
-                var returnValue: InviteAvatars? = nil
+                var returnValue: InviteAvatars?? = nil
                 DispatchQueue.main.sync {
                     returnValue = getInviteAvatarsDisplayPolicyUnderlyingReturnValue
                 }
@@ -1180,9 +1249,9 @@ open class ClientSDKMock: MatrixRustSDK.Client, @unchecked Sendable {
             }
         }
     }
-    open var getInviteAvatarsDisplayPolicyClosure: (() async throws -> InviteAvatars)?
+    open var getInviteAvatarsDisplayPolicyClosure: (() async throws -> InviteAvatars?)?
 
-    open override func getInviteAvatarsDisplayPolicy() async throws -> InviteAvatars {
+    open override func getInviteAvatarsDisplayPolicy() async throws -> InviteAvatars? {
         if let error = getInviteAvatarsDisplayPolicyThrowableError {
             throw error
         }
@@ -1375,13 +1444,13 @@ open class ClientSDKMock: MatrixRustSDK.Client, @unchecked Sendable {
         return getMediaPreviewDisplayPolicyCallsCount > 0
     }
 
-    var getMediaPreviewDisplayPolicyUnderlyingReturnValue: MediaPreviews!
-    open var getMediaPreviewDisplayPolicyReturnValue: MediaPreviews! {
+    var getMediaPreviewDisplayPolicyUnderlyingReturnValue: MediaPreviews?
+    open var getMediaPreviewDisplayPolicyReturnValue: MediaPreviews? {
         get {
             if Thread.isMainThread {
                 return getMediaPreviewDisplayPolicyUnderlyingReturnValue
             } else {
-                var returnValue: MediaPreviews? = nil
+                var returnValue: MediaPreviews?? = nil
                 DispatchQueue.main.sync {
                     returnValue = getMediaPreviewDisplayPolicyUnderlyingReturnValue
                 }
@@ -1399,9 +1468,9 @@ open class ClientSDKMock: MatrixRustSDK.Client, @unchecked Sendable {
             }
         }
     }
-    open var getMediaPreviewDisplayPolicyClosure: (() async throws -> MediaPreviews)?
+    open var getMediaPreviewDisplayPolicyClosure: (() async throws -> MediaPreviews?)?
 
-    open override func getMediaPreviewDisplayPolicy() async throws -> MediaPreviews {
+    open override func getMediaPreviewDisplayPolicy() async throws -> MediaPreviews? {
         if let error = getMediaPreviewDisplayPolicyThrowableError {
             throw error
         }

--- a/ElementX/Sources/Other/SDKListener.swift
+++ b/ElementX/Sources/Other/SDKListener.swift
@@ -30,6 +30,10 @@ extension SDKListener: QrLoginProgressListener where T == QrLoginProgress {
 
 // MARK: ClientProxy
 
+extension SDKListener: MediaPreviewConfigListener where T == MediaPreviewConfig? {
+    func onChange(mediaPreviewConfig: MediaPreviewConfig?) { onUpdateClosure(mediaPreviewConfig) }
+}
+
 extension SDKListener: SyncServiceStateObserver where T == SyncServiceState {
     func onUpdate(state: SyncServiceState) { onUpdateClosure(state) }
 }

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -104,7 +104,9 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
             }
             .store(in: &cancellables)
         
-        appSettings.$hideInviteAvatars
+        userSession.clientProxy.hideInviteAvatarsPublisher
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
             .weakAssign(to: \.state.hideInviteAvatars, on: self)
             .store(in: &cancellables)
         

--- a/ElementX/Sources/Screens/JoinRoomScreen/JoinRoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/JoinRoomScreen/JoinRoomScreenViewModel.swift
@@ -41,7 +41,9 @@ class JoinRoomScreenViewModel: JoinRoomScreenViewModelType, JoinRoomScreenViewMo
         
         super.init(initialViewState: JoinRoomScreenViewState(roomID: roomID), mediaProvider: mediaProvider)
         
-        appSettings.$hideInviteAvatars
+        clientProxy.hideInviteAvatarsPublisher
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
             .weakAssign(to: \.state.hideInviteAvatars, on: self)
             .store(in: &cancellables)
         

--- a/ElementX/Sources/Screens/JoinRoomScreen/View/JoinRoomScreen.swift
+++ b/ElementX/Sources/Screens/JoinRoomScreen/View/JoinRoomScreen.swift
@@ -363,9 +363,8 @@ struct JoinRoomScreen_Previews: PreviewProvider, TestablePreview {
     static func makeViewModel(mode: JoinRoomScreenMode, hideInviteAvatars: Bool = false) -> JoinRoomScreenViewModel {
         let appSettings = AppSettings()
         appSettings.knockingEnabled = true
-        appSettings.hideInviteAvatars = hideInviteAvatars
         
-        let clientProxy = ClientProxyMock(.init())
+        let clientProxy = ClientProxyMock(.init(hideInviteAvatars: hideInviteAvatars))
         
         switch mode {
         case .unknown:

--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/View/SecurityAndPrivacyScreen.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/View/SecurityAndPrivacyScreen.swift
@@ -158,7 +158,8 @@ struct SecurityAndPrivacyScreen: View {
         
         Section {
             ListRow(label: .plain(title: L10n.screenSecurityAndPrivacyRoomDirectoryVisibilityToggleTitle),
-                    details: .isWaiting(context.desiredSettings.isVisibileInRoomDirectory == nil),
+                    details:
+                    context.desiredSettings.isVisibileInRoomDirectory == nil ? .isWaiting(true) : nil,
                     kind: context.desiredSettings.isVisibileInRoomDirectory == nil ? .label : .toggle(binding))
         } footer: {
             Text(L10n.screenSecurityAndPrivacyRoomDirectoryVisibilitySectionFooter(context.viewState.serverName))

--- a/ElementX/Sources/Screens/Settings/AvancedOptionsScreen/AdvancedSettingsScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Settings/AvancedOptionsScreen/AdvancedSettingsScreenCoordinator.swift
@@ -11,13 +11,18 @@ import SwiftUI
 struct AdvancedSettingsScreenCoordinatorParameters {
     let appSettings: AppSettings
     let analytics: AnalyticsService
+    let clientProxy: ClientProxyProtocol
+    let userIndicatorController: UserIndicatorControllerProtocol
 }
 
 final class AdvancedSettingsScreenCoordinator: CoordinatorProtocol {
     private var viewModel: AdvancedSettingsScreenViewModelProtocol
     
     init(parameters: AdvancedSettingsScreenCoordinatorParameters) {
-        viewModel = AdvancedSettingsScreenViewModel(advancedSettings: parameters.appSettings, analytics: parameters.analytics)
+        viewModel = AdvancedSettingsScreenViewModel(advancedSettings: parameters.appSettings,
+                                                    analytics: parameters.analytics,
+                                                    clientProxy: parameters.clientProxy,
+                                                    userIndicatorController: parameters.userIndicatorController)
     }
             
     func toPresentable() -> AnyView {

--- a/ElementX/Sources/Screens/Settings/AvancedOptionsScreen/AdvancedSettingsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/AvancedOptionsScreen/AdvancedSettingsScreenModels.swift
@@ -8,6 +8,10 @@
 import Foundation
 
 struct AdvancedSettingsScreenViewState: BindableState {
+    var timelineMediaVisibility: TimelineMediaVisibility
+    var hideInviteAvatars: Bool
+    var isWaitingTimelineMediaVisibility = false
+    var isWaitingHideInviteAvatars = false
     var bindings: AdvancedSettingsScreenViewStateBindings
 }
 
@@ -28,14 +32,14 @@ struct AdvancedSettingsScreenViewStateBindings {
 
 enum AdvancedSettingsScreenViewAction {
     case optimizeMediaUploadsChanged
+    case updateTimelineMediaVisibility(TimelineMediaVisibility)
+    case updateHideInviteAvatars(Bool)
 }
 
 protocol AdvancedSettingsProtocol: AnyObject {
     var viewSourceEnabled: Bool { get set }
     var appAppearance: AppAppearance { get set }
     var sharePresence: Bool { get set }
-    var timelineMediaVisibility: TimelineMediaVisibility { get set }
-    var hideInviteAvatars: Bool { get set }
     var optimizeMediaUploads: Bool { get set }
 }
 

--- a/ElementX/Sources/Screens/Settings/AvancedOptionsScreen/View/AdvancedSettingsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/AvancedOptionsScreen/View/AdvancedSettingsScreen.swift
@@ -52,7 +52,7 @@ struct AdvancedSettingsScreen: View {
         
         Section {
             ListRow(label: .plain(title: L10n.screenAdvancedSettingsHideInviteAvatarsToggleTitle),
-                    details: .isWaiting(context.viewState.isWaitingHideInviteAvatars),
+                    details: context.viewState.isWaitingHideInviteAvatars ? .isWaiting(true) : nil,
                     kind: .toggle(binding))
                 .disabled(context.viewState.isWaitingHideInviteAvatars)
         } header: {

--- a/ElementX/Sources/Screens/Settings/AvancedOptionsScreen/View/AdvancedSettingsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/AvancedOptionsScreen/View/AdvancedSettingsScreen.swift
@@ -42,21 +42,39 @@ struct AdvancedSettingsScreen: View {
         .navigationBarTitleDisplayMode(.inline)
     }
     
+    @ViewBuilder
     private var moderationAndSafetySection: some View {
+        let binding = Binding(get: {
+            context.viewState.hideInviteAvatars
+        }, set: { newValue in
+            context.send(viewAction: .updateHideInviteAvatars(newValue))
+        })
+        
         Section {
             ListRow(label: .plain(title: L10n.screenAdvancedSettingsHideInviteAvatarsToggleTitle),
-                    kind: .toggle($context.hideInviteAvatars))
+                    details: .isWaiting(context.viewState.isWaitingHideInviteAvatars),
+                    kind: .toggle(binding))
+                .disabled(context.viewState.isWaitingHideInviteAvatars)
         } header: {
             Text(L10n.screenAdvancedSettingsModerationAndSafetySectionTitle)
                 .compoundListSectionHeader()
         }
     }
     
+    @ViewBuilder
     private var timelineMediaSection: some View {
+        let binding = Binding(get: {
+            context.viewState.timelineMediaVisibility
+        }, set: { newValue in
+            context.send(viewAction: .updateTimelineMediaVisibility(newValue))
+        })
+        
         Section {
             ListRow(label: .plain(title: L10n.screenAdvancedSettingsShowMediaTimelineTitle),
-                    kind: .inlinePicker(selection: $context.timelineMediaVisibility,
+                    details: .isWaiting(context.viewState.isWaitingTimelineMediaVisibility),
+                    kind: .inlinePicker(selection: binding,
                                         items: TimelineMediaVisibility.items))
+                .disabled(context.viewState.isWaitingTimelineMediaVisibility)
         } header: {
             Text(L10n.screenAdvancedSettingsShowMediaTimelineTitle)
                 .compoundListSectionHeader()
@@ -84,7 +102,9 @@ private extension AppAppearance {
 
 struct AdvancedSettingsScreen_Previews: PreviewProvider, TestablePreview {
     static let viewModel = AdvancedSettingsScreenViewModel(advancedSettings: ServiceLocator.shared.settings,
-                                                           analytics: ServiceLocator.shared.analytics)
+                                                           analytics: ServiceLocator.shared.analytics,
+                                                           clientProxy: ClientProxyMock(.init()),
+                                                           userIndicatorController: UserIndicatorControllerMock())
     static var previews: some View {
         NavigationStack {
             AdvancedSettingsScreen(context: viewModel.context)

--- a/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
@@ -88,7 +88,7 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
                                                                 timelineControllerFactory: timelineControllerFactory,
                                                                 clientProxy: clientProxy)
         
-        let hideTimelineMedia = switch appSettings.timelineMediaVisibility {
+        let hideTimelineMedia = switch clientProxy.timelineMediaVisibilityPublisher.value {
         case .always:
             false
         case .privateOnly:
@@ -525,7 +525,7 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
             .weakAssign(to: \.state.isViewSourceEnabled, on: self)
             .store(in: &cancellables)
         
-        appSettings.$timelineMediaVisibility
+        clientProxy.timelineMediaVisibilityPublisher
             .removeDuplicates()
             .flatMap { [weak self] timelineMediaVisibility -> AnyPublisher<Bool, Never> in
                 switch timelineMediaVisibility {
@@ -538,10 +538,10 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
                     return roomProxy.infoPublisher
                         .map { !$0.isPrivate }
                         .removeDuplicates()
-                        .receive(on: DispatchQueue.main)
                         .eraseToAnyPublisher()
                 }
             }
+            .receive(on: DispatchQueue.main)
             .weakAssign(to: \.state.hideTimelineMedia, on: self)
             .store(in: &cancellables)
     }

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -39,6 +39,9 @@ class ClientProxy: ClientProxyProtocol {
     // periphery:ignore - required for instance retention in the rust codebase
     private var sendQueueListenerTaskHandle: TaskHandle?
     
+    // periphery:ignore - required for instance retention in the rust codebase
+    private var mediaPreviewConfigListenerTaskHandle: TaskHandle?
+    
     private var delegateHandle: TaskHandle?
     
     // These following summary providers both operate on the same allRooms() list but
@@ -130,6 +133,16 @@ class ClientProxy: ClientProxyProtocol {
     private let verificationStateSubject = CurrentValueSubject<SessionVerificationState, Never>(.unknown)
     var verificationStatePublisher: CurrentValuePublisher<SessionVerificationState, Never> {
         verificationStateSubject.asCurrentValuePublisher()
+    }
+    
+    private let timelineMediaVisibilitySubject = CurrentValueSubject<TimelineMediaVisibility, Never>(.always)
+    var timelineMediaVisibilityPublisher: CurrentValuePublisher<TimelineMediaVisibility, Never> {
+        timelineMediaVisibilitySubject.asCurrentValuePublisher()
+    }
+    
+    private let hideInviteAvatarsSubject = CurrentValueSubject<Bool, Never>(false)
+    var hideInviteAvatarsPublisher: CurrentValuePublisher<Bool, Never> {
+        hideInviteAvatarsSubject.asCurrentValuePublisher()
     }
     
     var roomsToAwait: Set<String> = []
@@ -229,6 +242,10 @@ class ClientProxy: ClientProxyProtocol {
             } catch {
                 MXLog.error("Failed setting media retention policy with error: \(error)")
             }
+        }
+        
+        Task {
+            mediaPreviewConfigListenerTaskHandle = await createMediaPreviewConfigObserver()
         }
     }
     
@@ -724,6 +741,16 @@ class ClientProxy: ClientProxyProtocol {
             return .failure(.sdkError(error))
         }
     }
+    
+    func fetchMediaPreviewConfig() async -> Result<MediaPreviewConfig?, ClientProxyError> {
+        do {
+            let config = try await client.fetchMediaPreviewConfig()
+            return .success(config)
+        } catch {
+            MXLog.error("Failed fetching media preview config with error: \(error)")
+            return .failure(.sdkError(error))
+        }
+    }
         
     // MARK: Ignored users
     
@@ -798,6 +825,28 @@ class ClientProxy: ClientProxyProtocol {
         return users.elements
     }
     
+    // MARK: Moderation & Safety
+    
+    func setTimelineMediaVisibility(_ value: TimelineMediaVisibility) async -> Result<Void, ClientProxyError> {
+        do {
+            try await client.setMediaPreviewDisplayPolicy(policy: value.rustValue)
+            return .success(())
+        } catch {
+            MXLog.error("Failed to set timeline media visibility: \(error)")
+            return .failure(.sdkError(error))
+        }
+    }
+    
+    func setHideInviteAvatars(_ value: Bool) async -> Result<Void, ClientProxyError> {
+        do {
+            try await client.setInviteAvatarsDisplayPolicy(policy: value ? .off : .on)
+            return .success(())
+        } catch {
+            MXLog.error("Failed to set hide invite avatars: \(error)")
+            return .failure(.sdkError(error))
+        }
+    }
+    
     // MARK: - Private
     
     private func cacheAccountURL() async {
@@ -866,6 +915,26 @@ class ClientProxy: ClientProxyProtocol {
                 break
             }
         })
+    }
+    
+    private func createMediaPreviewConfigObserver() async -> TaskHandle? {
+        do {
+            return try await client.subscribeToMediaPreviewConfig(listener: SDKListener { [weak self] config in
+                guard let self else { return }
+                
+                if let config {
+                    timelineMediaVisibilitySubject.send(config.mediaPreviewVisibility)
+                    hideInviteAvatarsSubject.send(config.hideInviteAvatars)
+                } else {
+                    // return default values
+                    timelineMediaVisibilitySubject.send(.always)
+                    hideInviteAvatarsSubject.send(false)
+                }
+            })
+        } catch {
+            MXLog.error("Failed creating media preview config observer: \(error)")
+            return nil
+        }
     }
 
     private func createRoomListServiceObserver(_ roomListService: RoomListService) -> TaskHandle {
@@ -1131,5 +1200,40 @@ private struct ClientProxyServices {
         
         self.syncService = syncService
         self.roomListService = roomListService
+    }
+}
+
+private extension MediaPreviewConfig {
+    var mediaPreviewVisibility: TimelineMediaVisibility {
+        switch mediaPreviews {
+        case .on:
+            .always
+        case .private:
+            .privateOnly
+        case .off:
+            .never
+        }
+    }
+    
+    var hideInviteAvatars: Bool {
+        switch inviteAvatars {
+        case .off:
+            true
+        case .on:
+            false
+        }
+    }
+}
+
+private extension TimelineMediaVisibility {
+    var rustValue: MediaPreviews {
+        switch self {
+        case .always:
+            .on
+        case .never:
+            .off
+        case .privateOnly:
+            .private
+        }
     }
 }

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -742,7 +742,7 @@ class ClientProxy: ClientProxyProtocol {
         }
     }
     
-    func fetchMediaPreviewConfig() async -> Result<MediaPreviewConfig?, ClientProxyError> {
+    func fetchMediaPreviewConfiguration() async -> Result<MediaPreviewConfig?, ClientProxyError> {
         do {
             let config = try await client.fetchMediaPreviewConfig()
             return .success(config)

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -63,8 +63,8 @@ enum SessionVerificationState {
     case unverified
 }
 
-// The `Codable` conformance is just for the purpose of migration
-enum TimelineMediaVisibility: Codable {
+// The `Decodable` conformance is just for the purpose of migration
+enum TimelineMediaVisibility: Decodable {
     case always
     case privateOnly
     case never
@@ -197,7 +197,7 @@ protocol ClientProxyProtocol: AnyObject, MediaLoaderProtocol {
     
     @discardableResult func clearCaches() async -> Result<Void, ClientProxyError>
     
-    func fetchMediaPreviewConfig() async -> Result<MediaPreviewConfig?, ClientProxyError>
+    func fetchMediaPreviewConfiguration() async -> Result<MediaPreviewConfig?, ClientProxyError>
 
     // MARK: - Ignored users
     

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -63,6 +63,13 @@ enum SessionVerificationState {
     case unverified
 }
 
+// The `Codable` conformance is just for the purpose of migration
+enum TimelineMediaVisibility: Codable {
+    case always
+    case privateOnly
+    case never
+}
+
 // sourcery: AutoMockable
 protocol ClientProxyProtocol: AnyObject, MediaLoaderProtocol {
     var actionsPublisher: AnyPublisher<ClientProxyAction, Never> { get }
@@ -92,6 +99,10 @@ protocol ClientProxyProtocol: AnyObject, MediaLoaderProtocol {
 
     /// We delay fetching this until after the first sync. Nil until then
     var ignoredUsersPublisher: CurrentValuePublisher<[String]?, Never> { get }
+    
+    var timelineMediaVisibilityPublisher: CurrentValuePublisher<TimelineMediaVisibility, Never> { get }
+    
+    var hideInviteAvatarsPublisher: CurrentValuePublisher<Bool, Never> { get }
     
     var pusherNotificationClientIdentifier: String? { get }
     
@@ -185,6 +196,8 @@ protocol ClientProxyProtocol: AnyObject, MediaLoaderProtocol {
     func isAliasAvailable(_ alias: String) async -> Result<Bool, ClientProxyError>
     
     @discardableResult func clearCaches() async -> Result<Void, ClientProxyError>
+    
+    func fetchMediaPreviewConfig() async -> Result<MediaPreviewConfig?, ClientProxyError>
 
     // MARK: - Ignored users
     
@@ -210,4 +223,9 @@ protocol ClientProxyProtocol: AnyObject, MediaLoaderProtocol {
     func resetIdentity() async -> Result<IdentityResetHandle?, ClientProxyError>
     
     func userIdentity(for userID: String) async -> Result<UserIdentityProxyProtocol?, ClientProxyError>
+    
+    // MARK: - Moderation & Safety
+    
+    func setTimelineMediaVisibility(_ value: TimelineMediaVisibility) async -> Result<Void, ClientProxyError>
+    func setHideInviteAvatars(_ value: Bool) async -> Result<Void, ClientProxyError>
 }

--- a/NSE/Sources/NSEUserSession.swift
+++ b/NSE/Sources/NSEUserSession.swift
@@ -18,6 +18,28 @@ final class NSEUserSession {
                                                                                imageCache: .onlyOnDisk,
                                                                                networkMonitor: nil)
     private let delegateHandle: TaskHandle?
+    
+    var mediaPreviewVisibility: MediaPreviews {
+        get async {
+            do {
+                return try await baseClient.getMediaPreviewDisplayPolicy() ?? .on
+            } catch {
+                MXLog.error("Failed to get media preview visibility, defaulting to on. Error: \(error)")
+                return .on
+            }
+        }
+    }
+    
+    var inviteAvatarsVisibility: InviteAvatars {
+        get async {
+            do {
+                return try await baseClient.getInviteAvatarsDisplayPolicy() ?? .on
+            } catch {
+                MXLog.error("Failed to get invite avatars visibility, defaulting to on. Error: \(error)")
+                return .on
+            }
+        }
+    }
 
     init(credentials: KeychainCredentials,
          roomID: String,

--- a/NSE/Sources/NotificationContentBuilder.swift
+++ b/NSE/Sources/NotificationContentBuilder.swift
@@ -15,7 +15,7 @@ import Version
 
 struct NotificationContentBuilder {
     let messageEventStringBuilder: RoomMessageEventStringBuilder
-    let settings: CommonSettingsProtocol
+    let userSession: NSEUserSession
     
     /// Process the given notification item proxy
     /// - Parameters:
@@ -104,7 +104,7 @@ struct NotificationContentBuilder {
                             senderID: notificationItem.senderID,
                             senderName: notificationItem.senderDisplayName ?? notificationItem.roomDisplayName,
                             icon: icon(for: notificationItem),
-                            forcePlaceholder: settings.hideInviteAvatars,
+                            forcePlaceholder: userSession.inviteAvatarsVisibility == .off,
                             mediaProvider: mediaProvider)
     }
     
@@ -146,8 +146,9 @@ struct NotificationContentBuilder {
         let displayName = notificationItem.senderDisplayName ?? notificationItem.roomDisplayName
         notificationContent.body = String(messageEventStringBuilder.buildAttributedString(for: messageType, senderDisplayName: displayName, isOutgoing: false).characters)
         
-        guard settings.timelineMediaVisibility == .always ||
-            (settings.timelineMediaVisibility == .privateOnly && notificationItem.isRoomPrivate)
+        let timelineMediaVisibility = await userSession.mediaPreviewVisibility
+        guard timelineMediaVisibility == .on ||
+            (timelineMediaVisibility == .private && notificationItem.isRoomPrivate)
         else {
             return
         }

--- a/NSE/Sources/NotificationHandler.swift
+++ b/NSE/Sources/NotificationHandler.swift
@@ -36,7 +36,7 @@ class NotificationHandler {
                                                                destination: .notification)
         
         notificationContentBuilder = NotificationContentBuilder(messageEventStringBuilder: eventStringBuilder,
-                                                                settings: settings)
+                                                                userSession: userSession)
     }
     
     func processEvent(_ eventID: String, roomID: String) async {

--- a/project.yml
+++ b/project.yml
@@ -69,7 +69,7 @@ packages:
     # path: ../matrix-rust-sdk
   Compound:
     url: https://github.com/element-hq/compound-ios
-    revision: acbe59727c8352c6768f8444acc6deb07e4b7563
+    revision: 139d4f3d1ed19cc513686e5e39750ecef54c8403
     # path: ../compound-ios
   AnalyticsEvents:
     url: https://github.com/matrix-org/matrix-analytics-events

--- a/project.yml
+++ b/project.yml
@@ -69,7 +69,7 @@ packages:
     # path: ../matrix-rust-sdk
   Compound:
     url: https://github.com/element-hq/compound-ios
-    revision: 81ba8bd8b3971beac252129c5466d7eac2f2ec31
+    revision: acbe59727c8352c6768f8444acc6deb07e4b7563
     # path: ../compound-ios
   AnalyticsEvents:
     url: https://github.com/matrix-org/matrix-analytics-events


### PR DESCRIPTION
Implemented APIs that update our media preview visibility and invite avatars visibility settings through account data.

The local settings are now discarded and a migration is implemented to check wether server configurations exist or not. In the latter case we simply push our current local configuration on the server to perform the migration, so that the user will still keep their setting.

This PR alo updates compound, so that is now possible to have loaders in inline pickers and toggles.

fixes #3923