### PR TITLE
Add a few more labels when sending a rageshake.

### DIFF
--- a/ElementX/Sources/Screens/BugReportScreen/BugReportScreenViewModel.swift
+++ b/ElementX/Sources/Screens/BugReportScreen/BugReportScreenViewModel.swift
@@ -97,17 +97,16 @@ class BugReportScreenViewModel: BugReportScreenViewModelType, BugReportScreenVie
                 // Continue anyway without the screenshot.
             }
         }
-        let ed25519 = await clientProxy?.ed25519Base64()
-        let curve25519 = await clientProxy?.curve25519Base64()
-        let bugReport = BugReport(userID: clientProxy?.userID,
-                                  deviceID: clientProxy?.deviceID,
-                                  ed25519: ed25519,
-                                  curve25519: curve25519,
-                                  text: context.reportText,
-                                  logFiles: context.sendingLogsEnabled ? logFiles : nil,
-                                  canContact: context.canContact,
-                                  githubLabels: [],
-                                  files: files)
+        
+        let bugReport = await BugReport(userID: clientProxy?.userID,
+                                        deviceID: clientProxy?.deviceID,
+                                        ed25519: clientProxy?.ed25519Base64(),
+                                        curve25519: clientProxy?.curve25519Base64(),
+                                        text: context.reportText,
+                                        logFiles: context.sendingLogsEnabled ? logFiles : nil,
+                                        canContact: context.canContact,
+                                        githubLabels: [],
+                                        files: files)
         
         switch await bugReportService.submitBugReport(bugReport,
                                                       progressListener: progressSubject) {


### PR DESCRIPTION
Rageshakes are currently unlabelled so this PR helps. It will label:

- `crash` when including a crash report link
- `login` when the user is reporting from the login flow (aka doesn't have a user ID)
- `Nightly` when sending from the Nightly app
- `Element-Pro` when sending from the Pro app.