### PR TITLE
Accessibiliy Tests part 2

### DIFF
--- a/.github/workflows/accessibility_tests.yml
+++ b/.github/workflows/accessibility_tests.yml
@@ -6,8 +6,6 @@ on:
   schedule:
     - cron:  '0 2 * * 1-5'
     
-  pull_request:
-
 jobs:
   tests:
     name: Tests

--- a/.github/workflows/accessibility_tests.yml
+++ b/.github/workflows/accessibility_tests.yml
@@ -35,13 +35,13 @@ jobs:
       - name: Zip results # for faster upload
         if: failure()
         working-directory: fastlane/test_output
-        run: zip -r UITests.xcresult.zip UITests.xcresult
+        run: zip -r AccessibilityTests.xcresult.zip AccessibilityTests.xcresult
 
       - name: Archive artifacts
         uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ${{ matrix.device }}
-          path: fastlane/test_output/UITests.xcresult.zip
+          path: fastlane/test_output/AccessibilityTests.xcresult.zip
           retention-days: 7
           if-no-files-found: ignore

--- a/.github/workflows/accessibility_tests.yml
+++ b/.github/workflows/accessibility_tests.yml
@@ -1,0 +1,47 @@
+name: Accessibility Tests
+
+on:
+  workflow_dispatch:
+
+  schedule:
+    - cron:  '0 2 * * 1-5'
+
+jobs:
+  tests:
+    name: Tests
+    runs-on: macos-15
+
+    concurrency:
+      # Only allow a single run of this workflow on each branch, automatically cancelling older runs.
+      group: ${{ format('accessibility-tests-{0}', github.ref) }}
+      cancel-in-progress: true
+
+    steps:
+      - uses: nschloe/action-cached-lfs-checkout@f46300cd8952454b9f0a21a3d133d4bd5684cfc2 #v1.2.3
+
+      - uses: actions/cache@v4
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+
+      - name: Setup environment
+        run: source ci_scripts/ci_common.sh && setup_github_actions_environment
+
+      - name: Run tests
+        run: bundle exec fastlane accessibility_tests
+
+      - name: Zip results # for faster upload
+        if: failure()
+        working-directory: fastlane/test_output
+        run: zip -r UITests.xcresult.zip UITests.xcresult
+
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: ${{ matrix.device }}
+          path: fastlane/test_output/UITests.xcresult.zip
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/accessibility_tests.yml
+++ b/.github/workflows/accessibility_tests.yml
@@ -5,6 +5,8 @@ on:
 
   schedule:
     - cron:  '0 2 * * 1-5'
+    
+  pull_request:
 
 jobs:
   tests:

--- a/.github/workflows/accessibility_tests.yml
+++ b/.github/workflows/accessibility_tests.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: ${{ matrix.device }}
+          name: Results
           path: fastlane/test_output/AccessibilityTests.xcresult.zip
           retention-days: 7
           if-no-files-found: ignore

