### PR TITLE
Stop VoiceOver from reading the screen behind the current call.

### DIFF
--- a/ElementX/Sources/Application/Navigation/NavigationCoordinators.swift
+++ b/ElementX/Sources/Application/Navigation/NavigationCoordinators.swift
@@ -437,6 +437,7 @@ private struct NavigationSplitCoordinatorView: View {
             module.coordinator?.toPresentable()
                 .id(module.id)
         }
+        .accessibilityHidden(navigationSplitCoordinator.overlayModule?.coordinator != nil && navigationSplitCoordinator.overlayPresentationMode == .fullScreen)
         .overlay {
             Group {
                 if let coordinator = navigationSplitCoordinator.overlayModule?.coordinator {


### PR DESCRIPTION
As we're using an overlay for the presentation (to keep the web view alive when minimized), we need to make sure to hide everything behind the overlay from VoiceOver.

Everything works well now and as expected (but VoiceOver redirects its audio output during the call so I couldn't capture anything useful to include in this PR).