### PR TITLE
Update Element Call to the actual release of 0.13.0.

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -8771,7 +8771,7 @@
 			repositoryURL = "https://github.com/element-hq/element-call-swift";
 			requirement = {
 				kind = exactVersion;
-				version = "0.13.0-rc.1";
+				version = 0.13.0;
 			};
 		};
 		821C67C9A7F8CC3FD41B28B4 /* XCRemoteSwiftPackageReference "emojibase-bindings" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/element-call-swift",
       "state" : {
-        "revision" : "b3ceeddf59652a0806c008858ef9885bdd924d4c",
-        "version" : "0.13.0-rc.1"
+        "revision" : "81b22d696dd14c7657c4a8bd0051b8d69afb9f67",
+        "version" : "0.13.0"
       }
     },
     {

--- a/project.yml
+++ b/project.yml
@@ -77,7 +77,7 @@ packages:
     # path: ../matrix-analytics-events
   EmbeddedElementCall:
     url: https://github.com/element-hq/element-call-swift
-    exactVersion: 0.13.0-rc.1
+    exactVersion: 0.13.0
   Emojibase:
     url: https://github.com/matrix-org/emojibase-bindings
     minorVersion: 1.4.2


### PR DESCRIPTION
As requested by @toger5 this PR updates Element Call to the necessary version for the next release.