### PR TITLE
Fetching room tweaks

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -8708,7 +8708,7 @@
 			repositoryURL = "https://github.com/element-hq/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 25.05.21;
+				version = 25.05.26;
 			};
 		};
 		701C7BEF8F70F7A83E852DCC /* XCRemoteSwiftPackageReference "GZIP" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/matrix-rust-components-swift",
       "state" : {
-        "revision" : "ce4a5f25ada21246d62e4b54c26fb1414432fb77",
-        "version" : "25.5.21"
+        "revision" : "966e64d8145b857a4dd586c735024a7762efe603",
+        "version" : "25.5.26"
       }
     },
     {

--- a/ElementX/Sources/Application/TargetConfiguration.swift
+++ b/ElementX/Sources/Application/TargetConfiguration.swift
@@ -27,25 +27,25 @@ enum Target: String {
                                                                   traceLogPacks: traceLogPacks,
                                                                   currentTarget: rawValue,
                                                                   filePrefix: nil)
-            initPlatform(config: tracingConfiguration, useLightweightTokioRuntime: false)
+            try? initPlatform(config: tracingConfiguration, useLightweightTokioRuntime: false)
         case .nse:
             let tracingConfiguration = Tracing.buildConfiguration(logLevel: logLevel,
                                                                   traceLogPacks: traceLogPacks,
                                                                   currentTarget: rawValue,
                                                                   filePrefix: rawValue)
-            initPlatform(config: tracingConfiguration, useLightweightTokioRuntime: true)
+            try? initPlatform(config: tracingConfiguration, useLightweightTokioRuntime: true)
         case .shareExtension:
             let tracingConfiguration = Tracing.buildConfiguration(logLevel: logLevel,
                                                                   traceLogPacks: traceLogPacks,
                                                                   currentTarget: rawValue,
                                                                   filePrefix: rawValue)
-            initPlatform(config: tracingConfiguration, useLightweightTokioRuntime: true)
+            try? initPlatform(config: tracingConfiguration, useLightweightTokioRuntime: true)
         case .tests:
             let tracingConfiguration = Tracing.buildConfiguration(logLevel: logLevel,
                                                                   traceLogPacks: traceLogPacks,
                                                                   currentTarget: rawValue,
                                                                   filePrefix: rawValue)
-            initPlatform(config: tracingConfiguration, useLightweightTokioRuntime: false)
+            try? initPlatform(config: tracingConfiguration, useLightweightTokioRuntime: false)
         }
         
         MXLog.configure(currentTarget: rawValue)

--- a/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.2.6 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.2.7 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable all
@@ -13283,6 +13283,75 @@ open class RoomSDKMock: MatrixRustSDK.Room, @unchecked Sendable {
             return invitedMembersCountClosure()
         } else {
             return invitedMembersCountReturnValue
+        }
+    }
+
+    //MARK: - inviter
+
+    open var inviterThrowableError: Error?
+    var inviterUnderlyingCallsCount = 0
+    open var inviterCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return inviterUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = inviterUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                inviterUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    inviterUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var inviterCalled: Bool {
+        return inviterCallsCount > 0
+    }
+
+    var inviterUnderlyingReturnValue: RoomMember?
+    open var inviterReturnValue: RoomMember? {
+        get {
+            if Thread.isMainThread {
+                return inviterUnderlyingReturnValue
+            } else {
+                var returnValue: RoomMember?? = nil
+                DispatchQueue.main.sync {
+                    returnValue = inviterUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                inviterUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    inviterUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    open var inviterClosure: (() async throws -> RoomMember?)?
+
+    open override func inviter() async throws -> RoomMember? {
+        if let error = inviterThrowableError {
+            throw error
+        }
+        inviterCallsCount += 1
+        if let inviterClosure = inviterClosure {
+            return try await inviterClosure()
+        } else {
+            return inviterReturnValue
         }
     }
 

--- a/ElementX/Sources/Other/Logging/Tracing.swift
+++ b/ElementX/Sources/Other/Logging/Tracing.swift
@@ -45,7 +45,8 @@ enum Tracing {
                      writeToFiles: .init(path: logsDirectory.path(percentEncoded: false),
                                          filePrefix: fileName,
                                          fileSuffix: fileExtension,
-                                         maxFiles: maxFiles))
+                                         maxFiles: maxFiles),
+                     sentryDsn: nil)
     }
     
     /// A list of all log file URLs, sorted chronologically. This is only public for testing purposes, within

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -908,9 +908,12 @@ class ClientProxy: ClientProxyProtocol {
             
             switch roomListItem.membership() {
             case .invited:
-                return try await .invited(InvitedRoomProxy(roomListItem: roomListItem,
-                                                           roomPreview: roomListItem.previewRoom(via: []),
-                                                           ownUserID: userID))
+                guard let room = try client.getRoom(roomId: roomID) else {
+                    MXLog.error("Could not find room with ID: \(roomID)")
+                    return nil
+                }
+                
+                return try await .invited(InvitedRoomProxy(room: room))
             case .knocked:
                 if appSettings.knockingEnabled {
                     return try await .knocked(KnockedRoomProxy(roomListItem: roomListItem,

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -904,33 +904,20 @@ class ClientProxy: ClientProxyProtocol {
     
     private func buildRoomForIdentifier(_ roomID: String) async -> RoomProxyType? {
         do {
-            let roomListItem = try roomListService.room(roomId: roomID)
+            guard let room = try client.getRoom(roomId: roomID) else {
+                return nil
+            }
             
-            switch roomListItem.membership() {
+            switch room.membership() {
             case .invited:
-                guard let room = try client.getRoom(roomId: roomID) else {
-                    MXLog.error("Could not find room with ID: \(roomID)")
-                    return nil
-                }
-                
                 return try await .invited(InvitedRoomProxy(room: room))
             case .knocked:
                 guard appSettings.knockingEnabled else {
                     return nil
                 }
                 
-                guard let room = try client.getRoom(roomId: roomID) else {
-                    MXLog.error("Could not find room with ID: \(roomID)")
-                    return nil
-                }
-                
                 return try await .knocked(KnockedRoomProxy(room: room))
             case .joined:
-                guard let room = try client.getRoom(roomId: roomID) else {
-                    MXLog.error("Could not find room with ID: \(roomID)")
-                    return nil
-                }
-                
                 let roomProxy = try await JoinedRoomProxy(roomListService: roomListService,
                                                           room: room)
                 

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -915,12 +915,16 @@ class ClientProxy: ClientProxyProtocol {
                 
                 return try await .invited(InvitedRoomProxy(room: room))
             case .knocked:
-                if appSettings.knockingEnabled {
-                    return try await .knocked(KnockedRoomProxy(roomListItem: roomListItem,
-                                                               roomPreview: roomListItem.previewRoom(via: []),
-                                                               ownUserID: userID))
+                guard appSettings.knockingEnabled else {
+                    return nil
                 }
-                return nil
+                
+                guard let room = try client.getRoom(roomId: roomID) else {
+                    MXLog.error("Could not find room with ID: \(roomID)")
+                    return nil
+                }
+                
+                return try await .knocked(KnockedRoomProxy(room: room))
             case .joined:
                 guard let room = try client.getRoom(roomId: roomID) else {
                     MXLog.error("Could not find room with ID: \(roomID)")

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -932,7 +932,6 @@ class ClientProxy: ClientProxyProtocol {
                 }
                 
                 let roomProxy = try await JoinedRoomProxy(roomListService: roomListService,
-                                                          roomListItem: roomListItem,
                                                           room: room)
                 
                 return .joined(roomProxy)

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -938,9 +938,7 @@ class ClientProxy: ClientProxyProtocol {
             case .left:
                 return .left
             case .banned:
-                return try await .banned(BannedRoomProxy(roomListItem: roomListItem,
-                                                         roomPreview: roomListItem.previewRoom(via: []),
-                                                         ownUserID: userID))
+                return try await .banned(BannedRoomProxy(room: room))
             }
         } catch {
             MXLog.error("Failed retrieving room: \(roomID), with error: \(error)")

--- a/ElementX/Sources/Services/Room/BannedRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/BannedRoomProxy.swift
@@ -9,29 +9,22 @@ import Foundation
 import MatrixRustSDK
 
 class BannedRoomProxy: BannedRoomProxyProtocol {
-    private let roomListItem: RoomListItemProtocol
-    private let roomPreview: RoomPreviewProtocol
+    private let room: Room
     
-    // A room identifier is constant and lazy stops it from being fetched
-    // multiple times over FFI
-    lazy var id = info.id
-    
-    let ownUserID: String
+    lazy var id = room.id()
+    lazy var ownUserID = room.ownUserId()
     
     let info: BaseRoomInfoProxyProtocol
         
-    init(roomListItem: RoomListItemProtocol,
-         roomPreview: RoomPreviewProtocol,
-         ownUserID: String) throws {
-        self.roomListItem = roomListItem
-        self.roomPreview = roomPreview
-        self.ownUserID = ownUserID
-        info = try RoomPreviewInfoProxy(roomPreviewInfo: roomPreview.info())
+    init(room: Room) async throws {
+        self.room = room
+        
+        info = try await RoomInfoProxy(roomInfo: room.roomInfo())
     }
     
     func forgetRoom() async -> Result<Void, RoomProxyError> {
         do {
-            return try await .success(roomPreview.forget())
+            return try await .success(room.forget())
         } catch {
             MXLog.error("Failed forgetting the room with error: \(error)")
             return .failure(.sdkError(error))

--- a/ElementX/Sources/Services/Room/InvitedRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/InvitedRoomProxy.swift
@@ -10,31 +10,25 @@ import MatrixRustSDK
 import UIKit
 
 class InvitedRoomProxy: InvitedRoomProxyProtocol {
-    private let roomListItem: RoomListItemProtocol
-    private let roomPreview: RoomPreviewProtocol
+    private let room: Room
     
-    // A room identifier is constant and lazy stops it from being fetched
-    // multiple times over FFI
-    lazy var id: String = info.id
-    
-    let ownUserID: String
+    lazy var id: String = room.id()
+    lazy var ownUserID: String = room.ownUserId()
     
     let info: BaseRoomInfoProxyProtocol
     let inviter: RoomMemberProxyProtocol?
+            
+    init(room: Room) async throws {
+        self.room = room
         
-    init(roomListItem: RoomListItemProtocol,
-         roomPreview: RoomPreviewProtocol,
-         ownUserID: String) async throws {
-        self.roomListItem = roomListItem
-        self.roomPreview = roomPreview
-        self.ownUserID = ownUserID
-        info = try RoomPreviewInfoProxy(roomPreviewInfo: roomPreview.info())
-        inviter = await roomPreview.inviter().map(RoomMemberProxy.init)
+        info = try await RoomInfoProxy(roomInfo: room.roomInfo())
+        
+        inviter = try? await room.inviter().map(RoomMemberProxy.init)
     }
     
     func rejectInvitation() async -> Result<Void, RoomProxyError> {
         do {
-            return try await .success(roomPreview.leave())
+            return try await .success(room.leave())
         } catch {
             MXLog.error("Failed rejecting invitiation with error: \(error)")
             return .failure(.sdkError(error))

--- a/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
@@ -12,7 +12,6 @@ import UIKit
 
 class JoinedRoomProxy: JoinedRoomProxyProtocol {
     private let roomListService: RoomListServiceProtocol
-    private let roomListItem: RoomListItemProtocol
     private let room: RoomProtocol
     
     // periphery:ignore - required for instance retention in the rust codebase
@@ -63,10 +62,8 @@ class JoinedRoomProxy: JoinedRoomProxyProtocol {
     }
     
     init(roomListService: RoomListServiceProtocol,
-         roomListItem: RoomListItemProtocol,
          room: RoomProtocol) async throws {
         self.roomListService = roomListService
-        self.roomListItem = roomListItem
         self.room = room
         
         infoSubject = try await .init(RoomInfoProxy(roomInfo: room.roomInfo()))

--- a/ElementX/Sources/Services/Room/KnockedRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/KnockedRoomProxy.swift
@@ -9,31 +9,24 @@ import Foundation
 import MatrixRustSDK
 
 class KnockedRoomProxy: KnockedRoomProxyProtocol {
-    private let roomListItem: RoomListItemProtocol
-    private let roomPreview: RoomPreviewProtocol
+    private let room: Room
     
-    // A room identifier is constant and lazy stops it from being fetched
-    // multiple times over FFI
-    lazy var id = info.id
-    
-    let ownUserID: String
+    lazy var id: String = room.id()
+    lazy var ownUserID: String = room.ownUserId()
     
     let info: BaseRoomInfoProxyProtocol
         
-    init(roomListItem: RoomListItemProtocol,
-         roomPreview: RoomPreviewProtocol,
-         ownUserID: String) throws {
-        self.roomListItem = roomListItem
-        self.roomPreview = roomPreview
-        self.ownUserID = ownUserID
-        info = try RoomPreviewInfoProxy(roomPreviewInfo: roomPreview.info())
+    init(room: Room) async throws {
+        self.room = room
+        
+        info = try await RoomInfoProxy(roomInfo: room.roomInfo())
     }
     
     func cancelKnock() async -> Result<Void, RoomProxyError> {
         do {
-            return try await .success(roomPreview.leave())
+            return try await .success(room.leave())
         } catch {
-            MXLog.error("Failed cancelling the knock with error: \(error)")
+            MXLog.error("Failed rejecting invitiation with error: \(error)")
             return .failure(.sdkError(error))
         }
     }

--- a/project.yml
+++ b/project.yml
@@ -65,7 +65,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/element-hq/matrix-rust-components-swift
-    exactVersion: 25.05.21
+    exactVersion: 25.05.26
     # path: ../matrix-rust-sdk
   Compound:
     url: https://github.com/element-hq/compound-ios


### PR DESCRIPTION
This patch stops automatically fetching the room preview when building a room through the client proxy. It also stops relying on the room list item and interacts with the room directly to speed up joins and leaves.

This reverts a lot of the work introduced in https://github.com/element-hq/element-x-ios/pull/3530 so I would both your eyes on it.