### PR TITLE
Use a Task instead of a DispatchQueue to help fix the flakey observation tests.

### DIFF
--- a/ElementX/Sources/Other/Extensions/Observable.swift
+++ b/ElementX/Sources/Other/Extensions/Observable.swift
@@ -20,8 +20,8 @@ extension Observable {
                 let value = withObservationTracking {
                     self[keyPath: property]
                 } onChange: {
-                    // Dispatch the update as this is willSet not didSet.
-                    DispatchQueue.main.async {
+                    // Handle the update on the next run loop as this is willSet not didSet.
+                    Task {
                         guard isActive else { return }
                         observe()
                     }


### PR DESCRIPTION
When debugging this issue it became apparent that sometimes the new value hadn't been set after dispatching to the main queue. Whereas it has with a Task. Not sure I fully understand why and it's annoying that there aren't any observation APIs for didSet. It's still not perfect but the flake rate is way lower on my local machine at least.

It does introduce a second "this will be an error in Swift 6" error, but as it's the same as the first one I'm going to kick that can down the road and we can start using `Mutex` when we drop iOS 17.