### PR TITLE
Fix earpiece button visibility in Element Call.

### DIFF
--- a/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
@@ -294,7 +294,7 @@ class CallScreenViewModel: CallScreenViewModelType, CallScreenViewModelProtocol 
         
         let deviceList = if currentOutput.portType == .builtInSpeaker {
             // This allows the webview to display the earpiece option
-            "{id: '\(currentOutput.uid)', name: '\(currentOutput.portName)', forEarpiece: true}"
+            "{id: '\(currentOutput.uid)', name: '\(currentOutput.portName)', forEarpiece: true, isSpeaker: true}"
         } else {
             // Doesn't matter because the switch is handled through the OS
             "{id: 'dummy', name: 'dummy'}"


### PR DESCRIPTION
This is required so that EC "thinks" there is a speaker and an earpiece. If this condition is not met it will not show the toggle button.

So this fixes showing the toggle button on EX for earpiece speaker toggle.

### Pull Request Checklist

- [ ] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