--- a/AccessibilityTests/Sources/AccessibilityTests.swift
+++ b/AccessibilityTests/Sources/AccessibilityTests.swift
@@ -17,18 +17,18 @@ final class AccessibilityTests: XCTestCase {
         await client.waitForApp()
         defer { try? client.stop() }
         
+        try client.send(.accessibilityAudit(.nextPreview))
         // To handle system interrupts
-        let allowButtonPredicate = NSPredicate(format: "label == 'Allow Once' || label == 'Allow While Using App'")
-        _ = addUIInterruptionMonitor(withDescription: "Allow to access your location?") { alert -> Bool in
-            let alwaysAllowButton = alert.buttons.matching(allowButtonPredicate).element.firstMatch
+        _ = addUIInterruptionMonitor(withDescription: "Location access alert handler") { alert in
+            let alwaysAllowButton = alert.buttons["Allow While Using App"]
             if alwaysAllowButton.exists {
                 alwaysAllowButton.tap()
                 return true
             }
             return false
         }
+        app.tap()
         
-        try client.send(.accessibilityAudit(.nextPreview))
         forLoop: for await signal in client.signals.values {
             switch signal {
             case .accessibilityAudit(let auditSignal):

--- a/AccessibilityTests/Sources/AccessibilityTests.swift
+++ b/AccessibilityTests/Sources/AccessibilityTests.swift
@@ -34,33 +34,8 @@ final class AccessibilityTests: XCTestCase {
             case .accessibilityAudit(let auditSignal):
                 switch auditSignal {
                 case .nextPreviewReady(let name):
-                    // Alows us to log the name of the preview that is being tested
-                    XCTContext.runActivity(named: name) { _ in
-                        do {
-                            // We have removed `textClipping` and `contrast` for now
-                            try app.performAccessibilityAudit(for: [.dynamicType, .elementDetection, .hitRegion, .sufficientElementDescription, .trait]) { issue in
-                                // Removew false positives for null elements
-                                guard let element = issue.element else {
-                                    return true
-                                }
-                                
-                                // Filter out false positives for specific cases
-                                if AccessibilityTests.ignoredA11yIdentifiers[element.identifier]?.contains(issue.auditType) == true {
-                                    return true
-                                }
-                                
-                                // We are fine with elements that only partially support dynamic types
-                                guard issue.compactDescription != "Dynamic Type font sizes are partially unsupported" else {
-                                    return true
-                                }
-                                
-                                return false
-                            }
-                        } catch {
-                            XCTFail("Failed to perform the accessibility audit: \(error)")
-                        }
-                    }
-                    try? client.send(.accessibilityAudit(.nextPreview))
+                    performAccessibilityAuditForPreview(named: name)
+                    try client.send(.accessibilityAudit(.nextPreview))
                 case .noMorePreviews:
                     break forLoop
                 default:
@@ -74,5 +49,60 @@ final class AccessibilityTests: XCTestCase {
         app.terminate()
     }
     
-    private static let ignoredA11yIdentifiers: [String: [XCUIAccessibilityAuditType]] = [A11yIdentifiers.authenticationStartScreen.appVersion: [.hitRegion]]
+    private func performAccessibilityAuditForPreview(named name: String) {
+        // Alows us to log the name of the preview that is being tested
+        XCTContext.runActivity(named: name) { _ in
+            do {
+                // We have removed `textClipped` and `contrast` for now
+                try app.performAccessibilityAudit(for: [.dynamicType, .elementDetection, .hitRegion, .sufficientElementDescription, .trait]) { issue in
+                    // Remove false positives for null elements
+                    guard let element = issue.element else {
+                        return true
+                    }
+                    
+                    // We are fine with elements that only partially support dynamic types
+                    guard issue.compactDescription != Self.partiallyUnsupportedDynamicTypeMessage else {
+                        return true
+                    }
+                    
+                    // Additional filters for specific elements that lead to false positives or neglectable issues.
+                    if Self.ignoredA11yIdentifiers[element.identifier]?.isAccessibilityIssueFiltered(issue) == true {
+                        return true
+                    }
+                    
+                    return false
+                }
+            } catch {
+                XCTFail("Failed to perform the accessibility audit: \(error)")
+            }
+        }
+    }
+    
+    private static let partiallyUnsupportedDynamicTypeMessage = "Dynamic Type font sizes are partially unsupported"
+    
+    /// Use this array to filter add specific filters to ignore specific issues for certain elements
+    private static let ignoredA11yIdentifiers: [String: [FilterType]] = [A11yIdentifiers.authenticationStartScreen.appVersion: [.auditType(.hitRegion)]]
+}
+
+private enum FilterType {
+    /// Filter by the content of the compactDescription of the issue
+    case compactDescription(String)
+    /// Filter by the type of the issue
+    case auditType(XCUIAccessibilityAuditType)
+}
+
+private extension Array where Element == FilterType {
+    func isAccessibilityIssueFiltered(_ issue: XCUIAccessibilityAuditIssue) -> Bool {
+        for filter in self {
+            switch filter {
+            case .auditType(issue.auditType):
+                return true
+            case .compactDescription(issue.compactDescription):
+                return true
+            default:
+                break
+            }
+        }
+        return false
+    }
 }

--- a/AccessibilityTests/Sources/AccessibilityTests.swift
+++ b/AccessibilityTests/Sources/AccessibilityTests.swift
@@ -60,14 +60,14 @@ final class AccessibilityTests: XCTestCase {
                     guard let element = issue.element else {
                         return true
                     }
-                                        
+                    
                     // We are fine with elements that only partially support dynamic types
                     guard issue.compactDescription != Self.partiallyUnsupportedDynamicTypeMessage else {
                         return true
                     }
                     
                     // We can filter out matrix entities from the non human-readable error
-                    if issue.compactDescription == "Label not human-readable", Self.isMatrixString(element.label) {
+                    if issue.compactDescription == Self.notHumanReadableMessage, Self.isMatrixIdentifier(element.label) {
                         return true
                     }
                     
@@ -84,12 +84,12 @@ final class AccessibilityTests: XCTestCase {
         }
     }
     
-    private static func isMatrixString(_ string: String) -> Bool {
-        MatrixEntityRegex.isMatrixRoomAlias(string) || MatrixEntityRegex.isMatrixUserIdentifier(string)
+    private static func isMatrixIdentifier(_ string: String) -> Bool {
+        MatrixEntityRegex.isMatrixRoomAlias(string) || MatrixEntityRegex.isMatrixUserIdentifier(string) || string == PillUtilities.atRoom
     }
     
     private static let partiallyUnsupportedDynamicTypeMessage = "Dynamic Type font sizes are partially unsupported"
-    private static let notHumanReadableMessage = ""
+    private static let notHumanReadableMessage = "Label not human-readable"
     
     /// Use this array to filter add specific filters to ignore specific issues for certain elements
     private static let ignoredA11yIdentifiers: [String: [FilterType]] = [A11yIdentifiers.authenticationStartScreen.appVersion: [.auditType(.hitRegion)]]

--- a/AccessibilityTests/Sources/AccessibilityTests.swift
+++ b/AccessibilityTests/Sources/AccessibilityTests.swift
@@ -34,21 +34,45 @@ final class AccessibilityTests: XCTestCase {
             case .accessibilityAudit(let auditSignal):
                 switch auditSignal {
                 case .nextPreviewReady(let name):
-                    try? app.performAccessibilityAudit { issue in
-                        XCTFail("\(name): \(issue)")
-                        return true
+                    // Alows us to log the name of the preview that is being tested
+                    XCTContext.runActivity(named: name) { _ in
+                        do {
+                            // We have removed `textClipping` and `contrast` for now
+                            try app.performAccessibilityAudit(for: [.dynamicType, .elementDetection, .hitRegion, .sufficientElementDescription, .trait]) { issue in
+                                // Removew false positives for null elements
+                                guard let element = issue.element else {
+                                    return true
+                                }
+                                
+                                // Filter out false positives for specific cases
+                                if AccessibilityTests.ignoredA11yIdentifiers[element.identifier]?.contains(issue.auditType) == true {
+                                    return true
+                                }
+                                
+                                // We are fine with elements that only partially support dynamic types
+                                guard issue.compactDescription != "Dynamic Type font sizes are partially unsupported" else {
+                                    return true
+                                }
+                                
+                                return false
+                            }
+                        } catch {
+                            XCTFail("Failed to perform the accessibility audit: \(error)")
+                        }
                     }
                     try? client.send(.accessibilityAudit(.nextPreview))
                 case .noMorePreviews:
                     break forLoop
                 default:
-                    fatalError("Unhandled signal")
+                    XCTFail("Unhandled signal")
                 }
             default:
-                fatalError("Unhandled signal")
+                XCTFail("Unhandled signal")
             }
         }
         
         app.terminate()
     }
+    
+    private static let ignoredA11yIdentifiers: [String: [XCUIAccessibilityAuditType]] = [A11yIdentifiers.authenticationStartScreen.appVersion: [.hitRegion]]
 }

--- a/AccessibilityTests/Sources/AccessibilityTests.swift
+++ b/AccessibilityTests/Sources/AccessibilityTests.swift
@@ -17,6 +17,17 @@ final class AccessibilityTests: XCTestCase {
         await client.waitForApp()
         defer { try? client.stop() }
         
+        // To handle system interrupts
+        let allowButtonPredicate = NSPredicate(format: "label == 'Always Allow' || label == 'Allow'")
+        _ = addUIInterruptionMonitor(withDescription: "Allow to access your location?") { alert -> Bool in
+            let alwaysAllowButton = alert.buttons.matching(allowButtonPredicate).element.firstMatch
+            if alwaysAllowButton.exists {
+                alwaysAllowButton.tap()
+                return true
+            }
+            return false
+        }
+        
         try client.send(.accessibilityAudit(.nextPreview))
         forLoop: for await signal in client.signals.values {
             switch signal {

--- a/AccessibilityTests/Sources/AccessibilityTests.swift
+++ b/AccessibilityTests/Sources/AccessibilityTests.swift
@@ -8,12 +8,12 @@
 import XCTest
 
 @MainActor
-class Test: XCTestCase {
+final class AccessibilityTests: XCTestCase {
     var app: XCUIApplication!
     
-    func test() async throws {
+    func performAccessibilityAudit(named name: String) async throws {
         let client = try UITestsSignalling.Client(mode: .tests)
-        app = Application.launch(viewID: "SecureBackupLogoutConfirmationScreen_Previews")
+        app = Application.launch(viewID: name)
         await client.waitForApp()
         defer { try? client.stop() }
         

--- a/AccessibilityTests/Sources/AccessibilityTests.swift
+++ b/AccessibilityTests/Sources/AccessibilityTests.swift
@@ -18,7 +18,7 @@ final class AccessibilityTests: XCTestCase {
         defer { try? client.stop() }
         
         // To handle system interrupts
-        let allowButtonPredicate = NSPredicate(format: "label == 'Always Allow' || label == 'Allow'")
+        let allowButtonPredicate = NSPredicate(format: "label == 'Allow Once' || label == 'Allow While Using App'")
         _ = addUIInterruptionMonitor(withDescription: "Allow to access your location?") { alert -> Bool in
             let alwaysAllowButton = alert.buttons.matching(allowButtonPredicate).element.firstMatch
             if alwaysAllowButton.exists {

--- a/AccessibilityTests/Sources/GeneratedAccessibilityTests.swift
+++ b/AccessibilityTests/Sources/GeneratedAccessibilityTests.swift
@@ -6,571 +6,760 @@
 
 
 extension AccessibilityTests {
-    func test_AdvancedSettingsScreen_Previews() async throws {
+
+    func testAdvancedSettingsScreen() async throws {
         try await performAccessibilityAudit(named: "AdvancedSettingsScreen_Previews")
     }
-    func test_AnalyticsPromptScreen_Previews() async throws {
+
+    func testAnalyticsPromptScreen() async throws {
         try await performAccessibilityAudit(named: "AnalyticsPromptScreen_Previews")
     }
-    func test_AnalyticsSettingsScreen_Previews() async throws {
+
+    func testAnalyticsSettingsScreen() async throws {
         try await performAccessibilityAudit(named: "AnalyticsSettingsScreen_Previews")
     }
-    func test_AppLockScreen_Previews() async throws {
+
+    func testAppLockScreen() async throws {
         try await performAccessibilityAudit(named: "AppLockScreen_Previews")
     }
-    func test_AppLockSetupBiometricsScreen_Previews() async throws {
+
+    func testAppLockSetupBiometricsScreen() async throws {
         try await performAccessibilityAudit(named: "AppLockSetupBiometricsScreen_Previews")
     }
-    func test_AppLockSetupPINScreen_Previews() async throws {
+
+    func testAppLockSetupPINScreen() async throws {
         try await performAccessibilityAudit(named: "AppLockSetupPINScreen_Previews")
     }
-    func test_AppLockSetupSettingsScreen_Previews() async throws {
+
+    func testAppLockSetupSettingsScreen() async throws {
         try await performAccessibilityAudit(named: "AppLockSetupSettingsScreen_Previews")
     }
-    func test_AudioMediaEventsTimelineView_Previews() async throws {
+
+    func testAudioMediaEventsTimelineView() async throws {
         try await performAccessibilityAudit(named: "AudioMediaEventsTimelineView_Previews")
     }
-    func test_AudioRoomTimelineView_Previews() async throws {
+
+    func testAudioRoomTimelineView() async throws {
         try await performAccessibilityAudit(named: "AudioRoomTimelineView_Previews")
     }
-    func test_AuthenticationStartScreen_Previews() async throws {
+
+    func testAuthenticationStartScreen() async throws {
         try await performAccessibilityAudit(named: "AuthenticationStartScreen_Previews")
     }
-    func test_AvatarHeaderView_Previews() async throws {
+
+    func testAvatarHeaderView() async throws {
         try await performAccessibilityAudit(named: "AvatarHeaderView_Previews")
     }
-    func test_BadgeLabel_Previews() async throws {
+
+    func testBadgeLabel() async throws {
         try await performAccessibilityAudit(named: "BadgeLabel_Previews")
     }
-    func test_BigIcon_Previews() async throws {
+
+    func testBigIcon() async throws {
         try await performAccessibilityAudit(named: "BigIcon_Previews")
     }
-    func test_BlockedUsersScreen_Previews() async throws {
+
+    func testBlockedUsersScreen() async throws {
         try await performAccessibilityAudit(named: "BlockedUsersScreen_Previews")
     }
-    func test_BugReportScreen_Previews() async throws {
+
+    func testBugReportScreen() async throws {
         try await performAccessibilityAudit(named: "BugReportScreen_Previews")
     }
-    func test_CallInviteRoomTimelineView_Previews() async throws {
+
+    func testCallInviteRoomTimelineView() async throws {
         try await performAccessibilityAudit(named: "CallInviteRoomTimelineView_Previews")
     }
-    func test_CallNotificationRoomTimelineView_Previews() async throws {
+
+    func testCallNotificationRoomTimelineView() async throws {
         try await performAccessibilityAudit(named: "CallNotificationRoomTimelineView_Previews")
     }
-    func test_CollapsibleRoomTimelineView_Previews() async throws {
+
+    func testCollapsibleRoomTimelineView() async throws {
         try await performAccessibilityAudit(named: "CollapsibleRoomTimelineView_Previews")
     }
-    func test_CompletionSuggestion_Previews() async throws {
+
+    func testCompletionSuggestion() async throws {
         try await performAccessibilityAudit(named: "CompletionSuggestion_Previews")
     }
-    func test_ComposerToolbar_Previews() async throws {
+
+    func testComposerToolbar() async throws {
         try await performAccessibilityAudit(named: "ComposerToolbar_Previews")
     }
-    func test_CreateRoom_Previews() async throws {
+
+    func testCreateRoom() async throws {
         try await performAccessibilityAudit(named: "CreateRoom_Previews")
     }
-    func test_DeactivateAccountScreen_Previews() async throws {
+
+    func testDeactivateAccountScreen() async throws {
         try await performAccessibilityAudit(named: "DeactivateAccountScreen_Previews")
     }
-    func test_DeclineAndBlockScreen_Previews() async throws {
+
+    func testDeclineAndBlockScreen() async throws {
         try await performAccessibilityAudit(named: "DeclineAndBlockScreen_Previews")
     }
-    func test_EditRoomAddressScreen_Previews() async throws {
+
+    func testEditRoomAddressScreen() async throws {
         try await performAccessibilityAudit(named: "EditRoomAddressScreen_Previews")
     }
-    func test_ElementTextFieldStyle_Previews() async throws {
+
+    func testElementTextFieldStyle() async throws {
         try await performAccessibilityAudit(named: "ElementTextFieldStyle_Previews")
     }
-    func test_EmojiPickerScreenHeaderView_Previews() async throws {
+
+    func testEmojiPickerScreenHeaderView() async throws {
         try await performAccessibilityAudit(named: "EmojiPickerScreenHeaderView_Previews")
     }
-    func test_EmojiPickerScreen_Previews() async throws {
+
+    func testEmojiPickerScreen() async throws {
         try await performAccessibilityAudit(named: "EmojiPickerScreen_Previews")
     }
-    func test_EmoteRoomTimelineView_Previews() async throws {
+
+    func testEmoteRoomTimelineView() async throws {
         try await performAccessibilityAudit(named: "EmoteRoomTimelineView_Previews")
     }
-    func test_EncryptedRoomTimelineView_Previews() async throws {
+
+    func testEncryptedRoomTimelineView() async throws {
         try await performAccessibilityAudit(named: "EncryptedRoomTimelineView_Previews")
     }
-    func test_EncryptionResetPasswordScreen_Previews() async throws {
+
+    func testEncryptionResetPasswordScreen() async throws {
         try await performAccessibilityAudit(named: "EncryptionResetPasswordScreen_Previews")
     }
-    func test_EncryptionResetScreen_Previews() async throws {
+
+    func testEncryptionResetScreen() async throws {
         try await performAccessibilityAudit(named: "EncryptionResetScreen_Previews")
     }
-    func test_EstimatedWaveformView_Previews() async throws {
+
+    func testEstimatedWaveformView() async throws {
         try await performAccessibilityAudit(named: "EstimatedWaveformView_Previews")
     }
-    func test_FileMediaEventsTimelineView_Previews() async throws {
+
+    func testFileMediaEventsTimelineView() async throws {
         try await performAccessibilityAudit(named: "FileMediaEventsTimelineView_Previews")
     }
-    func test_FileRoomTimelineView_Previews() async throws {
+
+    func testFileRoomTimelineView() async throws {
         try await performAccessibilityAudit(named: "FileRoomTimelineView_Previews")
     }
-    func test_FormButtonStyles_Previews() async throws {
+
+    func testFormButtonStyles() async throws {
         try await performAccessibilityAudit(named: "FormButtonStyles_Previews")
     }
-    func test_FormattedBodyText_Previews() async throws {
+
+    func testFormattedBodyText() async throws {
         try await performAccessibilityAudit(named: "FormattedBodyText_Previews")
     }
-    func test_FormattingToolbar_Previews() async throws {
+
+    func testFormattingToolbar() async throws {
         try await performAccessibilityAudit(named: "FormattingToolbar_Previews")
     }
-    func test_FullscreenDialog_Previews() async throws {
+
+    func testFullscreenDialog() async throws {
         try await performAccessibilityAudit(named: "FullscreenDialog_Previews")
     }
-    func test_GlobalSearchScreenListRow_Previews() async throws {
+
+    func testGlobalSearchScreenListRow() async throws {
         try await performAccessibilityAudit(named: "GlobalSearchScreenListRow_Previews")
     }
-    func test_GlobalSearchScreen_Previews() async throws {
+
+    func testGlobalSearchScreen() async throws {
         try await performAccessibilityAudit(named: "GlobalSearchScreen_Previews")
     }
-    func test_HighlightedTimelineItemModifier_Previews() async throws {
+
+    func testHighlightedTimelineItemModifier() async throws {
         try await performAccessibilityAudit(named: "HighlightedTimelineItemModifier_Previews")
     }
-    func test_HomeScreenEmptyStateView_Previews() async throws {
+
+    func testHomeScreenEmptyStateView() async throws {
         try await performAccessibilityAudit(named: "HomeScreenEmptyStateView_Previews")
     }
-    func test_HomeScreenInviteCell_Previews() async throws {
+
+    func testHomeScreenInviteCell() async throws {
         try await performAccessibilityAudit(named: "HomeScreenInviteCell_Previews")
     }
-    func test_HomeScreenKnockedCell_Previews() async throws {
+
+    func testHomeScreenKnockedCell() async throws {
         try await performAccessibilityAudit(named: "HomeScreenKnockedCell_Previews")
     }
-    func test_HomeScreenRecoveryKeyConfirmationBanner_Previews() async throws {
+
+    func testHomeScreenRecoveryKeyConfirmationBanner() async throws {
         try await performAccessibilityAudit(named: "HomeScreenRecoveryKeyConfirmationBanner_Previews")
     }
-    func test_HomeScreenRoomCell_Previews() async throws {
+
+    func testHomeScreenRoomCell() async throws {
         try await performAccessibilityAudit(named: "HomeScreenRoomCell_Previews")
     }
-    func test_HomeScreen_Previews() async throws {
+
+    func testHomeScreen() async throws {
         try await performAccessibilityAudit(named: "HomeScreen_Previews")
     }
-    func test_IdentityConfirmationScreen_Previews() async throws {
+
+    func testIdentityConfirmationScreen() async throws {
         try await performAccessibilityAudit(named: "IdentityConfirmationScreen_Previews")
     }
-    func test_IdentityConfirmedScreen_Previews() async throws {
+
+    func testIdentityConfirmedScreen() async throws {
         try await performAccessibilityAudit(named: "IdentityConfirmedScreen_Previews")
     }
-    func test_ImageMediaEventsTimelineView_Previews() async throws {
+
+    func testImageMediaEventsTimelineView() async throws {
         try await performAccessibilityAudit(named: "ImageMediaEventsTimelineView_Previews")
     }
-    func test_ImageRoomTimelineView_Previews() async throws {
+
+    func testImageRoomTimelineView() async throws {
         try await performAccessibilityAudit(named: "ImageRoomTimelineView_Previews")
     }
-    func test_InviteUsersScreenSelectedItem_Previews() async throws {
+
+    func testInviteUsersScreenSelectedItem() async throws {
         try await performAccessibilityAudit(named: "InviteUsersScreenSelectedItem_Previews")
     }
-    func test_InviteUsersScreen_Previews() async throws {
+
+    func testInviteUsersScreen() async throws {
         try await performAccessibilityAudit(named: "InviteUsersScreen_Previews")
     }
-    func test_JoinRoomByAddressView_Previews() async throws {
+
+    func testJoinRoomByAddressView() async throws {
         try await performAccessibilityAudit(named: "JoinRoomByAddressView_Previews")
     }
-    func test_JoinRoomScreen_Previews() async throws {
+
+    func testJoinRoomScreen() async throws {
         try await performAccessibilityAudit(named: "JoinRoomScreen_Previews")
     }
-    func test_KnockRequestCell_Previews() async throws {
+
+    func testKnockRequestCell() async throws {
         try await performAccessibilityAudit(named: "KnockRequestCell_Previews")
     }
-    func test_KnockRequestsBannerView_Previews() async throws {
+
+    func testKnockRequestsBannerView() async throws {
         try await performAccessibilityAudit(named: "KnockRequestsBannerView_Previews")
     }
-    func test_KnockRequestsListEmptyStateView_Previews() async throws {
+
+    func testKnockRequestsListEmptyStateView() async throws {
         try await performAccessibilityAudit(named: "KnockRequestsListEmptyStateView_Previews")
     }
-    func test_KnockRequestsListScreen_Previews() async throws {
+
+    func testKnockRequestsListScreen() async throws {
         try await performAccessibilityAudit(named: "KnockRequestsListScreen_Previews")
     }
-    func test_LegalInformationScreen_Previews() async throws {
+
+    func testLegalInformationScreen() async throws {
         try await performAccessibilityAudit(named: "LegalInformationScreen_Previews")
     }
-    func test_LoadableImage_Previews() async throws {
+
+    func testLoadableImage() async throws {
         try await performAccessibilityAudit(named: "LoadableImage_Previews")
     }
-    func test_LocationMarkerView_Previews() async throws {
+
+    func testLocationMarkerView() async throws {
         try await performAccessibilityAudit(named: "LocationMarkerView_Previews")
     }
-    func test_LocationRoomTimelineView_Previews() async throws {
+
+    func testLocationRoomTimelineView() async throws {
         try await performAccessibilityAudit(named: "LocationRoomTimelineView_Previews")
     }
-    func test_LoginScreen_Previews() async throws {
+
+    func testLoginScreen() async throws {
         try await performAccessibilityAudit(named: "LoginScreen_Previews")
     }
-    func test_LongPressWithFeedback_Previews() async throws {
+
+    func testLongPressWithFeedback() async throws {
         try await performAccessibilityAudit(named: "LongPressWithFeedback_Previews")
     }
-    func test_ManageRoomMemberSheetView_Previews() async throws {
+
+    func testManageRoomMemberSheetView() async throws {
         try await performAccessibilityAudit(named: "ManageRoomMemberSheetView_Previews")
     }
-    func test_MapLibreStaticMapView_Previews() async throws {
+
+    func testMapLibreStaticMapView() async throws {
         try await performAccessibilityAudit(named: "MapLibreStaticMapView_Previews")
     }
-    func test_MatrixUserPermalink_Previews() async throws {
+
+    func testMatrixUserPermalink() async throws {
         try await performAccessibilityAudit(named: "MatrixUserPermalink_Previews")
     }
-    func test_MediaEventsTimelineScreen_Previews() async throws {
+
+    func testMediaEventsTimelineScreen() async throws {
         try await performAccessibilityAudit(named: "MediaEventsTimelineScreen_Previews")
     }
-    func test_MediaUploadPreviewScreen_Previews() async throws {
+
+    func testMediaUploadPreviewScreen() async throws {
         try await performAccessibilityAudit(named: "MediaUploadPreviewScreen_Previews")
     }
-    func test_MentionSuggestionItemView_Previews() async throws {
+
+    func testMentionSuggestionItemView() async throws {
         try await performAccessibilityAudit(named: "MentionSuggestionItemView_Previews")
     }
-    func test_MessageComposerTextField_Previews() async throws {
+
+    func testMessageComposerTextField() async throws {
         try await performAccessibilityAudit(named: "MessageComposerTextField_Previews")
     }
-    func test_MessageComposer_Previews() async throws {
+
+    func testMessageComposer() async throws {
         try await performAccessibilityAudit(named: "MessageComposer_Previews")
     }
-    func test_MessageForwardingScreen_Previews() async throws {
+
+    func testMessageForwardingScreen() async throws {
         try await performAccessibilityAudit(named: "MessageForwardingScreen_Previews")
     }
-    func test_MessageText_Previews() async throws {
+
+    func testMessageText() async throws {
         try await performAccessibilityAudit(named: "MessageText_Previews")
     }
-    func test_NoticeRoomTimelineView_Previews() async throws {
+
+    func testNoticeRoomTimelineView() async throws {
         try await performAccessibilityAudit(named: "NoticeRoomTimelineView_Previews")
     }
-    func test_NotificationPermissionsScreen_Previews() async throws {
+
+    func testNotificationPermissionsScreen() async throws {
         try await performAccessibilityAudit(named: "NotificationPermissionsScreen_Previews")
     }
-    func test_NotificationSettingsEditScreenRoomCell_Previews() async throws {
+
+    func testNotificationSettingsEditScreenRoomCell() async throws {
         try await performAccessibilityAudit(named: "NotificationSettingsEditScreenRoomCell_Previews")
     }
-    func test_NotificationSettingsEditScreen_Previews() async throws {
+
+    func testNotificationSettingsEditScreen() async throws {
         try await performAccessibilityAudit(named: "NotificationSettingsEditScreen_Previews")
     }
-    func test_NotificationSettingsScreen_Previews() async throws {
+
+    func testNotificationSettingsScreen() async throws {
         try await performAccessibilityAudit(named: "NotificationSettingsScreen_Previews")
     }
-    func test_PINTextField_Previews() async throws {
+
+    func testPINTextField() async throws {
         try await performAccessibilityAudit(named: "PINTextField_Previews")
     }
-    func test_PaginationIndicatorRoomTimelineView_Previews() async throws {
+
+    func testPaginationIndicatorRoomTimelineView() async throws {
         try await performAccessibilityAudit(named: "PaginationIndicatorRoomTimelineView_Previews")
     }
-    func test_PillViewOnBubble_Previews() async throws {
+
+    func testPillViewOnBubble() async throws {
         try await performAccessibilityAudit(named: "PillViewOnBubble_Previews")
     }
-    func test_PillView_Previews() async throws {
+
+    func testPillView() async throws {
         try await performAccessibilityAudit(named: "PillView_Previews")
     }
-    func test_PinnedEventsTimelineScreen_Previews() async throws {
+
+    func testPinnedEventsTimelineScreen() async throws {
         try await performAccessibilityAudit(named: "PinnedEventsTimelineScreen_Previews")
     }
-    func test_PinnedItemsBannerView_Previews() async throws {
+
+    func testPinnedItemsBannerView() async throws {
         try await performAccessibilityAudit(named: "PinnedItemsBannerView_Previews")
     }
-    func test_PinnedItemsIndicatorView_Previews() async throws {
+
+    func testPinnedItemsIndicatorView() async throws {
         try await performAccessibilityAudit(named: "PinnedItemsIndicatorView_Previews")
     }
-    func test_PlaceholderAvatarImage_Previews() async throws {
+
+    func testPlaceholderAvatarImage() async throws {
         try await performAccessibilityAudit(named: "PlaceholderAvatarImage_Previews")
     }
-    func test_PlaceholderScreen_Previews() async throws {
+
+    func testPlaceholderScreen() async throws {
         try await performAccessibilityAudit(named: "PlaceholderScreen_Previews")
     }
-    func test_PollFormScreen_Previews() async throws {
+
+    func testPollFormScreen() async throws {
         try await performAccessibilityAudit(named: "PollFormScreen_Previews")
     }
-    func test_PollOptionView_Previews() async throws {
+
+    func testPollOptionView() async throws {
         try await performAccessibilityAudit(named: "PollOptionView_Previews")
     }
-    func test_PollRoomTimelineView_Previews() async throws {
+
+    func testPollRoomTimelineView() async throws {
         try await performAccessibilityAudit(named: "PollRoomTimelineView_Previews")
     }
-    func test_PollView_Previews() async throws {
+
+    func testPollView() async throws {
         try await performAccessibilityAudit(named: "PollView_Previews")
     }
-    func test_QRCodeLoginScreen_Previews() async throws {
+
+    func testQRCodeLoginScreen() async throws {
         try await performAccessibilityAudit(named: "QRCodeLoginScreen_Previews")
     }
-    func test_ReactionsSummaryView_Previews() async throws {
+
+    func testReactionsSummaryView() async throws {
         try await performAccessibilityAudit(named: "ReactionsSummaryView_Previews")
     }
-    func test_ReadMarkerRoomTimelineView_Previews() async throws {
+
+    func testReadMarkerRoomTimelineView() async throws {
         try await performAccessibilityAudit(named: "ReadMarkerRoomTimelineView_Previews")
     }
-    func test_ReadReceiptCell_Previews() async throws {
+
+    func testReadReceiptCell() async throws {
         try await performAccessibilityAudit(named: "ReadReceiptCell_Previews")
     }
-    func test_ReadReceiptsSummaryView_Previews() async throws {
+
+    func testReadReceiptsSummaryView() async throws {
         try await performAccessibilityAudit(named: "ReadReceiptsSummaryView_Previews")
     }
-    func test_RedactedRoomTimelineView_Previews() async throws {
+
+    func testRedactedRoomTimelineView() async throws {
         try await performAccessibilityAudit(named: "RedactedRoomTimelineView_Previews")
     }
-    func test_ReportContentScreen_Previews() async throws {
+
+    func testReportContentScreen() async throws {
         try await performAccessibilityAudit(named: "ReportContentScreen_Previews")
     }
-    func test_ReportRoomScreen_Previews() async throws {
+
+    func testReportRoomScreen() async throws {
         try await performAccessibilityAudit(named: "ReportRoomScreen_Previews")
     }
-    func test_ResolveVerifiedUserSendFailureScreen_Previews() async throws {
+
+    func testResolveVerifiedUserSendFailureScreen() async throws {
         try await performAccessibilityAudit(named: "ResolveVerifiedUserSendFailureScreen_Previews")
     }
-    func test_RoomAttachmentPicker_Previews() async throws {
+
+    func testRoomAttachmentPicker() async throws {
         try await performAccessibilityAudit(named: "RoomAttachmentPicker_Previews")
     }
-    func test_RoomAvatarImage_Previews() async throws {
+
+    func testRoomAvatarImage() async throws {
         try await performAccessibilityAudit(named: "RoomAvatarImage_Previews")
     }
-    func test_RoomChangePermissionsScreen_Previews() async throws {
+
+    func testRoomChangePermissionsScreen() async throws {
         try await performAccessibilityAudit(named: "RoomChangePermissionsScreen_Previews")
     }
-    func test_RoomChangeRolesScreenRow_Previews() async throws {
+
+    func testRoomChangeRolesScreenRow() async throws {
         try await performAccessibilityAudit(named: "RoomChangeRolesScreenRow_Previews")
     }
-    func test_RoomChangeRolesScreenSelectedItem_Previews() async throws {
+
+    func testRoomChangeRolesScreenSelectedItem() async throws {
         try await performAccessibilityAudit(named: "RoomChangeRolesScreenSelectedItem_Previews")
     }
-    func test_RoomChangeRolesScreen_Previews() async throws {
+
+    func testRoomChangeRolesScreen() async throws {
         try await performAccessibilityAudit(named: "RoomChangeRolesScreen_Previews")
     }
-    func test_RoomDetailsEditScreen_Previews() async throws {
+
+    func testRoomDetailsEditScreen() async throws {
         try await performAccessibilityAudit(named: "RoomDetailsEditScreen_Previews")
     }
-    func test_RoomDetailsScreen_Previews() async throws {
+
+    func testRoomDetailsScreen() async throws {
         try await performAccessibilityAudit(named: "RoomDetailsScreen_Previews")
     }
-    func test_RoomDirectorySearchCell_Previews() async throws {
+
+    func testRoomDirectorySearchCell() async throws {
         try await performAccessibilityAudit(named: "RoomDirectorySearchCell_Previews")
     }
-    func test_RoomDirectorySearchScreen_Previews() async throws {
+
+    func testRoomDirectorySearchScreen() async throws {
         try await performAccessibilityAudit(named: "RoomDirectorySearchScreen_Previews")
     }
-    func test_RoomHeaderView_Previews() async throws {
+
+    func testRoomHeaderView() async throws {
         try await performAccessibilityAudit(named: "RoomHeaderView_Previews")
     }
-    func test_RoomInviterLabel_Previews() async throws {
+
+    func testRoomInviterLabel() async throws {
         try await performAccessibilityAudit(named: "RoomInviterLabel_Previews")
     }
-    func test_RoomListFilterView_Previews() async throws {
+
+    func testRoomListFilterView() async throws {
         try await performAccessibilityAudit(named: "RoomListFilterView_Previews")
     }
-    func test_RoomListFiltersEmptyStateView_Previews() async throws {
+
+    func testRoomListFiltersEmptyStateView() async throws {
         try await performAccessibilityAudit(named: "RoomListFiltersEmptyStateView_Previews")
     }
-    func test_RoomListFiltersView_Previews() async throws {
+
+    func testRoomListFiltersView() async throws {
         try await performAccessibilityAudit(named: "RoomListFiltersView_Previews")
     }
-    func test_RoomMemberDetailsScreen_Previews() async throws {
+
+    func testRoomMemberDetailsScreen() async throws {
         try await performAccessibilityAudit(named: "RoomMemberDetailsScreen_Previews")
     }
-    func test_RoomMembersListMemberCell_Previews() async throws {
+
+    func testRoomMembersListMemberCell() async throws {
         try await performAccessibilityAudit(named: "RoomMembersListMemberCell_Previews")
     }
-    func test_RoomMembersListScreen_Previews() async throws {
+
+    func testRoomMembersListScreen() async throws {
         try await performAccessibilityAudit(named: "RoomMembersListScreen_Previews")
     }
-    func test_RoomNotificationSettingsCustomSectionView_Previews() async throws {
+
+    func testRoomNotificationSettingsCustomSectionView() async throws {
         try await performAccessibilityAudit(named: "RoomNotificationSettingsCustomSectionView_Previews")
     }
-    func test_RoomNotificationSettingsScreen_Previews() async throws {
+
+    func testRoomNotificationSettingsScreen() async throws {
         try await performAccessibilityAudit(named: "RoomNotificationSettingsScreen_Previews")
     }
-    func test_RoomNotificationSettingsUserDefinedScreen_Previews() async throws {
+
+    func testRoomNotificationSettingsUserDefinedScreen() async throws {
         try await performAccessibilityAudit(named: "RoomNotificationSettingsUserDefinedScreen_Previews")
     }
-    func test_RoomPollsHistoryScreen_Previews() async throws {
+
+    func testRoomPollsHistoryScreen() async throws {
         try await performAccessibilityAudit(named: "RoomPollsHistoryScreen_Previews")
     }
-    func test_RoomRolesAndPermissionsScreen_Previews() async throws {
+
+    func testRoomRolesAndPermissionsScreen() async throws {
         try await performAccessibilityAudit(named: "RoomRolesAndPermissionsScreen_Previews")
     }
-    func test_RoomScreenFooterView_Previews() async throws {
+
+    func testRoomScreenFooterView() async throws {
         try await performAccessibilityAudit(named: "RoomScreenFooterView_Previews")
     }
-    func test_RoomScreen_Previews() async throws {
+
+    func testRoomScreen() async throws {
         try await performAccessibilityAudit(named: "RoomScreen_Previews")
     }
-    func test_RoomSelectionScreen_Previews() async throws {
+
+    func testRoomSelectionScreen() async throws {
         try await performAccessibilityAudit(named: "RoomSelectionScreen_Previews")
     }
-    func test_SFNumberedListView_Previews() async throws {
+
+    func testSFNumberedListView() async throws {
         try await performAccessibilityAudit(named: "SFNumberedListView_Previews")
     }
-    func test_SecureBackupKeyBackupScreen_Previews() async throws {
+
+    func testSecureBackupKeyBackupScreen() async throws {
         try await performAccessibilityAudit(named: "SecureBackupKeyBackupScreen_Previews")
     }
-    func test_SecureBackupLogoutConfirmationScreen_Previews() async throws {
+
+    func testSecureBackupLogoutConfirmationScreen() async throws {
         try await performAccessibilityAudit(named: "SecureBackupLogoutConfirmationScreen_Previews")
     }
-    func test_SecureBackupRecoveryKeyScreen_Previews() async throws {
+
+    func testSecureBackupRecoveryKeyScreen() async throws {
         try await performAccessibilityAudit(named: "SecureBackupRecoveryKeyScreen_Previews")
     }
-    func test_SecureBackupScreen_Previews() async throws {
+
+    func testSecureBackupScreen() async throws {
         try await performAccessibilityAudit(named: "SecureBackupScreen_Previews")
     }
-    func test_SecurityAndPrivacyScreen_Previews() async throws {
+
+    func testSecurityAndPrivacyScreen() async throws {
         try await performAccessibilityAudit(named: "SecurityAndPrivacyScreen_Previews")
     }
-    func test_SendInviteConfirmationView_Previews() async throws {
+
+    func testSendInviteConfirmationView() async throws {
         try await performAccessibilityAudit(named: "SendInviteConfirmationView_Previews")
     }
-    func test_SeparatorMediaEventsTimelineView_Previews() async throws {
+
+    func testSeparatorMediaEventsTimelineView() async throws {
         try await performAccessibilityAudit(named: "SeparatorMediaEventsTimelineView_Previews")
     }
-    func test_SeparatorRoomTimelineView_Previews() async throws {
+
+    func testSeparatorRoomTimelineView() async throws {
         try await performAccessibilityAudit(named: "SeparatorRoomTimelineView_Previews")
     }
-    func test_ServerConfirmationScreen_Previews() async throws {
+
+    func testServerConfirmationScreen() async throws {
         try await performAccessibilityAudit(named: "ServerConfirmationScreen_Previews")
     }
-    func test_ServerSelection_Previews() async throws {
+
+    func testServerSelection() async throws {
         try await performAccessibilityAudit(named: "ServerSelection_Previews")
     }
-    func test_SessionVerificationRequestDetailsView_Previews() async throws {
+
+    func testSessionVerificationRequestDetailsView() async throws {
         try await performAccessibilityAudit(named: "SessionVerificationRequestDetailsView_Previews")
     }
-    func test_SessionVerification_Previews() async throws {
+
+    func testSessionVerification() async throws {
         try await performAccessibilityAudit(named: "SessionVerification_Previews")
     }
-    func test_SettingsScreen_Previews() async throws {
+
+    func testSettingsScreen() async throws {
         try await performAccessibilityAudit(named: "SettingsScreen_Previews")
     }
-    func test_ShimmerOverlay_Previews() async throws {
+
+    func testShimmerOverlay() async throws {
         try await performAccessibilityAudit(named: "ShimmerOverlay_Previews")
     }
-    func test_SoftLogoutScreen_Previews() async throws {
+
+    func testSoftLogoutScreen() async throws {
         try await performAccessibilityAudit(named: "SoftLogoutScreen_Previews")
     }
-    func test_SplashScreen_Previews() async throws {
+
+    func testSplashScreen() async throws {
         try await performAccessibilityAudit(named: "SplashScreen_Previews")
     }
-    func test_StackedAvatarsView_Previews() async throws {
+
+    func testStackedAvatarsView() async throws {
         try await performAccessibilityAudit(named: "StackedAvatarsView_Previews")
     }
-    func test_StartChatScreen_Previews() async throws {
+
+    func testStartChatScreen() async throws {
         try await performAccessibilityAudit(named: "StartChatScreen_Previews")
     }
-    func test_StateRoomTimelineView_Previews() async throws {
+
+    func testStateRoomTimelineView() async throws {
         try await performAccessibilityAudit(named: "StateRoomTimelineView_Previews")
     }
-    func test_StaticLocationScreenViewer_Previews() async throws {
+
+    func testStaticLocationScreenViewer() async throws {
         try await performAccessibilityAudit(named: "StaticLocationScreenViewer_Previews")
     }
-    func test_StickerRoomTimelineView_Previews() async throws {
+
+    func testStickerRoomTimelineView() async throws {
         try await performAccessibilityAudit(named: "StickerRoomTimelineView_Previews")
     }
-    func test_SwipeRightAction_Previews() async throws {
+
+    func testSwipeRightAction() async throws {
         try await performAccessibilityAudit(named: "SwipeRightAction_Previews")
     }
-    func test_SwipeToReplyView_Previews() async throws {
+
+    func testSwipeToReplyView() async throws {
         try await performAccessibilityAudit(named: "SwipeToReplyView_Previews")
     }
-    func test_TextRoomTimelineView_Previews() async throws {
+
+    func testTextRoomTimelineView() async throws {
         try await performAccessibilityAudit(named: "TextRoomTimelineView_Previews")
     }
-    func test_ThreadDecorator_Previews() async throws {
+
+    func testThreadDecorator() async throws {
         try await performAccessibilityAudit(named: "ThreadDecorator_Previews")
     }
-    func test_TimelineDeliveryStatusView_Previews() async throws {
+
+    func testTimelineDeliveryStatusView() async throws {
         try await performAccessibilityAudit(named: "TimelineDeliveryStatusView_Previews")
     }
-    func test_TimelineItemBubbledStylerView_Previews() async throws {
+
+    func testTimelineItemBubbledStylerView() async throws {
         try await performAccessibilityAudit(named: "TimelineItemBubbledStylerView_Previews")
     }
-    func test_TimelineItemDebugView_Previews() async throws {
+
+    func testTimelineItemDebugView() async throws {
         try await performAccessibilityAudit(named: "TimelineItemDebugView_Previews")
     }
-    func test_TimelineItemMenu_Previews() async throws {
+
+    func testTimelineItemMenu() async throws {
         try await performAccessibilityAudit(named: "TimelineItemMenu_Previews")
     }
-    func test_TimelineItemSendInfoLabel_Previews() async throws {
+
+    func testTimelineItemSendInfoLabel() async throws {
         try await performAccessibilityAudit(named: "TimelineItemSendInfoLabel_Previews")
     }
-    func test_TimelineItemStyler_Previews() async throws {
+
+    func testTimelineItemStyler() async throws {
         try await performAccessibilityAudit(named: "TimelineItemStyler_Previews")
     }
-    func test_TimelineMediaPreviewDetailsView_Previews() async throws {
+
+    func testTimelineMediaPreviewDetailsView() async throws {
         try await performAccessibilityAudit(named: "TimelineMediaPreviewDetailsView_Previews")
     }
-    func test_TimelineMediaPreviewRedactConfirmationView_Previews() async throws {
+
+    func testTimelineMediaPreviewRedactConfirmationView() async throws {
         try await performAccessibilityAudit(named: "TimelineMediaPreviewRedactConfirmationView_Previews")
     }
-    func test_TimelineReactionView_Previews() async throws {
+
+    func testTimelineReactionView() async throws {
         try await performAccessibilityAudit(named: "TimelineReactionView_Previews")
     }
-    func test_TimelineReadReceiptsView_Previews() async throws {
+
+    func testTimelineReadReceiptsView() async throws {
         try await performAccessibilityAudit(named: "TimelineReadReceiptsView_Previews")
     }
-    func test_TimelineReplyView_Previews() async throws {
+
+    func testTimelineReplyView() async throws {
         try await performAccessibilityAudit(named: "TimelineReplyView_Previews")
     }
-    func test_TimelineStartRoomTimelineView_Previews() async throws {
+
+    func testTimelineStartRoomTimelineView() async throws {
         try await performAccessibilityAudit(named: "TimelineStartRoomTimelineView_Previews")
     }
-    func test_TimelineThreadSummaryView_Previews() async throws {
+
+    func testTimelineThreadSummaryView() async throws {
         try await performAccessibilityAudit(named: "TimelineThreadSummaryView_Previews")
     }
-    func test_TimelineView_Previews() async throws {
+
+    func testTimelineView() async throws {
         try await performAccessibilityAudit(named: "TimelineView_Previews")
     }
-    func test_TombstonedAvatarImage_Previews() async throws {
+
+    func testTombstonedAvatarImage() async throws {
         try await performAccessibilityAudit(named: "TombstonedAvatarImage_Previews")
     }
-    func test_TypingIndicatorView_Previews() async throws {
+
+    func testTypingIndicatorView() async throws {
         try await performAccessibilityAudit(named: "TypingIndicatorView_Previews")
     }
-    func test_UnsupportedRoomTimelineView_Previews() async throws {
+
+    func testUnsupportedRoomTimelineView() async throws {
         try await performAccessibilityAudit(named: "UnsupportedRoomTimelineView_Previews")
     }
-    func test_UserDetailsEditScreen_Previews() async throws {
+
+    func testUserDetailsEditScreen() async throws {
         try await performAccessibilityAudit(named: "UserDetailsEditScreen_Previews")
     }
-    func test_UserIndicatorModalView_Previews() async throws {
+
+    func testUserIndicatorModalView() async throws {
         try await performAccessibilityAudit(named: "UserIndicatorModalView_Previews")
     }
-    func test_UserIndicatorToastView_Previews() async throws {
+
+    func testUserIndicatorToastView() async throws {
         try await performAccessibilityAudit(named: "UserIndicatorToastView_Previews")
     }
-    func test_UserProfileCell_Previews() async throws {
+
+    func testUserProfileCell() async throws {
         try await performAccessibilityAudit(named: "UserProfileCell_Previews")
     }
-    func test_UserProfileScreen_Previews() async throws {
+
+    func testUserProfileScreen() async throws {
         try await performAccessibilityAudit(named: "UserProfileScreen_Previews")
     }
-    func test_VerificationBadge_Previews() async throws {
+
+    func testVerificationBadge() async throws {
         try await performAccessibilityAudit(named: "VerificationBadge_Previews")
     }
-    func test_VideoMediaEventsTimelineView_Previews() async throws {
+
+    func testVideoMediaEventsTimelineView() async throws {
         try await performAccessibilityAudit(named: "VideoMediaEventsTimelineView_Previews")
     }
-    func test_VideoRoomTimelineView_Previews() async throws {
+
+    func testVideoRoomTimelineView() async throws {
         try await performAccessibilityAudit(named: "VideoRoomTimelineView_Previews")
     }
-    func test_VisualListItem_Previews() async throws {
+
+    func testVisualListItem() async throws {
         try await performAccessibilityAudit(named: "VisualListItem_Previews")
     }
-    func test_VoiceMessageButton_Previews() async throws {
+
+    func testVoiceMessageButton() async throws {
         try await performAccessibilityAudit(named: "VoiceMessageButton_Previews")
     }
-    func test_VoiceMessageMediaEventsTimelineView_Previews() async throws {
+
+    func testVoiceMessageMediaEventsTimelineView() async throws {
         try await performAccessibilityAudit(named: "VoiceMessageMediaEventsTimelineView_Previews")
     }
-    func test_VoiceMessagePreviewComposer_Previews() async throws {
+
+    func testVoiceMessagePreviewComposer() async throws {
         try await performAccessibilityAudit(named: "VoiceMessagePreviewComposer_Previews")
     }
-    func test_VoiceMessageRecordingButton_Previews() async throws {
+
+    func testVoiceMessageRecordingButton() async throws {
         try await performAccessibilityAudit(named: "VoiceMessageRecordingButton_Previews")
     }
-    func test_VoiceMessageRecordingComposer_Previews() async throws {
+
+    func testVoiceMessageRecordingComposer() async throws {
         try await performAccessibilityAudit(named: "VoiceMessageRecordingComposer_Previews")
     }
-    func test_VoiceMessageRecordingView_Previews() async throws {
+
+    func testVoiceMessageRecordingView() async throws {
         try await performAccessibilityAudit(named: "VoiceMessageRecordingView_Previews")
     }
-    func test_VoiceMessageRoomPlaybackView_Previews() async throws {
+
+    func testVoiceMessageRoomPlaybackView() async throws {
         try await performAccessibilityAudit(named: "VoiceMessageRoomPlaybackView_Previews")
     }
-    func test_VoiceMessageRoomTimelineView_Previews() async throws {
+
+    func testVoiceMessageRoomTimelineView() async throws {
         try await performAccessibilityAudit(named: "VoiceMessageRoomTimelineView_Previews")
     }
-    func test_WaveformCursorView_Previews() async throws {
+
+    func testWaveformCursorView() async throws {
         try await performAccessibilityAudit(named: "WaveformCursorView_Previews")
     }
 }

--- a/AccessibilityTests/Sources/GeneratedTests.swift
+++ b/AccessibilityTests/Sources/GeneratedTests.swift
@@ -1,0 +1,579 @@
+// Generated using Sourcery 2.2.7 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+// swiftlint:disable all
+// swiftformat:disable all
+
+
+extension AccessibilityTests {
+    func test_AdvancedSettingsScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "AdvancedSettingsScreen_Previews")
+    }
+    func test_AnalyticsPromptScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "AnalyticsPromptScreen_Previews")
+    }
+    func test_AnalyticsSettingsScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "AnalyticsSettingsScreen_Previews")
+    }
+    func test_AppLockScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "AppLockScreen_Previews")
+    }
+    func test_AppLockSetupBiometricsScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "AppLockSetupBiometricsScreen_Previews")
+    }
+    func test_AppLockSetupPINScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "AppLockSetupPINScreen_Previews")
+    }
+    func test_AppLockSetupSettingsScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "AppLockSetupSettingsScreen_Previews")
+    }
+    func test_AudioMediaEventsTimelineView_Previews() async throws {
+        try await performAccessibilityAudit(named: "AudioMediaEventsTimelineView_Previews")
+    }
+    func test_AudioRoomTimelineView_Previews() async throws {
+        try await performAccessibilityAudit(named: "AudioRoomTimelineView_Previews")
+    }
+    func test_AuthenticationStartScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "AuthenticationStartScreen_Previews")
+    }
+    func test_AvatarHeaderView_Previews() async throws {
+        try await performAccessibilityAudit(named: "AvatarHeaderView_Previews")
+    }
+    func test_BadgeLabel_Previews() async throws {
+        try await performAccessibilityAudit(named: "BadgeLabel_Previews")
+    }
+    func test_BigIcon_Previews() async throws {
+        try await performAccessibilityAudit(named: "BigIcon_Previews")
+    }
+    func test_BlockedUsersScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "BlockedUsersScreen_Previews")
+    }
+    func test_BugReportScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "BugReportScreen_Previews")
+    }
+    func test_CallInviteRoomTimelineView_Previews() async throws {
+        try await performAccessibilityAudit(named: "CallInviteRoomTimelineView_Previews")
+    }
+    func test_CallNotificationRoomTimelineView_Previews() async throws {
+        try await performAccessibilityAudit(named: "CallNotificationRoomTimelineView_Previews")
+    }
+    func test_CollapsibleRoomTimelineView_Previews() async throws {
+        try await performAccessibilityAudit(named: "CollapsibleRoomTimelineView_Previews")
+    }
+    func test_CompletionSuggestion_Previews() async throws {
+        try await performAccessibilityAudit(named: "CompletionSuggestion_Previews")
+    }
+    func test_ComposerToolbar_Previews() async throws {
+        try await performAccessibilityAudit(named: "ComposerToolbar_Previews")
+    }
+    func test_CreateRoom_Previews() async throws {
+        try await performAccessibilityAudit(named: "CreateRoom_Previews")
+    }
+    func test_DeactivateAccountScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "DeactivateAccountScreen_Previews")
+    }
+    func test_DeclineAndBlockScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "DeclineAndBlockScreen_Previews")
+    }
+    func test_EditRoomAddressScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "EditRoomAddressScreen_Previews")
+    }
+    func test_ElementTextFieldStyle_Previews() async throws {
+        try await performAccessibilityAudit(named: "ElementTextFieldStyle_Previews")
+    }
+    func test_EmojiPickerScreenHeaderView_Previews() async throws {
+        try await performAccessibilityAudit(named: "EmojiPickerScreenHeaderView_Previews")
+    }
+    func test_EmojiPickerScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "EmojiPickerScreen_Previews")
+    }
+    func test_EmoteRoomTimelineView_Previews() async throws {
+        try await performAccessibilityAudit(named: "EmoteRoomTimelineView_Previews")
+    }
+    func test_EncryptedRoomTimelineView_Previews() async throws {
+        try await performAccessibilityAudit(named: "EncryptedRoomTimelineView_Previews")
+    }
+    func test_EncryptionResetPasswordScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "EncryptionResetPasswordScreen_Previews")
+    }
+    func test_EncryptionResetScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "EncryptionResetScreen_Previews")
+    }
+    func test_EstimatedWaveformView_Previews() async throws {
+        try await performAccessibilityAudit(named: "EstimatedWaveformView_Previews")
+    }
+    func test_FileMediaEventsTimelineView_Previews() async throws {
+        try await performAccessibilityAudit(named: "FileMediaEventsTimelineView_Previews")
+    }
+    func test_FileRoomTimelineView_Previews() async throws {
+        try await performAccessibilityAudit(named: "FileRoomTimelineView_Previews")
+    }
+    func test_FormButtonStyles_Previews() async throws {
+        try await performAccessibilityAudit(named: "FormButtonStyles_Previews")
+    }
+    func test_FormattedBodyText_Previews() async throws {
+        try await performAccessibilityAudit(named: "FormattedBodyText_Previews")
+    }
+    func test_FormattingToolbar_Previews() async throws {
+        try await performAccessibilityAudit(named: "FormattingToolbar_Previews")
+    }
+    func test_FullscreenDialog_Previews() async throws {
+        try await performAccessibilityAudit(named: "FullscreenDialog_Previews")
+    }
+    func test_GlobalSearchScreenListRow_Previews() async throws {
+        try await performAccessibilityAudit(named: "GlobalSearchScreenListRow_Previews")
+    }
+    func test_GlobalSearchScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "GlobalSearchScreen_Previews")
+    }
+    func test_HighlightedTimelineItemModifier_Previews() async throws {
+        try await performAccessibilityAudit(named: "HighlightedTimelineItemModifier_Previews")
+    }
+    func test_HomeScreenEmptyStateView_Previews() async throws {
+        try await performAccessibilityAudit(named: "HomeScreenEmptyStateView_Previews")
+    }
+    func test_HomeScreenInviteCell_Previews() async throws {
+        try await performAccessibilityAudit(named: "HomeScreenInviteCell_Previews")
+    }
+    func test_HomeScreenKnockedCell_Previews() async throws {
+        try await performAccessibilityAudit(named: "HomeScreenKnockedCell_Previews")
+    }
+    func test_HomeScreenRecoveryKeyConfirmationBanner_Previews() async throws {
+        try await performAccessibilityAudit(named: "HomeScreenRecoveryKeyConfirmationBanner_Previews")
+    }
+    func test_HomeScreenRoomCell_Previews() async throws {
+        try await performAccessibilityAudit(named: "HomeScreenRoomCell_Previews")
+    }
+    func test_HomeScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "HomeScreen_Previews")
+    }
+    func test_IdentityConfirmationScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "IdentityConfirmationScreen_Previews")
+    }
+    func test_IdentityConfirmedScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "IdentityConfirmedScreen_Previews")
+    }
+    func test_ImageMediaEventsTimelineView_Previews() async throws {
+        try await performAccessibilityAudit(named: "ImageMediaEventsTimelineView_Previews")
+    }
+    func test_ImageRoomTimelineView_Previews() async throws {
+        try await performAccessibilityAudit(named: "ImageRoomTimelineView_Previews")
+    }
+    func test_InviteUsersScreenSelectedItem_Previews() async throws {
+        try await performAccessibilityAudit(named: "InviteUsersScreenSelectedItem_Previews")
+    }
+    func test_InviteUsersScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "InviteUsersScreen_Previews")
+    }
+    func test_JoinRoomByAddressView_Previews() async throws {
+        try await performAccessibilityAudit(named: "JoinRoomByAddressView_Previews")
+    }
+    func test_JoinRoomScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "JoinRoomScreen_Previews")
+    }
+    func test_KnockRequestCell_Previews() async throws {
+        try await performAccessibilityAudit(named: "KnockRequestCell_Previews")
+    }
+    func test_KnockRequestsBannerView_Previews() async throws {
+        try await performAccessibilityAudit(named: "KnockRequestsBannerView_Previews")
+    }
+    func test_KnockRequestsListEmptyStateView_Previews() async throws {
+        try await performAccessibilityAudit(named: "KnockRequestsListEmptyStateView_Previews")
+    }
+    func test_KnockRequestsListScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "KnockRequestsListScreen_Previews")
+    }
+    func test_LegalInformationScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "LegalInformationScreen_Previews")
+    }
+    func test_LoadableImage_Previews() async throws {
+        try await performAccessibilityAudit(named: "LoadableImage_Previews")
+    }
+    func test_LocationMarkerView_Previews() async throws {
+        try await performAccessibilityAudit(named: "LocationMarkerView_Previews")
+    }
+    func test_LocationRoomTimelineView_Previews() async throws {
+        try await performAccessibilityAudit(named: "LocationRoomTimelineView_Previews")
+    }
+    func test_LoginScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "LoginScreen_Previews")
+    }
+    func test_LongPressWithFeedback_Previews() async throws {
+        try await performAccessibilityAudit(named: "LongPressWithFeedback_Previews")
+    }
+    func test_ManageRoomMemberSheetView_Previews() async throws {
+        try await performAccessibilityAudit(named: "ManageRoomMemberSheetView_Previews")
+    }
+    func test_MapLibreStaticMapView_Previews() async throws {
+        try await performAccessibilityAudit(named: "MapLibreStaticMapView_Previews")
+    }
+    func test_MatrixUserPermalink_Previews() async throws {
+        try await performAccessibilityAudit(named: "MatrixUserPermalink_Previews")
+    }
+    func test_MediaEventsTimelineScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "MediaEventsTimelineScreen_Previews")
+    }
+    func test_MediaUploadPreviewScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "MediaUploadPreviewScreen_Previews")
+    }
+    func test_MentionSuggestionItemView_Previews() async throws {
+        try await performAccessibilityAudit(named: "MentionSuggestionItemView_Previews")
+    }
+    func test_MessageComposerTextField_Previews() async throws {
+        try await performAccessibilityAudit(named: "MessageComposerTextField_Previews")
+    }
+    func test_MessageComposer_Previews() async throws {
+        try await performAccessibilityAudit(named: "MessageComposer_Previews")
+    }
+    func test_MessageForwardingScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "MessageForwardingScreen_Previews")
+    }
+    func test_MessageText_Previews() async throws {
+        try await performAccessibilityAudit(named: "MessageText_Previews")
+    }
+    func test_NoticeRoomTimelineView_Previews() async throws {
+        try await performAccessibilityAudit(named: "NoticeRoomTimelineView_Previews")
+    }
+    func test_NotificationPermissionsScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "NotificationPermissionsScreen_Previews")
+    }
+    func test_NotificationSettingsEditScreenRoomCell_Previews() async throws {
+        try await performAccessibilityAudit(named: "NotificationSettingsEditScreenRoomCell_Previews")
+    }
+    func test_NotificationSettingsEditScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "NotificationSettingsEditScreen_Previews")
+    }
+    func test_NotificationSettingsScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "NotificationSettingsScreen_Previews")
+    }
+    func test_PINTextField_Previews() async throws {
+        try await performAccessibilityAudit(named: "PINTextField_Previews")
+    }
+    func test_PaginationIndicatorRoomTimelineView_Previews() async throws {
+        try await performAccessibilityAudit(named: "PaginationIndicatorRoomTimelineView_Previews")
+    }
+    func test_PillViewOnBubble_Previews() async throws {
+        try await performAccessibilityAudit(named: "PillViewOnBubble_Previews")
+    }
+    func test_PillView_Previews() async throws {
+        try await performAccessibilityAudit(named: "PillView_Previews")
+    }
+    func test_PinnedEventsTimelineScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "PinnedEventsTimelineScreen_Previews")
+    }
+    func test_PinnedItemsBannerView_Previews() async throws {
+        try await performAccessibilityAudit(named: "PinnedItemsBannerView_Previews")
+    }
+    func test_PinnedItemsIndicatorView_Previews() async throws {
+        try await performAccessibilityAudit(named: "PinnedItemsIndicatorView_Previews")
+    }
+    func test_PlaceholderAvatarImage_Previews() async throws {
+        try await performAccessibilityAudit(named: "PlaceholderAvatarImage_Previews")
+    }
+    func test_PlaceholderScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "PlaceholderScreen_Previews")
+    }
+    func test_PollFormScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "PollFormScreen_Previews")
+    }
+    func test_PollOptionView_Previews() async throws {
+        try await performAccessibilityAudit(named: "PollOptionView_Previews")
+    }
+    func test_PollRoomTimelineView_Previews() async throws {
+        try await performAccessibilityAudit(named: "PollRoomTimelineView_Previews")
+    }
+    func test_PollView_Previews() async throws {
+        try await performAccessibilityAudit(named: "PollView_Previews")
+    }
+    func test_QRCodeLoginScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "QRCodeLoginScreen_Previews")
+    }
+    func test_ReactionsSummaryView_Previews() async throws {
+        try await performAccessibilityAudit(named: "ReactionsSummaryView_Previews")
+    }
+    func test_ReadMarkerRoomTimelineView_Previews() async throws {
+        try await performAccessibilityAudit(named: "ReadMarkerRoomTimelineView_Previews")
+    }
+    func test_ReadReceiptCell_Previews() async throws {
+        try await performAccessibilityAudit(named: "ReadReceiptCell_Previews")
+    }
+    func test_ReadReceiptsSummaryView_Previews() async throws {
+        try await performAccessibilityAudit(named: "ReadReceiptsSummaryView_Previews")
+    }
+    func test_RedactedRoomTimelineView_Previews() async throws {
+        try await performAccessibilityAudit(named: "RedactedRoomTimelineView_Previews")
+    }
+    func test_ReportContentScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "ReportContentScreen_Previews")
+    }
+    func test_ReportRoomScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "ReportRoomScreen_Previews")
+    }
+    func test_ResolveVerifiedUserSendFailureScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "ResolveVerifiedUserSendFailureScreen_Previews")
+    }
+    func test_RoomAttachmentPicker_Previews() async throws {
+        try await performAccessibilityAudit(named: "RoomAttachmentPicker_Previews")
+    }
+    func test_RoomAvatarImage_Previews() async throws {
+        try await performAccessibilityAudit(named: "RoomAvatarImage_Previews")
+    }
+    func test_RoomChangePermissionsScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "RoomChangePermissionsScreen_Previews")
+    }
+    func test_RoomChangeRolesScreenRow_Previews() async throws {
+        try await performAccessibilityAudit(named: "RoomChangeRolesScreenRow_Previews")
+    }
+    func test_RoomChangeRolesScreenSelectedItem_Previews() async throws {
+        try await performAccessibilityAudit(named: "RoomChangeRolesScreenSelectedItem_Previews")
+    }
+    func test_RoomChangeRolesScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "RoomChangeRolesScreen_Previews")
+    }
+    func test_RoomDetailsEditScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "RoomDetailsEditScreen_Previews")
+    }
+    func test_RoomDetailsScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "RoomDetailsScreen_Previews")
+    }
+    func test_RoomDirectorySearchCell_Previews() async throws {
+        try await performAccessibilityAudit(named: "RoomDirectorySearchCell_Previews")
+    }
+    func test_RoomDirectorySearchScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "RoomDirectorySearchScreen_Previews")
+    }
+    func test_RoomHeaderView_Previews() async throws {
+        try await performAccessibilityAudit(named: "RoomHeaderView_Previews")
+    }
+    func test_RoomInviterLabel_Previews() async throws {
+        try await performAccessibilityAudit(named: "RoomInviterLabel_Previews")
+    }
+    func test_RoomListFilterView_Previews() async throws {
+        try await performAccessibilityAudit(named: "RoomListFilterView_Previews")
+    }
+    func test_RoomListFiltersEmptyStateView_Previews() async throws {
+        try await performAccessibilityAudit(named: "RoomListFiltersEmptyStateView_Previews")
+    }
+    func test_RoomListFiltersView_Previews() async throws {
+        try await performAccessibilityAudit(named: "RoomListFiltersView_Previews")
+    }
+    func test_RoomMemberDetailsScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "RoomMemberDetailsScreen_Previews")
+    }
+    func test_RoomMembersListMemberCell_Previews() async throws {
+        try await performAccessibilityAudit(named: "RoomMembersListMemberCell_Previews")
+    }
+    func test_RoomMembersListScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "RoomMembersListScreen_Previews")
+    }
+    func test_RoomNotificationSettingsCustomSectionView_Previews() async throws {
+        try await performAccessibilityAudit(named: "RoomNotificationSettingsCustomSectionView_Previews")
+    }
+    func test_RoomNotificationSettingsScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "RoomNotificationSettingsScreen_Previews")
+    }
+    func test_RoomNotificationSettingsUserDefinedScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "RoomNotificationSettingsUserDefinedScreen_Previews")
+    }
+    func test_RoomPollsHistoryScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "RoomPollsHistoryScreen_Previews")
+    }
+    func test_RoomRolesAndPermissionsScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "RoomRolesAndPermissionsScreen_Previews")
+    }
+    func test_RoomScreenFooterView_Previews() async throws {
+        try await performAccessibilityAudit(named: "RoomScreenFooterView_Previews")
+    }
+    func test_RoomScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "RoomScreen_Previews")
+    }
+    func test_RoomSelectionScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "RoomSelectionScreen_Previews")
+    }
+    func test_SFNumberedListView_Previews() async throws {
+        try await performAccessibilityAudit(named: "SFNumberedListView_Previews")
+    }
+    func test_SecureBackupKeyBackupScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "SecureBackupKeyBackupScreen_Previews")
+    }
+    func test_SecureBackupLogoutConfirmationScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "SecureBackupLogoutConfirmationScreen_Previews")
+    }
+    func test_SecureBackupRecoveryKeyScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "SecureBackupRecoveryKeyScreen_Previews")
+    }
+    func test_SecureBackupScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "SecureBackupScreen_Previews")
+    }
+    func test_SecurityAndPrivacyScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "SecurityAndPrivacyScreen_Previews")
+    }
+    func test_SendInviteConfirmationView_Previews() async throws {
+        try await performAccessibilityAudit(named: "SendInviteConfirmationView_Previews")
+    }
+    func test_SeparatorMediaEventsTimelineView_Previews() async throws {
+        try await performAccessibilityAudit(named: "SeparatorMediaEventsTimelineView_Previews")
+    }
+    func test_SeparatorRoomTimelineView_Previews() async throws {
+        try await performAccessibilityAudit(named: "SeparatorRoomTimelineView_Previews")
+    }
+    func test_ServerConfirmationScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "ServerConfirmationScreen_Previews")
+    }
+    func test_ServerSelection_Previews() async throws {
+        try await performAccessibilityAudit(named: "ServerSelection_Previews")
+    }
+    func test_SessionVerificationRequestDetailsView_Previews() async throws {
+        try await performAccessibilityAudit(named: "SessionVerificationRequestDetailsView_Previews")
+    }
+    func test_SessionVerification_Previews() async throws {
+        try await performAccessibilityAudit(named: "SessionVerification_Previews")
+    }
+    func test_SettingsScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "SettingsScreen_Previews")
+    }
+    func test_ShimmerOverlay_Previews() async throws {
+        try await performAccessibilityAudit(named: "ShimmerOverlay_Previews")
+    }
+    func test_SoftLogoutScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "SoftLogoutScreen_Previews")
+    }
+    func test_SplashScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "SplashScreen_Previews")
+    }
+    func test_StackedAvatarsView_Previews() async throws {
+        try await performAccessibilityAudit(named: "StackedAvatarsView_Previews")
+    }
+    func test_StartChatScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "StartChatScreen_Previews")
+    }
+    func test_StateRoomTimelineView_Previews() async throws {
+        try await performAccessibilityAudit(named: "StateRoomTimelineView_Previews")
+    }
+    func test_StaticLocationScreenViewer_Previews() async throws {
+        try await performAccessibilityAudit(named: "StaticLocationScreenViewer_Previews")
+    }
+    func test_StickerRoomTimelineView_Previews() async throws {
+        try await performAccessibilityAudit(named: "StickerRoomTimelineView_Previews")
+    }
+    func test_SwipeRightAction_Previews() async throws {
+        try await performAccessibilityAudit(named: "SwipeRightAction_Previews")
+    }
+    func test_SwipeToReplyView_Previews() async throws {
+        try await performAccessibilityAudit(named: "SwipeToReplyView_Previews")
+    }
+    func test_TextRoomTimelineView_Previews() async throws {
+        try await performAccessibilityAudit(named: "TextRoomTimelineView_Previews")
+    }
+    func test_ThreadDecorator_Previews() async throws {
+        try await performAccessibilityAudit(named: "ThreadDecorator_Previews")
+    }
+    func test_TimelineDeliveryStatusView_Previews() async throws {
+        try await performAccessibilityAudit(named: "TimelineDeliveryStatusView_Previews")
+    }
+    func test_TimelineItemBubbledStylerView_Previews() async throws {
+        try await performAccessibilityAudit(named: "TimelineItemBubbledStylerView_Previews")
+    }
+    func test_TimelineItemDebugView_Previews() async throws {
+        try await performAccessibilityAudit(named: "TimelineItemDebugView_Previews")
+    }
+    func test_TimelineItemMenu_Previews() async throws {
+        try await performAccessibilityAudit(named: "TimelineItemMenu_Previews")
+    }
+    func test_TimelineItemSendInfoLabel_Previews() async throws {
+        try await performAccessibilityAudit(named: "TimelineItemSendInfoLabel_Previews")
+    }
+    func test_TimelineItemStyler_Previews() async throws {
+        try await performAccessibilityAudit(named: "TimelineItemStyler_Previews")
+    }
+    func test_TimelineMediaPreviewDetailsView_Previews() async throws {
+        try await performAccessibilityAudit(named: "TimelineMediaPreviewDetailsView_Previews")
+    }
+    func test_TimelineMediaPreviewRedactConfirmationView_Previews() async throws {
+        try await performAccessibilityAudit(named: "TimelineMediaPreviewRedactConfirmationView_Previews")
+    }
+    func test_TimelineReactionView_Previews() async throws {
+        try await performAccessibilityAudit(named: "TimelineReactionView_Previews")
+    }
+    func test_TimelineReadReceiptsView_Previews() async throws {
+        try await performAccessibilityAudit(named: "TimelineReadReceiptsView_Previews")
+    }
+    func test_TimelineReplyView_Previews() async throws {
+        try await performAccessibilityAudit(named: "TimelineReplyView_Previews")
+    }
+    func test_TimelineStartRoomTimelineView_Previews() async throws {
+        try await performAccessibilityAudit(named: "TimelineStartRoomTimelineView_Previews")
+    }
+    func test_TimelineThreadSummaryView_Previews() async throws {
+        try await performAccessibilityAudit(named: "TimelineThreadSummaryView_Previews")
+    }
+    func test_TimelineView_Previews() async throws {
+        try await performAccessibilityAudit(named: "TimelineView_Previews")
+    }
+    func test_TombstonedAvatarImage_Previews() async throws {
+        try await performAccessibilityAudit(named: "TombstonedAvatarImage_Previews")
+    }
+    func test_TypingIndicatorView_Previews() async throws {
+        try await performAccessibilityAudit(named: "TypingIndicatorView_Previews")
+    }
+    func test_UnsupportedRoomTimelineView_Previews() async throws {
+        try await performAccessibilityAudit(named: "UnsupportedRoomTimelineView_Previews")
+    }
+    func test_UserDetailsEditScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "UserDetailsEditScreen_Previews")
+    }
+    func test_UserIndicatorModalView_Previews() async throws {
+        try await performAccessibilityAudit(named: "UserIndicatorModalView_Previews")
+    }
+    func test_UserIndicatorToastView_Previews() async throws {
+        try await performAccessibilityAudit(named: "UserIndicatorToastView_Previews")
+    }
+    func test_UserProfileCell_Previews() async throws {
+        try await performAccessibilityAudit(named: "UserProfileCell_Previews")
+    }
+    func test_UserProfileScreen_Previews() async throws {
+        try await performAccessibilityAudit(named: "UserProfileScreen_Previews")
+    }
+    func test_VerificationBadge_Previews() async throws {
+        try await performAccessibilityAudit(named: "VerificationBadge_Previews")
+    }
+    func test_VideoMediaEventsTimelineView_Previews() async throws {
+        try await performAccessibilityAudit(named: "VideoMediaEventsTimelineView_Previews")
+    }
+    func test_VideoRoomTimelineView_Previews() async throws {
+        try await performAccessibilityAudit(named: "VideoRoomTimelineView_Previews")
+    }
+    func test_VisualListItem_Previews() async throws {
+        try await performAccessibilityAudit(named: "VisualListItem_Previews")
+    }
+    func test_VoiceMessageButton_Previews() async throws {
+        try await performAccessibilityAudit(named: "VoiceMessageButton_Previews")
+    }
+    func test_VoiceMessageMediaEventsTimelineView_Previews() async throws {
+        try await performAccessibilityAudit(named: "VoiceMessageMediaEventsTimelineView_Previews")
+    }
+    func test_VoiceMessagePreviewComposer_Previews() async throws {
+        try await performAccessibilityAudit(named: "VoiceMessagePreviewComposer_Previews")
+    }
+    func test_VoiceMessageRecordingButton_Previews() async throws {
+        try await performAccessibilityAudit(named: "VoiceMessageRecordingButton_Previews")
+    }
+    func test_VoiceMessageRecordingComposer_Previews() async throws {
+        try await performAccessibilityAudit(named: "VoiceMessageRecordingComposer_Previews")
+    }
+    func test_VoiceMessageRecordingView_Previews() async throws {
+        try await performAccessibilityAudit(named: "VoiceMessageRecordingView_Previews")
+    }
+    func test_VoiceMessageRoomPlaybackView_Previews() async throws {
+        try await performAccessibilityAudit(named: "VoiceMessageRoomPlaybackView_Previews")
+    }
+    func test_VoiceMessageRoomTimelineView_Previews() async throws {
+        try await performAccessibilityAudit(named: "VoiceMessageRoomTimelineView_Previews")
+    }
+    func test_WaveformCursorView_Previews() async throws {
+        try await performAccessibilityAudit(named: "WaveformCursorView_Previews")
+    }
+}
+
+// swiftlint:enable all
+// swiftformat:enable all

--- a/AccessibilityTests/SupportingFiles/target.yml
+++ b/AccessibilityTests/SupportingFiles/target.yml
@@ -49,4 +49,7 @@ targets:
     - path: ../SupportingFiles
     - path: ../../ElementX/Sources/UITests/UITestsSignalling.swift
     - path: ../../ElementX/Sources/Other/AccessibilityIdentifiers.swift
+    - path: ../../ElementX/Sources/Other/MatrixEntityRegex.swift
+    - path: ../../ElementX/Sources/Other/Pills/PillUtilities.swift
+    - path: ../../ElementX/Sources/Other/Extensions/NSRegularExpresion.swift
 

--- a/AccessibilityTests/SupportingFiles/target.yml
+++ b/AccessibilityTests/SupportingFiles/target.yml
@@ -48,4 +48,5 @@ targets:
     - path: ../Sources
     - path: ../SupportingFiles
     - path: ../../ElementX/Sources/UITests/UITestsSignalling.swift
+    - path: ../../ElementX/Sources/Other/AccessibilityIdentifiers.swift
 

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -1040,6 +1040,7 @@
 		C85C7A201E4CFDA477ACEBEB /* AppLockSetupSettingsScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8610C1D21565C950BCA6A454 /* AppLockSetupSettingsScreenViewModelProtocol.swift */; };
 		C8A9C595038AFA2D707AC8C1 /* NotificationPermissionsScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E69F67D2A70ABD08CA6D54 /* NotificationPermissionsScreenViewModelProtocol.swift */; };
 		C8BD80891BAD688EF2C15CDB /* MediaUploadPreviewScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74DD0855F2F76D47E5555082 /* MediaUploadPreviewScreenCoordinator.swift */; };
+		C8D1D18E22672D48C11A5366 /* AccessibilityIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BB8DDE245ED86C489BA983 /* AccessibilityIdentifiers.swift */; };
 		C8E0FA0FF2CD6613264FA6B9 /* MessageForwardingScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFEA446F8618DBA79A9239CC /* MessageForwardingScreen.swift */; };
 		C8E1E4E06B7C7A3A8246FC9B /* MediaEventsTimelineScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8512B82404B1751D0BCC82D2 /* MediaEventsTimelineScreenCoordinator.swift */; };
 		C915347779B3C7FDD073A87A /* AVMetadataMachineReadableCodeObjectExtensionsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E1FF0DFBB3768F79FDBF6D /* AVMetadataMachineReadableCodeObjectExtensionsTest.swift */; };
@@ -7119,6 +7120,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C8D1D18E22672D48C11A5366 /* AccessibilityIdentifiers.swift in Sources */,
 				EDD45A73B688B87D84B9C2E9 /* AccessibilityTests.swift in Sources */,
 				F996259EAE68664BC345C197 /* Application.swift in Sources */,
 				F886618F630E65613A1685E7 /* GeneratedTests.swift in Sources */,

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -990,6 +990,7 @@
 		BDA68E8D95B2B24B28825B8B /* LoginScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C368CAB3063EF275357ECD4 /* LoginScreenViewModel.swift */; };
 		BDC4EB54CC3036730475CB8B /* QRCodeLoginScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25E7E9B7FEAB6169D960C206 /* QRCodeLoginScreenViewModelTests.swift */; };
 		BDED6DA7AD1E76018C424143 /* LegalInformationScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C34667458773B02AB5FB0B2 /* LegalInformationScreenViewModel.swift */; };
+		BDFF0AEBF57B5B124062DAEF /* GeneratedAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4CEB4590CCF70F0E3C0B171 /* GeneratedAccessibilityTests.swift */; };
 		BE8E5985771DF9137C6CE89A /* ProcessInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077B01C13BBA2996272C5FB5 /* ProcessInfo.swift */; };
 		BEC6DFEA506085D3027E353C /* MediaEventsTimelineScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002399C6CB875C4EBB01CBC0 /* MediaEventsTimelineScreen.swift */; };
 		BED59052E5C5163D2B065CA6 /* EventTimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A81FD0C60175FA081EB19AD /* EventTimelineItem.swift */; };
@@ -1275,7 +1276,6 @@
 		F7DA19B5122AD8FA8F91B753 /* DeclineAndBlockScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 951F277E0585E50AC91987C8 /* DeclineAndBlockScreenViewModelProtocol.swift */; };
 		F833D5B5BE6707F961FA88DB /* SecureBackupController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1119E9C63AE530252640D2 /* SecureBackupController.swift */; };
 		F86102DC2C68BBBB0521BAAE /* SoftLogoutScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BB385E148DE55C85C0A02D6 /* SoftLogoutScreenModels.swift */; };
-		F886618F630E65613A1685E7 /* GeneratedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9219DF9AAC2A5EE624EE8F0 /* GeneratedTests.swift */; };
 		F8B2F5CBCF2A0E0798E8D646 /* TimelineViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5B00A014307CE37B2812CD /* TimelineViewModelProtocol.swift */; };
 		F8C87130FD999F7F1076208C /* RoomChangePermissionsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89AAEA70CFF3284920811941 /* RoomChangePermissionsScreen.swift */; };
 		F8E725D42023ECA091349245 /* AudioRoomTimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAAF82432B0B53881CF826 /* AudioRoomTimelineItem.swift */; };
@@ -2560,7 +2560,6 @@
 		E8A1F98AE670377B20679FF5 /* MediaPlayerProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPlayerProvider.swift; sourceTree = "<group>"; };
 		E8AE4B3273BA189FDCD4055C /* UserIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserIndicator.swift; sourceTree = "<group>"; };
 		E8CA187FE656EE5A3F6C7DE5 /* UIFont+AttributedStringBuilder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIFont+AttributedStringBuilder.m"; sourceTree = "<group>"; };
-		E9219DF9AAC2A5EE624EE8F0 /* GeneratedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratedTests.swift; sourceTree = "<group>"; };
 		E944F717FC10A428D027074D /* RoomPowerLevelsProxyMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomPowerLevelsProxyMock.swift; sourceTree = "<group>"; };
 		E96ED747FF90332EA1333C22 /* RoomTimelineItemFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomTimelineItemFixtures.swift; sourceTree = "<group>"; };
 		E992D7B8BE54B2AB454613AF /* XCUIElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCUIElement.swift; sourceTree = "<group>"; };
@@ -2623,6 +2622,7 @@
 		F409D44C2E6BE50462E82F8A /* en-US */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-US"; path = "en-US.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		F4469F6AE311BDC439B3A5EC /* UserSessionMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSessionMock.swift; sourceTree = "<group>"; };
 		F4548A9BDE5CB3AB864BCA9F /* EffectsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EffectsView.swift; sourceTree = "<group>"; };
+		F4CEB4590CCF70F0E3C0B171 /* GeneratedAccessibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratedAccessibilityTests.swift; sourceTree = "<group>"; };
 		F506C6ADB1E1DA6638078E11 /* UITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F51D674A5B5F1FE1B878E20F /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/Localizable.strings; sourceTree = "<group>"; };
 		F5311C989EC15B4C2D699025 /* StaticLocationScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticLocationScreenViewModel.swift; sourceTree = "<group>"; };
@@ -6045,7 +6045,7 @@
 			children = (
 				7A6D867A7FBB70C6EFDBCBC5 /* AccessibilityTests.swift */,
 				2D9DBE1C69F3A60D93B2203F /* Application.swift */,
-				E9219DF9AAC2A5EE624EE8F0 /* GeneratedTests.swift */,
+				F4CEB4590CCF70F0E3C0B171 /* GeneratedAccessibilityTests.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -7123,7 +7123,7 @@
 				C8D1D18E22672D48C11A5366 /* AccessibilityIdentifiers.swift in Sources */,
 				EDD45A73B688B87D84B9C2E9 /* AccessibilityTests.swift in Sources */,
 				F996259EAE68664BC345C197 /* Application.swift in Sources */,
-				F886618F630E65613A1685E7 /* GeneratedTests.swift in Sources */,
+				BDFF0AEBF57B5B124062DAEF /* GeneratedAccessibilityTests.swift in Sources */,
 				E323A54F317604BDD6968D79 /* UITestsSignalling.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -503,6 +503,7 @@
 		60ED66E63A169E47489348A8 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 886A0A498FA01E8EDD451D05 /* Sentry */; };
 		611BEE29B8B622204E1E6B04 /* SecurityAndPrivacyScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97F2F6B6E56055EF173A2DD3 /* SecurityAndPrivacyScreenCoordinator.swift */; };
 		617624A97BDBB75ED3DD8156 /* RoomScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00C7A331B72C0F05C00392F /* RoomScreenViewModelProtocol.swift */; };
+		6183BD3916CAA7134B6070D2 /* MatrixEntityRegex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD1A853D605C2146B0DC028 /* MatrixEntityRegex.swift */; };
 		6189B4ABD535CE526FA1107B /* StartChatViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF438EAFC732D2D95D34BF6 /* StartChatViewModelTests.swift */; };
 		61941DEE5F3834765770BE01 /* InviteUsersScreenSelectedItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10F32E0B4B83D2A11EE8D011 /* InviteUsersScreenSelectedItem.swift */; };
 		61A36B9BB2ADE36CEFF5E98C /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E93A1BE7D8A2EBCAD51EEB4 /* Array.swift */; };
@@ -644,6 +645,7 @@
 		7B66DA4E7E5FE4D1A0FCEAA4 /* JoinRoomScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEAB5662310AE73D93815134 /* JoinRoomScreenViewModelProtocol.swift */; };
 		7BB31E67648CF32D2AB5E502 /* RoomScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CE3C90E487B255B735D73C8 /* RoomScreenViewModel.swift */; };
 		7BD2123144A32F082CECC108 /* AudioRoomTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2EAFFD44F81F86012D6EC27 /* AudioRoomTimelineView.swift */; };
+		7BDC3976D88D40D2A45BEB8C /* NSRegularExpresion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95BAC0F6C9644336E9567EE6 /* NSRegularExpresion.swift */; };
 		7BF368A78E6D9AFD222F25AF /* SecureBackupScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AE094FCB6387D268C436161 /* SecureBackupScreenViewModel.swift */; };
 		7C0E29E0279866C62EC67A28 /* JoinRoomScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5127D6EA05B2E45D0A7D59 /* JoinRoomScreenViewModelTests.swift */; };
 		7C164A642E8932B5F9004550 /* test_voice_message.m4a in Resources */ = {isa = PBXBuildFile; fileRef = DCA2D836BD10303F37FAAEED /* test_voice_message.m4a */; };
@@ -734,6 +736,7 @@
 		8B41D0357B91CD3B6F6A3BCA /* EmoteRoomTimelineItemContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE378083653EF0C9B5E9D580 /* EmoteRoomTimelineItemContent.swift */; };
 		8B76191B9DDD1AC90A6E3A35 /* MediaFileHandleProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC1D382565A4E9CAC2F14EA /* MediaFileHandleProxy.swift */; };
 		8BC8EF6705A78946C1F22891 /* SoftLogoutScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71A7D4DDEEE5D2CA0C8D63CD /* SoftLogoutScreen.swift */; };
+		8BD22815DC34D7F9E9C1F2FE /* PillUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = C537DE821FED94D23467B6C4 /* PillUtilities.swift */; };
 		8C050A8012E6078BEAEF5BC8 /* PillTextAttachmentData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 913C8E13B8B602C7B6C0C4AE /* PillTextAttachmentData.swift */; };
 		8C1A5ECAF895D4CAF8C4D461 /* AppActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F21ED7205048668BEB44A38 /* AppActivityView.swift */; };
 		8C706DA7EAC0974CA2F8F1CD /* MentionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15748C254911E3654C93B0ED /* MentionBuilder.swift */; };
@@ -7124,6 +7127,9 @@
 				EDD45A73B688B87D84B9C2E9 /* AccessibilityTests.swift in Sources */,
 				F996259EAE68664BC345C197 /* Application.swift in Sources */,
 				BDFF0AEBF57B5B124062DAEF /* GeneratedAccessibilityTests.swift in Sources */,
+				6183BD3916CAA7134B6070D2 /* MatrixEntityRegex.swift in Sources */,
+				7BDC3976D88D40D2A45BEB8C /* NSRegularExpresion.swift in Sources */,
+				8BD22815DC34D7F9E9C1F2FE /* PillUtilities.swift in Sources */,
 				E323A54F317604BDD6968D79 /* UITestsSignalling.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -847,7 +847,6 @@
 		A1672EF491FE6F3BBF7878BE /* test_apple_image.heic in Resources */ = {isa = PBXBuildFile; fileRef = BB576F4118C35E6B5124FA22 /* test_apple_image.heic */; };
 		A17FAD2EBC53E17B5FD384DB /* InviteUsersScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22730A30C50AC2E3D5BA8642 /* InviteUsersScreenViewModelProtocol.swift */; };
 		A1BA8D6BABAFA9BAAEAA3FFD /* NotificationSettingsProxyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDD775CFD72DD2D3C8A8390 /* NotificationSettingsProxyProtocol.swift */; };
-		A1C8951A632AC5F350FE0A6C /* Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932E4E8BB476283CBF219427 /* Test.swift */; };
 		A1DF0E1E526A981ED6D5DF44 /* UserIndicatorControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2429224EB0EEA34D35CE9249 /* UserIndicatorControllerTests.swift */; };
 		A216C83ADCF32BA5EF8A6FBC /* InviteUsersViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845DDBDE5A0887E73D38B826 /* InviteUsersViewModelTests.swift */; };
 		A2172B5A26976F9174228B8A /* AppHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E4AB573FAEBB7B853DD04C /* AppHooks.swift */; };
@@ -1211,6 +1210,7 @@
 		ED635D7F00FA07E94D3CE1E8 /* PreviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9B796D347E53631576F631C /* PreviewTests.swift */; };
 		ED90A59F068FD0CA27E602ED /* UserProfileListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10DA51DBC8C7E1460DBCCBD /* UserProfileListRow.swift */; };
 		EDB6915EC953BB2A44AA608E /* EditRoomAddressScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 906451FB8CF27C628152BF7A /* EditRoomAddressScreenViewModelTests.swift */; };
+		EDD45A73B688B87D84B9C2E9 /* AccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6D867A7FBB70C6EFDBCBC5 /* AccessibilityTests.swift */; };
 		EDF8919F15DE0FF00EF99E70 /* DocumentPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5567A7EF6F2AB9473236F6 /* DocumentPicker.swift */; };
 		EE4E2C1922BBF5169E213555 /* PillAttachmentViewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B53D6C5C0D14B04D3AB3F6E /* PillAttachmentViewProvider.swift */; };
 		EE56238683BC3ECA9BA00684 /* GlobalSearchScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA4D639E27D5882A6A71AECF /* GlobalSearchScreenViewModelTests.swift */; };
@@ -1274,6 +1274,7 @@
 		F7DA19B5122AD8FA8F91B753 /* DeclineAndBlockScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 951F277E0585E50AC91987C8 /* DeclineAndBlockScreenViewModelProtocol.swift */; };
 		F833D5B5BE6707F961FA88DB /* SecureBackupController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1119E9C63AE530252640D2 /* SecureBackupController.swift */; };
 		F86102DC2C68BBBB0521BAAE /* SoftLogoutScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BB385E148DE55C85C0A02D6 /* SoftLogoutScreenModels.swift */; };
+		F886618F630E65613A1685E7 /* GeneratedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9219DF9AAC2A5EE624EE8F0 /* GeneratedTests.swift */; };
 		F8B2F5CBCF2A0E0798E8D646 /* TimelineViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5B00A014307CE37B2812CD /* TimelineViewModelProtocol.swift */; };
 		F8C87130FD999F7F1076208C /* RoomChangePermissionsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89AAEA70CFF3284920811941 /* RoomChangePermissionsScreen.swift */; };
 		F8E725D42023ECA091349245 /* AudioRoomTimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAAF82432B0B53881CF826 /* AudioRoomTimelineItem.swift */; };
@@ -1989,6 +1990,7 @@
 		796CBD0C56FA0D3AEDAB255B /* SessionVerificationScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionVerificationScreenCoordinator.swift; sourceTree = "<group>"; };
 		79A106D76741914F82664959 /* StateStoreViewModelV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateStoreViewModelV2.swift; sourceTree = "<group>"; };
 		7A03E073077D92AA19C43DCF /* IdentityConfirmationScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityConfirmationScreenCoordinator.swift; sourceTree = "<group>"; };
+		7A6D867A7FBB70C6EFDBCBC5 /* AccessibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityTests.swift; sourceTree = "<group>"; };
 		7AAD8C633AA57948B34EDCF7 /* RoomChangeRolesScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomChangeRolesScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		7AC0CD1CAFD3F8B057F9AEA5 /* ClientBuilderHook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientBuilderHook.swift; sourceTree = "<group>"; };
 		7AC1E3FE9B59EA094867863E /* TimelineControllerFactoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineControllerFactoryProtocol.swift; sourceTree = "<group>"; };
@@ -2122,7 +2124,6 @@
 		922E498EB74CF6F5CC236F81 /* AdvancedSettingsScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsScreenModels.swift; sourceTree = "<group>"; };
 		92390F9FA98255440A6BF5F8 /* OIDCAuthenticationPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OIDCAuthenticationPresenter.swift; sourceTree = "<group>"; };
 		92DB574F954CC2B40F7BE892 /* QRCodeScannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeScannerView.swift; sourceTree = "<group>"; };
-		932E4E8BB476283CBF219427 /* Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test.swift; sourceTree = "<group>"; };
 		9332DFE9642F0A46ECA0497B /* BlurHashEncode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurHashEncode.swift; sourceTree = "<group>"; };
 		933B074F006F8E930DB98B4E /* TimelineMediaFrame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineMediaFrame.swift; sourceTree = "<group>"; };
 		9342F5D6729627B6393AF853 /* ServerConfirmationScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerConfirmationScreenModels.swift; sourceTree = "<group>"; };
@@ -2558,6 +2559,7 @@
 		E8A1F98AE670377B20679FF5 /* MediaPlayerProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPlayerProvider.swift; sourceTree = "<group>"; };
 		E8AE4B3273BA189FDCD4055C /* UserIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserIndicator.swift; sourceTree = "<group>"; };
 		E8CA187FE656EE5A3F6C7DE5 /* UIFont+AttributedStringBuilder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIFont+AttributedStringBuilder.m"; sourceTree = "<group>"; };
+		E9219DF9AAC2A5EE624EE8F0 /* GeneratedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratedTests.swift; sourceTree = "<group>"; };
 		E944F717FC10A428D027074D /* RoomPowerLevelsProxyMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomPowerLevelsProxyMock.swift; sourceTree = "<group>"; };
 		E96ED747FF90332EA1333C22 /* RoomTimelineItemFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomTimelineItemFixtures.swift; sourceTree = "<group>"; };
 		E992D7B8BE54B2AB454613AF /* XCUIElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCUIElement.swift; sourceTree = "<group>"; };
@@ -6040,8 +6042,9 @@
 		EB9C851423AA9BC8CEC381DC /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				7A6D867A7FBB70C6EFDBCBC5 /* AccessibilityTests.swift */,
 				2D9DBE1C69F3A60D93B2203F /* Application.swift */,
-				932E4E8BB476283CBF219427 /* Test.swift */,
+				E9219DF9AAC2A5EE624EE8F0 /* GeneratedTests.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -6861,7 +6864,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which sourcery >/dev/null; then\n    sourcery --config Tools/Sourcery/TestablePreviewsDictionary.yml\nelse\n    echo \"warning: Sourcery not installed, run swift run tools setup-project\"\nfi\n";
+			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which sourcery >/dev/null; then\n    sourcery --config Tools/Sourcery/TestablePreviewsDictionary.yml\n    sourcery --config Tools/Sourcery/AccessibilityTests.yml\nelse\n    echo \"warning: Sourcery not installed, run swift run tools setup-project\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -7116,8 +7119,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EDD45A73B688B87D84B9C2E9 /* AccessibilityTests.swift in Sources */,
 				F996259EAE68664BC345C197 /* Application.swift in Sources */,
-				A1C8951A632AC5F350FE0A6C /* Test.swift in Sources */,
+				F886618F630E65613A1685E7 /* GeneratedTests.swift in Sources */,
 				E323A54F317604BDD6968D79 /* UITestsSignalling.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ElementX/Sources/AccessibilityTests/AccessibilityTestsAppCoordinator.swift
+++ b/ElementX/Sources/AccessibilityTests/AccessibilityTestsAppCoordinator.swift
@@ -144,6 +144,9 @@ struct PreviewsWrapperView: View {
         switch fulfillmentSource {
         case .publisher(let publisher):
             _ = await publisher
+                // Not sure whye byt some publisher seem to not properly comunicate their completion,
+                // so we added a timeout. Since we are going to migrate from publishers to stream,
+                // this is a temporary solution
                 .timeout(.seconds(1), scheduler: DispatchQueue.main)
                 .values.first { $0 == true }
         case .stream(let stream):

--- a/ElementX/Sources/AccessibilityTests/AccessibilityTestsAppCoordinator.swift
+++ b/ElementX/Sources/AccessibilityTests/AccessibilityTestsAppCoordinator.swift
@@ -143,7 +143,9 @@ struct PreviewsWrapperView: View {
         
         switch fulfillmentSource {
         case .publisher(let publisher):
-            _ = await publisher.values.first { $0 == true }
+            _ = await publisher
+                .timeout(.seconds(1), scheduler: DispatchQueue.main)
+                .values.first { $0 == true }
         case .stream(let stream):
             _ = await stream.first { $0 == true }
         case .none:

--- a/ElementX/Sources/AccessibilityTests/AccessibilityTestsAppCoordinator.swift
+++ b/ElementX/Sources/AccessibilityTests/AccessibilityTestsAppCoordinator.swift
@@ -6,6 +6,7 @@
 //
 
 import Combine
+import CoreLocation
 import SwiftUI
 
 class AccessibilityTestsAppCoordinator: AppCoordinatorProtocol {
@@ -51,8 +52,10 @@ class AccessibilityTestsAppCoordinator: AppCoordinatorProtocol {
             fatalError("Unable to launch with unknown screen.")
         }
         previewsWrapper = .init(name: name, previews: previewType._allPreviews)
-        
+                
         setupSignalling()
+        // Used to get rid of the request check for the rest of the tests on CI
+        CLLocationManager().requestWhenInUseAuthorization()
     }
     
     func toPresentable() -> AnyView {

--- a/ElementX/Sources/AccessibilityTests/AccessibilityTestsAppCoordinator.swift
+++ b/ElementX/Sources/AccessibilityTests/AccessibilityTestsAppCoordinator.swift
@@ -52,9 +52,9 @@ class AccessibilityTestsAppCoordinator: AppCoordinatorProtocol {
             fatalError("Unable to launch with unknown screen.")
         }
         previewsWrapper = .init(name: name, previews: previewType._allPreviews)
-                
+        
         setupSignalling()
-        // Used to get rid of the request check for the rest of the tests on CI
+        // Used to perform the request check before the tests run on CI, so it can be immediately dismissed.
         CLLocationManager().requestWhenInUseAuthorization()
     }
     

--- a/ElementX/Sources/Other/MatrixEntityRegex.swift
+++ b/ElementX/Sources/Other/MatrixEntityRegex.swift
@@ -26,7 +26,7 @@ enum MatrixEntityRegex: String {
         case .uri:
             return "matrix:(r|u|roomid)\\/[A-Z0-9\\-._~:/?#\\[\\]@!$&'()*+,;=%]*(?:\\?[A-Z0-9\\-._~:/?#\\[\\]@!$&'()*+,;=%]*)?"
         case .allUsers:
-            return "@room"
+            return PillUtilities.atRoom
         }
     }
     

--- a/ElementX/Sources/Other/MatrixEntityRegex.swift
+++ b/ElementX/Sources/Other/MatrixEntityRegex.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import MatrixRustSDK
 
 // https://spec.matrix.org/latest/appendices/#identifier-grammar
 enum MatrixEntityRegex: String {
@@ -27,7 +26,7 @@ enum MatrixEntityRegex: String {
         case .uri:
             return "matrix:(r|u|roomid)\\/[A-Z0-9\\-._~:/?#\\[\\]@!$&'()*+,;=%]*(?:\\?[A-Z0-9\\-._~:/?#\\[\\]@!$&'()*+,;=%]*)?"
         case .allUsers:
-            return PillUtilities.atRoom
+            return "@room"
         }
     }
     

--- a/ElementX/Sources/Other/Pills/PillUtilities.swift
+++ b/ElementX/Sources/Other/Pills/PillUtilities.swift
@@ -8,10 +8,8 @@
 import Foundation
 
 enum PillUtilities {
+    // Make sure to change also the matrix entity regex one
     static let atRoom = "@room"
-    static var everyone: String {
-        L10n.commonEveryone
-    }
 
     /// Used by the WYSIWYG as the urlString value to identify @room mentions
     static let composerAtRoomURLString = "#"

--- a/ElementX/Sources/Other/Pills/PillUtilities.swift
+++ b/ElementX/Sources/Other/Pills/PillUtilities.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 enum PillUtilities {
-    // Make sure to change also the matrix entity regex one
     static let atRoom = "@room"
 
     /// Used by the WYSIWYG as the urlString value to identify @room mentions

--- a/ElementX/Sources/Other/SwiftUI/Views/RoomHeaderView.swift
+++ b/ElementX/Sources/Other/SwiftUI/Views/RoomHeaderView.swift
@@ -21,6 +21,9 @@ struct RoomHeaderView: View {
             // https://github.com/element-hq/element-x-ios/issues/4180
             // Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'NSLayoutConstraint constant is not finite!
             content
+        } else if ProcessInfo.isRunningAccessibilityTests {
+            // Accessibility tests scale up the dynamic size in real time which may break the view
+            content
         } else {
             content
                 // Take up as much space as possible, with a leading alignment for use in the principal toolbar position

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/CompletionSuggestionService.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/CompletionSuggestionService.swift
@@ -168,3 +168,9 @@ final class CompletionSuggestionService: CompletionSuggestionServiceProtocol {
         return roomName.localizedStandardContains(searchText) || roomAlias.localizedStandardContains(searchText)
     }
 }
+
+extension PillUtilities {
+    static var everyone: String {
+        L10n.commonEveryone
+    }
+}

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
@@ -124,7 +124,8 @@ struct RoomScreen: View {
     private var composer: some View {
         if context.viewState.hasSuccessor {
             tombstonedDialogue
-        } else if context.viewState.canSendMessage {
+        } else if context.viewState.canSendMessage, !ProcessInfo.isRunningAccessibilityTests {
+            // We are not sure why but when wrapped in the room screen the composer toolbar breaks the accessibility tests
             composerToolbar
         } else {
             ComposerDisabledView()

--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -189,6 +189,7 @@ targets:
         export PATH="$PATH:/opt/homebrew/bin"
         if which sourcery >/dev/null; then
             sourcery --config Tools/Sourcery/TestablePreviewsDictionary.yml
+            sourcery --config Tools/Sourcery/AccessibilityTests.yml
         else
             echo "warning: Sourcery not installed, run swift run tools setup-project"
         fi

--- a/Tools/Sourcery/AccessibilityTests.stencil
+++ b/Tools/Sourcery/AccessibilityTests.stencil
@@ -16,10 +16,14 @@ import {{ import }}
 {% endfor %}
 
 extension AccessibilityTests {
+
     {% for type in types.types where (type.implements.TestablePreview or type.based.TestablePreview or type|annotated:"TestablePreview") and type.name != "TestablePreview" %}
-    func test_{{ type.name }}() async throws {
+    func test{{ type.name|replace:"_Previews", "" }}() async throws {
         try await performAccessibilityAudit(named: "{{ type.name }}")
     }
+    {%- if not forloop.last %}
+
+    {% endif %}
     {% endfor %}
 }
 

--- a/Tools/Sourcery/AccessibilityTests.stencil
+++ b/Tools/Sourcery/AccessibilityTests.stencil
@@ -1,0 +1,27 @@
+// swiftlint:disable all
+// swiftformat:disable all
+
+{% if argument.mainTarget %}
+@testable import {{ argument.mainTarget }}
+{% endif %}
+{% for import in argument.imports %}
+{% if import != "last" %}
+import {{ import }}
+{% endif %}
+{% endfor %}
+{% for import in argument.testableImports %}
+{% if import != "last" %}
+@testable import {{ import }}
+{% endif %}
+{% endfor %}
+
+extension AccessibilityTests {
+    {% for type in types.types where (type.implements.TestablePreview or type.based.TestablePreview or type|annotated:"TestablePreview") and type.name != "TestablePreview" %}
+    func test_{{ type.name }}() async throws {
+        try await performAccessibilityAudit(named: "{{ type.name }}")
+    }
+    {% endfor %}
+}
+
+// swiftlint:enable all
+// swiftformat:enable all

--- a/Tools/Sourcery/AccessibilityTests.yml
+++ b/Tools/Sourcery/AccessibilityTests.yml
@@ -1,0 +1,7 @@
+sources:
+  include:
+    - ../../ElementX
+templates:
+  - AccessibilityTests.stencil
+output:
+  ../../AccessibilityTests/Sources/GeneratedTests.swift

--- a/Tools/Sourcery/AccessibilityTests.yml
+++ b/Tools/Sourcery/AccessibilityTests.yml
@@ -4,4 +4,4 @@ sources:
 templates:
   - AccessibilityTests.stencil
 output:
-  ../../AccessibilityTests/Sources/GeneratedTests.swift
+  ../../AccessibilityTests/Sources/GeneratedAccessibilityTests.swift

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -101,7 +101,6 @@ lane :accessibility_tests do |options|
     ensure_devices_found: true,
     prelaunch_simulator: false,
     result_bundle: true,
-    only_testing: test_to_run,
     number_of_retries: 0,
     reset_simulator: reset_simulator
   )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -85,6 +85,28 @@ lane :ui_tests do |options|
   )
 end
 
+lane :accessibility_tests do |options|
+  
+  create_simulator_if_necessary(
+    name: "iPhone-18.5",
+    type: "com.apple.CoreSimulator.SimDeviceType.iPhone-16",
+    runtime: "com.apple.CoreSimulator.SimRuntime.iOS-18-4"
+  )
+
+  reset_simulator = ENV.key?('CI')
+  
+  run_tests(
+    scheme: "AccessibilityTests",
+    device: "iPhone-18.5",
+    ensure_devices_found: true,
+    prelaunch_simulator: false,
+    result_bundle: true,
+    only_testing: test_to_run,
+    number_of_retries: 0,
+    reset_simulator: reset_simulator
+  )
+end
+
 
 lane :integration_tests do
   clear_derived_data()

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -86,18 +86,11 @@ lane :ui_tests do |options|
 end
 
 lane :accessibility_tests do |options|
-  
-  create_simulator_if_necessary(
-    name: "iPhone-18.5",
-    type: "com.apple.CoreSimulator.SimDeviceType.iPhone-16",
-    runtime: "com.apple.CoreSimulator.SimRuntime.iOS-18-4"
-  )
-
   reset_simulator = ENV.key?('CI')
   
   run_tests(
     scheme: "AccessibilityTests",
-    device: "iPhone-18.5",
+    device: "iPhone 16 (18.5)",
     ensure_devices_found: true,
     prelaunch_simulator: false,
     result_bundle: true,


### PR DESCRIPTION
## What does this PR include

- A generated test for each testable preview
- Some fixes to not make tests crash
- CI setup that archives the results
- a way for specific accessibility elements to be reported as a failure for a specific test subset or error
- Filtering some other false positives like matrix entities being marked as non readable, or partially supported dynamic types for which we are fine with
- A way to handle that nasty location sharing popup which broke some of the tests


## What is missing?

- a way for the previews do decide if they should be included in the accessibility tests
- Contrast and text clipping tests are avoided, since the requirements for Apple seem to be way stricter than what is considered fine by our design standard, maybe would be worth looking into them at a later point?
