### PR TITLE
Use mock log files for the BugReportScreenViewModelTests.

### DIFF
--- a/ElementX/Sources/Screens/BugReportScreen/BugReportScreenViewModel.swift
+++ b/ElementX/Sources/Screens/BugReportScreen/BugReportScreenViewModel.swift
@@ -14,7 +14,7 @@ class BugReportScreenViewModel: BugReportScreenViewModelType, BugReportScreenVie
     private let bugReportService: BugReportServiceProtocol
     private let clientProxy: ClientProxyProtocol?
     
-    private let logFiles = Tracing.logFiles
+    private let logFiles: [URL]
     
     private let actionsSubject: PassthroughSubject<BugReportScreenViewModelAction, Never> = .init()
     // periphery:ignore - when set to nil this is automatically cancelled
@@ -26,10 +26,12 @@ class BugReportScreenViewModel: BugReportScreenViewModelType, BugReportScreenVie
     
     init(bugReportService: BugReportServiceProtocol,
          clientProxy: ClientProxyProtocol?,
+         logFiles: [URL] = Tracing.logFiles,
          screenshot: UIImage?,
          isModallyPresented: Bool) {
         self.bugReportService = bugReportService
         self.clientProxy = clientProxy
+        self.logFiles = logFiles
         
         let canSendLogFiles = Self.validate(logFiles)
         let bindings = BugReportScreenViewStateBindings(reportText: "", sendingLogsEnabled: canSendLogFiles, canContact: false)

--- a/UnitTests/Sources/BugReportScreenViewModelTests.swift
+++ b/UnitTests/Sources/BugReportScreenViewModelTests.swift
@@ -11,6 +11,8 @@ import XCTest
 
 @MainActor
 class BugReportScreenViewModelTests: XCTestCase {
+    let logFiles: [URL] = [URL(filePath: "/path/to/file1.log"), URL(filePath: "/path/to/file2.log")]
+    
     enum TestError: Error {
         case testError
     }
@@ -19,6 +21,7 @@ class BugReportScreenViewModelTests: XCTestCase {
         let clientProxy = ClientProxyMock(.init(userID: "@mock.client.com"))
         let viewModel = BugReportScreenViewModel(bugReportService: BugReportServiceMock(),
                                                  clientProxy: clientProxy,
+                                                 logFiles: logFiles,
                                                  screenshot: nil,
                                                  isModallyPresented: false)
         let context = viewModel.context
@@ -32,6 +35,7 @@ class BugReportScreenViewModelTests: XCTestCase {
         let clientProxy = ClientProxyMock(.init(userID: "@mock.client.com"))
         let viewModel = BugReportScreenViewModel(bugReportService: BugReportServiceMock(),
                                                  clientProxy: clientProxy,
+                                                 logFiles: logFiles,
                                                  screenshot: UIImage.actions,
                                                  isModallyPresented: false)
         let context = viewModel.context
@@ -44,7 +48,9 @@ class BugReportScreenViewModelTests: XCTestCase {
         let clientProxy = ClientProxyMock(.init(userID: "@mock.client.com"))
         let viewModel = BugReportScreenViewModel(bugReportService: BugReportServiceMock(),
                                                  clientProxy: clientProxy,
-                                                 screenshot: nil, isModallyPresented: false)
+                                                 logFiles: logFiles,
+                                                 screenshot: nil,
+                                                 isModallyPresented: false)
         let context = viewModel.context
         XCTAssertNil(context.viewState.screenshot)
         context.send(viewAction: .attachScreenshot(UIImage.actions))
@@ -64,7 +70,9 @@ class BugReportScreenViewModelTests: XCTestCase {
         
         let viewModel = BugReportScreenViewModel(bugReportService: mockService,
                                                  clientProxy: clientProxy,
-                                                 screenshot: nil, isModallyPresented: false)
+                                                 logFiles: logFiles,
+                                                 screenshot: nil,
+                                                 isModallyPresented: false)
         let context = viewModel.context
         context.reportText = "This will succeed"
         
@@ -86,7 +94,7 @@ class BugReportScreenViewModelTests: XCTestCase {
         XCTAssertEqual(mockService.submitBugReportProgressListenerReceivedArguments?.bugReport.curve25519, "THECURVEKEYKEY")
         XCTAssertEqual(mockService.submitBugReportProgressListenerReceivedArguments?.bugReport.ed25519, "THEEDKEYKEY")
         XCTAssertEqual(mockService.submitBugReportProgressListenerReceivedArguments?.bugReport.text, "This will succeed")
-        XCTAssertEqual(mockService.submitBugReportProgressListenerReceivedArguments?.bugReport.logFiles?.isEmpty, false)
+        XCTAssertEqual(mockService.submitBugReportProgressListenerReceivedArguments?.bugReport.logFiles, logFiles)
         XCTAssertEqual(mockService.submitBugReportProgressListenerReceivedArguments?.bugReport.canContact, false)
         XCTAssertEqual(mockService.submitBugReportProgressListenerReceivedArguments?.bugReport.githubLabels, [])
         XCTAssertEqual(mockService.submitBugReportProgressListenerReceivedArguments?.bugReport.files, [])


### PR DESCRIPTION
Just a hypothesis, but the array would potentially be empty if `LoggingTests` already ran and deleted the logs.