### PR TITLE
Add a placeholder association for localhost in developer mode.

### DIFF
--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -119,6 +119,7 @@ targets:
         - applinks:call.element.io
         - applinks:call.element.dev
         - applinks:matrix.to
+        # - applinks:localhost?mode=developer # developer mode only works with https (but self-signed is fine).
         - webcredentials:*.element.io
         com.apple.developer.usernotifications.communication: true
         com.apple.security.app-sandbox: true


### PR DESCRIPTION
Just a nice quality-of-life tweak so we don't need to check the [docs](https://developer.apple.com/documentation/BundleResources/Entitlements/com.apple.developer.associated-domains) for the correct syntax for alternate modes.

Note: I didn't try this with localhost specifically (it just seemed the most obvious placeholder).