### PR TITLE
Make sure UI tests are run to completion on the remaining device, even if the other one fails.

### DIFF
--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -15,6 +15,7 @@ jobs:
     name: Tests
     runs-on: macos-15
     strategy:
+      fail-fast: false
       matrix:
         device: [iPhone, iPad]
 


### PR DESCRIPTION
Currently, if e.g. iPhone fails, then iPad will be cancelled:

https://github.com/element-hq/element-x-ios/actions/runs/15314948958