### PR TITLE
Use the close formatting option a11y label

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/ComposerToolbar.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/ComposerToolbar.swift
@@ -127,7 +127,7 @@ struct ComposerToolbar: View {
                 .scaledFrame(size: 30, relativeTo: .compound.headingLG)
                 .scaledPadding(7, relativeTo: .compound.headingLG)
         }
-        .accessibilityLabel(L10n.actionClose)
+        .accessibilityLabel(L10n.richTextEditorCloseFormattingOptions)
         .accessibilityIdentifier(A11yIdentifiers.roomScreen.composerToolbar.closeFormattingOptions)
     }
     


### PR DESCRIPTION
Seems like we already had an accessibility label for it but was never used.
