### PR TITLE
Re-enable share_pos persistance.

### DIFF
--- a/ElementX/Sources/Application/Settings/AppSettings.swift
+++ b/ElementX/Sources/Application/Settings/AppSettings.swift
@@ -58,7 +58,7 @@ final class AppSettings {
         case knockingEnabled
         case threadsEnabled
         case developerOptionsEnabled
-        case sharePosEnabled
+        case sharePosEnabledV2
         
         // Doug's tweaks 🔧
         case hideUnreadMessagesBadge
@@ -349,7 +349,7 @@ final class AppSettings {
     @UserPreference(key: UserDefaultsKeys.developerOptionsEnabled, defaultValue: isDevelopmentBuild, storageType: .userDefaults(store))
     var developerOptionsEnabled
     
-    @UserPreference(key: UserDefaultsKeys.sharePosEnabled, defaultValue: false, storageType: .userDefaults(store))
+    @UserPreference(key: UserDefaultsKeys.sharePosEnabledV2, defaultValue: true, storageType: .userDefaults(store))
     var sharePosEnabled
     
     #endif


### PR DESCRIPTION
The flag still exists but has a new UserDefaults key and now defaults to `true`.