### PR TITLE
Make BugReportService `reportUrl` optional

### DIFF
--- a/ElementX/Sources/FlowCoordinators/AuthenticationFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/AuthenticationFlowCoordinator.swift
@@ -16,7 +16,7 @@ protocol AuthenticationFlowCoordinatorDelegate: AnyObject {
 
 class AuthenticationFlowCoordinator: FlowCoordinatorProtocol {
     private let authenticationService: AuthenticationServiceProtocol
-    private let bugReportService: BugReportServiceProtocol
+    private let bugReportService: BugReportServiceProtocol?
     private let navigationRootCoordinator: NavigationRootCoordinator
     private let navigationStackCoordinator: NavigationStackCoordinator
     private let appMediator: AppMediatorProtocol
@@ -103,7 +103,7 @@ class AuthenticationFlowCoordinator: FlowCoordinatorProtocol {
     
     init(authenticationService: AuthenticationServiceProtocol,
          qrCodeLoginService: QRCodeLoginServiceProtocol,
-         bugReportService: BugReportServiceProtocol,
+         bugReportService: BugReportServiceProtocol?,
          navigationRootCoordinator: NavigationRootCoordinator,
          appMediator: AppMediatorProtocol,
          appSettings: AppSettings,
@@ -263,7 +263,7 @@ class AuthenticationFlowCoordinator: FlowCoordinatorProtocol {
     private func showStartScreen(fromState: State, applying provisioningParameters: AccountProvisioningParameters? = nil) {
         let parameters = AuthenticationStartScreenParameters(authenticationService: authenticationService,
                                                              provisioningParameters: provisioningParameters,
-                                                             isBugReportServiceEnabled: bugReportService.isEnabled,
+                                                             isBugReportServiceEnabled: bugReportService?.isEnabled ?? false,
                                                              appSettings: appSettings,
                                                              userIndicatorController: userIndicatorController)
         let coordinator = AuthenticationStartScreenCoordinator(parameters: parameters)
@@ -436,6 +436,11 @@ class AuthenticationFlowCoordinator: FlowCoordinatorProtocol {
     // MARK: - Bug Report
     
     private func startBugReportFlow() {
+        guard let bugReportService else {
+            MXLog.warning("Can't launch `BugReportFlowCoordinator` from `AuthenticationFlowCoordinator`: `bugReportService` is nil.")
+            return
+        }
+
         let coordinator = BugReportFlowCoordinator(parameters: .init(presentationMode: .sheet(navigationStackCoordinator),
                                                                      userIndicatorController: userIndicatorController,
                                                                      bugReportService: bugReportService,

--- a/ElementX/Sources/FlowCoordinators/AuthenticationFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/AuthenticationFlowCoordinator.swift
@@ -16,7 +16,7 @@ protocol AuthenticationFlowCoordinatorDelegate: AnyObject {
 
 class AuthenticationFlowCoordinator: FlowCoordinatorProtocol {
     private let authenticationService: AuthenticationServiceProtocol
-    private let bugReportService: BugReportServiceProtocol?
+    private let bugReportService: BugReportServiceProtocol
     private let navigationRootCoordinator: NavigationRootCoordinator
     private let navigationStackCoordinator: NavigationStackCoordinator
     private let appMediator: AppMediatorProtocol
@@ -103,7 +103,7 @@ class AuthenticationFlowCoordinator: FlowCoordinatorProtocol {
     
     init(authenticationService: AuthenticationServiceProtocol,
          qrCodeLoginService: QRCodeLoginServiceProtocol,
-         bugReportService: BugReportServiceProtocol?,
+         bugReportService: BugReportServiceProtocol,
          navigationRootCoordinator: NavigationRootCoordinator,
          appMediator: AppMediatorProtocol,
          appSettings: AppSettings,
@@ -263,7 +263,7 @@ class AuthenticationFlowCoordinator: FlowCoordinatorProtocol {
     private func showStartScreen(fromState: State, applying provisioningParameters: AccountProvisioningParameters? = nil) {
         let parameters = AuthenticationStartScreenParameters(authenticationService: authenticationService,
                                                              provisioningParameters: provisioningParameters,
-                                                             isBugReportServiceEnabled: bugReportService?.isEnabled ?? false,
+                                                             isBugReportServiceEnabled: bugReportService.isEnabled,
                                                              appSettings: appSettings,
                                                              userIndicatorController: userIndicatorController)
         let coordinator = AuthenticationStartScreenCoordinator(parameters: parameters)
@@ -436,11 +436,6 @@ class AuthenticationFlowCoordinator: FlowCoordinatorProtocol {
     // MARK: - Bug Report
     
     private func startBugReportFlow() {
-        guard let bugReportService else {
-            MXLog.warning("Can't launch `BugReportFlowCoordinator` from `AuthenticationFlowCoordinator`: `bugReportService` is nil.")
-            return
-        }
-
         let coordinator = BugReportFlowCoordinator(parameters: .init(presentationMode: .sheet(navigationStackCoordinator),
                                                                      userIndicatorController: userIndicatorController,
                                                                      bugReportService: bugReportService,

--- a/ElementX/Sources/Services/BugReport/BugReportService.swift
+++ b/ElementX/Sources/Services/BugReport/BugReportService.swift
@@ -140,7 +140,7 @@ class BugReportService: NSObject, BugReportServiceProtocol {
             decoder.keyDecodingStrategy = .convertFromSnakeCase
             let uploadResponse = try decoder.decode(SubmitBugReportResponse.self, from: data)
             
-            if !uploadResponse.reportUrl.isEmpty {
+            if !(uploadResponse.reportUrl?.isEmpty ?? false) {
                 lastCrashEventID = nil
             }
             

--- a/ElementX/Sources/Services/BugReport/BugReportServiceProtocol.swift
+++ b/ElementX/Sources/Services/BugReport/BugReportServiceProtocol.swift
@@ -22,7 +22,7 @@ struct BugReport: Equatable {
 }
 
 struct SubmitBugReportResponse: Decodable {
-    var reportUrl: String
+    var reportUrl: String?
 }
 
 enum BugReportServiceError: LocalizedError {


### PR DESCRIPTION
The `BugReportService` can optionally return a `reportUrl` value. The Matrix Specification specifies it as optional.

In current ElementX code, the `reportUrl` is considered mandatory.

This PR allows `reportUrl` to be optional.


