### PR TITLE
Add support for threaded read receipts

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -8767,7 +8767,7 @@
 			repositoryURL = "https://github.com/element-hq/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 25.07.03;
+				version = 25.07.04;
 			};
 		};
 		701C7BEF8F70F7A83E852DCC /* XCRemoteSwiftPackageReference "GZIP" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/matrix-rust-components-swift",
       "state" : {
-        "revision" : "ab5a18fc12ff4b66a523edacecb8371b1d6fe86f",
-        "version" : "25.7.3"
+        "revision" : "9ca4d9e3b6fc15f1decf024a7474b368525ef52a",
+        "version" : "25.7.4"
       }
     },
     {

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -19,6 +19,7 @@ protocol CommonSettingsProtocol {
     var enableOnlySignedDeviceIsolationMode: Bool { get }
     var enableKeyShareOnInvite: Bool { get }
     var hideQuietNotificationAlerts: Bool { get }
+    var threadsEnabled: Bool { get }
 }
 
 /// Store Element specific app settings.
@@ -343,9 +344,6 @@ final class AppSettings {
     @UserPreference(key: UserDefaultsKeys.knockingEnabled, defaultValue: false, storageType: .userDefaults(store))
     var knockingEnabled
     
-    @UserPreference(key: UserDefaultsKeys.threadsEnabled, defaultValue: false, storageType: .userDefaults(store))
-    var threadsEnabled
-    
     @UserPreference(key: UserDefaultsKeys.threadsEnabled, defaultValue: isDevelopmentBuild, storageType: .userDefaults(store))
     var developerOptionsEnabled
     
@@ -372,6 +370,9 @@ final class AppSettings {
 
     @UserPreference(key: UserDefaultsKeys.hideQuietNotificationAlerts, defaultValue: false, storageType: .userDefaults(store))
     var hideQuietNotificationAlerts
+    
+    @UserPreference(key: UserDefaultsKeys.threadsEnabled, defaultValue: false, storageType: .userDefaults(store))
+    var threadsEnabled
 }
 
 extension AppSettings: CommonSettingsProtocol { }

--- a/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
@@ -7173,6 +7173,77 @@ open class ClientBuilderSDKMock: MatrixRustSDK.ClientBuilder, @unchecked Sendabl
         }
     }
 
+    //MARK: - threadsEnabled
+
+    var threadsEnabledEnabledUnderlyingCallsCount = 0
+    open var threadsEnabledEnabledCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return threadsEnabledEnabledUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = threadsEnabledEnabledUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                threadsEnabledEnabledUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    threadsEnabledEnabledUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var threadsEnabledEnabledCalled: Bool {
+        return threadsEnabledEnabledCallsCount > 0
+    }
+    open var threadsEnabledEnabledReceivedEnabled: Bool?
+    open var threadsEnabledEnabledReceivedInvocations: [Bool] = []
+
+    var threadsEnabledEnabledUnderlyingReturnValue: ClientBuilder!
+    open var threadsEnabledEnabledReturnValue: ClientBuilder! {
+        get {
+            if Thread.isMainThread {
+                return threadsEnabledEnabledUnderlyingReturnValue
+            } else {
+                var returnValue: ClientBuilder? = nil
+                DispatchQueue.main.sync {
+                    returnValue = threadsEnabledEnabledUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                threadsEnabledEnabledUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    threadsEnabledEnabledUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    open var threadsEnabledEnabledClosure: ((Bool) -> ClientBuilder)?
+
+    open override func threadsEnabled(enabled: Bool) -> ClientBuilder {
+        threadsEnabledEnabledCallsCount += 1
+        threadsEnabledEnabledReceivedEnabled = enabled
+        DispatchQueue.main.async {
+            self.threadsEnabledEnabledReceivedInvocations.append(enabled)
+        }
+        if let threadsEnabledEnabledClosure = threadsEnabledEnabledClosure {
+            return threadsEnabledEnabledClosure(enabled)
+        } else {
+            return threadsEnabledEnabledReturnValue
+        }
+    }
+
     //MARK: - userAgent
 
     var userAgentUserAgentUnderlyingCallsCount = 0
@@ -10011,13 +10082,13 @@ open class NotificationClientSDKMock: MatrixRustSDK.NotificationClient, @uncheck
     open var getNotificationRoomIdEventIdReceivedArguments: (roomId: String, eventId: String)?
     open var getNotificationRoomIdEventIdReceivedInvocations: [(roomId: String, eventId: String)] = []
 
-    var getNotificationRoomIdEventIdUnderlyingReturnValue: NotificationItem?
-    open var getNotificationRoomIdEventIdReturnValue: NotificationItem? {
+    var getNotificationRoomIdEventIdUnderlyingReturnValue: NotificationStatus!
+    open var getNotificationRoomIdEventIdReturnValue: NotificationStatus! {
         get {
             if Thread.isMainThread {
                 return getNotificationRoomIdEventIdUnderlyingReturnValue
             } else {
-                var returnValue: NotificationItem?? = nil
+                var returnValue: NotificationStatus? = nil
                 DispatchQueue.main.sync {
                     returnValue = getNotificationRoomIdEventIdUnderlyingReturnValue
                 }
@@ -10035,9 +10106,9 @@ open class NotificationClientSDKMock: MatrixRustSDK.NotificationClient, @uncheck
             }
         }
     }
-    open var getNotificationRoomIdEventIdClosure: ((String, String) async throws -> NotificationItem?)?
+    open var getNotificationRoomIdEventIdClosure: ((String, String) async throws -> NotificationStatus)?
 
-    open override func getNotification(roomId: String, eventId: String) async throws -> NotificationItem? {
+    open override func getNotification(roomId: String, eventId: String) async throws -> NotificationStatus {
         if let error = getNotificationRoomIdEventIdThrowableError {
             throw error
         }
@@ -10086,13 +10157,13 @@ open class NotificationClientSDKMock: MatrixRustSDK.NotificationClient, @uncheck
     open var getNotificationsRequestsReceivedRequests: [NotificationItemsRequest]?
     open var getNotificationsRequestsReceivedInvocations: [[NotificationItemsRequest]] = []
 
-    var getNotificationsRequestsUnderlyingReturnValue: [String: NotificationItem]!
-    open var getNotificationsRequestsReturnValue: [String: NotificationItem]! {
+    var getNotificationsRequestsUnderlyingReturnValue: [String: BatchNotificationResult]!
+    open var getNotificationsRequestsReturnValue: [String: BatchNotificationResult]! {
         get {
             if Thread.isMainThread {
                 return getNotificationsRequestsUnderlyingReturnValue
             } else {
-                var returnValue: [String: NotificationItem]? = nil
+                var returnValue: [String: BatchNotificationResult]? = nil
                 DispatchQueue.main.sync {
                     returnValue = getNotificationsRequestsUnderlyingReturnValue
                 }
@@ -10110,9 +10181,9 @@ open class NotificationClientSDKMock: MatrixRustSDK.NotificationClient, @uncheck
             }
         }
     }
-    open var getNotificationsRequestsClosure: (([NotificationItemsRequest]) async throws -> [String: NotificationItem])?
+    open var getNotificationsRequestsClosure: (([NotificationItemsRequest]) async throws -> [String: BatchNotificationResult])?
 
-    open override func getNotifications(requests: [NotificationItemsRequest]) async throws -> [String: NotificationItem] {
+    open override func getNotifications(requests: [NotificationItemsRequest]) async throws -> [String: BatchNotificationResult] {
         if let error = getNotificationsRequestsThrowableError {
             throw error
         }

--- a/ElementX/Sources/Other/Extensions/ClientBuilder.swift
+++ b/ElementX/Sources/Other/Extensions/ClientBuilder.swift
@@ -18,12 +18,14 @@ extension ClientBuilder {
                             enableOnlySignedDeviceIsolationMode: Bool,
                             enableKeyShareOnInvite: Bool,
                             requestTimeout: UInt64? = 30000,
-                            maxRequestRetryTime: UInt64? = nil) -> ClientBuilder {
+                            maxRequestRetryTime: UInt64? = nil,
+                            threadsEnabled: Bool) -> ClientBuilder {
         var builder = ClientBuilder()
             .crossProcessStoreLocksHolderName(holderName: InfoPlistReader.main.bundleIdentifier)
             .enableOidcRefreshLock()
             .setSessionDelegate(sessionDelegate: sessionDelegate)
             .userAgent(userAgent: UserAgentBuilder.makeASCIIUserAgent())
+            .threadsEnabled(enabled: threadsEnabled)
             .requestConfig(config: .init(retryLimit: 0,
                                          timeout: requestTimeout,
                                          maxConcurrentRequests: nil,

--- a/ElementX/Sources/Services/Authentication/AuthenticationClientBuilder.swift
+++ b/ElementX/Sources/Services/Authentication/AuthenticationClientBuilder.swift
@@ -49,7 +49,8 @@ struct AuthenticationClientBuilder: AuthenticationClientBuilderProtocol {
                          sessionDelegate: clientSessionDelegate,
                          appHooks: appHooks,
                          enableOnlySignedDeviceIsolationMode: appSettings.enableOnlySignedDeviceIsolationMode,
-                         enableKeyShareOnInvite: appSettings.enableKeyShareOnInvite)
+                         enableKeyShareOnInvite: appSettings.enableKeyShareOnInvite,
+                         threadsEnabled: appSettings.threadsEnabled)
             .sessionPaths(dataPath: sessionDirectories.dataPath,
                           cachePath: sessionDirectories.cachePath)
             .sessionPassphrase(passphrase: passphrase)

--- a/ElementX/Sources/Services/Timeline/TimelineController/TimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/TimelineController.swift
@@ -124,16 +124,11 @@ class TimelineController: TimelineControllerProtocol {
     func sendReadReceipt(for itemID: TimelineItemIdentifier) async {
         let receiptType: MatrixRustSDK.ReceiptType = appSettings.sharePresence ? .read : .readPrivate
         
-        // Mark the whole room as read if it's the last timeline item
-        if timelineItems.last?.id == itemID {
-            _ = await roomProxy.markAsRead(receiptType: receiptType)
-        } else {
-            guard let eventID = itemID.eventID else {
-                return
-            }
-            
-            _ = await activeTimeline.sendReadReceipt(for: eventID, type: receiptType)
+        guard let eventID = itemID.eventID else {
+            return
         }
+            
+        _ = await activeTimeline.sendReadReceipt(for: eventID, type: receiptType)
     }
     
     func processItemAppearance(_ itemID: TimelineItemIdentifier) async {

--- a/ElementX/Sources/Services/UserSession/UserSessionStore.swift
+++ b/ElementX/Sources/Services/UserSession/UserSessionStore.swift
@@ -124,7 +124,8 @@ class UserSessionStore: UserSessionStoreProtocol {
                          sessionDelegate: keychainController,
                          appHooks: appHooks,
                          enableOnlySignedDeviceIsolationMode: appSettings.enableOnlySignedDeviceIsolationMode,
-                         enableKeyShareOnInvite: appSettings.enableKeyShareOnInvite)
+                         enableKeyShareOnInvite: appSettings.enableKeyShareOnInvite,
+                         threadsEnabled: appSettings.threadsEnabled)
             .sessionPaths(dataPath: credentials.restorationToken.sessionDirectories.dataPath,
                           cachePath: credentials.restorationToken.sessionDirectories.cachePath)
             .username(username: credentials.userID)

--- a/NSE/Sources/NSEUserSession.swift
+++ b/NSE/Sources/NSEUserSession.swift
@@ -63,7 +63,8 @@ final class NSEUserSession {
                          enableOnlySignedDeviceIsolationMode: appSettings.enableOnlySignedDeviceIsolationMode,
                          enableKeyShareOnInvite: appSettings.enableKeyShareOnInvite,
                          requestTimeout: 15000,
-                         maxRequestRetryTime: 5000)
+                         maxRequestRetryTime: 5000,
+                         threadsEnabled: appSettings.threadsEnabled)
             .systemIsMemoryConstrained()
             .sessionPaths(dataPath: credentials.restorationToken.sessionDirectories.dataPath,
                           cachePath: credentials.restorationToken.sessionDirectories.cachePath)

--- a/NSE/Sources/NSEUserSession.swift
+++ b/NSE/Sources/NSEUserSession.swift
@@ -82,15 +82,21 @@ final class NSEUserSession {
     
     func notificationItemProxy(roomID: String, eventID: String) async -> NotificationItemProxyProtocol? {
         do {
-            let notification = try await notificationClient.getNotification(roomId: roomID, eventId: eventID)
+            let notificationStatus = try await notificationClient.getNotification(roomId: roomID, eventId: eventID)
                 
-            guard let notification else {
+            switch notificationStatus {
+            case .event(let notification):
+                return NotificationItemProxy(notificationItem: notification,
+                                             eventID: eventID,
+                                             receiverID: userID,
+                                             roomID: roomID)
+            case .eventNotFound:
+                MXLog.error("Notification event not found - roomID: \(roomID) eventID: \(eventID)")
+                return nil
+            case .eventFilteredOut:
+                MXLog.warning("Notification event filtered out - roomID: \(roomID) eventID: \(eventID)")
                 return nil
             }
-            return NotificationItemProxy(notificationItem: notification,
-                                         eventID: eventID,
-                                         receiverID: userID,
-                                         roomID: roomID)
         } catch {
             MXLog.error("Could not get notification's content creating an empty notification instead, error: \(error)")
             return EmptyNotificationItemProxy(eventID: eventID, roomID: roomID, receiverID: userID)

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "01d488b353462f8c88d3d89a9de08ed94fa42ef1cb444fc438e0c6aaaab83320",
+  "originHash" : "fe65ad02360ab82a9283496b072022b8c403593a427e973b39783ab541e11a2f",
   "pins" : [
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "011f0c765fb46d9cac61bca19be0527e99c98c8b",
-        "version" : "1.5.1"
+        "revision" : "309a47b2b1d9b5e991f36961c983ecec72275be3",
+        "version" : "1.6.1"
       }
     },
     {

--- a/project.yml
+++ b/project.yml
@@ -65,7 +65,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/element-hq/matrix-rust-components-swift
-    exactVersion: 25.07.03
+    exactVersion: 25.07.04
     # path: ../matrix-rust-sdk
   Compound:
     url: https://github.com/element-hq/compound-ios


### PR DESCRIPTION
- add support for the new client wide threads feature flag
- send all receipts through the active timeline and remove unecessary making of a room as read (already handled)