### PR TITLE
Attempt to fix message composer layout crashes when running as an iPad app on MacOS

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/MessageComposerTextField.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/MessageComposerTextField.swift
@@ -96,8 +96,7 @@ private struct UITextViewWrapper: UIViewRepresentable {
 
     func sizeThatFits(_ proposal: ProposedViewSize, uiView: UITextView, context: Context) -> CGSize? {
         // Note: Coalescing a width of zero here returns a size for the view with 1 line of text visible.
-        let newSize = uiView.sizeThatFits(CGSize(width: proposal.width ?? .zero,
-                                                 height: CGFloat.greatestFiniteMagnitude))
+        let newSize = uiView.sizeThatFits(CGSize(width: proposal.width ?? .zero, height: maxHeight))
         let width = proposal.width ?? newSize.width
         let height = min(maxHeight, newSize.height)
 


### PR DESCRIPTION
Based on the limited information available here https://sentry.tools.element.io/organizations/element/issues/1999190/?project=44&query=is%3Aunresolved&referrer=issue-stream&stream_index=1

`UITextViewWrapper.sizeThatFits(MessageComposerTextField.swift:99)` -> `iPad Pro (12.9-inch) (3rd generation) (MacBookAir10,1)`

Potentially fixes https://sentry.tools.element.io/organizations/element/issues/2363233/?project=44&query=is%3Aunresolved&referrer=issue-stream&stream_index=0 and https://sentry.tools.element.io/organizations/element/issues/91043/?project=44&query=is%3Aunresolved&referrer=issue-stream&stream_index=3 too