### PR TITLE
Be more lenient with the power levels

### DIFF
--- a/ElementX/Sources/Screens/KnockRequestsListScreen/KnockRequestsListScreenViewModel.swift
+++ b/ElementX/Sources/Screens/KnockRequestsListScreen/KnockRequestsListScreenViewModel.swift
@@ -26,7 +26,7 @@ class KnockRequestsListScreenViewModel: KnockRequestsListScreenViewModelType, Kn
         self.userIndicatorController = userIndicatorController
         super.init(initialViewState: KnockRequestsListScreenViewState(), mediaProvider: mediaProvider)
         
-        updateRoomInfo(roomInfo: roomProxy.infoPublisher.value)
+        updateRoomInfo(roomProxy.infoPublisher.value)
         
         setupSubscriptions()
     }
@@ -185,7 +185,7 @@ class KnockRequestsListScreenViewModel: KnockRequestsListScreenViewModelType, Kn
         roomProxy.infoPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] roomInfo in
-                self?.updateRoomInfo(roomInfo: roomInfo)
+                self?.updateRoomInfo(roomInfo)
             }
             .store(in: &cancellables)
         
@@ -210,7 +210,7 @@ class KnockRequestsListScreenViewModel: KnockRequestsListScreenViewModelType, Kn
             .store(in: &cancellables)
     }
     
-    private func updateRoomInfo(roomInfo: RoomInfoProxyProtocol) {
+    private func updateRoomInfo(_ roomInfo: RoomInfoProxyProtocol) {
         switch roomInfo.joinRule {
         case .knock, .knockRestricted:
             state.isKnockableRoom = true
@@ -218,10 +218,11 @@ class KnockRequestsListScreenViewModel: KnockRequestsListScreenViewModelType, Kn
             state.isKnockableRoom = false
         }
         
-        guard let powerLevels = roomProxy.infoPublisher.value.powerLevels else { fatalError("Missing room power levels") }
-        state.canAccept = powerLevels.canOwnUserInvite()
-        state.canDecline = powerLevels.canOwnUserKick()
-        state.canBan = powerLevels.canOwnUserBan()
+        if let powerLevels = roomProxy.infoPublisher.value.powerLevels {
+            state.canAccept = powerLevels.canOwnUserInvite()
+            state.canDecline = powerLevels.canOwnUserKick()
+            state.canBan = powerLevels.canOwnUserBan()
+        }
     }
     
     private static let loadingIndicatorIdentifier = "\(KnockRequestsListScreenViewModel.self)-Loading"

--- a/ElementX/Sources/Screens/RoomDetailsEditScreen/RoomDetailsEditScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomDetailsEditScreen/RoomDetailsEditScreenViewModel.swift
@@ -39,6 +39,13 @@ class RoomDetailsEditScreenViewModel: RoomDetailsEditScreenViewModelType, RoomDe
                                                                     avatarURL: roomAvatar,
                                                                     bindings: .init(name: roomName ?? "", topic: roomTopic ?? "")), mediaProvider: mediaProvider)
         
+        roomProxy.infoPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] roomInfo in
+                self?.updateRoomInfo(roomInfo: roomInfo)
+            }
+            .store(in: &cancellables)
+        
         updateRoomInfo(roomInfo: roomProxy.infoPublisher.value)
     }
     
@@ -87,10 +94,11 @@ class RoomDetailsEditScreenViewModel: RoomDetailsEditScreenViewModelType, RoomDe
     // MARK: - Private
     
     private func updateRoomInfo(roomInfo: RoomInfoProxyProtocol) {
-        guard let powerLevels = roomInfo.powerLevels else { fatalError("Missing room power levels") }
-        state.canEditAvatar = powerLevels.canOwnUser(sendStateEvent: .roomAvatar)
-        state.canEditName = powerLevels.canOwnUser(sendStateEvent: .roomName)
-        state.canEditTopic = powerLevels.canOwnUser(sendStateEvent: .roomTopic)
+        if let powerLevels = roomInfo.powerLevels {
+            state.canEditAvatar = powerLevels.canOwnUser(sendStateEvent: .roomAvatar)
+            state.canEditName = powerLevels.canOwnUser(sendStateEvent: .roomName)
+            state.canEditTopic = powerLevels.canOwnUser(sendStateEvent: .roomTopic)
+        }
     }
     
     private func saveRoomDetails() {

--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
@@ -179,7 +179,7 @@ class RoomDetailsScreenViewModel: RoomDetailsScreenViewModelType, RoomDetailsScr
     
     private func setupRoomSubscription() {
         roomProxy.infoPublisher
-            .throttle(for: .milliseconds(200), scheduler: DispatchQueue.main, latest: true)
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] roomInfo in
                 self?.updateRoomInfo(roomInfo)
             }
