### PR TITLE
voice over focuses title when it changes in session verification view

### DIFF
--- a/ElementX/Sources/Screens/Onboarding/SessionVerificationScreen/View/SessionVerificationScreen.swift
+++ b/ElementX/Sources/Screens/Onboarding/SessionVerificationScreen/View/SessionVerificationScreen.swift
@@ -10,7 +10,12 @@ import MatrixRustSDK
 import SwiftUI
 
 struct SessionVerificationScreen: View {
+    enum AccessibilityFocus {
+        case title
+    }
+    
     @ObservedObject var context: SessionVerificationScreenViewModel.Context
+    @AccessibilityFocusState private var accessibilityFocus: AccessibilityFocus?
     
     var body: some View {
         FullscreenDialog {
@@ -56,6 +61,10 @@ struct SessionVerificationScreen: View {
                 .foregroundColor(.compound.textPrimary)
                 .padding(.bottom, 8)
                 .accessibilityIdentifier(context.viewState.titleAccessibilityIdentifier)
+                .onChange(of: context.viewState.title) { _, _ in
+                    accessibilityFocus = .title
+                }
+                .accessibilityFocused($accessibilityFocus, equals: .title)
 
             Text(context.viewState.message)
                 .font(.compound.bodyMD)


### PR DESCRIPTION
The reason behind this PR is that when the view changes its title, or it disappears, it automatically shifts its focus to the buttons, so we should always refocus the title in voice over when it changes