### PR TITLE
Stop failing bug reports when the reportURL is omitted.

### DIFF
--- a/ElementX/Sources/Screens/BugReportScreen/BugReportScreenViewModel.swift
+++ b/ElementX/Sources/Screens/BugReportScreen/BugReportScreenViewModel.swift
@@ -89,7 +89,7 @@ class BugReportScreenViewModel: BugReportScreenViewModelType, BugReportScreenVie
         switch await bugReportService.submitBugReport(bugReport,
                                                       progressListener: progressSubject) {
         case .success(let response):
-            MXLog.info("Submission uploaded to: \(response.reportUrl)")
+            MXLog.info("Submission uploaded: \(response.reportURL ?? "The server didn't generate a report URL")")
             actionsSubject.send(.submitFinished)
         case .failure(let error):
             MXLog.error("Submission failed: \(error)")

--- a/ElementX/Sources/Services/BugReport/BugReportService.swift
+++ b/ElementX/Sources/Services/BugReport/BugReportService.swift
@@ -140,9 +140,7 @@ class BugReportService: NSObject, BugReportServiceProtocol {
             decoder.keyDecodingStrategy = .convertFromSnakeCase
             let uploadResponse = try decoder.decode(SubmitBugReportResponse.self, from: data)
             
-            if !(uploadResponse.reportUrl?.isEmpty ?? false) {
-                lastCrashEventID = nil
-            }
+            lastCrashEventID = nil
             
             MXLog.info("Feedback submitted.")
             

--- a/ElementX/Sources/Services/BugReport/BugReportService.swift
+++ b/ElementX/Sources/Services/BugReport/BugReportService.swift
@@ -140,7 +140,7 @@ class BugReportService: NSObject, BugReportServiceProtocol {
             decoder.keyDecodingStrategy = .convertFromSnakeCase
             let uploadResponse = try decoder.decode(SubmitBugReportResponse.self, from: data)
             
-            if !uploadResponse.reportUrl.isEmpty {
+            if !(uploadResponse.reportUrl?.isEmpty ?? false) {
                 lastCrashEventID = nil
             }
             

--- a/ElementX/Sources/Services/BugReport/BugReportService.swift
+++ b/ElementX/Sources/Services/BugReport/BugReportService.swift
@@ -137,7 +137,6 @@ class BugReportService: NSObject, BugReportServiceProtocol {
             
             // Parse the JSON data
             let decoder = JSONDecoder()
-            decoder.keyDecodingStrategy = .convertFromSnakeCase
             let uploadResponse = try decoder.decode(SubmitBugReportResponse.self, from: data)
             
             lastCrashEventID = nil

--- a/ElementX/Sources/Services/BugReport/BugReportServiceProtocol.swift
+++ b/ElementX/Sources/Services/BugReport/BugReportServiceProtocol.swift
@@ -22,7 +22,7 @@ struct BugReport: Equatable {
 }
 
 struct SubmitBugReportResponse: Decodable {
-    var reportUrl: String
+    var reportUrl: String?
 }
 
 enum BugReportServiceError: LocalizedError {

--- a/ElementX/Sources/Services/BugReport/BugReportServiceProtocol.swift
+++ b/ElementX/Sources/Services/BugReport/BugReportServiceProtocol.swift
@@ -22,7 +22,11 @@ struct BugReport: Equatable {
 }
 
 struct SubmitBugReportResponse: Decodable {
-    var reportUrl: String?
+    var reportURL: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case reportURL = "report_url"
+    }
 }
 
 enum BugReportServiceError: LocalizedError {

--- a/UnitTests/Sources/BugReportScreenViewModelTests.swift
+++ b/UnitTests/Sources/BugReportScreenViewModelTests.swift
@@ -55,7 +55,7 @@ class BugReportScreenViewModelTests: XCTestCase {
         let mockService = BugReportServiceMock()
         mockService.submitBugReportProgressListenerClosure = { _, _ in
             await Task.yield()
-            return .success(SubmitBugReportResponse(reportUrl: "https://test.test"))
+            return .success(SubmitBugReportResponse(reportURL: "https://test.test"))
         }
         
         let clientProxy = ClientProxyMock(.init(userID: "@mock.client.com", deviceID: "ABCDEFGH"))

--- a/UnitTests/Sources/BugReportServiceTests.swift
+++ b/UnitTests/Sources/BugReportServiceTests.swift
@@ -17,7 +17,7 @@ class BugReportServiceTests: XCTestCase {
     override func setUpWithError() throws {
         let bugReportServiceMock = BugReportServiceMock()
         bugReportServiceMock.underlyingCrashedLastRun = false
-        bugReportServiceMock.submitBugReportProgressListenerReturnValue = .success(SubmitBugReportResponse(reportUrl: "https://www.example.com/123"))
+        bugReportServiceMock.submitBugReportProgressListenerReturnValue = .success(SubmitBugReportResponse(reportURL: "https://www.example.com/123"))
         bugReportService = bugReportServiceMock
     }
 
@@ -37,7 +37,8 @@ class BugReportServiceTests: XCTestCase {
                                   files: [])
         let progressSubject = CurrentValueSubject<Double, Never>(0.0)
         let response = try await bugReportService.submitBugReport(bugReport, progressListener: progressSubject).get()
-        XCTAssertFalse(response.reportUrl.isEmpty)
+        let reportURL = try XCTUnwrap(response.reportURL)
+        XCTAssertFalse(reportURL.isEmpty)
     }
     
     func testInitialStateWithRealService() throws {
@@ -82,7 +83,7 @@ class BugReportServiceTests: XCTestCase {
         let progressSubject = CurrentValueSubject<Double, Never>(0.0)
         let response = try await service.submitBugReport(bugReport, progressListener: progressSubject).get()
         
-        XCTAssertEqual(response.reportUrl, "https://example.com/123")
+        XCTAssertEqual(response.reportURL, "https://example.com/123")
     }
     
     func testLogsMaxSize() {


### PR DESCRIPTION
Contains a couple of tweaks on top of #4195

- Refactored `reportUrl` to `reportURL`.
- Silenced a warning from interpolating an optional value to a string.
- Stop checking the report URL before clearing the crash ID (if the code reaches that point, the submission was successful).

Rageshake API docs are here: https://github.com/matrix-org/rageshake/blob/main/docs/api.md