### PR TITLE
Add a section for pr-a11y in the release notes.

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -15,6 +15,9 @@ changelog:
     - title: 🗣 Translations
       labels:
         - pr-i18n
+    - title: 🦻 Accessibility
+      labels:
+        - pr-a11y
     - title: 🧱 Build
       labels:
         - pr-build


### PR DESCRIPTION
Looking at the release notes for 25.06.4 it became obvious that the `pr-a11y` doesn't have its own section.