### PR TITLE
Downgrade Element Call back to 0.12.2 for now.

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -8771,7 +8771,7 @@
 			repositoryURL = "https://github.com/element-hq/element-call-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 0.13.0;
+				version = 0.12.2;
 			};
 		};
 		821C67C9A7F8CC3FD41B28B4 /* XCRemoteSwiftPackageReference "emojibase-bindings" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/element-call-swift",
       "state" : {
-        "revision" : "81b22d696dd14c7657c4a8bd0051b8d69afb9f67",
-        "version" : "0.13.0"
+        "revision" : "46e04acd94d139223364806063eda083f17007d0",
+        "version" : "0.12.2"
       }
     },
     {

--- a/ElementX/Sources/Screens/CallScreen/CallScreenModels.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenModels.swift
@@ -56,8 +56,6 @@ enum CallScreenJavaScriptMessageName: String, CaseIterable {
     case showNativeOutputDevicePicker
     /// Used to determine if the webview has selected the earpiece or not.
     case onOutputDeviceSelect
-    /// Used to handle the webview back button
-    case onBackButtonPressed
     
     private var postMessageScript: String {
         switch self {
@@ -88,12 +86,6 @@ enum CallScreenJavaScriptMessageName: String, CaseIterable {
             window.controls.\(rawValue) = (id) => {
                 window.webkit.messageHandlers.\(rawValue).postMessage(id);
             };
-            """
-        case .onBackButtonPressed:
-            """
-            window.controls.\(rawValue) = () => {
-                window.webkit.messageHandlers.\(rawValue).postMessage("");
-            }
             """
         }
     }

--- a/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
@@ -114,7 +114,7 @@ class CallScreenViewModel: CallScreenViewModelType, CallScreenViewModelProtocol 
         setupCall()
         
         timeoutTask = Task { [weak self] in
-            try? await Task.sleep(for: .seconds(10))
+            try? await Task.sleep(for: .seconds(30))
             guard !Task.isCancelled, let self else { return }
             MXLog.error("Failed to join Element Call: Timeout")
             state.bindings.alertInfo = .init(id: UUID(),

--- a/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
+++ b/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
@@ -16,10 +16,21 @@ struct CallScreen: View {
     @ObservedObject var context: CallScreenViewModel.Context
     
     var body: some View {
-        content
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color.compound.bgCanvasDefault.ignoresSafeArea())
-            .alert(item: $context.alertInfo)
+        NavigationStack {
+            content
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Color.compound.bgCanvasDefault.ignoresSafeArea())
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button { context.send(viewAction: .navigateBack) } label: {
+                            Image(systemSymbol: .chevronBackward)
+                                .fontWeight(.semibold)
+                        }
+                    }
+                }
+        }
+        .alert(item: $context.alertInfo)
     }
     
     @ViewBuilder
@@ -174,8 +185,6 @@ private struct CallView: UIViewRepresentable {
             case .onOutputDeviceSelect:
                 guard let deviceID = message.body as? String else { return }
                 viewModelContext?.send(viewAction: .outputDeviceSelected(deviceID: deviceID))
-            case .onBackButtonPressed:
-                viewModelContext?.send(viewAction: .navigateBack)
             }
         }
         
@@ -345,6 +354,8 @@ struct CallScreen_Previews: PreviewProvider {
     }()
     
     static var previews: some View {
-        CallScreen(context: viewModel.context)
+        NavigationStack {
+            CallScreen(context: viewModel.context)
+        }
     }
 }

--- a/ElementX/Sources/Services/ElementCall/ElementCallWidgetDriver.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallWidgetDriver.swift
@@ -83,7 +83,7 @@ class ElementCallWidgetDriver: WidgetCapabilitiesProvider, ElementCallWidgetDriv
                                                                           widgetId: widgetID,
                                                                           parentUrl: nil,
                                                                           header: .appBar,
-                                                                          hideHeader: true,
+                                                                          hideHeader: nil,
                                                                           preload: nil,
                                                                           fontScale: nil,
                                                                           appPrompt: false,

--- a/project.yml
+++ b/project.yml
@@ -77,7 +77,7 @@ packages:
     # path: ../matrix-analytics-events
   EmbeddedElementCall:
     url: https://github.com/element-hq/element-call-swift
-    exactVersion: 0.13.0
+    exactVersion: 0.12.2
   Emojibase:
     url: https://github.com/matrix-org/emojibase-bindings
     minorVersion: 1.4.2


### PR DESCRIPTION
This reverts "EC: handle back navigation from the webview" 37cbf733d49aa774c43c24c0e42290ba8f0260c6.

0.13.0 introduced a regression with bluetooth headsets.