### PR TITLE
Exclude protocol files from code coverage checks.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -19,6 +19,7 @@ ignore:
   - "**/Mock*.swift"
   - "**/*Mock.swift"
   - "**/*Proxy.swift"
+  - "**/*Protocol.swift"
 
 flag_management:
   default_rules:


### PR DESCRIPTION
Because they're generally uncoverable and there's no logic to them.