### PR TITLE
Run Xcode select on the Translations and CalVer workflows.

### DIFF
--- a/.github/workflows/automatic-calendar-version.yml
+++ b/.github/workflows/automatic-calendar-version.yml
@@ -15,6 +15,11 @@ jobs:
     # Skip in forks
     if: github.repository == 'element-hq/element-x-ios'
     steps:
+      # While fastlane has its own way of selecting Xcode, that only works inside of fastlane.
+      # So we need to set it globally to allow other actions like our custom tools to use the same Xcode version.
+      - name: Select Xcode 16.3
+        run: sudo xcode-select -s /Applications/Xcode_16.3.app
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,7 +17,8 @@ jobs:
       cancel-in-progress: false
 
     steps:
-        # While fastlane has its own way of selecting Xcode, will only work inside fastlane, so we need to set it globally to allow other actions like xcresultparser to use the same Xcode version.
+      # While fastlane has its own way of selecting Xcode, that only works inside of fastlane.
+      # So we need to set it globally to allow other actions like xcresultparser to use the same Xcode version.
       - name: Select Xcode 16.3
         run: sudo xcode-select -s /Applications/Xcode_16.3.app
         

--- a/.github/workflows/translations-pr.yml
+++ b/.github/workflows/translations-pr.yml
@@ -11,6 +11,11 @@ jobs:
     # Skip in forks
     if: github.repository == 'element-hq/element-x-ios'
     steps:
+      # While fastlane has its own way of selecting Xcode, that only works inside of fastlane.
+      # So we need to set it globally to allow other actions like our custom tools to use the same Xcode version.
+      - name: Select Xcode 16.3
+        run: sudo xcode-select -s /Applications/Xcode_16.3.app
+      
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -25,7 +25,8 @@ jobs:
       cancel-in-progress: true
 
     steps:
-        # While fastlane has its own way of selecting Xcode, will only work inside fastlane, so we need to set it globally to allow other actions like xcresultparser to use the same Xcode version.
+      # While fastlane has its own way of selecting Xcode, that only works inside of fastlane.
+      # So we need to set it globally to allow other actions like xcresultparser to use the same Xcode version.
       - name: Select Xcode 16.3
         run: sudo xcode-select -s /Applications/Xcode_16.3.app
         

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -19,7 +19,8 @@ jobs:
       cancel-in-progress: true
 
     steps:
-    # While fastlane has its own way of selecting Xcode, will only work inside fastlane, so we need to set it globally to allow other actions like xcresultparser to use the same Xcode version.
+      # While fastlane has its own way of selecting Xcode, that only works inside of fastlane.
+      # So we need to set it globally to allow other actions like xcresultparser to use the same Xcode version.
       - name: Select Xcode 16.3
         run: sudo xcode-select -s /Applications/Xcode_16.3.app
         


### PR DESCRIPTION
Seems the Translations PR workflow was failing since bumping the Swift tools version to 6.1. This should fix that 🤞