@@ -233,8 +233,6 @@ class RoomDetailsScreenViewModel: RoomDetailsScreenViewModelType, RoomDetailsScr
             state.canBanUsers = powerLevels.canOwnUserBan()
             state.canJoinCall = powerLevels.canOwnUserJoinCall()
             state.canEditRolesOrPermissions = powerLevels.suggestedRole(forUser: roomProxy.ownUserID) == .administrator
-        } else {
-            fatalError("Missing room power levels")
         }
     }
     

--- a/ElementX/Sources/Screens/RoomMemberListScreen/RoomMembersListScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomMemberListScreen/RoomMembersListScreenViewModel.swift
@@ -103,10 +103,11 @@ class RoomMembersListScreenViewModel: RoomMembersListScreenViewModelType, RoomMe
                                bannedMembers: roomMembersDetails.bannedMembers,
                                bindings: state.bindings)
             
-            guard let powerLevels = roomProxy.infoPublisher.value.powerLevels else { fatalError("Missing room power levels") }
-            self.state.canInviteUsers = powerLevels.canOwnUserInvite()
-            self.state.canKickUsers = powerLevels.canOwnUserKick()
-            self.state.canBanUsers = powerLevels.canOwnUserBan()
+            if let powerLevels = roomProxy.infoPublisher.value.powerLevels {
+                self.state.canInviteUsers = powerLevels.canOwnUserInvite()
+                self.state.canKickUsers = powerLevels.canOwnUserKick()
+                self.state.canBanUsers = powerLevels.canOwnUserBan()
+            }
         }
     }
     

