### PR TITLE
Advertise support for `matrix` as a URL scheme.

### DIFF
--- a/ElementX/SupportingFiles/Info.plist
+++ b/ElementX/SupportingFiles/Info.plist
@@ -55,6 +55,7 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>$(BASE_BUNDLE_IDENTIFIER)</string>
+				<string>matrix</string>
 			</array>
 		</dict>
 	</array>

--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -62,7 +62,8 @@ targets:
             CFBundleTypeRole: Editor,
             CFBundleURLName: "Application",
             CFBundleURLSchemes: [
-              $(BASE_BUNDLE_IDENTIFIER)
+              $(BASE_BUNDLE_IDENTIFIER), # The app's own scheme for custom routes
+              "matrix" # Matrix URI scheme for permalinks
             ]
           }
         ]


### PR DESCRIPTION
Internally everything is already in place to handle Matrix URIs as we support them within the app. Fixes #4233.

https://github.com/user-attachments/assets/b07e18cf-d178-4f4c-b544-f55fd54cee98

