### PR TITLE
Make BugReportService optional

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -34,6 +34,8 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
                 configureElementCallService()
                 configureNotificationManager()
                 observeUserSessionChanges()
+                // Set up Bug Report service after user is logged because baseUrl can be dependant on user's HomeServer that is known only after logged in.
+                setupServiceLocatorBugReport(appSettings: appSettings)
                 startSync()
                 performSettingsToAccountDataMigration(userSession: userSession)
                 Task { await appHooks.configure(with: userSession) }
@@ -372,15 +374,27 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
     private static func setupServiceLocator(appSettings: AppSettings, appHooks: AppHooks) {
         ServiceLocator.shared.register(userIndicatorController: UserIndicatorController())
         ServiceLocator.shared.register(appSettings: appSettings)
-        ServiceLocator.shared.register(bugReportService: BugReportService(baseURL: appSettings.bugReportServiceBaseURL,
-                                                                          applicationID: appSettings.bugReportApplicationID,
-                                                                          sdkGitSHA: sdkGitSha(),
-                                                                          maxUploadSize: appSettings.bugReportMaxUploadSize,
-                                                                          appHooks: appHooks))
+        // Set up Bug Report service after user is logged because baseUrl can be dependant on user's HomeServer that is known only after logged in.
+//        ServiceLocator.shared.register(bugReportService: BugReportService(baseURL: appSettings.bugReportServiceBaseURL,
+//                                                                          applicationID: appSettings.bugReportApplicationID,
+//                                                                          sdkGitSHA: sdkGitSha(),
+//                                                                          maxUploadSize: appSettings.bugReportMaxUploadSize,
+//                                                                          appHooks: appHooks))
         let posthogAnalyticsClient = PostHogAnalyticsClient()
         posthogAnalyticsClient.updateSuperProperties(AnalyticsEvent.SuperProperties(appPlatform: .EXI, cryptoSDK: .Rust, cryptoSDKVersion: sdkGitSha()))
         ServiceLocator.shared.register(analytics: AnalyticsService(client: posthogAnalyticsClient,
                                                                    appSettings: appSettings))
+    }
+    
+    // Set up Bug Report service after user is logged because baseUrl can be dependant on user's HomeServer that is known only after logged in.
+    private func setupServiceLocatorBugReport(appSettings: AppSettings) {
+        // We can force unwrap and value here because user session is initialized.
+        // swiftlint:disable:next force_unwrapping
+        ServiceLocator.shared.register(bugReportService: BugReportService(baseURL: URL(string: userSession!.clientProxy.homeserver)?.appendingPathComponent("bugreports"),
+                                                                          applicationID: appSettings.bugReportApplicationID,
+                                                                          sdkGitSHA: sdkGitSha(),
+                                                                          maxUploadSize: appSettings.bugReportMaxUploadSize,
+                                                                          appHooks: appHooks))
     }
     
     /// Perform any required migrations for the app to function correctly.


### PR DESCRIPTION
Make `BugReportService` optional (because it can be undefined before user is logged in).

On Tchap, the HomeServer is known only after user is logged in (because the HomeServer is dependant on the department of the user).

The `Report a problem` button on the Start Page can't report a bug if the `BugReportService` is not defined.

Making BugReportService optional (and then nil) on the Start Page make the `Report a problem` button automatically disappear. 👍 

So, it better to:
- make `BugReportService` optional
- not instantiate it with other servioces in `setupServiceLocator`
- instantiate it when the user is logged (in `userSession::didSet`)
- check if `BugReportService` is instantiated at the beginning of `startBugReportFlow`