--- a/ElementX/Sources/Screens/RoomRolesAndPermissionsScreen/RoomRolesAndPermissionsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomRolesAndPermissionsScreen/RoomRolesAndPermissionsScreenViewModel.swift
@@ -114,8 +114,9 @@ class RoomRolesAndPermissionsScreenViewModel: RoomRolesAndPermissionsScreenViewM
     // MARK: - Permissions
     
     private func updateRoomInfo(roomInfo: RoomInfoProxyProtocol) {
-        guard let powerLevels = roomInfo.powerLevels else { fatalError("Missing room power levels") }
-        state.permissions = .init(powerLevels: powerLevels.values)
+        if let powerLevels = roomInfo.powerLevels {
+            state.permissions = .init(powerLevels: powerLevels.values)
+        }
     }
     
     private func editPermissions(group: RoomRolesAndPermissionsScreenPermissionsGroup) {

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/CompletionSuggestionService.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/CompletionSuggestionService.swift
@@ -19,9 +19,12 @@ private enum SuggestionTriggerRegex {
 final class CompletionSuggestionService: CompletionSuggestionServiceProtocol {
     private let roomProxy: JoinedRoomProxyProtocol
     private var canMentionAllUsers = false
+    
     private(set) var suggestionsPublisher: AnyPublisher<[SuggestionItem], Never> = Empty().eraseToAnyPublisher()
     
     private let suggestionTriggerSubject = CurrentValueSubject<SuggestionTrigger?, Never>(nil)
+    
+    private var cancellables = Set<AnyCancellable>()
     
     init(roomProxy: JoinedRoomProxyProtocol,
          roomListPublisher: AnyPublisher<[RoomSummary], Never>) {
@@ -47,8 +50,14 @@ final class CompletionSuggestionService: CompletionSuggestionServiceProtocol {
                 self?.suggestionTriggerSubject.value != nil ? .milliseconds(500) : .milliseconds(0)
             }
         
-        guard let powerLevels = roomProxy.infoPublisher.value.powerLevels else { fatalError("Missing room power levels") }
-        canMentionAllUsers = powerLevels.canOwnUserTriggerRoomNotification()
+        roomProxy.infoPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] roomInfo in
+                self?.updateRoomInfo(roomInfo)
+            }
+            .store(in: &cancellables)
+        
+        updateRoomInfo(roomProxy.infoPublisher.value)
     }
     
     func processTextMessage(_ textMessage: String, selectedRange: NSRange) {
@@ -60,6 +69,12 @@ final class CompletionSuggestionService: CompletionSuggestionServiceProtocol {
     }
     
     // MARK: - Private
+    
+    private func updateRoomInfo(_ roomInfo: RoomInfoProxyProtocol) {
+        if let powerLevels = roomProxy.infoPublisher.value.powerLevels {
+            canMentionAllUsers = powerLevels.canOwnUserTriggerRoomNotification()
+        }
+    }
     
     private func membersSuggestions(suggestionTrigger: SuggestionTrigger,
                                     members: [RoomMemberProxyProtocol],

--- a/UnitTests/Sources/RoomScreenViewModelTests.swift
+++ b/UnitTests/Sources/RoomScreenViewModelTests.swift
@@ -165,15 +165,19 @@ class RoomScreenViewModelTests: XCTestCase {
     
     func testRoomInfoUpdate() async throws {
         var configuration = JoinedRoomProxyMockConfiguration(id: "TestID", name: "StartingName", avatarURL: nil, hasOngoingCall: false)
-        let infoSubject = CurrentValueSubject<RoomInfoProxyProtocol, Never>(RoomInfoProxyMock(configuration))
         let roomProxyMock = JoinedRoomProxyMock(configuration)
         
         let powerLevelsMock = RoomPowerLevelsProxyMock(configuration: .init())
+        powerLevelsMock.canUserJoinCallUserIDReturnValue = .success(false)
+        powerLevelsMock.canOwnUserJoinCallReturnValue = false
         roomProxyMock.powerLevelsReturnValue = .success(powerLevelsMock)
         
-        // setup the room proxy actions publisher
-        powerLevelsMock.canUserJoinCallUserIDReturnValue = .success(false)
+        let roomInfoProxyMock = RoomInfoProxyMock(configuration)
+        roomInfoProxyMock.powerLevels = powerLevelsMock
+        
+        let infoSubject = CurrentValueSubject<RoomInfoProxyProtocol, Never>(roomInfoProxyMock)
         roomProxyMock.underlyingInfoPublisher = infoSubject.asCurrentValuePublisher()
+        
         let viewModel = RoomScreenViewModel(clientProxy: ClientProxyMock(),
                                             roomProxy: roomProxyMock,
                                             initialSelectedPinnedEventID: nil,
@@ -186,27 +190,25 @@ class RoomScreenViewModelTests: XCTestCase {
                                             userIndicatorController: ServiceLocator.shared.userIndicatorController)
         self.viewModel = viewModel
         
-        var deferred = deferFulfillment(viewModel.context.$viewState) { viewState in
-            viewState.roomTitle == "StartingName" &&
-                viewState.roomAvatar == .room(id: "TestID", name: "StartingName", avatarURL: nil) &&
-                !viewState.canJoinCall &&
-                !viewState.hasOngoingCall
-        }
-        try await deferred.fulfill()
-        
-        configuration.name = "NewName"
-        configuration.avatarURL = .mockMXCAvatar
-        configuration.hasOngoingCall = true
-        powerLevelsMock.canUserJoinCallUserIDReturnValue = .success(true)
-        
-        deferred = deferFulfillment(viewModel.context.$viewState) { viewState in
+        XCTAssertEqual(viewModel.state.roomTitle, "StartingName")
+        XCTAssertEqual(viewModel.state.roomAvatar, .room(id: "TestID", name: "StartingName", avatarURL: nil))
+        XCTAssertFalse(viewModel.state.canJoinCall)
+        XCTAssertFalse(viewModel.state.hasOngoingCall)
+                
+        let deferred = deferFulfillment(viewModel.context.$viewState) { viewState in
             viewState.roomTitle == "NewName" &&
                 viewState.roomAvatar == .room(id: "TestID", name: "NewName", avatarURL: .mockMXCAvatar) &&
                 viewState.canJoinCall &&
                 viewState.hasOngoingCall
         }
         
+        configuration.name = "NewName"
+        configuration.avatarURL = .mockMXCAvatar
+        configuration.hasOngoingCall = true
+        powerLevelsMock.canUserJoinCallUserIDReturnValue = .success(true)
+        
         infoSubject.send(RoomInfoProxyMock(configuration))
+        
         try await deferred.fulfill()
     }
     


### PR DESCRIPTION
… as they can still be missing at the time the various screens are created e.g. after accepting an invite.

The correct solution is to subscribe to update and update the UI accordingly when receiving them, which this PR does along with converging on similar approaches in all the screens.