### PR TITLE
Hide accesibility for decorative onboarding image

### DIFF
--- a/ElementX/Sources/Screens/Onboarding/NotificationPermissionsScreen/View/NotificationPermissionsScreen.swift
+++ b/ElementX/Sources/Screens/Onboarding/NotificationPermissionsScreen/View/NotificationPermissionsScreen.swift
@@ -40,7 +40,11 @@ struct NotificationPermissionsScreen: View {
                 .multilineTextAlignment(.center)
                 .foregroundColor(.compound.textSecondary)
             
-            Asset.Images.notificationsPromptGraphic.swiftUIImage.resizable().aspectRatio(contentMode: .fit)
+            Asset.Images.notificationsPromptGraphic
+                .swiftUIImage
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .accessibilityHidden(true)
         }
     }
 


### PR DESCRIPTION
Hiding accessibility on the onboarding notification screen, for a decorative image