### PR TITLE
Adopt new `canOwnUser*` power level methods instead of the throwing ones

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -8748,7 +8748,7 @@
 			repositoryURL = "https://github.com/element-hq/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 25.06.25;
+				version = "25.06.25-2";
 			};
 		};
 		701C7BEF8F70F7A83E852DCC /* XCRemoteSwiftPackageReference "GZIP" */ = {

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -8748,7 +8748,7 @@
 			repositoryURL = "https://github.com/element-hq/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 25.06.24;
+				version = 25.06.25;
 			};
 		};
 		701C7BEF8F70F7A83E852DCC /* XCRemoteSwiftPackageReference "GZIP" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/matrix-rust-components-swift",
       "state" : {
-        "revision" : "f1fc74b64905ebde2f759916bf4018daf3406f40",
-        "version" : "25.6.24"
+        "revision" : "28083837b3c743eb76b23c12c6ef5873668190e6",
+        "version" : "25.6.25"
       }
     },
     {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/matrix-rust-components-swift",
       "state" : {
-        "revision" : "28083837b3c743eb76b23c12c6ef5873668190e6",
-        "version" : "25.6.25"
+        "revision" : "302397835194e0bb73de876dc2ef2d3e1a7c7740",
+        "version" : "25.6.25-2"
       }
     },
     {

--- a/ElementX/Sources/Mocks/BannedRoomProxyMock.swift
+++ b/ElementX/Sources/Mocks/BannedRoomProxyMock.swift
@@ -40,7 +40,6 @@ extension RoomInfoProxyMock {
         avatarURL = configuration.avatarURL
         
         isDirect = false
-        isPublic = false
         isSpace = false
         successor = nil
         isFavourite = false

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -13585,6 +13585,76 @@ class RoomPowerLevelsProxyMock: RoomPowerLevelsProxyProtocol, @unchecked Sendabl
     var underlyingValues: RoomPowerLevelsValues!
     var userPowerLevels: [String: Int64] = [:]
 
+    //MARK: - suggestedRole
+
+    var suggestedRoleForUserUnderlyingCallsCount = 0
+    var suggestedRoleForUserCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return suggestedRoleForUserUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = suggestedRoleForUserUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                suggestedRoleForUserUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    suggestedRoleForUserUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var suggestedRoleForUserCalled: Bool {
+        return suggestedRoleForUserCallsCount > 0
+    }
+    var suggestedRoleForUserReceivedUserID: String?
+    var suggestedRoleForUserReceivedInvocations: [String] = []
+
+    var suggestedRoleForUserUnderlyingReturnValue: RoomMemberRole!
+    var suggestedRoleForUserReturnValue: RoomMemberRole! {
+        get {
+            if Thread.isMainThread {
+                return suggestedRoleForUserUnderlyingReturnValue
+            } else {
+                var returnValue: RoomMemberRole? = nil
+                DispatchQueue.main.sync {
+                    returnValue = suggestedRoleForUserUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                suggestedRoleForUserUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    suggestedRoleForUserUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    var suggestedRoleForUserClosure: ((String) -> RoomMemberRole)?
+
+    func suggestedRole(forUser userID: String) -> RoomMemberRole {
+        suggestedRoleForUserCallsCount += 1
+        suggestedRoleForUserReceivedUserID = userID
+        DispatchQueue.main.async {
+            self.suggestedRoleForUserReceivedInvocations.append(userID)
+        }
+        if let suggestedRoleForUserClosure = suggestedRoleForUserClosure {
+            return suggestedRoleForUserClosure(userID)
+        } else {
+            return suggestedRoleForUserReturnValue
+        }
+    }
     //MARK: - canOwnUser
 
     var canOwnUserSendMessageUnderlyingCallsCount = 0

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -13427,16 +13427,6 @@ class RoomInfoProxyMock: RoomInfoProxyProtocol, @unchecked Sendable {
         set(value) { underlyingIsDirect = value }
     }
     var underlyingIsDirect: Bool!
-    var isPublic: Bool {
-        get { return underlyingIsPublic }
-        set(value) { underlyingIsPublic = value }
-    }
-    var underlyingIsPublic: Bool!
-    var isPrivate: Bool {
-        get { return underlyingIsPrivate }
-        set(value) { underlyingIsPrivate = value }
-    }
-    var underlyingIsPrivate: Bool!
     var isSpace: Bool {
         get { return underlyingIsSpace }
         set(value) { underlyingIsSpace = value }

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -8651,13 +8651,13 @@ class JoinedRoomProxyMock: JoinedRoomProxyProtocol, @unchecked Sendable {
         return powerLevelsCallsCount > 0
     }
 
-    var powerLevelsUnderlyingReturnValue: Result<RoomPowerLevelsProxyProtocol, RoomProxyError>!
-    var powerLevelsReturnValue: Result<RoomPowerLevelsProxyProtocol, RoomProxyError>! {
+    var powerLevelsUnderlyingReturnValue: Result<RoomPowerLevelsProxyProtocol?, RoomProxyError>!
+    var powerLevelsReturnValue: Result<RoomPowerLevelsProxyProtocol?, RoomProxyError>! {
         get {
             if Thread.isMainThread {
                 return powerLevelsUnderlyingReturnValue
             } else {
-                var returnValue: Result<RoomPowerLevelsProxyProtocol, RoomProxyError>? = nil
+                var returnValue: Result<RoomPowerLevelsProxyProtocol?, RoomProxyError>? = nil
                 DispatchQueue.main.sync {
                     returnValue = powerLevelsUnderlyingReturnValue
                 }
@@ -8675,9 +8675,9 @@ class JoinedRoomProxyMock: JoinedRoomProxyProtocol, @unchecked Sendable {
             }
         }
     }
-    var powerLevelsClosure: (() async -> Result<RoomPowerLevelsProxyProtocol, RoomProxyError>)?
+    var powerLevelsClosure: (() async -> Result<RoomPowerLevelsProxyProtocol?, RoomProxyError>)?
 
-    func powerLevels() async -> Result<RoomPowerLevelsProxyProtocol, RoomProxyError> {
+    func powerLevels() async -> Result<RoomPowerLevelsProxyProtocol?, RoomProxyError> {
         powerLevelsCallsCount += 1
         if let powerLevelsClosure = powerLevelsClosure {
             return await powerLevelsClosure()
@@ -13518,11 +13518,7 @@ class RoomInfoProxyMock: RoomInfoProxyProtocol, @unchecked Sendable {
         set(value) { underlyingHistoryVisibility = value }
     }
     var underlyingHistoryVisibility: RoomHistoryVisibility!
-    var powerLevels: RoomPowerLevelsProxyProtocol {
-        get { return underlyingPowerLevels }
-        set(value) { underlyingPowerLevels = value }
-    }
-    var underlyingPowerLevels: RoomPowerLevelsProxyProtocol!
+    var powerLevels: RoomPowerLevelsProxyProtocol?
     var successor: SuccessorRoom?
     var heroes: [RoomHero] = []
 
@@ -13587,6 +13583,7 @@ class RoomPowerLevelsProxyMock: RoomPowerLevelsProxyProtocol, @unchecked Sendabl
         set(value) { underlyingValues = value }
     }
     var underlyingValues: RoomPowerLevelsValues!
+    var userPowerLevels: [String: Int64] = [:]
 
     //MARK: - canOwnUser
 

--- a/ElementX/Sources/Mocks/InvitedRoomProxyMock.swift
+++ b/ElementX/Sources/Mocks/InvitedRoomProxyMock.swift
@@ -44,7 +44,6 @@ extension RoomInfoProxyMock {
         avatarURL = configuration.avatarURL
         
         isDirect = false
-        isPublic = false
         isSpace = false
         successor = nil
         isFavourite = false

--- a/ElementX/Sources/Mocks/JoinedRoomProxyMock.swift
+++ b/ElementX/Sources/Mocks/JoinedRoomProxyMock.swift
@@ -21,7 +21,6 @@ struct JoinedRoomProxyMockConfiguration {
     var avatarURL: URL?
     var isDirect = false
     var isSpace = false
-    var isPublic = false
     var isEncrypted = true
     var hasOngoingCall = true
     var canonicalAlias: String?
@@ -38,7 +37,7 @@ struct JoinedRoomProxyMockConfiguration {
     
     var shouldUseAutoUpdatingTimeline = false
     
-    var joinRule: JoinRule?
+    var joinRule: JoinRule? = .invite
     var membership: Membership = .joined
     
     var isVisibleInPublicDirectory = false
@@ -172,7 +171,6 @@ extension RoomInfoProxyMock {
         topic = configuration.topic
         avatarURL = configuration.avatarURL
         isDirect = configuration.isDirect
-        isPublic = configuration.isPublic
         isSpace = configuration.isSpace
         successor = configuration.successor
         isFavourite = false

--- a/ElementX/Sources/Mocks/JoinedRoomProxyMock.swift
+++ b/ElementX/Sources/Mocks/JoinedRoomProxyMock.swift
@@ -117,6 +117,14 @@ extension JoinedRoomProxyMock {
             self?.membersPublisher.value.first { $0.userID == configuration.ownUserID }?.role ?? .user != .user
         }
         
+        powerLevelsProxyMock.suggestedRoleForUserClosure = { [weak self] userID in
+            guard let member = self?.membersPublisher.value.first(where: { $0.userID == userID }) else {
+                return .user
+            }
+            
+            return member.role
+        }
+        
         powerLevelsReturnValue = .success(powerLevelsProxyMock)
         
         kickUserReasonReturnValue = .success(())

--- a/ElementX/Sources/Mocks/JoinedRoomProxyMock.swift
+++ b/ElementX/Sources/Mocks/JoinedRoomProxyMock.swift
@@ -99,11 +99,22 @@ extension JoinedRoomProxyMock {
         powerLevelsProxyMock.canUserUserIDSendStateEventClosure = { [weak self] userID, _ in
             .success(self?.membersPublisher.value.first { $0.userID == userID }?.role ?? .user != .user)
         }
+        powerLevelsProxyMock.canOwnUserSendStateEventClosure = { [weak self] _ in
+            self?.membersPublisher.value.first { $0.userID == configuration.ownUserID }?.role ?? .user != .user
+        }
+        
         powerLevelsProxyMock.canUserKickUserIDClosure = { [weak self] userID in
             .success(self?.membersPublisher.value.first { $0.userID == userID }?.role ?? .user != .user)
         }
+        powerLevelsProxyMock.canOwnUserKickClosure = { [weak self] in
+            self?.membersPublisher.value.first { $0.userID == configuration.ownUserID }?.role ?? .user != .user
+        }
+        
         powerLevelsProxyMock.canUserBanUserIDClosure = { [weak self] userID in
             .success(self?.membersPublisher.value.first { $0.userID == userID }?.role ?? .user != .user)
+        }
+        powerLevelsProxyMock.canOwnUserBanClosure = { [weak self] in
+            self?.membersPublisher.value.first { $0.userID == configuration.ownUserID }?.role ?? .user != .user
         }
         
         powerLevelsReturnValue = .success(powerLevelsProxyMock)

--- a/ElementX/Sources/Mocks/KnockedRoomProxyMock.swift
+++ b/ElementX/Sources/Mocks/KnockedRoomProxyMock.swift
@@ -40,7 +40,6 @@ extension RoomInfoProxyMock {
         avatarURL = configuration.avatarURL
         
         isDirect = false
-        isPublic = false
         isSpace = false
         successor = nil
         isFavourite = false

--- a/ElementX/Sources/Mocks/RoomPowerLevelsProxyMock.swift
+++ b/ElementX/Sources/Mocks/RoomPowerLevelsProxyMock.swift
@@ -26,6 +26,8 @@ extension RoomPowerLevelsProxyMock {
         
         underlyingValues = RoomPowerLevelsValues.mock
         
+        suggestedRoleForUserReturnValue = .administrator
+        
         canOwnUserSendMessageReturnValue = configuration.canUserSendMessage
         canOwnUserSendStateEventReturnValue = configuration.canUserSendState
         canOwnUserInviteReturnValue = configuration.canUserInvite

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -364,7 +364,7 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
                 return
             }
             
-            if roomProxy.infoPublisher.value.isPublic {
+            if !roomProxy.infoPublisher.value.isPrivate {
                 state.bindings.leaveRoomAlertItem = LeaveRoomAlertItem(roomID: roomID, isDM: roomProxy.isDirectOneToOneRoom, state: .public)
             } else {
                 state.bindings.leaveRoomAlertItem = if roomProxy.infoPublisher.value.joinedMembersCount > 1 {

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -364,7 +364,7 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
                 return
             }
             
-            if !roomProxy.infoPublisher.value.isPrivate {
+            if !(roomProxy.infoPublisher.value.isPrivate ?? true) {
                 state.bindings.leaveRoomAlertItem = LeaveRoomAlertItem(roomID: roomID, isDM: roomProxy.isDirectOneToOneRoom, state: .public)
             } else {
                 state.bindings.leaveRoomAlertItem = if roomProxy.infoPublisher.value.joinedMembersCount > 1 {

--- a/ElementX/Sources/Screens/KnockRequestsListScreen/KnockRequestsListScreenViewModel.swift
+++ b/ElementX/Sources/Screens/KnockRequestsListScreen/KnockRequestsListScreenViewModel.swift
@@ -218,9 +218,10 @@ class KnockRequestsListScreenViewModel: KnockRequestsListScreenViewModelType, Kn
             state.isKnockableRoom = false
         }
         
-        state.canAccept = roomInfo.powerLevels.canOwnUserInvite()
-        state.canDecline = roomInfo.powerLevels.canOwnUserKick()
-        state.canBan = roomInfo.powerLevels.canOwnUserBan()
+        guard let powerLevels = roomProxy.infoPublisher.value.powerLevels else { fatalError("Missing room power levels") }
+        state.canAccept = powerLevels.canOwnUserInvite()
+        state.canDecline = powerLevels.canOwnUserKick()
+        state.canBan = powerLevels.canOwnUserBan()
     }
     
     private static let loadingIndicatorIdentifier = "\(KnockRequestsListScreenViewModel.self)-Loading"

--- a/ElementX/Sources/Screens/KnockRequestsListScreen/KnockRequestsListScreenViewModel.swift
+++ b/ElementX/Sources/Screens/KnockRequestsListScreen/KnockRequestsListScreenViewModel.swift
@@ -218,9 +218,9 @@ class KnockRequestsListScreenViewModel: KnockRequestsListScreenViewModelType, Kn
             state.isKnockableRoom = false
         }
         
-        state.canAccept = (try? roomInfo.powerLevels.canUserInvite(userID: roomProxy.ownUserID).get()) == true
-        state.canDecline = (try? roomInfo.powerLevels.canUserKick(userID: roomProxy.ownUserID).get()) == true
-        state.canBan = (try? roomInfo.powerLevels.canUserBan(userID: roomProxy.ownUserID).get()) == true
+        state.canAccept = roomInfo.powerLevels.canOwnUserInvite()
+        state.canDecline = roomInfo.powerLevels.canOwnUserKick()
+        state.canBan = roomInfo.powerLevels.canOwnUserBan()
     }
     
     private static let loadingIndicatorIdentifier = "\(KnockRequestsListScreenViewModel.self)-Loading"

--- a/ElementX/Sources/Screens/RoomDetailsEditScreen/RoomDetailsEditScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomDetailsEditScreen/RoomDetailsEditScreenViewModel.swift
@@ -87,9 +87,9 @@ class RoomDetailsEditScreenViewModel: RoomDetailsEditScreenViewModelType, RoomDe
     // MARK: - Private
     
     private func updateRoomInfo(roomInfo: RoomInfoProxyProtocol) {
-        state.canEditAvatar = (try? roomInfo.powerLevels.canUser(userID: roomProxy.ownUserID, sendStateEvent: .roomAvatar).get()) == .some(true)
-        state.canEditName = (try? roomInfo.powerLevels.canUser(userID: roomProxy.ownUserID, sendStateEvent: .roomName).get()) == .some(true)
-        state.canEditTopic = (try? roomInfo.powerLevels.canUser(userID: roomProxy.ownUserID, sendStateEvent: .roomTopic).get()) == .some(true)
+        state.canEditAvatar = roomInfo.powerLevels.canOwnUser(sendStateEvent: .roomAvatar)
+        state.canEditName = roomInfo.powerLevels.canOwnUser(sendStateEvent: .roomName)
+        state.canEditTopic = roomInfo.powerLevels.canOwnUser(sendStateEvent: .roomTopic)
     }
     
     private func saveRoomDetails() {

--- a/ElementX/Sources/Screens/RoomDetailsEditScreen/RoomDetailsEditScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomDetailsEditScreen/RoomDetailsEditScreenViewModel.swift
@@ -87,9 +87,10 @@ class RoomDetailsEditScreenViewModel: RoomDetailsEditScreenViewModelType, RoomDe
     // MARK: - Private
     
     private func updateRoomInfo(roomInfo: RoomInfoProxyProtocol) {
-        state.canEditAvatar = roomInfo.powerLevels.canOwnUser(sendStateEvent: .roomAvatar)
-        state.canEditName = roomInfo.powerLevels.canOwnUser(sendStateEvent: .roomName)
-        state.canEditTopic = roomInfo.powerLevels.canOwnUser(sendStateEvent: .roomTopic)
+        guard let powerLevels = roomInfo.powerLevels else { fatalError("Missing room power levels") }
+        state.canEditAvatar = powerLevels.canOwnUser(sendStateEvent: .roomAvatar)
+        state.canEditName = powerLevels.canOwnUser(sendStateEvent: .roomName)
+        state.canEditTopic = powerLevels.canOwnUser(sendStateEvent: .roomTopic)
     }
     
     private func saveRoomDetails() {

--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
@@ -232,12 +232,9 @@ class RoomDetailsScreenViewModel: RoomDetailsScreenViewModelType, RoomDetailsScr
             state.canKickUsers = powerLevels.canOwnUserKick()
             state.canBanUsers = powerLevels.canOwnUserBan()
             state.canJoinCall = powerLevels.canOwnUserJoinCall()
+            state.canEditRolesOrPermissions = powerLevels.suggestedRole(forUser: roomProxy.ownUserID) == .administrator
         } else {
             fatalError("Missing room power levels")
-        }
-        
-        Task {
-            state.canEditRolesOrPermissions = await (try? roomProxy.suggestedRole(for: roomProxy.ownUserID).get()) == .administrator
         }
     }
     

--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
@@ -125,7 +125,7 @@ class RoomDetailsScreenViewModel: RoomDetailsScreenViewModelType, RoomDetailsScr
             }
             state.bindings.leaveRoomAlertItem = LeaveRoomAlertItem(roomID: roomProxy.id,
                                                                    isDM: roomProxy.isDirectOneToOneRoom,
-                                                                   state: roomProxy.infoPublisher.value.isPublic ? .public : .private)
+                                                                   state: roomProxy.infoPublisher.value.isPrivate ? .private : .public)
         case .confirmLeave:
             Task { await leaveRoom() }
         case .processTapIgnore:

--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
@@ -125,7 +125,7 @@ class RoomDetailsScreenViewModel: RoomDetailsScreenViewModelType, RoomDetailsScr
             }
             state.bindings.leaveRoomAlertItem = LeaveRoomAlertItem(roomID: roomProxy.id,
                                                                    isDM: roomProxy.isDirectOneToOneRoom,
-                                                                   state: roomProxy.infoPublisher.value.isPrivate ? .private : .public)
+                                                                   state: roomProxy.infoPublisher.value.isPrivate ?? true ? .private : .public)
         case .confirmLeave:
             Task { await leaveRoom() }
         case .processTapIgnore:

--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
@@ -224,13 +224,17 @@ class RoomDetailsScreenViewModel: RoomDetailsScreenViewModelType, RoomDetailsScr
             state.isKnockableRoom = false
         }
         
-        state.canEditRoomName = roomInfo.powerLevels.canOwnUser(sendStateEvent: .roomName)
-        state.canEditRoomTopic = roomInfo.powerLevels.canOwnUser(sendStateEvent: .roomTopic)
-        state.canEditRoomAvatar = roomInfo.powerLevels.canOwnUser(sendStateEvent: .roomAvatar)
-        state.canInviteUsers = roomInfo.powerLevels.canOwnUserInvite()
-        state.canKickUsers = roomInfo.powerLevels.canOwnUserKick()
-        state.canBanUsers = roomInfo.powerLevels.canOwnUserBan()
-        state.canJoinCall = roomInfo.powerLevels.canOwnUserJoinCall()
+        if let powerLevels = roomInfo.powerLevels {
+            state.canEditRoomName = powerLevels.canOwnUser(sendStateEvent: .roomName)
+            state.canEditRoomTopic = powerLevels.canOwnUser(sendStateEvent: .roomTopic)
+            state.canEditRoomAvatar = powerLevels.canOwnUser(sendStateEvent: .roomAvatar)
+            state.canInviteUsers = powerLevels.canOwnUserInvite()
+            state.canKickUsers = powerLevels.canOwnUserKick()
+            state.canBanUsers = powerLevels.canOwnUserBan()
+            state.canJoinCall = powerLevels.canOwnUserJoinCall()
+        } else {
+            fatalError("Missing room power levels")
+        }
         
         Task {
             state.canEditRolesOrPermissions = await (try? roomProxy.suggestedRole(for: roomProxy.ownUserID).get()) == .administrator

--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
@@ -224,13 +224,13 @@ class RoomDetailsScreenViewModel: RoomDetailsScreenViewModelType, RoomDetailsScr
             state.isKnockableRoom = false
         }
         
-        state.canEditRoomName = (try? roomInfo.powerLevels.canUser(userID: roomProxy.ownUserID, sendStateEvent: .roomName).get()) == true
-        state.canEditRoomTopic = (try? roomInfo.powerLevels.canUser(userID: roomProxy.ownUserID, sendStateEvent: .roomTopic).get()) == true
-        state.canEditRoomAvatar = (try? roomInfo.powerLevels.canUser(userID: roomProxy.ownUserID, sendStateEvent: .roomAvatar).get()) == true
-        state.canInviteUsers = (try? roomInfo.powerLevels.canUserInvite(userID: roomProxy.ownUserID).get()) == true
-        state.canKickUsers = (try? roomInfo.powerLevels.canUserKick(userID: roomProxy.ownUserID).get()) == true
-        state.canBanUsers = (try? roomInfo.powerLevels.canUserBan(userID: roomProxy.ownUserID).get()) == true
-        state.canJoinCall = (try? roomInfo.powerLevels.canUserJoinCall(userID: roomProxy.ownUserID).get()) == true
+        state.canEditRoomName = roomInfo.powerLevels.canOwnUser(sendStateEvent: .roomName)
+        state.canEditRoomTopic = roomInfo.powerLevels.canOwnUser(sendStateEvent: .roomTopic)
+        state.canEditRoomAvatar = roomInfo.powerLevels.canOwnUser(sendStateEvent: .roomAvatar)
+        state.canInviteUsers = roomInfo.powerLevels.canOwnUserInvite()
+        state.canKickUsers = roomInfo.powerLevels.canOwnUserKick()
+        state.canBanUsers = roomInfo.powerLevels.canOwnUserBan()
+        state.canJoinCall = roomInfo.powerLevels.canOwnUserJoinCall()
         
         Task {
             state.canEditRolesOrPermissions = await (try? roomProxy.suggestedRole(for: roomProxy.ownUserID).get()) == .administrator

--- a/ElementX/Sources/Screens/RoomDetailsScreen/View/RoomDetailsScreen.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/View/RoomDetailsScreen.swift
@@ -338,13 +338,13 @@ struct RoomDetailsScreen_Previews: PreviewProvider, TestablePreview {
     static var previews: some View {
         RoomDetailsScreen(context: genericRoomViewModel.context)
             .snapshotPreferences(expect: genericRoomViewModel.context.$viewState.map { state in
-                state.canSeeSecurityAndPrivacy == true
+                state.permalink != nil
             })
             .previewDisplayName("Generic Room")
         
         RoomDetailsScreen(context: simpleRoomViewModel.context)
             .snapshotPreferences(expect: simpleRoomViewModel.context.$viewState.map { state in
-                state.canSeeSecurityAndPrivacy == true
+                state.permalink != nil
             })
             .previewDisplayName("Simple Room")
         
@@ -356,7 +356,7 @@ struct RoomDetailsScreen_Previews: PreviewProvider, TestablePreview {
         
         RoomDetailsScreen(context: dmRoomVerifiedViewModel.context)
             .snapshotPreferences(expect: dmRoomVerifiedViewModel.context.$viewState.map { state in
-                state.accountOwner != nil
+                state.dmRecipientInfo?.verificationState == .verified
             })
             .previewDisplayName("DM Room Verified")
         

--- a/ElementX/Sources/Screens/RoomMemberListScreen/RoomMembersListScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomMemberListScreen/RoomMembersListScreenViewModel.swift
@@ -88,6 +88,10 @@ class RoomMembersListScreenViewModel: RoomMembersListScreenViewModelType, RoomMe
         Task {
             showLoadingIndicator(Self.updateStateLoadingIndicatorIdentifier)
             
+            defer {
+                hideLoadingIndicator(Self.updateStateLoadingIndicatorIdentifier)
+            }
+            
             let members = members.sorted()
             let roomMembersDetails = await buildMembersDetails(members: members)
             self.members = members
@@ -99,12 +103,10 @@ class RoomMembersListScreenViewModel: RoomMembersListScreenViewModelType, RoomMe
                                bannedMembers: roomMembersDetails.bannedMembers,
                                bindings: state.bindings)
             
-            let powerLevels = roomProxy.infoPublisher.value.powerLevels
+            guard let powerLevels = roomProxy.infoPublisher.value.powerLevels else { fatalError("Missing room power levels") }
             self.state.canInviteUsers = powerLevels.canOwnUserInvite()
             self.state.canKickUsers = powerLevels.canOwnUserKick()
             self.state.canBanUsers = powerLevels.canOwnUserBan()
-                        
-            hideLoadingIndicator(Self.updateStateLoadingIndicatorIdentifier)
         }
     }
     

--- a/ElementX/Sources/Screens/RoomMemberListScreen/RoomMembersListScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomMemberListScreen/RoomMembersListScreenViewModel.swift
@@ -100,9 +100,9 @@ class RoomMembersListScreenViewModel: RoomMembersListScreenViewModelType, RoomMe
                                bindings: state.bindings)
             
             let powerLevels = roomProxy.infoPublisher.value.powerLevels
-            self.state.canInviteUsers = (try? powerLevels.canUserInvite(userID: roomProxy.ownUserID).get()) == true
-            self.state.canKickUsers = (try? powerLevels.canUserKick(userID: roomProxy.ownUserID).get()) == true
-            self.state.canBanUsers = (try? powerLevels.canUserBan(userID: roomProxy.ownUserID).get()) == true
+            self.state.canInviteUsers = powerLevels.canOwnUserInvite()
+            self.state.canKickUsers = powerLevels.canOwnUserKick()
+            self.state.canBanUsers = powerLevels.canOwnUserBan()
                         
             hideLoadingIndicator(Self.updateStateLoadingIndicatorIdentifier)
         }

--- a/ElementX/Sources/Screens/RoomRolesAndPermissionsScreen/RoomRolesAndPermissionsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomRolesAndPermissionsScreen/RoomRolesAndPermissionsScreenViewModel.swift
@@ -114,7 +114,8 @@ class RoomRolesAndPermissionsScreenViewModel: RoomRolesAndPermissionsScreenViewM
     // MARK: - Permissions
     
     private func updateRoomInfo(roomInfo: RoomInfoProxyProtocol) {
-        state.permissions = .init(powerLevels: roomInfo.powerLevels.values)
+        guard let powerLevels = roomInfo.powerLevels else { fatalError("Missing room power levels") }
+        state.permissions = .init(powerLevels: powerLevels.values)
     }
     
     private func editPermissions(group: RoomRolesAndPermissionsScreenPermissionsGroup) {

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/CompletionSuggestionService.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/CompletionSuggestionService.swift
@@ -47,7 +47,7 @@ final class CompletionSuggestionService: CompletionSuggestionServiceProtocol {
                 self?.suggestionTriggerSubject.value != nil ? .milliseconds(500) : .milliseconds(0)
             }
         
-        canMentionAllUsers = (try? roomProxy.infoPublisher.value.powerLevels.canUserTriggerRoomNotification(userID: roomProxy.ownUserID).get()) == true
+        canMentionAllUsers = roomProxy.infoPublisher.value.powerLevels.canOwnUserTriggerRoomNotification()
     }
     
     func processTextMessage(_ textMessage: String, selectedRange: NSRange) {

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/CompletionSuggestionService.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/CompletionSuggestionService.swift
@@ -47,7 +47,8 @@ final class CompletionSuggestionService: CompletionSuggestionServiceProtocol {
                 self?.suggestionTriggerSubject.value != nil ? .milliseconds(500) : .milliseconds(0)
             }
         
-        canMentionAllUsers = roomProxy.infoPublisher.value.powerLevels.canOwnUserTriggerRoomNotification()
+        guard let powerLevels = roomProxy.infoPublisher.value.powerLevels else { fatalError("Missing room power levels") }
+        canMentionAllUsers = powerLevels.canOwnUserTriggerRoomNotification()
     }
     
     func processTextMessage(_ textMessage: String, selectedRange: NSRange) {

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -348,11 +348,12 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
             state.isKnockableRoom = false
         }
 
-        state.canSendMessage = roomInfo.powerLevels.canOwnUser(sendMessage: .roomMessage)
-        state.canJoinCall = roomInfo.powerLevels.canOwnUserJoinCall()
-        state.canAcceptKnocks = roomInfo.powerLevels.canOwnUserInvite()
-        state.canDeclineKnocks = roomInfo.powerLevels.canOwnUserKick()
-        state.canBan = roomInfo.powerLevels.canOwnUserBan()
+        guard let powerLevels = roomInfo.powerLevels else { fatalError("Missing room power levels") }
+        state.canSendMessage = powerLevels.canOwnUser(sendMessage: .roomMessage)
+        state.canJoinCall = powerLevels.canOwnUserJoinCall()
+        state.canAcceptKnocks = powerLevels.canOwnUserInvite()
+        state.canDeclineKnocks = powerLevels.canOwnUserKick()
+        state.canBan = powerLevels.canOwnUserBan()
     }
     
     private func setupPinnedEventsTimelineItemProviderIfNeeded() {

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -348,11 +348,11 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
             state.isKnockableRoom = false
         }
 
-        state.canSendMessage = (try? roomInfo.powerLevels.canUser(userID: roomProxy.ownUserID, sendMessage: .roomMessage).get()) == true
-        state.canJoinCall = (try? roomInfo.powerLevels.canUserJoinCall(userID: roomProxy.ownUserID).get()) == true
-        state.canAcceptKnocks = (try? roomInfo.powerLevels.canUserInvite(userID: roomProxy.ownUserID).get()) == true
-        state.canDeclineKnocks = (try? roomInfo.powerLevels.canUserKick(userID: roomProxy.ownUserID).get()) == true
-        state.canBan = (try? roomInfo.powerLevels.canUserBan(userID: roomProxy.ownUserID).get()) == true
+        state.canSendMessage = roomInfo.powerLevels.canOwnUser(sendMessage: .roomMessage)
+        state.canJoinCall = roomInfo.powerLevels.canOwnUserJoinCall()
+        state.canAcceptKnocks = roomInfo.powerLevels.canOwnUserInvite()
+        state.canDeclineKnocks = roomInfo.powerLevels.canOwnUserKick()
+        state.canBan = roomInfo.powerLevels.canOwnUserBan()
     }
     
     private func setupPinnedEventsTimelineItemProviderIfNeeded() {

--- a/ElementX/Sources/Screens/ThreadTimelineScreen/ThreadTimelineScreenViewModel.swift
+++ b/ElementX/Sources/Screens/ThreadTimelineScreen/ThreadTimelineScreenViewModel.swift
@@ -63,6 +63,6 @@ class ThreadTimelineScreenViewModel: ThreadTimelineScreenViewModelType, ThreadTi
     // MARK: - Private
     
     private func handleRoomInfoUpdate(_ roomInfo: RoomInfoProxyProtocol) {
-        state.canSendMessage = (try? roomInfo.powerLevels.canUser(userID: roomProxy.ownUserID, sendMessage: .roomMessage).get()) == true
+        state.canSendMessage = roomInfo.powerLevels.canOwnUser(sendMessage: .roomMessage)
     }
 }

--- a/ElementX/Sources/Screens/ThreadTimelineScreen/ThreadTimelineScreenViewModel.swift
+++ b/ElementX/Sources/Screens/ThreadTimelineScreen/ThreadTimelineScreenViewModel.swift
@@ -63,6 +63,7 @@ class ThreadTimelineScreenViewModel: ThreadTimelineScreenViewModelType, ThreadTi
     // MARK: - Private
     
     private func handleRoomInfoUpdate(_ roomInfo: RoomInfoProxyProtocol) {
-        state.canSendMessage = roomInfo.powerLevels.canOwnUser(sendMessage: .roomMessage)
+        guard let powerLevels = roomInfo.powerLevels else { fatalError("Missing room power levels") }
+        state.canSendMessage = powerLevels.canOwnUser(sendMessage: .roomMessage)
     }
 }

--- a/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
@@ -405,12 +405,12 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
     private func updateRoomInfo(roomInfo: RoomInfoProxyProtocol) {
         state.pinnedEventIDs = roomInfo.pinnedEventIDs
         
-        state.canCurrentUserSendMessage = (try? roomInfo.powerLevels.canUser(userID: roomProxy.ownUserID, sendMessage: .roomMessage).get()) == true
-        state.canCurrentUserRedactOthers = (try? roomInfo.powerLevels.canUserRedactOther(userID: roomProxy.ownUserID).get()) == true
-        state.canCurrentUserRedactSelf = (try? roomInfo.powerLevels.canUserRedactOwn(userID: roomProxy.ownUserID).get()) == true
-        state.canCurrentUserPin = (try? roomInfo.powerLevels.canUserPinOrUnpin(userID: roomProxy.ownUserID).get()) == true
-        state.canCurrentUserKick = (try? roomInfo.powerLevels.canUserKick(userID: roomProxy.ownUserID).get()) == true
-        state.canCurrentUserBan = (try? roomInfo.powerLevels.canUserBan(userID: roomProxy.ownUserID).get()) == true
+        state.canCurrentUserSendMessage = roomInfo.powerLevels.canOwnUser(sendMessage: .roomMessage)
+        state.canCurrentUserRedactOthers = roomInfo.powerLevels.canOwnUserRedactOther()
+        state.canCurrentUserRedactSelf = roomInfo.powerLevels.canOwnUserRedactOwn()
+        state.canCurrentUserPin = roomInfo.powerLevels.canOwnUserPinOrUnpin()
+        state.canCurrentUserKick = roomInfo.powerLevels.canOwnUserKick()
+        state.canCurrentUserBan = roomInfo.powerLevels.canOwnUserBan()
     }
     
     private func setupSubscriptions() {

--- a/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
@@ -92,7 +92,7 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
         case .always:
             false
         case .privateOnly:
-            !roomProxy.infoPublisher.value.isPrivate
+            !(roomProxy.infoPublisher.value.isPrivate ?? true)
         case .never:
             true
         }
@@ -524,7 +524,7 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
                 case .privateOnly:
                     guard let self else { return Just(false).eraseToAnyPublisher() }
                     return roomProxy.infoPublisher
-                        .map { !$0.isPrivate }
+                        .map { !($0.isPrivate ?? false) }
                         .removeDuplicates()
                         .eraseToAnyPublisher()
                 }

--- a/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
@@ -405,12 +405,13 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
     private func updateRoomInfo(roomInfo: RoomInfoProxyProtocol) {
         state.pinnedEventIDs = roomInfo.pinnedEventIDs
         
-        state.canCurrentUserSendMessage = roomInfo.powerLevels.canOwnUser(sendMessage: .roomMessage)
-        state.canCurrentUserRedactOthers = roomInfo.powerLevels.canOwnUserRedactOther()
-        state.canCurrentUserRedactSelf = roomInfo.powerLevels.canOwnUserRedactOwn()
-        state.canCurrentUserPin = roomInfo.powerLevels.canOwnUserPinOrUnpin()
-        state.canCurrentUserKick = roomInfo.powerLevels.canOwnUserKick()
-        state.canCurrentUserBan = roomInfo.powerLevels.canOwnUserBan()
+        guard let powerLevels = roomInfo.powerLevels else { fatalError("Missing room power levels") }
+        state.canCurrentUserSendMessage = powerLevels.canOwnUser(sendMessage: .roomMessage)
+        state.canCurrentUserRedactOthers = powerLevels.canOwnUserRedactOther()
+        state.canCurrentUserRedactSelf = powerLevels.canOwnUserRedactOwn()
+        state.canCurrentUserPin = powerLevels.canOwnUserPinOrUnpin()
+        state.canCurrentUserKick = powerLevels.canOwnUserKick()
+        state.canCurrentUserBan = powerLevels.canOwnUserBan()
     }
     
     private func setupSubscriptions() {

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -752,7 +752,7 @@ class ClientProxy: ClientProxyProtocol {
     
     func clearCaches() async -> Result<Void, ClientProxyError> {
         do {
-            return try await .success(client.clearCaches())
+            return try await .success(client.clearCaches(syncService: syncService))
         } catch {
             MXLog.error("Failed clearing client caches with error: \(error)")
             return .failure(.sdkError(error))

--- a/ElementX/Sources/Services/ElementCall/ElementCallWidgetDriver.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallWidgetDriver.swift
@@ -82,6 +82,7 @@ class ElementCallWidgetDriver: WidgetCapabilitiesProvider, ElementCallWidgetDriv
             widgetSettings = try newVirtualElementCallWidget(props: .init(elementCallUrl: baseURL.absoluteString,
                                                                           widgetId: widgetID,
                                                                           parentUrl: nil,
+                                                                          header: .appBar,
                                                                           hideHeader: nil,
                                                                           preload: nil,
                                                                           fontScale: nil,

--- a/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
@@ -552,7 +552,7 @@ class JoinedRoomProxy: JoinedRoomProxyProtocol {
     
     // MARK: - Power Levels
     
-    func powerLevels() async -> Result<RoomPowerLevelsProxyProtocol, RoomProxyError> {
+    func powerLevels() async -> Result<RoomPowerLevelsProxyProtocol?, RoomProxyError> {
         do {
             return try await .success(RoomPowerLevelsProxy(room.getPowerLevels()))
         } catch {

--- a/ElementX/Sources/Services/Room/RoomInfoProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomInfoProxy.swift
@@ -27,9 +27,8 @@ struct RoomInfoProxy: RoomInfoProxyProtocol {
     var isEncrypted: Bool { roomInfo.encryptionState == .encrypted }
     
     var isDirect: Bool { roomInfo.isDirect }
-    var isPublic: Bool { roomInfo.isPublic }
-    
     var isSpace: Bool { roomInfo.isSpace }
+    
     var successor: SuccessorRoom? { roomInfo.successorRoom }
     var isFavourite: Bool { roomInfo.isFavourite }
     var canonicalAlias: String? { roomInfo.canonicalAlias }
@@ -72,6 +71,6 @@ struct RoomPreviewInfoProxy: BaseRoomInfoProxyProtocol {
     var activeMembersCount: Int { Int(roomPreviewInfo.numActiveMembers ?? roomPreviewInfo.numJoinedMembers) }
     var joinedMembersCount: Int { Int(roomPreviewInfo.numJoinedMembers) }
     
-    var joinRule: JoinRule { roomPreviewInfo.joinRule }
+    var joinRule: JoinRule? { roomPreviewInfo.joinRule }
     var membership: Membership? { roomPreviewInfo.membership }
 }

--- a/ElementX/Sources/Services/Room/RoomInfoProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomInfoProxy.swift
@@ -53,7 +53,7 @@ struct RoomInfoProxy: RoomInfoProxyProtocol {
     var joinRule: JoinRule? { roomInfo.joinRule }
     var historyVisibility: RoomHistoryVisibility { roomInfo.historyVisibility }
     
-    var powerLevels: RoomPowerLevelsProxyProtocol { RoomPowerLevelsProxy(roomInfo.powerLevels) }
+    var powerLevels: RoomPowerLevelsProxyProtocol? { RoomPowerLevelsProxy(roomInfo.powerLevels) }
 }
 
 struct RoomPreviewInfoProxy: BaseRoomInfoProxyProtocol {

--- a/ElementX/Sources/Services/Room/RoomInfoProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomInfoProxyProtocol.swift
@@ -79,12 +79,18 @@ extension BaseRoomInfoProxyProtocol {
 
 extension RoomInfoProxyProtocol {
     /// A room might be non public but also not private given the fact that the join rule might be missing or unsupported.
-    var isPrivate: Bool {
-        switch joinRule {
-        case .invite, .knock, .restricted, .knockRestricted:
+    var isPrivate: Bool? {
+        guard let joinRule else {
+            return nil
+        }
+        
+        return switch joinRule {
+        case .invite, .knock, .restricted, .knockRestricted, .private:
             true
-        default:
+        case .public:
             false
+        case .custom: // We don't know how to handle this
+            nil
         }
     }
     

--- a/ElementX/Sources/Services/Room/RoomInfoProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomInfoProxyProtocol.swift
@@ -35,13 +35,9 @@ protocol RoomInfoProxyProtocol: BaseRoomInfoProxyProtocol {
 
     var isEncrypted: Bool { get }
     var isDirect: Bool { get }
-    var isPublic: Bool { get }
-    
-    var isPrivate: Bool { get }
-    
     var isSpace: Bool { get }
-    
     var isFavourite: Bool { get }
+    
     var canonicalAlias: String? { get }
     var alternativeAliases: [String] { get }
     var membership: Membership { get }

--- a/ElementX/Sources/Services/Room/RoomInfoProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomInfoProxyProtocol.swift
@@ -63,7 +63,7 @@ protocol RoomInfoProxyProtocol: BaseRoomInfoProxyProtocol {
     var joinRule: JoinRule? { get }
     var historyVisibility: RoomHistoryVisibility { get }
     
-    var powerLevels: RoomPowerLevelsProxyProtocol { get }
+    var powerLevels: RoomPowerLevelsProxyProtocol? { get }
 }
 
 extension BaseRoomInfoProxyProtocol {

--- a/ElementX/Sources/Services/Room/RoomPowerLevelProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomPowerLevelProxyProtocol.swift
@@ -11,6 +11,8 @@ import MatrixRustSDK
 protocol RoomPowerLevelsProxyProtocol {
     var values: RoomPowerLevelsValues { get }
     
+    var userPowerLevels: [String: Int64] { get }
+    
     func canOwnUser(sendMessage messageType: MessageLikeEventType) -> Bool
     func canOwnUser(sendStateEvent event: StateEventType) -> Bool
     func canOwnUserInvite() -> Bool

--- a/ElementX/Sources/Services/Room/RoomPowerLevelProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomPowerLevelProxyProtocol.swift
@@ -10,8 +10,9 @@ import MatrixRustSDK
 // sourcery: AutoMockable
 protocol RoomPowerLevelsProxyProtocol {
     var values: RoomPowerLevelsValues { get }
-    
     var userPowerLevels: [String: Int64] { get }
+    
+    func suggestedRole(forUser userID: String) -> RoomMemberRole
     
     func canOwnUser(sendMessage messageType: MessageLikeEventType) -> Bool
     func canOwnUser(sendStateEvent event: StateEventType) -> Bool

--- a/ElementX/Sources/Services/Room/RoomPowerLevelsProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomPowerLevelsProxy.swift
@@ -26,6 +26,11 @@ struct RoomPowerLevelsProxy: RoomPowerLevelsProxyProtocol {
         powerLevels.userPowerLevels()
     }
     
+    func suggestedRole(forUser userID: String) -> RoomMemberRole {
+        let powerLevel = powerLevels.userPowerLevels()[userID] ?? 0
+        return suggestedRoleForPowerLevel(powerLevel: powerLevel)
+    }
+    
     func canOwnUser(sendMessage messageType: MessageLikeEventType) -> Bool {
         powerLevels.canOwnUserSendMessage(message: messageType)
     }

--- a/ElementX/Sources/Services/Room/RoomPowerLevelsProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomPowerLevelsProxy.swift
@@ -10,12 +10,20 @@ import MatrixRustSDK
 struct RoomPowerLevelsProxy: RoomPowerLevelsProxyProtocol {
     private let powerLevels: RoomPowerLevels
     
-    init(_ powerLevels: RoomPowerLevels) {
+    init?(_ powerLevels: RoomPowerLevels?) {
+        guard let powerLevels else {
+            return nil
+        }
+        
         self.powerLevels = powerLevels
     }
     
     var values: RoomPowerLevelsValues {
         powerLevels.values()
+    }
+    
+    var userPowerLevels: [String: Int64] {
+        powerLevels.userPowerLevels()
     }
     
     func canOwnUser(sendMessage messageType: MessageLikeEventType) -> Bool {

--- a/ElementX/Sources/Services/Room/RoomPowerLevelsProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomPowerLevelsProxy.swift
@@ -27,7 +27,7 @@ struct RoomPowerLevelsProxy: RoomPowerLevelsProxyProtocol {
     }
     
     func suggestedRole(forUser userID: String) -> RoomMemberRole {
-        let powerLevel = powerLevels.userPowerLevels()[userID] ?? 0
+        let powerLevel = powerLevels.userPowerLevels()[userID] ?? values.usersDefault
         return suggestedRoleForPowerLevel(powerLevel: powerLevel)
     }
     

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -188,7 +188,7 @@ extension JoinedRoomProxyProtocol {
                     avatar: infoPublisher.value.avatar,
                     canonicalAlias: infoPublisher.value.canonicalAlias,
                     isEncrypted: infoPublisher.value.isEncrypted,
-                    isPublic: infoPublisher.value.isPublic,
+                    isPublic: !infoPublisher.value.isPrivate,
                     isDirect: infoPublisher.value.isDirect)
     }
     

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -188,7 +188,7 @@ extension JoinedRoomProxyProtocol {
                     avatar: infoPublisher.value.avatar,
                     canonicalAlias: infoPublisher.value.canonicalAlias,
                     isEncrypted: infoPublisher.value.isEncrypted,
-                    isPublic: !infoPublisher.value.isPrivate,
+                    isPublic: !(infoPublisher.value.isPrivate ?? false),
                     isDirect: infoPublisher.value.isDirect)
     }
     

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -152,7 +152,7 @@ protocol JoinedRoomProxyProtocol: RoomProxyProtocol {
     
     // MARK: - Power Levels
     
-    func powerLevels() async -> Result<RoomPowerLevelsProxyProtocol, RoomProxyError>
+    func powerLevels() async -> Result<RoomPowerLevelsProxyProtocol?, RoomProxyError>
     func applyPowerLevelChanges(_ changes: RoomPowerLevelChanges) async -> Result<Void, RoomProxyError>
     func resetPowerLevels() async -> Result<Void, RoomProxyError>
     func suggestedRole(for userID: String) async -> Result<RoomMemberRole, RoomProxyError>

--- a/UnitTests/Sources/RoomDetailsViewModelTests.swift
+++ b/UnitTests/Sources/RoomDetailsViewModelTests.swift
@@ -367,6 +367,9 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
         powerLevelsProxyMock.canUserUserIDSendStateEventClosure = { _, event in
             .success(event == .roomAvatar)
         }
+        powerLevelsProxyMock.canOwnUserSendStateEventClosure = { event in
+            event == .roomAvatar
+        }
         roomProxyMock.powerLevelsReturnValue = .success(powerLevelsProxyMock)
         
         let roomInfoProxyMock = RoomInfoProxyMock(configuration)
@@ -405,6 +408,9 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
         powerLevelsProxyMock.canUserUserIDSendStateEventClosure = { _, event in
             .success(event == .roomName)
         }
+        powerLevelsProxyMock.canOwnUserSendStateEventClosure = { event in
+            event == .roomName
+        }
         roomProxyMock.powerLevelsReturnValue = .success(powerLevelsProxyMock)
         
         let roomInfoProxyMock = RoomInfoProxyMock(configuration)
@@ -442,6 +448,9 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
         let powerLevelsProxyMock = RoomPowerLevelsProxyMock(configuration: .init())
         powerLevelsProxyMock.canUserUserIDSendStateEventClosure = { _, event in
             .success(event == .roomTopic)
+        }
+        powerLevelsProxyMock.canOwnUserSendStateEventClosure = { event in
+            event == .roomTopic
         }
         roomProxyMock.powerLevelsReturnValue = .success(powerLevelsProxyMock)
         

--- a/UnitTests/Sources/RoomDetailsViewModelTests.swift
+++ b/UnitTests/Sources/RoomDetailsViewModelTests.swift
@@ -38,7 +38,7 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
     
     func testLeaveRoomTappedWhenPublic() async throws {
         let mockedMembers: [RoomMemberProxyMock] = [.mockBob, .mockAlice]
-        roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", isPublic: true, members: mockedMembers))
+        roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", members: mockedMembers, joinRule: .public))
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                clientProxy: ClientProxyMock(.init()),
                                                mediaProvider: MediaProviderMock(configuration: .init()),
@@ -61,7 +61,7 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
     
     func testLeaveRoomTappedWhenRoomNotPublic() async throws {
         let mockedMembers: [RoomMemberProxyMock] = [.mockBob, .mockAlice]
-        roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", isPublic: false, members: mockedMembers))
+        roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", members: mockedMembers))
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                clientProxy: ClientProxyMock(.init()),
                                                mediaProvider: MediaProviderMock(configuration: .init()),
@@ -85,7 +85,7 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
     
     func testLeaveRoomTappedWithLessThanTwoMembers() async {
         let mockedMembers: [RoomMemberProxyMock] = [.mockAlice]
-        roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", isPublic: false, members: mockedMembers))
+        roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", members: mockedMembers))
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                clientProxy: ClientProxyMock(.init()),
                                                mediaProvider: MediaProviderMock(configuration: .init()),
@@ -301,8 +301,8 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
     func testCannotInvitePeople() async {
         let mockedMembers: [RoomMemberProxyMock] = [.mockMe, .mockAlice]
         roomProxyMock = JoinedRoomProxyMock(.init(name: "Test",
-                                                  isPublic: true,
                                                   members: mockedMembers,
+                                                  joinRule: .public,
                                                   powerLevelsConfiguration: .init(canUserInvite: false)))
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                clientProxy: ClientProxyMock(.init()),
@@ -321,7 +321,7 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
     
     func testInvitePeople() async {
         let mockedMembers: [RoomMemberProxyMock] = [.mockMe, .mockBob, .mockAlice]
-        roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", isPublic: true, members: mockedMembers))
+        roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", members: mockedMembers, joinRule: .public))
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                clientProxy: ClientProxyMock(.init()),
                                                mediaProvider: MediaProviderMock(configuration: .init()),
@@ -358,7 +358,6 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
         
         let configuration = JoinedRoomProxyMockConfiguration(name: "Test",
                                                              isDirect: false,
-                                                             isPublic: false,
                                                              members: mockedMembers)
         
         roomProxyMock = JoinedRoomProxyMock(configuration)
@@ -399,7 +398,6 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
         
         let configuration = JoinedRoomProxyMockConfiguration(name: "Test",
                                                              isDirect: false,
-                                                             isPublic: false,
                                                              members: mockedMembers)
         
         roomProxyMock = JoinedRoomProxyMock(configuration)
@@ -440,7 +438,6 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
         
         let configuration = JoinedRoomProxyMockConfiguration(name: "Test",
                                                              isDirect: false,
-                                                             isPublic: false,
                                                              members: mockedMembers)
         
         roomProxyMock = JoinedRoomProxyMock(configuration)
@@ -478,7 +475,7 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
     
     func testCannotEditRoom() async {
         let mockedMembers: [RoomMemberProxyMock] = [.mockMe, .mockBob, .mockAlice]
-        roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", isDirect: false, isPublic: false, members: mockedMembers))
+        roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", isDirect: false, members: mockedMembers))
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                clientProxy: ClientProxyMock(.init()),
                                                mediaProvider: MediaProviderMock(configuration: .init()),
@@ -499,7 +496,7 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
     
     func testCannotEditDirectRoom() async {
         let mockedMembers: [RoomMemberProxyMock] = [.mockMeAdmin, .mockBob, .mockAlice]
-        roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", isDirect: true, isPublic: false, members: mockedMembers))
+        roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", isDirect: true, members: mockedMembers))
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                clientProxy: ClientProxyMock(.init()),
                                                mediaProvider: MediaProviderMock(configuration: .init()),
@@ -728,7 +725,7 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
     func testKnockRequestsCounter() async throws {
         ServiceLocator.shared.settings.knockingEnabled = true
         let mockedRequests: [KnockRequestProxyMock] = [.init(), .init()]
-        roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", isDirect: false, isPublic: false, knockRequestsState: .loaded(mockedRequests), joinRule: .knock))
+        roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", isDirect: false, knockRequestsState: .loaded(mockedRequests), joinRule: .knock))
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                clientProxy: ClientProxyMock(.init()),
                                                mediaProvider: MediaProviderMock(configuration: .init()),
@@ -751,7 +748,7 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
     
     func testKnockRequestsCounterIsLoading() async throws {
         ServiceLocator.shared.settings.knockingEnabled = true
-        roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", isDirect: false, isPublic: false, knockRequestsState: .loading, joinRule: .knock))
+        roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", isDirect: false, knockRequestsState: .loading, joinRule: .knock))
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                clientProxy: ClientProxyMock(.init()),
                                                mediaProvider: MediaProviderMock(configuration: .init()),
@@ -774,7 +771,6 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
         let mockedRequests: [KnockRequestProxyMock] = [.init(), .init()]
         roomProxyMock = JoinedRoomProxyMock(.init(name: "Test",
                                                   isDirect: false,
-                                                  isPublic: false,
                                                   knockRequestsState: .loaded(mockedRequests),
                                                   joinRule: .knock,
                                                   powerLevelsConfiguration: .init(canUserInvite: false)))
@@ -802,7 +798,7 @@ class RoomDetailsScreenViewModelTests: XCTestCase {
         ServiceLocator.shared.settings.knockingEnabled = true
         let mockedRequests: [KnockRequestProxyMock] = [.init(), .init()]
         let mockedMembers: [RoomMemberProxyMock] = [.mockMe, .mockAlice]
-        roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", isDirect: true, isPublic: false, members: mockedMembers, knockRequestsState: .loaded(mockedRequests), joinRule: .knock))
+        roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", isDirect: true, members: mockedMembers, knockRequestsState: .loaded(mockedRequests), joinRule: .knock))
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                clientProxy: ClientProxyMock(.init()),
                                                mediaProvider: MediaProviderMock(configuration: .init()),

--- a/UnitTests/Sources/TimelineViewModelTests.swift
+++ b/UnitTests/Sources/TimelineViewModelTests.swift
@@ -520,6 +520,7 @@ class TimelineViewModelTests: XCTestCase {
         
         let powerLevelsProxyMock = RoomPowerLevelsProxyMock(configuration: .init())
         powerLevelsProxyMock.canUserPinOrUnpinUserIDReturnValue = .success(false)
+        powerLevelsProxyMock.canOwnUserPinOrUnpinReturnValue = false
         roomProxyMock.powerLevelsReturnValue = .success(powerLevelsProxyMock)
         
         let roomInfoProxyMock = RoomInfoProxyMock(configuration)

--- a/project.yml
+++ b/project.yml
@@ -65,7 +65,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/element-hq/matrix-rust-components-swift
-    exactVersion: 25.06.25
+    exactVersion: 25.06.25-2
     # path: ../matrix-rust-sdk
   Compound:
     url: https://github.com/element-hq/compound-ios

--- a/project.yml
+++ b/project.yml
@@ -65,7 +65,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/element-hq/matrix-rust-components-swift
-    exactVersion: 25.06.24
+    exactVersion: 25.06.25
     # path: ../matrix-rust-sdk
   Compound:
     url: https://github.com/element-hq/compound-ios


### PR DESCRIPTION
* Switch to using the power levels for retrieving a user's role.
* Bump the SDK to v25.06.25; adopt the new optional RoomInfo `joinRule` and `isPublic`.
* Make the room power levels optional as they can be missing depending on what state events are requested