### PR TITLE
Thread aware drafting

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -8736,7 +8736,7 @@
 			repositoryURL = "https://github.com/element-hq/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = "25.06.12-2";
+				version = 25.06.13;
 			};
 		};
 		701C7BEF8F70F7A83E852DCC /* XCRemoteSwiftPackageReference "GZIP" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/matrix-rust-components-swift",
       "state" : {
-        "revision" : "0f239a906115a792bdca0741ca20fc59a64b8e39",
-        "version" : "25.6.12-2"
+        "revision" : "d0e83c772c0e52b18e50502b9e50f551077502f9",
+        "version" : "25.6.13"
       }
     },
     {

--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -500,7 +500,9 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
         
         let completionSuggestionService = CompletionSuggestionService(roomProxy: roomProxy,
                                                                       roomListPublisher: userSession.clientProxy.staticRoomSummaryProvider.roomListPublisher.eraseToAnyPublisher())
-        let composerDraftService = ComposerDraftService(roomProxy: roomProxy, timelineItemfactory: timelineItemFactory)
+        let composerDraftService = ComposerDraftService(roomProxy: roomProxy,
+                                                        timelineItemfactory: timelineItemFactory,
+                                                        threadRootEventID: nil)
         
         let parameters = RoomScreenCoordinatorParameters(clientProxy: userSession.clientProxy,
                                                          roomProxy: roomProxy,
@@ -581,11 +583,11 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
                                                           attributedStringBuilder: AttributedStringBuilder(mentionBuilder: MentionBuilder()),
                                                           stateEventStringBuilder: RoomStateEventStringBuilder(userID: userSession.clientProxy.userID))
         
-        guard let eventID = itemID.eventID else {
+        guard let threadRootEventID = itemID.eventID else {
             fatalError("Invalid thread event ID")
         }
         
-        guard case let .success(timelineController) = await timelineControllerFactory.buildThreadTimelineController(eventID: eventID,
+        guard case let .success(timelineController) = await timelineControllerFactory.buildThreadTimelineController(eventID: threadRootEventID,
                                                                                                                     roomProxy: roomProxy,
                                                                                                                     timelineItemFactory: timelineItemFactory,
                                                                                                                     mediaProvider: userSession.mediaProvider) else {
@@ -595,7 +597,9 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
         
         let completionSuggestionService = CompletionSuggestionService(roomProxy: roomProxy,
                                                                       roomListPublisher: userSession.clientProxy.staticRoomSummaryProvider.roomListPublisher.eraseToAnyPublisher())
-        let composerDraftService = ComposerDraftService(roomProxy: roomProxy, timelineItemfactory: timelineItemFactory)
+        let composerDraftService = ComposerDraftService(roomProxy: roomProxy,
+                                                        timelineItemfactory: timelineItemFactory,
+                                                        threadRootEventID: threadRootEventID)
         
         let coordinator = ThreadTimelineScreenCoordinator(parameters: .init(clientProxy: userSession.clientProxy,
                                                                             roomProxy: roomProxy,

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -10121,15 +10121,15 @@ class JoinedRoomProxyMock: JoinedRoomProxyProtocol, @unchecked Sendable {
     }
     //MARK: - saveDraft
 
-    var saveDraftUnderlyingCallsCount = 0
-    var saveDraftCallsCount: Int {
+    var saveDraftThreadRootEventIDUnderlyingCallsCount = 0
+    var saveDraftThreadRootEventIDCallsCount: Int {
         get {
             if Thread.isMainThread {
-                return saveDraftUnderlyingCallsCount
+                return saveDraftThreadRootEventIDUnderlyingCallsCount
             } else {
                 var returnValue: Int? = nil
                 DispatchQueue.main.sync {
-                    returnValue = saveDraftUnderlyingCallsCount
+                    returnValue = saveDraftThreadRootEventIDUnderlyingCallsCount
                 }
 
                 return returnValue!
@@ -10137,29 +10137,29 @@ class JoinedRoomProxyMock: JoinedRoomProxyProtocol, @unchecked Sendable {
         }
         set {
             if Thread.isMainThread {
-                saveDraftUnderlyingCallsCount = newValue
+                saveDraftThreadRootEventIDUnderlyingCallsCount = newValue
             } else {
                 DispatchQueue.main.sync {
-                    saveDraftUnderlyingCallsCount = newValue
+                    saveDraftThreadRootEventIDUnderlyingCallsCount = newValue
                 }
             }
         }
     }
-    var saveDraftCalled: Bool {
-        return saveDraftCallsCount > 0
+    var saveDraftThreadRootEventIDCalled: Bool {
+        return saveDraftThreadRootEventIDCallsCount > 0
     }
-    var saveDraftReceivedDraft: ComposerDraft?
-    var saveDraftReceivedInvocations: [ComposerDraft] = []
+    var saveDraftThreadRootEventIDReceivedArguments: (draft: ComposerDraft, threadRootEventID: String?)?
+    var saveDraftThreadRootEventIDReceivedInvocations: [(draft: ComposerDraft, threadRootEventID: String?)] = []
 
-    var saveDraftUnderlyingReturnValue: Result<Void, RoomProxyError>!
-    var saveDraftReturnValue: Result<Void, RoomProxyError>! {
+    var saveDraftThreadRootEventIDUnderlyingReturnValue: Result<Void, RoomProxyError>!
+    var saveDraftThreadRootEventIDReturnValue: Result<Void, RoomProxyError>! {
         get {
             if Thread.isMainThread {
-                return saveDraftUnderlyingReturnValue
+                return saveDraftThreadRootEventIDUnderlyingReturnValue
             } else {
                 var returnValue: Result<Void, RoomProxyError>? = nil
                 DispatchQueue.main.sync {
-                    returnValue = saveDraftUnderlyingReturnValue
+                    returnValue = saveDraftThreadRootEventIDUnderlyingReturnValue
                 }
 
                 return returnValue!
@@ -10167,39 +10167,39 @@ class JoinedRoomProxyMock: JoinedRoomProxyProtocol, @unchecked Sendable {
         }
         set {
             if Thread.isMainThread {
-                saveDraftUnderlyingReturnValue = newValue
+                saveDraftThreadRootEventIDUnderlyingReturnValue = newValue
             } else {
                 DispatchQueue.main.sync {
-                    saveDraftUnderlyingReturnValue = newValue
+                    saveDraftThreadRootEventIDUnderlyingReturnValue = newValue
                 }
             }
         }
     }
-    var saveDraftClosure: ((ComposerDraft) async -> Result<Void, RoomProxyError>)?
+    var saveDraftThreadRootEventIDClosure: ((ComposerDraft, String?) async -> Result<Void, RoomProxyError>)?
 
-    func saveDraft(_ draft: ComposerDraft) async -> Result<Void, RoomProxyError> {
-        saveDraftCallsCount += 1
-        saveDraftReceivedDraft = draft
+    func saveDraft(_ draft: ComposerDraft, threadRootEventID: String?) async -> Result<Void, RoomProxyError> {
+        saveDraftThreadRootEventIDCallsCount += 1
+        saveDraftThreadRootEventIDReceivedArguments = (draft: draft, threadRootEventID: threadRootEventID)
         DispatchQueue.main.async {
-            self.saveDraftReceivedInvocations.append(draft)
+            self.saveDraftThreadRootEventIDReceivedInvocations.append((draft: draft, threadRootEventID: threadRootEventID))
         }
-        if let saveDraftClosure = saveDraftClosure {
-            return await saveDraftClosure(draft)
+        if let saveDraftThreadRootEventIDClosure = saveDraftThreadRootEventIDClosure {
+            return await saveDraftThreadRootEventIDClosure(draft, threadRootEventID)
         } else {
-            return saveDraftReturnValue
+            return saveDraftThreadRootEventIDReturnValue
         }
     }
     //MARK: - loadDraft
 
-    var loadDraftUnderlyingCallsCount = 0
-    var loadDraftCallsCount: Int {
+    var loadDraftThreadRootEventIDUnderlyingCallsCount = 0
+    var loadDraftThreadRootEventIDCallsCount: Int {
         get {
             if Thread.isMainThread {
-                return loadDraftUnderlyingCallsCount
+                return loadDraftThreadRootEventIDUnderlyingCallsCount
             } else {
                 var returnValue: Int? = nil
                 DispatchQueue.main.sync {
-                    returnValue = loadDraftUnderlyingCallsCount
+                    returnValue = loadDraftThreadRootEventIDUnderlyingCallsCount
                 }
 
                 return returnValue!
@@ -10207,27 +10207,29 @@ class JoinedRoomProxyMock: JoinedRoomProxyProtocol, @unchecked Sendable {
         }
         set {
             if Thread.isMainThread {
-                loadDraftUnderlyingCallsCount = newValue
+                loadDraftThreadRootEventIDUnderlyingCallsCount = newValue
             } else {
                 DispatchQueue.main.sync {
-                    loadDraftUnderlyingCallsCount = newValue
+                    loadDraftThreadRootEventIDUnderlyingCallsCount = newValue
                 }
             }
         }
     }
-    var loadDraftCalled: Bool {
-        return loadDraftCallsCount > 0
+    var loadDraftThreadRootEventIDCalled: Bool {
+        return loadDraftThreadRootEventIDCallsCount > 0
     }
+    var loadDraftThreadRootEventIDReceivedThreadRootEventID: String?
+    var loadDraftThreadRootEventIDReceivedInvocations: [String?] = []
 
-    var loadDraftUnderlyingReturnValue: Result<ComposerDraft?, RoomProxyError>!
-    var loadDraftReturnValue: Result<ComposerDraft?, RoomProxyError>! {
+    var loadDraftThreadRootEventIDUnderlyingReturnValue: Result<ComposerDraft?, RoomProxyError>!
+    var loadDraftThreadRootEventIDReturnValue: Result<ComposerDraft?, RoomProxyError>! {
         get {
             if Thread.isMainThread {
-                return loadDraftUnderlyingReturnValue
+                return loadDraftThreadRootEventIDUnderlyingReturnValue
             } else {
                 var returnValue: Result<ComposerDraft?, RoomProxyError>? = nil
                 DispatchQueue.main.sync {
-                    returnValue = loadDraftUnderlyingReturnValue
+                    returnValue = loadDraftThreadRootEventIDUnderlyingReturnValue
                 }
 
                 return returnValue!
@@ -10235,35 +10237,39 @@ class JoinedRoomProxyMock: JoinedRoomProxyProtocol, @unchecked Sendable {
         }
         set {
             if Thread.isMainThread {
-                loadDraftUnderlyingReturnValue = newValue
+                loadDraftThreadRootEventIDUnderlyingReturnValue = newValue
             } else {
                 DispatchQueue.main.sync {
-                    loadDraftUnderlyingReturnValue = newValue
+                    loadDraftThreadRootEventIDUnderlyingReturnValue = newValue
                 }
             }
         }
     }
-    var loadDraftClosure: (() async -> Result<ComposerDraft?, RoomProxyError>)?
+    var loadDraftThreadRootEventIDClosure: ((String?) async -> Result<ComposerDraft?, RoomProxyError>)?
 
-    func loadDraft() async -> Result<ComposerDraft?, RoomProxyError> {
-        loadDraftCallsCount += 1
-        if let loadDraftClosure = loadDraftClosure {
-            return await loadDraftClosure()
+    func loadDraft(threadRootEventID: String?) async -> Result<ComposerDraft?, RoomProxyError> {
+        loadDraftThreadRootEventIDCallsCount += 1
+        loadDraftThreadRootEventIDReceivedThreadRootEventID = threadRootEventID
+        DispatchQueue.main.async {
+            self.loadDraftThreadRootEventIDReceivedInvocations.append(threadRootEventID)
+        }
+        if let loadDraftThreadRootEventIDClosure = loadDraftThreadRootEventIDClosure {
+            return await loadDraftThreadRootEventIDClosure(threadRootEventID)
         } else {
-            return loadDraftReturnValue
+            return loadDraftThreadRootEventIDReturnValue
         }
     }
     //MARK: - clearDraft
 
-    var clearDraftUnderlyingCallsCount = 0
-    var clearDraftCallsCount: Int {
+    var clearDraftThreadRootEventIDUnderlyingCallsCount = 0
+    var clearDraftThreadRootEventIDCallsCount: Int {
         get {
             if Thread.isMainThread {
-                return clearDraftUnderlyingCallsCount
+                return clearDraftThreadRootEventIDUnderlyingCallsCount
             } else {
                 var returnValue: Int? = nil
                 DispatchQueue.main.sync {
-                    returnValue = clearDraftUnderlyingCallsCount
+                    returnValue = clearDraftThreadRootEventIDUnderlyingCallsCount
                 }
 
                 return returnValue!
@@ -10271,27 +10277,29 @@ class JoinedRoomProxyMock: JoinedRoomProxyProtocol, @unchecked Sendable {
         }
         set {
             if Thread.isMainThread {
-                clearDraftUnderlyingCallsCount = newValue
+                clearDraftThreadRootEventIDUnderlyingCallsCount = newValue
             } else {
                 DispatchQueue.main.sync {
-                    clearDraftUnderlyingCallsCount = newValue
+                    clearDraftThreadRootEventIDUnderlyingCallsCount = newValue
                 }
             }
         }
     }
-    var clearDraftCalled: Bool {
-        return clearDraftCallsCount > 0
+    var clearDraftThreadRootEventIDCalled: Bool {
+        return clearDraftThreadRootEventIDCallsCount > 0
     }
+    var clearDraftThreadRootEventIDReceivedThreadRootEventID: String?
+    var clearDraftThreadRootEventIDReceivedInvocations: [String?] = []
 
-    var clearDraftUnderlyingReturnValue: Result<Void, RoomProxyError>!
-    var clearDraftReturnValue: Result<Void, RoomProxyError>! {
+    var clearDraftThreadRootEventIDUnderlyingReturnValue: Result<Void, RoomProxyError>!
+    var clearDraftThreadRootEventIDReturnValue: Result<Void, RoomProxyError>! {
         get {
             if Thread.isMainThread {
-                return clearDraftUnderlyingReturnValue
+                return clearDraftThreadRootEventIDUnderlyingReturnValue
             } else {
                 var returnValue: Result<Void, RoomProxyError>? = nil
                 DispatchQueue.main.sync {
-                    returnValue = clearDraftUnderlyingReturnValue
+                    returnValue = clearDraftThreadRootEventIDUnderlyingReturnValue
                 }
 
                 return returnValue!
@@ -10299,22 +10307,26 @@ class JoinedRoomProxyMock: JoinedRoomProxyProtocol, @unchecked Sendable {
         }
         set {
             if Thread.isMainThread {
-                clearDraftUnderlyingReturnValue = newValue
+                clearDraftThreadRootEventIDUnderlyingReturnValue = newValue
             } else {
                 DispatchQueue.main.sync {
-                    clearDraftUnderlyingReturnValue = newValue
+                    clearDraftThreadRootEventIDUnderlyingReturnValue = newValue
                 }
             }
         }
     }
-    var clearDraftClosure: (() async -> Result<Void, RoomProxyError>)?
+    var clearDraftThreadRootEventIDClosure: ((String?) async -> Result<Void, RoomProxyError>)?
 
-    func clearDraft() async -> Result<Void, RoomProxyError> {
-        clearDraftCallsCount += 1
-        if let clearDraftClosure = clearDraftClosure {
-            return await clearDraftClosure()
+    func clearDraft(threadRootEventID: String?) async -> Result<Void, RoomProxyError> {
+        clearDraftThreadRootEventIDCallsCount += 1
+        clearDraftThreadRootEventIDReceivedThreadRootEventID = threadRootEventID
+        DispatchQueue.main.async {
+            self.clearDraftThreadRootEventIDReceivedInvocations.append(threadRootEventID)
+        }
+        if let clearDraftThreadRootEventIDClosure = clearDraftThreadRootEventIDClosure {
+            return await clearDraftThreadRootEventIDClosure(threadRootEventID)
         } else {
-            return clearDraftReturnValue
+            return clearDraftThreadRootEventIDReturnValue
         }
     }
 }

--- a/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
@@ -12618,16 +12618,16 @@ open class RoomSDKMock: MatrixRustSDK.Room, @unchecked Sendable {
 
     //MARK: - clearComposerDraft
 
-    open var clearComposerDraftThrowableError: Error?
-    var clearComposerDraftUnderlyingCallsCount = 0
-    open var clearComposerDraftCallsCount: Int {
+    open var clearComposerDraftThreadRootThrowableError: Error?
+    var clearComposerDraftThreadRootUnderlyingCallsCount = 0
+    open var clearComposerDraftThreadRootCallsCount: Int {
         get {
             if Thread.isMainThread {
-                return clearComposerDraftUnderlyingCallsCount
+                return clearComposerDraftThreadRootUnderlyingCallsCount
             } else {
                 var returnValue: Int? = nil
                 DispatchQueue.main.sync {
-                    returnValue = clearComposerDraftUnderlyingCallsCount
+                    returnValue = clearComposerDraftThreadRootUnderlyingCallsCount
                 }
 
                 return returnValue!
@@ -12635,25 +12635,31 @@ open class RoomSDKMock: MatrixRustSDK.Room, @unchecked Sendable {
         }
         set {
             if Thread.isMainThread {
-                clearComposerDraftUnderlyingCallsCount = newValue
+                clearComposerDraftThreadRootUnderlyingCallsCount = newValue
             } else {
                 DispatchQueue.main.sync {
-                    clearComposerDraftUnderlyingCallsCount = newValue
+                    clearComposerDraftThreadRootUnderlyingCallsCount = newValue
                 }
             }
         }
     }
-    open var clearComposerDraftCalled: Bool {
-        return clearComposerDraftCallsCount > 0
+    open var clearComposerDraftThreadRootCalled: Bool {
+        return clearComposerDraftThreadRootCallsCount > 0
     }
-    open var clearComposerDraftClosure: (() async throws -> Void)?
+    open var clearComposerDraftThreadRootReceivedThreadRoot: String?
+    open var clearComposerDraftThreadRootReceivedInvocations: [String?] = []
+    open var clearComposerDraftThreadRootClosure: ((String?) async throws -> Void)?
 
-    open override func clearComposerDraft() async throws {
-        if let error = clearComposerDraftThrowableError {
+    open override func clearComposerDraft(threadRoot: String?) async throws {
+        if let error = clearComposerDraftThreadRootThrowableError {
             throw error
         }
-        clearComposerDraftCallsCount += 1
-        try await clearComposerDraftClosure?()
+        clearComposerDraftThreadRootCallsCount += 1
+        clearComposerDraftThreadRootReceivedThreadRoot = threadRoot
+        DispatchQueue.main.async {
+            self.clearComposerDraftThreadRootReceivedInvocations.append(threadRoot)
+        }
+        try await clearComposerDraftThreadRootClosure?(threadRoot)
     }
 
     //MARK: - clearEventCacheStorage
@@ -14291,16 +14297,16 @@ open class RoomSDKMock: MatrixRustSDK.Room, @unchecked Sendable {
 
     //MARK: - loadComposerDraft
 
-    open var loadComposerDraftThrowableError: Error?
-    var loadComposerDraftUnderlyingCallsCount = 0
-    open var loadComposerDraftCallsCount: Int {
+    open var loadComposerDraftThreadRootThrowableError: Error?
+    var loadComposerDraftThreadRootUnderlyingCallsCount = 0
+    open var loadComposerDraftThreadRootCallsCount: Int {
         get {
             if Thread.isMainThread {
-                return loadComposerDraftUnderlyingCallsCount
+                return loadComposerDraftThreadRootUnderlyingCallsCount
             } else {
                 var returnValue: Int? = nil
                 DispatchQueue.main.sync {
-                    returnValue = loadComposerDraftUnderlyingCallsCount
+                    returnValue = loadComposerDraftThreadRootUnderlyingCallsCount
                 }
 
                 return returnValue!
@@ -14308,27 +14314,29 @@ open class RoomSDKMock: MatrixRustSDK.Room, @unchecked Sendable {
         }
         set {
             if Thread.isMainThread {
-                loadComposerDraftUnderlyingCallsCount = newValue
+                loadComposerDraftThreadRootUnderlyingCallsCount = newValue
             } else {
                 DispatchQueue.main.sync {
-                    loadComposerDraftUnderlyingCallsCount = newValue
+                    loadComposerDraftThreadRootUnderlyingCallsCount = newValue
                 }
             }
         }
     }
-    open var loadComposerDraftCalled: Bool {
-        return loadComposerDraftCallsCount > 0
+    open var loadComposerDraftThreadRootCalled: Bool {
+        return loadComposerDraftThreadRootCallsCount > 0
     }
+    open var loadComposerDraftThreadRootReceivedThreadRoot: String?
+    open var loadComposerDraftThreadRootReceivedInvocations: [String?] = []
 
-    var loadComposerDraftUnderlyingReturnValue: ComposerDraft?
-    open var loadComposerDraftReturnValue: ComposerDraft? {
+    var loadComposerDraftThreadRootUnderlyingReturnValue: ComposerDraft?
+    open var loadComposerDraftThreadRootReturnValue: ComposerDraft? {
         get {
             if Thread.isMainThread {
-                return loadComposerDraftUnderlyingReturnValue
+                return loadComposerDraftThreadRootUnderlyingReturnValue
             } else {
                 var returnValue: ComposerDraft?? = nil
                 DispatchQueue.main.sync {
-                    returnValue = loadComposerDraftUnderlyingReturnValue
+                    returnValue = loadComposerDraftThreadRootUnderlyingReturnValue
                 }
 
                 return returnValue!
@@ -14336,25 +14344,29 @@ open class RoomSDKMock: MatrixRustSDK.Room, @unchecked Sendable {
         }
         set {
             if Thread.isMainThread {
-                loadComposerDraftUnderlyingReturnValue = newValue
+                loadComposerDraftThreadRootUnderlyingReturnValue = newValue
             } else {
                 DispatchQueue.main.sync {
-                    loadComposerDraftUnderlyingReturnValue = newValue
+                    loadComposerDraftThreadRootUnderlyingReturnValue = newValue
                 }
             }
         }
     }
-    open var loadComposerDraftClosure: (() async throws -> ComposerDraft?)?
+    open var loadComposerDraftThreadRootClosure: ((String?) async throws -> ComposerDraft?)?
 
-    open override func loadComposerDraft() async throws -> ComposerDraft? {
-        if let error = loadComposerDraftThrowableError {
+    open override func loadComposerDraft(threadRoot: String?) async throws -> ComposerDraft? {
+        if let error = loadComposerDraftThreadRootThrowableError {
             throw error
         }
-        loadComposerDraftCallsCount += 1
-        if let loadComposerDraftClosure = loadComposerDraftClosure {
-            return try await loadComposerDraftClosure()
+        loadComposerDraftThreadRootCallsCount += 1
+        loadComposerDraftThreadRootReceivedThreadRoot = threadRoot
+        DispatchQueue.main.async {
+            self.loadComposerDraftThreadRootReceivedInvocations.append(threadRoot)
+        }
+        if let loadComposerDraftThreadRootClosure = loadComposerDraftThreadRootClosure {
+            return try await loadComposerDraftThreadRootClosure(threadRoot)
         } else {
-            return loadComposerDraftReturnValue
+            return loadComposerDraftThreadRootReturnValue
         }
     }
 
@@ -15858,16 +15870,16 @@ open class RoomSDKMock: MatrixRustSDK.Room, @unchecked Sendable {
 
     //MARK: - saveComposerDraft
 
-    open var saveComposerDraftDraftThrowableError: Error?
-    var saveComposerDraftDraftUnderlyingCallsCount = 0
-    open var saveComposerDraftDraftCallsCount: Int {
+    open var saveComposerDraftDraftThreadRootThrowableError: Error?
+    var saveComposerDraftDraftThreadRootUnderlyingCallsCount = 0
+    open var saveComposerDraftDraftThreadRootCallsCount: Int {
         get {
             if Thread.isMainThread {
-                return saveComposerDraftDraftUnderlyingCallsCount
+                return saveComposerDraftDraftThreadRootUnderlyingCallsCount
             } else {
                 var returnValue: Int? = nil
                 DispatchQueue.main.sync {
-                    returnValue = saveComposerDraftDraftUnderlyingCallsCount
+                    returnValue = saveComposerDraftDraftThreadRootUnderlyingCallsCount
                 }
 
                 return returnValue!
@@ -15875,31 +15887,31 @@ open class RoomSDKMock: MatrixRustSDK.Room, @unchecked Sendable {
         }
         set {
             if Thread.isMainThread {
-                saveComposerDraftDraftUnderlyingCallsCount = newValue
+                saveComposerDraftDraftThreadRootUnderlyingCallsCount = newValue
             } else {
                 DispatchQueue.main.sync {
-                    saveComposerDraftDraftUnderlyingCallsCount = newValue
+                    saveComposerDraftDraftThreadRootUnderlyingCallsCount = newValue
                 }
             }
         }
     }
-    open var saveComposerDraftDraftCalled: Bool {
-        return saveComposerDraftDraftCallsCount > 0
+    open var saveComposerDraftDraftThreadRootCalled: Bool {
+        return saveComposerDraftDraftThreadRootCallsCount > 0
     }
-    open var saveComposerDraftDraftReceivedDraft: ComposerDraft?
-    open var saveComposerDraftDraftReceivedInvocations: [ComposerDraft] = []
-    open var saveComposerDraftDraftClosure: ((ComposerDraft) async throws -> Void)?
+    open var saveComposerDraftDraftThreadRootReceivedArguments: (draft: ComposerDraft, threadRoot: String?)?
+    open var saveComposerDraftDraftThreadRootReceivedInvocations: [(draft: ComposerDraft, threadRoot: String?)] = []
+    open var saveComposerDraftDraftThreadRootClosure: ((ComposerDraft, String?) async throws -> Void)?
 
-    open override func saveComposerDraft(draft: ComposerDraft) async throws {
-        if let error = saveComposerDraftDraftThrowableError {
+    open override func saveComposerDraft(draft: ComposerDraft, threadRoot: String?) async throws {
+        if let error = saveComposerDraftDraftThreadRootThrowableError {
             throw error
         }
-        saveComposerDraftDraftCallsCount += 1
-        saveComposerDraftDraftReceivedDraft = draft
+        saveComposerDraftDraftThreadRootCallsCount += 1
+        saveComposerDraftDraftThreadRootReceivedArguments = (draft: draft, threadRoot: threadRoot)
         DispatchQueue.main.async {
-            self.saveComposerDraftDraftReceivedInvocations.append(draft)
+            self.saveComposerDraftDraftThreadRootReceivedInvocations.append((draft: draft, threadRoot: threadRoot))
         }
-        try await saveComposerDraftDraftClosure?(draft)
+        try await saveComposerDraftDraftThreadRootClosure?(draft, threadRoot)
     }
 
     //MARK: - sendCallNotification
@@ -20953,6 +20965,71 @@ open class ThreadSummarySDKMock: MatrixRustSDK.ThreadSummary, @unchecked Sendabl
             return latestEventClosure()
         } else {
             return latestEventReturnValue
+        }
+    }
+
+    //MARK: - numReplies
+
+    var numRepliesUnderlyingCallsCount = 0
+    open var numRepliesCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return numRepliesUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = numRepliesUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                numRepliesUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    numRepliesUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var numRepliesCalled: Bool {
+        return numRepliesCallsCount > 0
+    }
+
+    var numRepliesUnderlyingReturnValue: UInt64!
+    open var numRepliesReturnValue: UInt64! {
+        get {
+            if Thread.isMainThread {
+                return numRepliesUnderlyingReturnValue
+            } else {
+                var returnValue: UInt64? = nil
+                DispatchQueue.main.sync {
+                    returnValue = numRepliesUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                numRepliesUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    numRepliesUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    open var numRepliesClosure: (() -> UInt64)?
+
+    open override func numReplies() -> UInt64 {
+        numRepliesCallsCount += 1
+        if let numRepliesClosure = numRepliesClosure {
+            return numRepliesClosure()
+        } else {
+            return numRepliesReturnValue
         }
     }
 }

--- a/ElementX/Sources/Mocks/JoinedRoomProxyMock.swift
+++ b/ElementX/Sources/Mocks/JoinedRoomProxyMock.swift
@@ -135,8 +135,8 @@ extension JoinedRoomProxyMock {
         
         matrixToPermalinkReturnValue = .success(.homeDirectory)
         matrixToEventPermalinkReturnValue = .success(.homeDirectory)
-        loadDraftReturnValue = .success(nil)
-        clearDraftReturnValue = .success(())
+        loadDraftThreadRootEventIDReturnValue = .success(nil)
+        clearDraftThreadRootEventIDReturnValue = .success(())
         sendTypingNotificationIsTypingReturnValue = .success(())
         isVisibleInRoomDirectoryReturnValue = .success(configuration.isVisibleInPublicDirectory)
         

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarModels.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarModels.swift
@@ -39,6 +39,8 @@ enum ComposerToolbarViewModelAction {
 
 enum ComposerToolbarViewAction {
     case composerAppeared
+    case composerDisappeared
+    
     case sendMessage
     case editLastMessage
     case cancelReply

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarViewModel.swift
@@ -161,9 +161,22 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
             }
         }
         .store(in: &cancellables)
+        
+        NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification).sink { [weak self] _ in
+            self?.saveDraft()
+        }
+        .store(in: &cancellables)
     }
     
     // MARK: - Public
+    
+    func start() {
+        Task { await loadDraft() }
+    }
+    
+    func stop() {
+        saveDraft()
+    }
 
     override func process(viewAction: ComposerToolbarViewAction) {
         switch viewAction {
@@ -172,6 +185,8 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
                 hasAppeard = true
                 wysiwygViewModel.setup()
             }
+        case .composerDisappeared:
+            saveDraft()
         case .sendMessage:
             guard !state.sendButtonDisabled else { return }
             

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarViewModelProtocol.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarViewModelProtocol.swift
@@ -13,8 +13,9 @@ import WysiwygComposer
 protocol ComposerToolbarViewModelProtocol {
     var actions: AnyPublisher<ComposerToolbarViewModelAction, Never> { get }
     var context: ComposerToolbarViewModelType.Context { get }
+    
+    func start()
+    func stop()
 
     func process(timelineAction: TimelineComposerAction)
-    func loadDraft() async
-    func saveDraft()
 }

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/ComposerToolbar.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/ComposerToolbar.swift
@@ -181,6 +181,9 @@ struct ComposerToolbar: View {
         } onAppearAction: {
             context.send(viewAction: .composerAppeared)
         }
+        .onDisappear {
+            context.send(viewAction: .composerDisappeared)
+        }
         .environmentObject(context)
         .focused($composerFocused)
         .padding(.leading, context.composerFormattingEnabled ? 7 : 0)

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
@@ -107,11 +107,6 @@ final class RoomScreenCoordinator: CoordinatorProtocol {
                                                          analyticsService: ServiceLocator.shared.analytics,
                                                          composerDraftService: parameters.composerDraftService)
         self.composerViewModel = composerViewModel
-        
-        NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification).sink { _ in
-            composerViewModel.saveDraft()
-        }
-        .store(in: &cancellables)
     }
     
     // MARK: - Public
@@ -193,8 +188,9 @@ final class RoomScreenCoordinator: CoordinatorProtocol {
             }
             .store(in: &cancellables)
         
-        // Loading the draft requires the subscriptions to be set up first otherwise the room won't be be able to propagate the information to the composer.
-        Task { await composerViewModel.loadDraft() }
+        // Loading the draft requires the subscriptions to be set up first otherwise
+        // the room won't be be able to propagate the information to the composer.
+        composerViewModel.start()
     }
     
     func focusOnEvent(_ focussedEvent: FocusEvent) {
@@ -212,7 +208,7 @@ final class RoomScreenCoordinator: CoordinatorProtocol {
     }
     
     func stop() {
-        composerViewModel.saveDraft()
+        composerViewModel.stop()
         roomViewModel.stop()
     }
     
@@ -221,10 +217,7 @@ final class RoomScreenCoordinator: CoordinatorProtocol {
 
         return AnyView(RoomScreen(context: roomViewModel.context,
                                   timelineContext: timelineViewModel.context,
-                                  composerToolbar: composerToolbar)
-                .onDisappear { [weak self] in
-                    self?.composerViewModel.saveDraft()
-                })
+                                  composerToolbar: composerToolbar))
     }
 }
 

--- a/ElementX/Sources/Screens/ThreadTimelineScreen/ThreadTimelineScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/ThreadTimelineScreen/ThreadTimelineScreenCoordinator.swift
@@ -74,8 +74,6 @@ final class ThreadTimelineScreenCoordinator: CoordinatorProtocol {
                                                         maxExpandedHeight: ComposerConstant.maxHeight,
                                                         parserStyle: .elementX)
         
-        #warning("Drafts are not handled and they can't be without rust side changes")
-        
         composerViewModel = ComposerToolbarViewModel(initialText: nil,
                                                      roomProxy: parameters.roomProxy,
                                                      isInThread: true,
@@ -144,9 +142,14 @@ final class ThreadTimelineScreenCoordinator: CoordinatorProtocol {
                 timelineViewModel.process(composerAction: action)
             }
             .store(in: &cancellables)
+        
+        // Loading the draft requires the subscriptions to be set up first otherwise
+        // the room won't be be able to propagate the information to the composer.
+        composerViewModel.start()
     }
     
     func stop() {
+        composerViewModel.stop()
         viewModel.stop()
     }
         

--- a/ElementX/Sources/Services/ComposerDraft/ComposerDraftService.swift
+++ b/ElementX/Sources/Services/ComposerDraft/ComposerDraftService.swift
@@ -11,16 +11,20 @@ import MatrixRustSDK
 
 final class ComposerDraftService: ComposerDraftServiceProtocol {
     private let roomProxy: JoinedRoomProxyProtocol
+    private let threadRootEventID: String?
     private let timelineItemfactory: RoomTimelineItemFactoryProtocol
     private var volatileDraft: ComposerDraftProxy?
     
-    init(roomProxy: JoinedRoomProxyProtocol, timelineItemfactory: RoomTimelineItemFactoryProtocol) {
+    init(roomProxy: JoinedRoomProxyProtocol,
+         timelineItemfactory: RoomTimelineItemFactoryProtocol,
+         threadRootEventID: String?) {
         self.roomProxy = roomProxy
+        self.threadRootEventID = threadRootEventID
         self.timelineItemfactory = timelineItemfactory
     }
     
     func saveDraft(_ draft: ComposerDraftProxy) async -> Result<Void, ComposerDraftServiceError> {
-        switch await roomProxy.saveDraft(draft.toRust) {
+        switch await roomProxy.saveDraft(draft.toRust, threadRootEventID: threadRootEventID) {
         case .success:
             MXLog.info("Successfully saved draft")
             return .success(())
@@ -31,7 +35,7 @@ final class ComposerDraftService: ComposerDraftServiceProtocol {
     }
     
     func loadDraft() async -> Result<ComposerDraftProxy?, ComposerDraftServiceError> {
-        switch await roomProxy.loadDraft() {
+        switch await roomProxy.loadDraft(threadRootEventID: threadRootEventID) {
         case .success(let draft):
             guard let draft else {
                 return .success(nil)
@@ -54,7 +58,7 @@ final class ComposerDraftService: ComposerDraftServiceProtocol {
     }
     
     func clearDraft() async -> Result<Void, ComposerDraftServiceError> {
-        switch await roomProxy.clearDraft() {
+        switch await roomProxy.clearDraft(threadRootEventID: threadRootEventID) {
         case .success:
             MXLog.info("Successfully cleared draft")
             return .success(())

--- a/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
@@ -772,9 +772,9 @@ class JoinedRoomProxy: JoinedRoomProxyProtocol {
     
     // MARK: - Drafts
     
-    func saveDraft(_ draft: ComposerDraft) async -> Result<Void, RoomProxyError> {
+    func saveDraft(_ draft: ComposerDraft, threadRootEventID: String?) async -> Result<Void, RoomProxyError> {
         do {
-            try await room.saveComposerDraft(draft: draft)
+            try await room.saveComposerDraft(draft: draft, threadRoot: threadRootEventID)
             return .success(())
         } catch {
             MXLog.error("Failed saving draft with error: \(error)")
@@ -782,18 +782,18 @@ class JoinedRoomProxy: JoinedRoomProxyProtocol {
         }
     }
     
-    func loadDraft() async -> Result<ComposerDraft?, RoomProxyError> {
+    func loadDraft(threadRootEventID: String?) async -> Result<ComposerDraft?, RoomProxyError> {
         do {
-            return try await .success(room.loadComposerDraft())
+            return try await .success(room.loadComposerDraft(threadRoot: threadRootEventID))
         } catch {
             MXLog.error("Failed restoring draft with error: \(error)")
             return .failure(.sdkError(error))
         }
     }
     
-    func clearDraft() async -> Result<Void, RoomProxyError> {
+    func clearDraft(threadRootEventID: String?) async -> Result<Void, RoomProxyError> {
         do {
-            try await room.clearComposerDraft()
+            try await room.clearComposerDraft(threadRoot: threadRootEventID)
             return .success(())
         } catch {
             MXLog.error("Failed clearing draft with error: \(error)")

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -187,9 +187,9 @@ protocol JoinedRoomProxyProtocol: RoomProxyProtocol {
     
     // MARK: - Drafts
     
-    func saveDraft(_ draft: ComposerDraft) async -> Result<Void, RoomProxyError>
-    func loadDraft() async -> Result<ComposerDraft?, RoomProxyError>
-    func clearDraft() async -> Result<Void, RoomProxyError>
+    func saveDraft(_ draft: ComposerDraft, threadRootEventID: String?) async -> Result<Void, RoomProxyError>
+    func loadDraft(threadRootEventID: String?) async -> Result<ComposerDraft?, RoomProxyError>
+    func clearDraft(threadRootEventID: String?) async -> Result<Void, RoomProxyError>
 }
 
 extension JoinedRoomProxyProtocol {

--- a/project.yml
+++ b/project.yml
@@ -65,7 +65,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/element-hq/matrix-rust-components-swift
-    exactVersion: 25.06.12-2
+    exactVersion: 25.06.13
     # path: ../matrix-rust-sdk
   Compound:
     url: https://github.com/element-hq/compound-ios


### PR DESCRIPTION
Adopt a newer version of the SDK (https://github.com/matrix-org/matrix-rust-sdk/pull/5227) and have threaded timelines properly suport the drafting facilities. 
This also abstracts away composer draft handling within the ComposerToolbar* files to make it easier to adopt in both types of timeline screens.