### PR TITLE
Fix subsequent media upload dialogue presentations 

### DIFF
--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinatorStateMachine.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinatorStateMachine.swift
@@ -361,8 +361,8 @@ extension RoomFlowCoordinator {
             case (.pollsHistoryForm, .dismissPollForm):
                 return .pollsHistory
                 
-            case (.mediaUploadPicker, .presentMediaUploadPreview(let fileURL)):
-                return .mediaUploadPreview(fileURL: fileURL, previousState: fromState)
+            case (.mediaUploadPicker(_, let previousMediaUploadPickerState), .presentMediaUploadPreview(let fileURL)):
+                return .mediaUploadPreview(fileURL: fileURL, previousState: previousMediaUploadPickerState)
                 
             case (_, .presentInviteUsersScreen):
                 return .inviteUsersScreen(previousState: fromState)


### PR DESCRIPTION
Have the media upload preview state transition to .room or .thread after being dismissed instead of back to the media upload picker.