### PR TITLE
Add a developer option that hides notification alerts when a sound wouldn't be played.

### DIFF
--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -19,6 +19,7 @@ protocol CommonSettingsProtocol {
     var enableOnlySignedDeviceIsolationMode: Bool { get }
     var hideInviteAvatars: Bool { get }
     var timelineMediaVisibility: TimelineMediaVisibility { get }
+    var hideQuietNotificationAlerts: Bool { get }
 }
 
 /// Store Element specific app settings.
@@ -45,7 +46,6 @@ final class AppSettings {
         case optimizeMediaUploads
         case appAppearance
         case sharePresence
-        case hideUnreadMessagesBadge
         case hideInviteAvatars
         case timelineMediaVisibility
         case isNewBloomEnabled
@@ -59,6 +59,10 @@ final class AppSettings {
         case knockingEnabled
         case threadsEnabled
         case developerOptionsEnabled
+        
+        // Doug's tweaks 🔧
+        case hideUnreadMessagesBadge
+        case hideQuietNotificationAlerts
     }
     
     private static var suiteName: String = InfoPlistReader.main.appGroupIdentifier
@@ -346,6 +350,9 @@ final class AppSettings {
     @UserPreference(key: UserDefaultsKeys.threadsEnabled, defaultValue: isDevelopmentBuild, storageType: .userDefaults(store))
     var developerOptionsEnabled
     
+    @UserPreference(key: UserDefaultsKeys.isNewBloomEnabled, defaultValue: false, storageType: .userDefaults(store))
+    var isNewBloomEnabled
+    
     #endif
     
     // MARK: - Shared
@@ -366,8 +373,8 @@ final class AppSettings {
     @UserPreference(key: UserDefaultsKeys.timelineMediaVisibility, defaultValue: TimelineMediaVisibility.always, storageType: .userDefaults(store))
     var timelineMediaVisibility
     
-    @UserPreference(key: UserDefaultsKeys.isNewBloomEnabled, defaultValue: false, storageType: .userDefaults(store))
-    var isNewBloomEnabled
+    @UserPreference(key: UserDefaultsKeys.hideQuietNotificationAlerts, defaultValue: false, storageType: .userDefaults(store))
+    var hideQuietNotificationAlerts
 }
 
 extension AppSettings: CommonSettingsProtocol { }

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
@@ -46,6 +46,7 @@ protocol DeveloperOptionsProtocol: AnyObject {
     var knockingEnabled: Bool { get set }
     var threadsEnabled: Bool { get set }
     var isNewBloomEnabled: Bool { get set }
+    var hideQuietNotificationAlerts: Bool { get set }
 }
 
 extension AppSettings: DeveloperOptionsProtocol { }

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
@@ -92,6 +92,13 @@ struct DeveloperOptionsScreen: View {
                 Text("Element Call remote URL override")
             }
             
+            Section("Notifications") {
+                Toggle(isOn: $context.hideQuietNotificationAlerts) {
+                    Text("Hide quiet alerts")
+                    Text("The badge count will still be updated")
+                }
+            }
+            
             Section {
                 Button {
                     showConfetti = true

--- a/NSE/Sources/NotificationHandler.swift
+++ b/NSE/Sources/NotificationHandler.swift
@@ -87,6 +87,10 @@ class NotificationHandler {
     }
     
     private func preprocessNotification(_ itemProxy: NotificationItemProxyProtocol) async -> NotificationProcessingResult {
+        if settings.hideQuietNotificationAlerts, !itemProxy.isNoisy {
+            return .processedShouldDiscard
+        }
+        
         guard case let .timeline(event) = itemProxy.event else {
             return .shouldDisplay
         }


### PR DESCRIPTION
Just trying a thing using the developer options…

Enabling this makes `isNoisy` behave like iMessage's Hide Alerts option, where the badge count is increased, but the notification alert isn't delivered.