### PR TITLE
Add a TabView to the root of the UserSession flow and refactor out a new Chats flow.

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -269,7 +269,6 @@
 		308BD9343B95657FAA583FB7 /* SwiftState in Frameworks */ = {isa = PBXBuildFile; productRef = 19CD5B074D7DD44AF4C58BB6 /* SwiftState */; };
 		30CC1DB7CE357659C82AA115 /* MediaProviderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EB16E7FE59A947CA441531 /* MediaProviderProtocol.swift */; };
 		30E5628F74AD3C27A061BF25 /* QRCodeLoginScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC1B7CB061C9865B2B91B56 /* QRCodeLoginScreenViewModel.swift */; };
-		3113065AABBC14CEAE6843FA /* UserSessionFlowCoordinatorStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8774CF614849664B5B3C2A1 /* UserSessionFlowCoordinatorStateMachine.swift */; };
 		311868F5E65BA61AFA6CCC2C /* CompoundHook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B89D6C760E8CAE29CA28FB1 /* CompoundHook.swift */; };
 		3118D9ABFD4BE5A3492FF88A /* ElementCallConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC437C491EA6996513B1CEAB /* ElementCallConfiguration.swift */; };
 		32B7891D937377A59606EDFC /* UserFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DD8599815136EFF5B73F38 /* UserFlowTests.swift */; };
@@ -322,6 +321,7 @@
 		3B5AB5CF8D8163599C5BF19B /* PillViewOnBubblePreviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2005B4AD70A792340E2694F1 /* PillViewOnBubblePreviews.swift */; };
 		3B98049F56025726FB646ABD /* SwipeToReplyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B0E0B55E2EE75AF67029924 /* SwipeToReplyView.swift */; };
 		3BEBDCB42BABFA3B456FECA7 /* MapTilerURLBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D262A26713C18BB70C82CA5 /* MapTilerURLBuilderTests.swift */; };
+		3C1E27520258D4C89058839E /* ChatsFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55B3BF242C93CD32C4C3E08D /* ChatsFlowCoordinator.swift */; };
 		3C312A3AEDE58BB1C9BBB07C /* preview_avatar_room.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 12FD5280AF55AB7F50F8E47D /* preview_avatar_room.jpg */; };
 		3C31E1A65EEB61E72E1113B4 /* AudioRecorderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBEC57C204D77908E355EF42 /* AudioRecorderProtocol.swift */; };
 		3C549A0BF39F8A854D45D9FD /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = 020597E28A4BC8E1BE8EDF6E /* KeychainAccess */; };
@@ -418,6 +418,7 @@
 		4DAEE2468669848B6C9F55B4 /* TimelineReadReceiptsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33035418BB35754232985871 /* TimelineReadReceiptsView.swift */; };
 		4DEEFB73181C3B023DB42686 /* NetworkMonitorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1575947B7A6FE08C57FE5EE4 /* NetworkMonitorProtocol.swift */; };
 		4E0D9E09B52CEC4C0E6211A8 /* MediaPickerScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64F49FB9EE2913234F06CE68 /* MediaPickerScreenCoordinator.swift */; };
+		4E1E13E5B913D35959E6BFCC /* ChatsFlowCoordinatorStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 566FB9DA81607C2739D8C6A0 /* ChatsFlowCoordinatorStateMachine.swift */; };
 		4E36A66E0EDA74BF3A036FD0 /* RoomChangeRolesScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AAD8C633AA57948B34EDCF7 /* RoomChangeRolesScreenViewModelProtocol.swift */; };
 		4E4EF97B9F9CEFAC726BA72F /* TimelineProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62EACAFB3F3E017060F9F1C5 /* TimelineProviderMock.swift */; };
 		4E8A2A2CFEB212F14E49E1A1 /* AppLockSetupSettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5484457C81B325660901B161 /* AppLockSetupSettingsScreen.swift */; };
@@ -515,7 +516,6 @@
 		61941DEE5F3834765770BE01 /* InviteUsersScreenSelectedItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10F32E0B4B83D2A11EE8D011 /* InviteUsersScreenSelectedItem.swift */; };
 		61A36B9BB2ADE36CEFF5E98C /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E93A1BE7D8A2EBCAD51EEB4 /* Array.swift */; };
 		62684AECDFC5C7DC989CBD9E /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 7B6BC3219ADD8AA0311D2B86 /* SnapshotTesting */; };
-		627139A3D79F032BA81E3A53 /* UserSessionFlowCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA29BAE9B0F2D90E57B261C /* UserSessionFlowCoordinatorTests.swift */; };
 		6298AB0906DDD3525CD78C6B /* KZFileWatchers in Frameworks */ = {isa = PBXBuildFile; productRef = 81DB3AB6CE996AB3954F4F03 /* KZFileWatchers */; };
 		62A7FC3A0191BC7181AA432B /* AudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907FA4DE17DEA1A3738EFB83 /* AudioRecorder.swift */; };
 		62C5876C4254C58C2086F0DE /* HomeScreenContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B4B58B79A6FA250B24A1EC /* HomeScreenContent.swift */; };
@@ -674,6 +674,7 @@
 		7E43FBB918AAC136034F2758 /* test_image.png in Resources */ = {isa = PBXBuildFile; fileRef = 810133CF215075C285FC6F3A /* test_image.png */; };
 		7E91BAC17963ED41208F489B /* UserSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E8BDC092D817B68CD9040C5 /* UserSessionStore.swift */; };
 		7F0B6EB5CB52D7B7A2BB7D15 /* BannedRoomProxyMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FD7E851E2BA8C5A8D284B2A /* BannedRoomProxyMock.swift */; };
+		7F464E540158C3C6EC24678B /* ChatsFlowCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD6906A41D00178F2FF3C097 /* ChatsFlowCoordinatorTests.swift */; };
 		7F61F9ACD5EC9E845EF3EFBF /* BugReportServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFFD3200F9960D4996159F10 /* BugReportServiceTests.swift */; };
 		7F7EA51A9A43125A8CB6AC90 /* NotificationSettingsScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46D560DDA3B20C82766ACFAD /* NotificationSettingsScreenViewModel.swift */; };
 		7F825CBD857D65DC986087BA /* NoticeRoomTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F54FA7C5CB7B342EF9B9B2F /* NoticeRoomTimelineView.swift */; };
@@ -1048,6 +1049,7 @@
 		C5627BCC3EBBB96A943B6D93 /* RestorationTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7978C9EFBDD7DE39BD86726 /* RestorationTokenTests.swift */; };
 		C58E305C380D3ADDF7912180 /* StickerRoomTimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 818695BED971753243FEF897 /* StickerRoomTimelineItem.swift */; };
 		C5A07E2D88BE7D51DCECD166 /* LoginScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D0B159AFFBBD8ECFD0E37FA /* LoginScreenModels.swift */; };
+		C5E3A4A678B4F8900830B76A /* NavigationTabCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C39B1D3FC8CF41D6C3B054F /* NavigationTabCoordinator.swift */; };
 		C67FCC854F3A6FC7A2EC04D0 /* MediaUploadPreviewScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C86696AC9521F8ED88FBEB /* MediaUploadPreviewScreen.swift */; };
 		C6C06DDA8881260303FBA3A0 /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2141693488CE5446BB391964 /* Date.swift */; };
 		C76892321558E75101E68ED6 /* ReadableFrameModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 398817652FA8ABAE0A31AC6D /* ReadableFrameModifier.swift */; };
@@ -1667,6 +1669,7 @@
 		2BB385E148DE55C85C0A02D6 /* SoftLogoutScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoftLogoutScreenModels.swift; sourceTree = "<group>"; };
 		2BDB3E65A79779EDA5D33D8A /* AudioPlayerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlayerState.swift; sourceTree = "<group>"; };
 		2BFDCA5A09EE70BC17F2EFA7 /* URLComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLComponents.swift; sourceTree = "<group>"; };
+		2C39B1D3FC8CF41D6C3B054F /* NavigationTabCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationTabCoordinator.swift; sourceTree = "<group>"; };
 		2C39D91A31409775B0F4268F /* et */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = et; path = et.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		2CEBCB9676FCD1D0F13188DD /* StringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringTests.swift; sourceTree = "<group>"; };
 		2CF9FE7E0CF9F40D1509E63A /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = bg; path = bg.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
@@ -1836,7 +1839,6 @@
 		4E7F7A975514E850A834B29F /* PaginationIndicatorRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationIndicatorRoomTimelineView.swift; sourceTree = "<group>"; };
 		4F5F0662483ED69791D63B16 /* et */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = et; path = et.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		4F75EF13F49DD2204E760910 /* FileRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileRoomTimelineView.swift; sourceTree = "<group>"; };
-		4FA29BAE9B0F2D90E57B261C /* UserSessionFlowCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSessionFlowCoordinatorTests.swift; sourceTree = "<group>"; };
 		4FCB2126C091EEF2454B4D56 /* RoomFlowCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomFlowCoordinatorTests.swift; sourceTree = "<group>"; };
 		4FDD775CFD72DD2D3C8A8390 /* NotificationSettingsProxyProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsProxyProtocol.swift; sourceTree = "<group>"; };
 		502F986D57158674172C58E3 /* AppLockSetupSettingsScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockSetupSettingsScreenModels.swift; sourceTree = "<group>"; };
@@ -1866,8 +1868,10 @@
 		54AD70D6E03D2031AE1B5A52 /* TimelineReactionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineReactionsView.swift; sourceTree = "<group>"; };
 		54C4E7B46099462F12000C91 /* DeveloperOptionsScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperOptionsScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		55AEEF8142DF1B59DB40FB93 /* TimelineItemSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineItemSender.swift; sourceTree = "<group>"; };
+		55B3BF242C93CD32C4C3E08D /* ChatsFlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatsFlowCoordinator.swift; sourceTree = "<group>"; };
 		5644919DB2022397D9D5825A /* MockSoftLogoutScreenState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSoftLogoutScreenState.swift; sourceTree = "<group>"; };
 		565F1B2B300597C616B37888 /* FullscreenDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullscreenDialog.swift; sourceTree = "<group>"; };
+		566FB9DA81607C2739D8C6A0 /* ChatsFlowCoordinatorStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatsFlowCoordinatorStateMachine.swift; sourceTree = "<group>"; };
 		56852036214ABA9D7D305768 /* ResolveVerifiedUserSendFailureScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolveVerifiedUserSendFailureScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		56D6F88FE35A0979D2821E06 /* AppLockScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockScreen.swift; sourceTree = "<group>"; };
 		57084488B03BDB33C7B7CA0E /* ResolveVerifiedUserSendFailureScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolveVerifiedUserSendFailureScreenViewModelTests.swift; sourceTree = "<group>"; };
@@ -2532,6 +2536,7 @@
 		DCDAB580109C09A6AA97AF7E /* PollFormScreenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollFormScreenTests.swift; sourceTree = "<group>"; };
 		DCF239C619971FDE48132550 /* SecureBackupLogoutConfirmationScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureBackupLogoutConfirmationScreenModels.swift; sourceTree = "<group>"; };
 		DD3C65634A34467CB407A061 /* target.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = target.yml; sourceTree = "<group>"; };
+		DD6906A41D00178F2FF3C097 /* ChatsFlowCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatsFlowCoordinatorTests.swift; sourceTree = "<group>"; };
 		DD955A0380C287C418F1A74D /* PhotoLibraryManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoLibraryManagerMock.swift; sourceTree = "<group>"; };
 		DD97F9661ABF08CE002054A2 /* AppLockServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockServiceTests.swift; sourceTree = "<group>"; };
 		DE5127D6EA05B2E45D0A7D59 /* JoinRoomScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinRoomScreenViewModelTests.swift; sourceTree = "<group>"; };
@@ -2588,7 +2593,6 @@
 		E78FC546F28E045A560F2963 /* EncryptionKeyProviderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptionKeyProviderProtocol.swift; sourceTree = "<group>"; };
 		E8294DB9E95C0C0630418466 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
 		E8495F37D6245AD0CFA1F60B /* AppLockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockTests.swift; sourceTree = "<group>"; };
-		E8774CF614849664B5B3C2A1 /* UserSessionFlowCoordinatorStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSessionFlowCoordinatorStateMachine.swift; sourceTree = "<group>"; };
 		E8A1F98AE670377B20679FF5 /* MediaPlayerProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPlayerProvider.swift; sourceTree = "<group>"; };
 		E8AE4B3273BA189FDCD4055C /* UserIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserIndicator.swift; sourceTree = "<group>"; };
 		E8CA187FE656EE5A3F6C7DE5 /* UIFont+AttributedStringBuilder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIFont+AttributedStringBuilder.m"; sourceTree = "<group>"; };
@@ -4102,6 +4106,8 @@
 				0DBB08A95EFA668F2CF27211 /* AppLockSetupFlowCoordinator.swift */,
 				A9B069D7772DDF6513E0F1B8 /* AuthenticationFlowCoordinator.swift */,
 				7367B3B9A8CAF902220F31D1 /* BugReportFlowCoordinator.swift */,
+				55B3BF242C93CD32C4C3E08D /* ChatsFlowCoordinator.swift */,
+				566FB9DA81607C2739D8C6A0 /* ChatsFlowCoordinatorStateMachine.swift */,
 				A07B011547B201A836C03052 /* EncryptionResetFlowCoordinator.swift */,
 				ECB836DD8BE31931F51B8AC9 /* EncryptionSettingsFlowCoordinator.swift */,
 				2178B951602AA921A5FD9DC8 /* MediaEventsTimelineFlowCoordinator.swift */,
@@ -4112,7 +4118,6 @@
 				0833F51229E166BCA141D004 /* RoomRolesAndPermissionsFlowCoordinator.swift */,
 				D28F7A6CEEA4A2815B0F0F55 /* SettingsFlowCoordinator.swift */,
 				C99FDEEB71173C4C6FA2734C /* UserSessionFlowCoordinator.swift */,
-				E8774CF614849664B5B3C2A1 /* UserSessionFlowCoordinatorStateMachine.swift */,
 			);
 			path = FlowCoordinators;
 			sourceTree = "<group>";
@@ -4405,6 +4410,7 @@
 				7EECE8B331CD169790EF284F /* BugReportScreenViewModelTests.swift */,
 				EFFD3200F9960D4996159F10 /* BugReportServiceTests.swift */,
 				CAD9547E47C58930E2CE8306 /* CallScreenViewModelTests.swift */,
+				DD6906A41D00178F2FF3C097 /* ChatsFlowCoordinatorTests.swift */,
 				D5EA0312A6262484AA393AC9 /* CompletionSuggestionServiceTests.swift */,
 				CA29952595B804DA221A0C1D /* ComposerToolbarViewModelTests.swift */,
 				69D42EE0102D2857933625DD /* CreateRoomViewModelTests.swift */,
@@ -4494,7 +4500,6 @@
 				2429224EB0EEA34D35CE9249 /* UserIndicatorControllerTests.swift */,
 				BA241DEEF7C8A7181C0AEDC9 /* UserPreferenceTests.swift */,
 				71E2E5103702D13361D09100 /* UserProfileScreenViewModelTests.swift */,
-				4FA29BAE9B0F2D90E57B261C /* UserSessionFlowCoordinatorTests.swift */,
 				283974987DA7EC61D2AB57D9 /* VoiceMessageCacheTests.swift */,
 				AC4F10BDD56FA77FEC742333 /* VoiceMessageMediaManagerTests.swift */,
 				D93C94C30E3135BC9290DE13 /* VoiceMessageRecorderTests.swift */,
@@ -4574,6 +4579,7 @@
 				B8F28602AC7AC881AED37EBA /* NavigationCoordinators.swift */,
 				9A22A05E472533ED3C5A31B3 /* NavigationModule.swift */,
 				CA28F29C9F93E93CC3C2C715 /* NavigationRootCoordinator.swift */,
+				2C39B1D3FC8CF41D6C3B054F /* NavigationTabCoordinator.swift */,
 			);
 			path = Navigation;
 			sourceTree = "<group>";
@@ -7024,6 +7030,7 @@
 				1B2F9F368619FFF8C63C87CC /* BugReportScreenViewModelTests.swift in Sources */,
 				7F61F9ACD5EC9E845EF3EFBF /* BugReportServiceTests.swift in Sources */,
 				366D5BFE52CB79E804C7D095 /* CallScreenViewModelTests.swift in Sources */,
+				7F464E540158C3C6EC24678B /* ChatsFlowCoordinatorTests.swift in Sources */,
 				B5321A1F5B26A0F3EC54909E /* CollapsibleFlowLayoutTests.swift in Sources */,
 				3A164187907DA43B7858F9EC /* CompletionSuggestionServiceTests.swift in Sources */,
 				0C932A5158C1D0604DFC5750 /* ComposerToolbarViewModelTests.swift in Sources */,
@@ -7127,7 +7134,6 @@
 				A1DF0E1E526A981ED6D5DF44 /* UserIndicatorControllerTests.swift in Sources */,
 				04F17DE71A50206336749BAC /* UserPreferenceTests.swift in Sources */,
 				73F547BEB41D3DAFAAF6E0AF /* UserProfileScreenViewModelTests.swift in Sources */,
-				627139A3D79F032BA81E3A53 /* UserSessionFlowCoordinatorTests.swift in Sources */,
 				81A7C020CB5F6232242A8414 /* UserSessionTests.swift in Sources */,
 				21AFEFB8CEFE56A3811A1F5B /* VoiceMessageCacheTests.swift in Sources */,
 				44BDD670FF9095ACE240A3A2 /* VoiceMessageMediaManagerTests.swift in Sources */,
@@ -7344,6 +7350,8 @@
 				E14E469CD97550D0FC58F3CA /* CancellableTask.swift in Sources */,
 				DF8F1211F2B0B56F0FCCA5C2 /* CertificateValidatorHook.swift in Sources */,
 				D885B783B95AD7832D4EF5DD /* CharacterSet.swift in Sources */,
+				3C1E27520258D4C89058839E /* ChatsFlowCoordinator.swift in Sources */,
+				4E1E13E5B913D35959E6BFCC /* ChatsFlowCoordinatorStateMachine.swift in Sources */,
 				A52090A4FE0DB826578DFC03 /* Client.swift in Sources */,
 				C80E06ED97CE52704A46C148 /* ClientBuilder.swift in Sources */,
 				87CEA3E07B602705BC2D2A20 /* ClientBuilderHook.swift in Sources */,
@@ -7626,6 +7634,7 @@
 				FA2BBAE9FC5E2E9F960C0980 /* NavigationCoordinators.swift in Sources */,
 				71C1347F23868324A4F43940 /* NavigationModule.swift in Sources */,
 				B5E455C9689EA600EDB3E9E0 /* NavigationRootCoordinator.swift in Sources */,
+				C5E3A4A678B4F8900830B76A /* NavigationTabCoordinator.swift in Sources */,
 				93BAF04D9CCBC0A8841414D0 /* NetworkMonitor.swift in Sources */,
 				96B3606E30F824095B1DD022 /* NetworkMonitorMock.swift in Sources */,
 				865DD5CA474C6AE6C2BC008E /* NetworkMonitorProtocol.swift in Sources */,
@@ -8097,7 +8106,6 @@
 				69A9B430397C15075D86193F /* UserPropertiesExt.swift in Sources */,
 				8AB8ED1051216546CB35FA0E /* UserSession.swift in Sources */,
 				4A618590DEB72C4F186BFED4 /* UserSessionFlowCoordinator.swift in Sources */,
-				3113065AABBC14CEAE6843FA /* UserSessionFlowCoordinatorStateMachine.swift in Sources */,
 				6586E1F1D5F0651D0638FFAF /* UserSessionMock.swift in Sources */,
 				978BB24F2A5D31EE59EEC249 /* UserSessionProtocol.swift in Sources */,
 				7E91BAC17963ED41208F489B /* UserSessionStore.swift in Sources */,
@@ -9176,7 +9184,7 @@
 			repositoryURL = "https://github.com/element-hq/compound-ios";
 			requirement = {
 				kind = revision;
-				revision = 089904dc1aeb3bacce3b7bb757b7637274e46008;
+				revision = afc59afb1b1e4f4960e2f2a15e52d4e2e33fc889;
 			};
 		};
 		F76A08D0EA29A07A54F4EB4D /* XCRemoteSwiftPackageReference "swift-collections" */ = {

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -1238,6 +1238,7 @@
 		EDB6915EC953BB2A44AA608E /* EditRoomAddressScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 906451FB8CF27C628152BF7A /* EditRoomAddressScreenViewModelTests.swift */; };
 		EDD45A73B688B87D84B9C2E9 /* AccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6D867A7FBB70C6EFDBCBC5 /* AccessibilityTests.swift */; };
 		EDF8919F15DE0FF00EF99E70 /* DocumentPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5567A7EF6F2AB9473236F6 /* DocumentPicker.swift */; };
+		EE17B7154DCA50677D931A94 /* NavigationTabCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B67DC84B42D86035FCFF6F8 /* NavigationTabCoordinatorTests.swift */; };
 		EE4E2C1922BBF5169E213555 /* PillAttachmentViewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B53D6C5C0D14B04D3AB3F6E /* PillAttachmentViewProvider.swift */; };
 		EE56238683BC3ECA9BA00684 /* GlobalSearchScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA4D639E27D5882A6A71AECF /* GlobalSearchScreenViewModelTests.swift */; };
 		EE8491AD81F47DF3C192497B /* DecorationTimelineItemProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 184CF8C196BE143AE226628D /* DecorationTimelineItemProtocol.swift */; };
@@ -1664,6 +1665,7 @@
 		2AE83A3DD63BCFBB956FE5CB /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = nl; path = nl.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		2AF715D4FD4710EBB637D661 /* SettingsScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		2B1FB56520A847DD2532D5C8 /* VideoMediaEventsTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoMediaEventsTimelineView.swift; sourceTree = "<group>"; };
+		2B67DC84B42D86035FCFF6F8 /* NavigationTabCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationTabCoordinatorTests.swift; sourceTree = "<group>"; };
 		2B9BCACD0CC4CB8E37F17732 /* lt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = lt; path = lt.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		2BA894BC09972DC45E497D37 /* TimelineInteractionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineInteractionHandler.swift; sourceTree = "<group>"; };
 		2BB385E148DE55C85C0A02D6 /* SoftLogoutScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoftLogoutScreenModels.swift; sourceTree = "<group>"; };
@@ -4444,6 +4446,7 @@
 				F875D71347DC81EAE7687446 /* NavigationRootCoordinatorTests.swift */,
 				78913D6E120D46138E97C107 /* NavigationSplitCoordinatorTests.swift */,
 				9C698E30698EC59302A8EEBD /* NavigationStackCoordinatorTests.swift */,
+				2B67DC84B42D86035FCFF6F8 /* NavigationTabCoordinatorTests.swift */,
 				8544F7058D31DBEB8DBFF0F5 /* NotificationSettingsEditScreenViewModelTests.swift */,
 				514363244AE7D68080D44C6F /* NotificationSettingsScreenViewModelTests.swift */,
 				FA3EB5B1848CF4F64E63C6B7 /* PermalinkTests.swift */,
@@ -7071,6 +7074,7 @@
 				981853650217B6C8ECDD998C /* NavigationRootCoordinatorTests.swift in Sources */,
 				69C7B956B74BEC3DB88224EA /* NavigationSplitCoordinatorTests.swift in Sources */,
 				4BB282209EA82015D0DF8F89 /* NavigationStackCoordinatorTests.swift in Sources */,
+				EE17B7154DCA50677D931A94 /* NavigationTabCoordinatorTests.swift in Sources */,
 				1B2DADC008EE211AF1DA5292 /* NotificationManagerTests.swift in Sources */,
 				C11939FDC40716C4387275A4 /* NotificationSettingsEditScreenViewModelTests.swift in Sources */,
 				E3AC72E3E58F364EF15C1CC7 /* NotificationSettingsScreenViewModelTests.swift in Sources */,

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/compound-design-tokens",
       "state" : {
-        "revision" : "9da344135825e0a949e41b7a68987ec9205b1d27",
-        "version" : "5.0.2"
+        "revision" : "be5d26dfd4ad659b0d3b3aec1ad1cccd0dc8d063",
+        "version" : "6.0.0"
       }
     },
     {
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/compound-ios",
       "state" : {
-        "revision" : "089904dc1aeb3bacce3b7bb757b7637274e46008"
+        "revision" : "afc59afb1b1e4f4960e2f2a15e52d4e2e33fc889"
       }
     },
     {

--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -46,7 +46,7 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
     private let appLockFlowCoordinator: AppLockFlowCoordinator
     // periphery:ignore - used to avoid deallocation
     private var appLockSetupFlowCoordinator: AppLockSetupFlowCoordinator?
-    private var userSessionFlowCoordinator: ChatsFlowCoordinator?
+    private var userSessionFlowCoordinator: UserSessionFlowCoordinator?
     private var softLogoutCoordinator: SoftLogoutScreenCoordinator?
     private var appDelegateObserver: AnyCancellable?
     private var userSessionObserver: AnyCancellable?
@@ -640,18 +640,18 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
             fatalError("User session not setup")
         }
         
-        let userSessionFlowCoordinator = ChatsFlowCoordinator(userSession: userSession,
-                                                              navigationRootCoordinator: navigationRootCoordinator,
-                                                              appLockService: appLockFlowCoordinator.appLockService,
-                                                              bugReportService: ServiceLocator.shared.bugReportService,
-                                                              elementCallService: elementCallService,
-                                                              timelineControllerFactory: TimelineControllerFactory(),
-                                                              appMediator: appMediator,
-                                                              appSettings: appSettings,
-                                                              appHooks: appHooks,
-                                                              analytics: ServiceLocator.shared.analytics,
-                                                              notificationManager: notificationManager,
-                                                              isNewLogin: isNewLogin)
+        let userSessionFlowCoordinator = UserSessionFlowCoordinator(userSession: userSession,
+                                                                    navigationRootCoordinator: navigationRootCoordinator,
+                                                                    appLockService: appLockFlowCoordinator.appLockService,
+                                                                    bugReportService: ServiceLocator.shared.bugReportService,
+                                                                    elementCallService: elementCallService,
+                                                                    timelineControllerFactory: TimelineControllerFactory(),
+                                                                    appMediator: appMediator,
+                                                                    appSettings: appSettings,
+                                                                    appHooks: appHooks,
+                                                                    analytics: ServiceLocator.shared.analytics,
+                                                                    notificationManager: notificationManager,
+                                                                    isNewLogin: isNewLogin)
         
         userSessionFlowCoordinator.actionsPublisher
             .sink { [weak self] action in

--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -46,7 +46,7 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
     private let appLockFlowCoordinator: AppLockFlowCoordinator
     // periphery:ignore - used to avoid deallocation
     private var appLockSetupFlowCoordinator: AppLockSetupFlowCoordinator?
-    private var userSessionFlowCoordinator: UserSessionFlowCoordinator?
+    private var userSessionFlowCoordinator: ChatsFlowCoordinator?
     private var softLogoutCoordinator: SoftLogoutScreenCoordinator?
     private var appDelegateObserver: AnyCancellable?
     private var userSessionObserver: AnyCancellable?
@@ -640,18 +640,18 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
             fatalError("User session not setup")
         }
         
-        let userSessionFlowCoordinator = UserSessionFlowCoordinator(userSession: userSession,
-                                                                    navigationRootCoordinator: navigationRootCoordinator,
-                                                                    appLockService: appLockFlowCoordinator.appLockService,
-                                                                    bugReportService: ServiceLocator.shared.bugReportService,
-                                                                    elementCallService: elementCallService,
-                                                                    timelineControllerFactory: TimelineControllerFactory(),
-                                                                    appMediator: appMediator,
-                                                                    appSettings: appSettings,
-                                                                    appHooks: appHooks,
-                                                                    analytics: ServiceLocator.shared.analytics,
-                                                                    notificationManager: notificationManager,
-                                                                    isNewLogin: isNewLogin)
+        let userSessionFlowCoordinator = ChatsFlowCoordinator(userSession: userSession,
+                                                              navigationRootCoordinator: navigationRootCoordinator,
+                                                              appLockService: appLockFlowCoordinator.appLockService,
+                                                              bugReportService: ServiceLocator.shared.bugReportService,
+                                                              elementCallService: elementCallService,
+                                                              timelineControllerFactory: TimelineControllerFactory(),
+                                                              appMediator: appMediator,
+                                                              appSettings: appSettings,
+                                                              appHooks: appHooks,
+                                                              analytics: ServiceLocator.shared.analytics,
+                                                              notificationManager: notificationManager,
+                                                              isNewLogin: isNewLogin)
         
         userSessionFlowCoordinator.actionsPublisher
             .sink { [weak self] action in

--- a/ElementX/Sources/Application/Navigation/NavigationCoordinators.swift
+++ b/ElementX/Sources/Application/Navigation/NavigationCoordinators.swift
@@ -449,6 +449,7 @@ private struct NavigationSplitCoordinatorView: View {
             .animation(.elementDefault, value: navigationSplitCoordinator.overlayPresentationMode)
             .animation(.elementDefault, value: navigationSplitCoordinator.overlayModule)
         }
+        .ignoresSafeArea() // Necessary when embedded in a TabView on iPadOS otherwise there's a gap at the top (as of 18.5).
     }
     
     /// The NavigationStack that will be used in compact layouts
@@ -512,7 +513,7 @@ class NavigationStackCoordinator: ObservableObject, CoordinatorProtocol, CustomS
         }
     }
     
-    // The stack's current root coordinator
+    /// The stack's current root coordinator
     var rootCoordinator: (any CoordinatorProtocol)? {
         rootModule?.coordinator
     }
@@ -533,8 +534,8 @@ class NavigationStackCoordinator: ObservableObject, CoordinatorProtocol, CustomS
     
     var presentationDetents: Set<PresentationDetent> = []
     
-    // The currently presented sheet coordinator
-    // Sheets will be presented through the NavigationSplitCoordinator if provided
+    /// The currently presented sheet coordinator
+    /// Sheets will be presented through the NavigationSplitCoordinator if provided
     var sheetCoordinator: (any CoordinatorProtocol)? {
         if let navigationSplitCoordinator {
             return navigationSplitCoordinator.sheetCoordinator
@@ -558,8 +559,8 @@ class NavigationStackCoordinator: ObservableObject, CoordinatorProtocol, CustomS
     }
     
     // periphery:ignore - might be useful to have
-    // The currently presented fullscreen cover coordinator
-    // Fullscreen covers will be presented through the NavigationSplitCoordinator if provided
+    /// The currently presented fullscreen cover coordinator
+    /// Fullscreen covers will be presented through the NavigationSplitCoordinator if provided
     var fullScreenCoverCoordinator: (any CoordinatorProtocol)? {
         if let navigationSplitCoordinator {
             return navigationSplitCoordinator.fullScreenCoverCoordinator
@@ -584,7 +585,7 @@ class NavigationStackCoordinator: ObservableObject, CoordinatorProtocol, CustomS
         }
     }
     
-    // The current navigation stack. Excludes the rootCoordinator
+    /// The current navigation stack. Excludes the rootCoordinator
     var stackCoordinators: [any CoordinatorProtocol] {
         stackModules.compactMap(\.coordinator)
     }

--- a/ElementX/Sources/Application/Navigation/NavigationTabCoordinator.swift
+++ b/ElementX/Sources/Application/Navigation/NavigationTabCoordinator.swift
@@ -17,6 +17,8 @@ import SwiftUI
         let selectedIcon: KeyPath<CompoundIcons, Image>
     }
     
+    // MARK: Tabs
+    
     fileprivate struct TabModule: Identifiable {
         let module: NavigationModule
         let title: String
@@ -58,7 +60,107 @@ import SwiftUI
         }
     }
     
+    // MARK: Sheets
+    
+    fileprivate var sheetModule: NavigationModule? {
+        didSet {
+            if let oldValue {
+                logPresentationChange("Remove sheet", oldValue)
+                oldValue.tearDown()
+            }
+            
+            if let sheetModule {
+                logPresentationChange("Set sheet", sheetModule)
+                sheetModule.coordinator?.start()
+            }
+        }
+    }
+    
+    var presentationDetents: Set<PresentationDetent> = []
+    
+    /// The currently presented sheet coordinator.
+    var sheetCoordinator: (any CoordinatorProtocol)? {
+        sheetModule?.coordinator
+    }
+    
+    /// Present a sheet on top of the stack. If this NavigationStackCoordinator is embedded within a NavigationSplitCoordinator
+    /// then the presentation will be proxied to the split
+    /// - Parameters:
+    ///   - coordinator: the coordinator to display
+    ///   - animated: whether to animate the transition or not. Default is true
+
+    ///   - dismissalCallback: called when the sheet has been dismissed, programatically or otherwise
+    func setSheetCoordinator(_ coordinator: (any CoordinatorProtocol)?, animated: Bool = true, dismissalCallback: (() -> Void)? = nil) {
+        guard let coordinator else {
+            sheetModule = nil
+            return
+        }
+        
+        if sheetModule?.coordinator === coordinator {
+            fatalError("Cannot use the same coordinator more than once")
+        }
+
+        var transaction = Transaction()
+        transaction.disablesAnimations = !animated
+
+        withTransaction(transaction) {
+            sheetModule = NavigationModule(coordinator, dismissalCallback: dismissalCallback)
+        }
+    }
+    
+    // MARK: Full Screen Cover
+    
+    fileprivate var fullScreenCoverModule: NavigationModule? {
+        didSet {
+            if let oldValue {
+                logPresentationChange("Remove fullscreen cover", oldValue)
+                oldValue.tearDown()
+            }
+            
+            if let fullScreenCoverModule {
+                logPresentationChange("Set fullscreen cover", fullScreenCoverModule)
+                fullScreenCoverModule.coordinator?.start()
+            }
+        }
+    }
+    
+    /// The currently presented fullscreen cover coordinator
+    /// Fullscreen covers will be presented through the NavigationSplitCoordinator if provided
+    var fullScreenCoverCoordinator: (any CoordinatorProtocol)? {
+        fullScreenCoverModule?.coordinator
+    }
+    
+    /// Present a fullscreen cover on top of the stack. If this NavigationStackCoordinator is embedded within a NavigationSplitCoordinator
+    /// then the presentation will be proxied to the split
+    /// - Parameters:
+    ///   - coordinator: the coordinator to display
+    ///   - animated: whether to animate the transition or not. Default is true
+    ///   - dismissalCallback: called when the fullscreen cover has been dismissed, programatically or otherwise
+    func setFullScreenCoverCoordinator(_ coordinator: (any CoordinatorProtocol)?, animated: Bool = true, dismissalCallback: (() -> Void)? = nil) {
+        guard let coordinator else {
+            fullScreenCoverModule = nil
+            return
+        }
+        
+        if fullScreenCoverModule?.coordinator === coordinator {
+            fatalError("Cannot use the same coordinator more than once")
+        }
+
+        var transaction = Transaction()
+        transaction.disablesAnimations = !animated
+
+        withTransaction(transaction) {
+            fullScreenCoverModule = NavigationModule(coordinator, dismissalCallback: dismissalCallback)
+        }
+    }
+    
     // MARK: - CoordinatorProtocol
+    
+    /// No idea if this is particuarly needed for the TabView but we do this for the NavigationStackCoordinator and NavigationSplitCoordinator so it
+    /// doesn't seem to harm to also do it here.
+    func stop() {
+        tabModules.forEach { $0.module.tearDown() }
+    }
     
     func toPresentable() -> AnyView {
         AnyView(NavigationTabCoordinatorView(navigationTabCoordinator: self))
@@ -98,6 +200,14 @@ private struct NavigationTabCoordinatorView: View {
                     .tag(module.id)
                     .id(module.id)
             }
+        }
+        .sheet(item: $navigationTabCoordinator.sheetModule) { module in
+            module.coordinator?.toPresentable()
+                .id(module.id)
+        }
+        .fullScreenCover(item: $navigationTabCoordinator.fullScreenCoverModule) { module in
+            module.coordinator?.toPresentable()
+                .id(module.id)
         }
     }
 }

--- a/ElementX/Sources/Application/Navigation/NavigationTabCoordinator.swift
+++ b/ElementX/Sources/Application/Navigation/NavigationTabCoordinator.swift
@@ -1,0 +1,103 @@
+//
+// Copyright 2025 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Compound
+import SwiftUI
+
+/// Class responsible for displaying an arbitrary number of coordinators within the tab bar.
+@Observable class NavigationTabCoordinator: CoordinatorProtocol, CustomStringConvertible {
+    struct Tab {
+        let coordinator: CoordinatorProtocol
+        let title: String
+        let icon: KeyPath<CompoundIcons, Image>
+        let selectedIcon: KeyPath<CompoundIcons, Image>
+    }
+    
+    fileprivate struct TabModule: Identifiable {
+        let module: NavigationModule
+        let title: String
+        let icon: KeyPath<CompoundIcons, Image>
+        let selectedIcon: KeyPath<CompoundIcons, Image>
+        
+        var id: ObjectIdentifier { module.id }
+        @MainActor var coordinator: CoordinatorProtocol? { module.coordinator }
+    }
+    
+    fileprivate var tabModules = [TabModule]() {
+        didSet {
+            let diffs = tabModules.map(\.module).difference(from: oldValue.map(\.module))
+            diffs.forEach { change in
+                switch change {
+                case .insert(_, let module, _):
+                    logPresentationChange("Set tab", module)
+                    module.coordinator?.start()
+                case .remove(_, let module, _):
+                    logPresentationChange("Remove tab", module)
+                    module.tearDown()
+                }
+            }
+        }
+    }
+    
+    /// The current set of coordinators displayed by the tabs.
+    var tabCoordinators: [any CoordinatorProtocol] {
+        tabModules.compactMap(\.module.coordinator)
+    }
+    
+    /// Updates the displayed tabs with the provided array.
+    func setTabs(_ tabs: [Tab], animated: Bool = true) {
+        var transaction = Transaction()
+        transaction.disablesAnimations = !animated
+        
+        withTransaction(transaction) {
+            tabModules = tabs.map { TabModule(module: .init($0.coordinator), title: $0.title, icon: $0.icon, selectedIcon: $0.selectedIcon) }
+        }
+    }
+    
+    // MARK: - CoordinatorProtocol
+    
+    func toPresentable() -> AnyView {
+        AnyView(NavigationTabCoordinatorView(navigationTabCoordinator: self))
+    }
+    
+    // MARK: - CustomStringConvertible
+    
+    var description: String {
+        guard !tabModules.isEmpty else { return "NavigationTabCoordinator(Empty)" }
+        return "NavigationTabCoordinator(\(tabCoordinators)"
+    }
+    
+    // MARK: - Private
+    
+    private func logPresentationChange(_ change: String, _ module: NavigationModule) {
+        if let coordinator = module.coordinator {
+            MXLog.info("\(self) \(change): \(coordinator)")
+        }
+    }
+}
+
+private struct NavigationTabCoordinatorView: View {
+    @Bindable var navigationTabCoordinator: NavigationTabCoordinator
+    @State private var selectedTab: ObjectIdentifier?
+    
+    var body: some View {
+        TabView(selection: $selectedTab) {
+            ForEach(navigationTabCoordinator.tabModules) { module in
+                module.coordinator?.toPresentable()
+                    .tabItem {
+                        Label {
+                            Text(module.title)
+                        } icon: {
+                            CompoundIcon(module.id == selectedTab ? module.selectedIcon : module.icon)
+                        }
+                    }
+                    .tag(module.id)
+                    .id(module.id)
+            }
+        }
+    }
+}

--- a/ElementX/Sources/Application/Navigation/NavigationTabCoordinator.swift
+++ b/ElementX/Sources/Application/Navigation/NavigationTabCoordinator.swift
@@ -15,6 +15,7 @@ import SwiftUI
         let title: String
         let icon: KeyPath<CompoundIcons, Image>
         let selectedIcon: KeyPath<CompoundIcons, Image>
+        var dismissalCallback: (() -> Void)?
     }
     
     // MARK: Tabs
@@ -56,7 +57,10 @@ import SwiftUI
         transaction.disablesAnimations = !animated
         
         withTransaction(transaction) {
-            tabModules = tabs.map { TabModule(module: .init($0.coordinator), title: $0.title, icon: $0.icon, selectedIcon: $0.selectedIcon) }
+            tabModules = tabs.map { TabModule(module: .init($0.coordinator, dismissalCallback: $0.dismissalCallback),
+                                              title: $0.title,
+                                              icon: $0.icon,
+                                              selectedIcon: $0.selectedIcon) }
         }
     }
     
@@ -199,6 +203,7 @@ private struct NavigationTabCoordinatorView: View {
                     }
                     .tag(module.id)
                     .id(module.id)
+                    .toolbar(.hidden, for: .tabBar)
             }
         }
         .sheet(item: $navigationTabCoordinator.sheetModule) { module in

--- a/ElementX/Sources/FlowCoordinators/ChatsFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/ChatsFlowCoordinator.swift
@@ -11,14 +11,14 @@ import Combine
 import MatrixRustSDK
 import SwiftUI
 
-enum UserSessionFlowCoordinatorAction {
+enum ChatsFlowCoordinatorAction {
     case logout
     case clearCache
     /// Logout without a confirmation. The user forgot their PIN.
     case forceLogout
 }
 
-class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
+class ChatsFlowCoordinator: FlowCoordinatorProtocol {
     private let userSession: UserSessionProtocol
     private let navigationRootCoordinator: NavigationRootCoordinator
     private let navigationSplitCoordinator: NavigationSplitCoordinator
@@ -30,7 +30,7 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
     private let analytics: AnalyticsService
     private let notificationManager: NotificationManagerProtocol
     
-    private let stateMachine: UserSessionFlowCoordinatorStateMachine
+    private let stateMachine: ChatsFlowCoordinatorStateMachine
     
     // periphery:ignore - retaining purpose
     private var roomFlowCoordinator: RoomFlowCoordinator?
@@ -56,13 +56,13 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
 
     private let selectedRoomSubject = CurrentValueSubject<String?, Never>(nil)
     
-    private let actionsSubject: PassthroughSubject<UserSessionFlowCoordinatorAction, Never> = .init()
-    var actionsPublisher: AnyPublisher<UserSessionFlowCoordinatorAction, Never> {
+    private let actionsSubject: PassthroughSubject<ChatsFlowCoordinatorAction, Never> = .init()
+    var actionsPublisher: AnyPublisher<ChatsFlowCoordinatorAction, Never> {
         actionsSubject.eraseToAnyPublisher()
     }
     
     /// For testing purposes.
-    var statePublisher: AnyPublisher<UserSessionFlowCoordinatorStateMachine.State, Never> { stateMachine.statePublisher }
+    var statePublisher: AnyPublisher<ChatsFlowCoordinatorStateMachine.State, Never> { stateMachine.statePublisher }
     
     init(userSession: UserSessionProtocol,
          navigationRootCoordinator: NavigationRootCoordinator,
@@ -76,7 +76,7 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
          analytics: AnalyticsService,
          notificationManager: NotificationManagerProtocol,
          isNewLogin: Bool) {
-        stateMachine = UserSessionFlowCoordinatorStateMachine()
+        stateMachine = ChatsFlowCoordinatorStateMachine()
         self.userSession = userSession
         self.navigationRootCoordinator = navigationRootCoordinator
         self.bugReportService = bugReportService
@@ -94,7 +94,7 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
         detailNavigationStackCoordinator = NavigationStackCoordinator(navigationSplitCoordinator: navigationSplitCoordinator)
         
         navigationSplitCoordinator.setSidebarCoordinator(sidebarNavigationStackCoordinator)
-                
+        
         settingsFlowCoordinator = SettingsFlowCoordinator(parameters: .init(userSession: userSession,
                                                                             windowManager: appMediator.windowManager,
                                                                             appLockService: appLockService,
@@ -242,7 +242,7 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
     private func setupStateMachine() {
         stateMachine.addTransitionHandler { [weak self] context in
             guard let self else { return }
-            let animated = (context.userInfo as? UserSessionFlowCoordinatorStateMachine.EventUserInfo)?.animated ?? true
+            let animated = (context.userInfo as? ChatsFlowCoordinatorStateMachine.EventUserInfo)?.animated ?? true
             switch (context.fromState, context.event, context.toState) {
             case (.initial, .start, .roomList):
                 presentHomeScreen()
@@ -1067,8 +1067,8 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
     
     // MARK: Toasts and loading indicators
     
-    private static let loadingIndicatorIdentifier = "\(UserSessionFlowCoordinator.self)-Loading"
-    private static let failureIndicatorIdentifier = "\(UserSessionFlowCoordinator.self)-Failure"
+    private static let loadingIndicatorIdentifier = "\(ChatsFlowCoordinator.self)-Loading"
+    private static let failureIndicatorIdentifier = "\(ChatsFlowCoordinator.self)-Failure"
     
     private func showLoadingIndicator(delay: Duration? = nil) {
         ServiceLocator.shared.userIndicatorController.submitIndicator(UserIndicator(id: Self.loadingIndicatorIdentifier,

--- a/ElementX/Sources/FlowCoordinators/ChatsFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/ChatsFlowCoordinator.swift
@@ -20,7 +20,6 @@ enum ChatsFlowCoordinatorAction {
 
 class ChatsFlowCoordinator: FlowCoordinatorProtocol {
     private let userSession: UserSessionProtocol
-    private let navigationRootCoordinator: NavigationRootCoordinator
     private let navigationSplitCoordinator: NavigationSplitCoordinator
     private let bugReportService: BugReportServiceProtocol
     private let elementCallService: ElementCallServiceProtocol
@@ -65,7 +64,7 @@ class ChatsFlowCoordinator: FlowCoordinatorProtocol {
     var statePublisher: AnyPublisher<ChatsFlowCoordinatorStateMachine.State, Never> { stateMachine.statePublisher }
     
     init(userSession: UserSessionProtocol,
-         navigationRootCoordinator: NavigationRootCoordinator,
+         navigationSplitCoordinator: NavigationSplitCoordinator,
          appLockService: AppLockServiceProtocol,
          bugReportService: BugReportServiceProtocol,
          elementCallService: ElementCallServiceProtocol,
@@ -78,7 +77,7 @@ class ChatsFlowCoordinator: FlowCoordinatorProtocol {
          isNewLogin: Bool) {
         stateMachine = ChatsFlowCoordinatorStateMachine()
         self.userSession = userSession
-        self.navigationRootCoordinator = navigationRootCoordinator
+        self.navigationSplitCoordinator = navigationSplitCoordinator
         self.bugReportService = bugReportService
         self.elementCallService = elementCallService
         self.timelineControllerFactory = timelineControllerFactory
@@ -87,8 +86,6 @@ class ChatsFlowCoordinator: FlowCoordinatorProtocol {
         self.appHooks = appHooks
         self.analytics = analytics
         self.notificationManager = notificationManager
-        
-        navigationSplitCoordinator = NavigationSplitCoordinator(placeholderCoordinator: PlaceholderScreenCoordinator())
         
         sidebarNavigationStackCoordinator = NavigationStackCoordinator(navigationSplitCoordinator: navigationSplitCoordinator)
         detailNavigationStackCoordinator = NavigationStackCoordinator(navigationSplitCoordinator: navigationSplitCoordinator)
@@ -554,8 +551,6 @@ class ChatsFlowCoordinator: FlowCoordinatorProtocol {
             .store(in: &cancellables)
         
         sidebarNavigationStackCoordinator.setRootCoordinator(coordinator)
-        
-        navigationRootCoordinator.setRootCoordinator(navigationSplitCoordinator)
     }
     
     private func presentReportRoom(for roomID: String) async {

--- a/ElementX/Sources/FlowCoordinators/ChatsFlowCoordinatorStateMachine.swift
+++ b/ElementX/Sources/FlowCoordinators/ChatsFlowCoordinatorStateMachine.swift
@@ -9,7 +9,7 @@ import Combine
 import Foundation
 import SwiftState
 
-class UserSessionFlowCoordinatorStateMachine {
+class ChatsFlowCoordinatorStateMachine {
     /// States the AppCoordinator can find itself in
     enum State: StateType {
         /// The initial state, used before the coordinator starts
@@ -138,7 +138,7 @@ class UserSessionFlowCoordinatorStateMachine {
     
     private let stateMachine: StateMachine<State, Event>
     
-    var state: UserSessionFlowCoordinatorStateMachine.State {
+    var state: ChatsFlowCoordinatorStateMachine.State {
         stateMachine.state
     }
     

--- a/ElementX/Sources/FlowCoordinators/ChatsFlowCoordinatorStateMachine.swift
+++ b/ElementX/Sources/FlowCoordinators/ChatsFlowCoordinatorStateMachine.swift
@@ -110,11 +110,6 @@ class ChatsFlowCoordinatorStateMachine {
         case showStartChatScreen
         /// Start chat has been dismissed
         case dismissedStartChatScreen
-                
-        /// Logout has been requested and this is the last session
-        case showLogoutConfirmationScreen
-        /// Logout has been cancelled
-        case dismissedLogoutConfirmationScreen
         
         /// Request presentation of the room directory search screen.
         case showRoomDirectorySearchScreen
@@ -185,11 +180,6 @@ class ChatsFlowCoordinatorStateMachine {
             case (.roomList(let roomListSelectedRoomID), .showStartChatScreen):
                 return .startChatScreen(roomListSelectedRoomID: roomListSelectedRoomID)
             case (.startChatScreen(let roomListSelectedRoomID), .dismissedStartChatScreen):
-                return .roomList(roomListSelectedRoomID: roomListSelectedRoomID)
-                            
-            case (.roomList(let roomListSelectedRoomID), .showLogoutConfirmationScreen):
-                return .logoutConfirmationScreen(roomListSelectedRoomID: roomListSelectedRoomID)
-            case (.logoutConfirmationScreen(let roomListSelectedRoomID), .dismissedLogoutConfirmationScreen):
                 return .roomList(roomListSelectedRoomID: roomListSelectedRoomID)
                 
             case (.roomList(let roomListSelectedRoomID), .showRoomDirectorySearchScreen):

--- a/ElementX/Sources/FlowCoordinators/OnboardingFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/OnboardingFlowCoordinator.swift
@@ -10,6 +10,8 @@ import Foundation
 import SwiftState
 
 enum OnboardingFlowCoordinatorAction {
+    case requestPresentation(animated: Bool)
+    case dismiss
     case logout
 }
 
@@ -19,7 +21,6 @@ class OnboardingFlowCoordinator: FlowCoordinatorProtocol {
     private let analyticsService: AnalyticsService
     private let appSettings: AppSettings
     private let notificationManager: NotificationManagerProtocol
-    private let rootNavigationStackCoordinator: NavigationStackCoordinator
     private let userIndicatorController: UserIndicatorControllerProtocol
     private let windowManager: WindowManagerProtocol
     private let isNewLogin: Bool
@@ -74,8 +75,7 @@ class OnboardingFlowCoordinator: FlowCoordinatorProtocol {
         self.windowManager = windowManager
         self.isNewLogin = isNewLogin
         
-        rootNavigationStackCoordinator = navigationStackCoordinator
-        self.navigationStackCoordinator = NavigationStackCoordinator()
+        self.navigationStackCoordinator = navigationStackCoordinator
         
         stateMachine = .init(state: .initial)
         
@@ -112,7 +112,7 @@ class OnboardingFlowCoordinator: FlowCoordinatorProtocol {
             fatalError("This flow coordinator shouldn't have been started")
         }
         
-        rootNavigationStackCoordinator.setFullScreenCoverCoordinator(navigationStackCoordinator, animated: !isNewLogin)
+        actionsSubject.send(.requestPresentation(animated: !isNewLogin))
 
         stateMachine.tryEvent(.next)
     }
@@ -224,7 +224,7 @@ class OnboardingFlowCoordinator: FlowCoordinatorProtocol {
             case (_, _, .notificationPermissions):
                 presentNotificationPermissionsScreen()
             case (_, _, .finished):
-                rootNavigationStackCoordinator.setFullScreenCoverCoordinator(nil)
+                actionsSubject.send(.dismiss)
                 stateMachine.tryState(.initial)
             case (.finished, _, .initial):
                 break

--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -81,8 +81,8 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
                                                               isNewLogin: isNewLogin)
         
         navigationTabCoordinator.setTabs([
-            .init(coordinator: chatsSplitCoordinator, title: L10n.screenHomeTabChats, icon: \.chat, selectedIcon: \.chatSolid),
-            .init(coordinator: BlankFormCoordinator(), title: L10n.screenHomeTabSpaces, icon: \.space, selectedIcon: \.spaceSolid)
+            .init(coordinator: chatsSplitCoordinator, title: L10n.screenHomeTabChats, icon: \.chat, selectedIcon: \.chatSolid)
+            // .init(coordinator: BlankFormCoordinator(), title: L10n.screenHomeTabSpaces, icon: \.space, selectedIcon: \.spaceSolid)
         ])
         
         setupObservers()

--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -1,0 +1,106 @@
+//
+// Copyright 2025 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Combine
+import Compound
+import MatrixRustSDK
+import SwiftUI
+
+enum UserSessionFlowCoordinatorAction {
+    case logout
+    case clearCache
+    /// Logout without a confirmation. The user forgot their PIN.
+    case forceLogout
+}
+
+class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
+    private let userSession: UserSessionProtocol
+    private let navigationRootCoordinator: NavigationRootCoordinator
+    private let navigationTabCoordinator: NavigationTabCoordinator
+    
+    private let chatsFlowCoordinator: ChatsFlowCoordinator
+    
+    private let actionsSubject: PassthroughSubject<UserSessionFlowCoordinatorAction, Never> = .init()
+    var actionsPublisher: AnyPublisher<UserSessionFlowCoordinatorAction, Never> {
+        actionsSubject.eraseToAnyPublisher()
+    }
+    
+    private var cancellables: Set<AnyCancellable> = []
+    
+    init(userSession: UserSessionProtocol,
+         navigationRootCoordinator: NavigationRootCoordinator,
+         appLockService: AppLockServiceProtocol,
+         bugReportService: BugReportServiceProtocol,
+         elementCallService: ElementCallServiceProtocol,
+         timelineControllerFactory: TimelineControllerFactoryProtocol,
+         appMediator: AppMediatorProtocol,
+         appSettings: AppSettings,
+         appHooks: AppHooks,
+         analytics: AnalyticsService,
+         notificationManager: NotificationManagerProtocol,
+         isNewLogin: Bool) {
+        self.userSession = userSession
+        self.navigationRootCoordinator = navigationRootCoordinator
+        
+        navigationTabCoordinator = NavigationTabCoordinator()
+        navigationRootCoordinator.setRootCoordinator(navigationTabCoordinator)
+        
+        let chatsSplitCoordinator = NavigationSplitCoordinator(placeholderCoordinator: PlaceholderScreenCoordinator())
+        chatsFlowCoordinator = ChatsFlowCoordinator(userSession: userSession,
+                                                    navigationSplitCoordinator: chatsSplitCoordinator,
+                                                    appLockService: appLockService,
+                                                    bugReportService: bugReportService,
+                                                    elementCallService: elementCallService,
+                                                    timelineControllerFactory: timelineControllerFactory,
+                                                    appMediator: appMediator,
+                                                    appSettings: appSettings,
+                                                    appHooks: appHooks,
+                                                    analytics: analytics,
+                                                    notificationManager: notificationManager,
+                                                    isNewLogin: isNewLogin)
+        
+        navigationTabCoordinator.setTabs([
+            .init(coordinator: chatsSplitCoordinator, title: L10n.screenHomeTabChats, icon: \.chat, selectedIcon: \.chatSolid),
+            .init(coordinator: BlankFormCoordinator(), title: L10n.screenHomeTabSpaces, icon: \.space, selectedIcon: \.spaceSolid)
+        ])
+        
+        chatsFlowCoordinator.actionsPublisher
+            .sink { [weak self] action in
+                guard let self else { return }
+                switch action {
+                case .logout:
+                    actionsSubject.send(.logout)
+                case .clearCache:
+                    actionsSubject.send(.clearCache)
+                case .forceLogout:
+                    actionsSubject.send(.forceLogout)
+                }
+            }
+            .store(in: &cancellables)
+    }
+    
+    func start() {
+        chatsFlowCoordinator.start()
+    }
+    
+    func stop() {
+        chatsFlowCoordinator.stop()
+    }
+    
+    func handleAppRoute(_ appRoute: AppRoute, animated: Bool) {
+        chatsFlowCoordinator.handleAppRoute(appRoute, animated: animated)
+    }
+    
+    func clearRoute(animated: Bool) {
+        chatsFlowCoordinator.clearRoute(animated: animated)
+    }
+    
+    #warning("Should this be a publisher instead??")
+    func isDisplayingRoomScreen(withRoomID roomID: String) -> Bool {
+        chatsFlowCoordinator.isDisplayingRoomScreen(withRoomID: roomID)
+    }
+}

--- a/ElementX/Sources/Screens/Onboarding/SessionVerificationScreen/SessionVerificationScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Onboarding/SessionVerificationScreen/SessionVerificationScreenCoordinator.swift
@@ -16,12 +16,12 @@ enum SessionVerificationScreenCoordinatorAction {
 enum SessionVerificationScreenFlow {
     case deviceInitiator
     case deviceResponder(requestDetails: SessionVerificationRequestDetails)
-    case userIntiator(userID: String)
+    case userInitiator(userID: String)
     case userResponder(requestDetails: SessionVerificationRequestDetails)
     
     var isResponder: Bool {
         switch self {
-        case .deviceInitiator, .userIntiator:
+        case .deviceInitiator, .userInitiator:
             false
         case .deviceResponder, .userResponder:
             true

--- a/ElementX/Sources/Screens/Onboarding/SessionVerificationScreen/SessionVerificationScreenModels.swift
+++ b/ElementX/Sources/Screens/Onboarding/SessionVerificationScreen/SessionVerificationScreenModels.swift
@@ -36,7 +36,7 @@ struct SessionVerificationScreenViewState: BindableState {
             switch flow {
             case .deviceInitiator, .deviceResponder:
                 return (\.devices, .defaultSolid)
-            case .userIntiator, .userResponder:
+            case .userInitiator, .userResponder:
                 return (\.userProfileSolid, .defaultSolid)
             }
         case .acceptingVerificationRequest:
@@ -74,7 +74,7 @@ struct SessionVerificationScreenViewState: BindableState {
             switch flow {
             case .deviceInitiator:
                 return L10n.screenSessionVerificationUseAnotherDeviceTitle
-            case .userIntiator:
+            case .userInitiator:
                 return L10n.screenSessionVerificationUserInitiatorTitle
             case .deviceResponder, .userResponder:
                 return L10n.screenSessionVerificationRequestTitle
@@ -108,7 +108,7 @@ struct SessionVerificationScreenViewState: BindableState {
         switch flow {
         case .deviceInitiator, .deviceResponder:
             return L10n.screenSessionVerificationWaitingOtherDeviceTitle
-        case .userIntiator, .userResponder:
+        case .userInitiator, .userResponder:
             return L10n.screenSessionVerificationWaitingOtherUserTitle
         }
     }
@@ -119,7 +119,7 @@ struct SessionVerificationScreenViewState: BindableState {
             switch flow {
             case .deviceInitiator:
                 return L10n.screenSessionVerificationUseAnotherDeviceSubtitle
-            case .userIntiator:
+            case .userInitiator:
                 return L10n.screenSessionVerificationUserInitiatorSubtitle
             case .deviceResponder:
                 return L10n.screenSessionVerificationRequestSubtitle
@@ -146,14 +146,14 @@ struct SessionVerificationScreenViewState: BindableState {
             switch flow {
             case .deviceInitiator, .deviceResponder:
                 return L10n.screenSessionVerificationCompareEmojisSubtitle
-            case .userIntiator, .userResponder:
+            case .userInitiator, .userResponder:
                 return L10n.screenSessionVerificationCompareEmojisUserSubtitle
             }
         case .verified:
             switch flow {
             case .deviceInitiator, .deviceResponder:
                 return L10n.screenSessionVerificationCompleteSubtitle
-            case .userIntiator, .userResponder:
+            case .userInitiator, .userResponder:
                 return L10n.screenSessionVerificationCompleteUserSubtitle
             }
             

--- a/ElementX/Sources/Screens/Onboarding/SessionVerificationScreen/SessionVerificationScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Onboarding/SessionVerificationScreen/SessionVerificationScreenViewModel.swift
@@ -178,7 +178,7 @@ class SessionVerificationScreenViewModel: SessionVerificationViewModelType, Sess
         switch flow {
         case .deviceInitiator:
             return await sessionVerificationControllerProxy.requestDeviceVerification()
-        case .userIntiator(let userID):
+        case .userInitiator(let userID):
             return await sessionVerificationControllerProxy.requestUserVerification(userID)
         default:
             fatalError("Incorrect API usage.")

--- a/ElementX/Sources/Screens/Onboarding/SessionVerificationScreen/View/SessionVerificationScreen.swift
+++ b/ElementX/Sources/Screens/Onboarding/SessionVerificationScreen/View/SessionVerificationScreen.swift
@@ -43,7 +43,7 @@ struct SessionVerificationScreen: View {
     private var toolbar: some ToolbarContent {
         ToolbarItem(placement: .cancellationAction) {
             switch context.viewState.flow {
-            case .userIntiator, .userResponder:
+            case .userInitiator, .userResponder:
                 Button(L10n.actionCancel) {
                     context.send(viewAction: .cancel)
                 }
@@ -91,7 +91,7 @@ struct SessionVerificationScreen: View {
                 SessionVerificationRequestDetailsView(details: details,
                                                       isUserVerification: true,
                                                       mediaProvider: context.mediaProvider)
-            case .userIntiator:
+            case .userInitiator:
                 Button(L10n.actionLearnMore) {
                     UIApplication.shared.open(context.viewState.learnMoreURL)
                 }
@@ -129,7 +129,7 @@ struct SessionVerificationScreen: View {
         switch context.viewState.verificationState {
         case .initial:
             switch context.viewState.flow {
-            case .deviceInitiator, .userIntiator:
+            case .deviceInitiator, .userInitiator:
                 Button(L10n.actionStartVerification) {
                     context.send(viewAction: .requestVerification)
                 }
@@ -152,7 +152,7 @@ struct SessionVerificationScreen: View {
             }
         case .cancelled:
             switch context.viewState.flow {
-            case .deviceInitiator, .userIntiator:
+            case .deviceInitiator, .userInitiator:
                 Button(L10n.actionRetry) {
                     context.send(viewAction: .restart)
                 }
@@ -214,7 +214,7 @@ struct SessionVerification_Previews: PreviewProvider, TestablePreview {
         sessionVerificationScreen(state: .initial, flow: .deviceInitiator)
             .previewDisplayName("Initial - Device Initiator")
         
-        sessionVerificationScreen(state: .initial, flow: .userIntiator(userID: "@bob:matrix.org"))
+        sessionVerificationScreen(state: .initial, flow: .userInitiator(userID: "@bob:matrix.org"))
             .previewDisplayName("Initial - User Initiator")
         
         let details = SessionVerificationRequestDetails(senderProfile: UserProfileProxy(userID: "@bob:matrix.org",

--- a/ElementX/Sources/UITests/UITestsAppCoordinator.swift
+++ b/ElementX/Sources/UITests/UITestsAppCoordinator.swift
@@ -582,26 +582,25 @@ class MockScreen: Identifiable {
             appSettings.hasRunIdentityConfirmationOnboarding = true
             appSettings.hasRunNotificationPermissionsOnboarding = true
             appSettings.analyticsConsentState = .optedOut
-            let navigationSplitCoordinator = NavigationSplitCoordinator(placeholderCoordinator: PlaceholderScreenCoordinator())
             
             let clientProxy = ClientProxyMock(.init(userID: "@mock:client.com", deviceID: "MOCKCLIENT", roomSummaryProvider: RoomSummaryProviderMock(.init(state: .loaded(.mockRooms)))))
             
             let appMediator = AppMediatorMock.default
             appMediator.underlyingWindowManager = windowManager
             
-            let flowCoordinator = ChatsFlowCoordinator(userSession: UserSessionMock(.init(clientProxy: clientProxy)),
-                                                       navigationRootCoordinator: navigationRootCoordinator,
-                                                       appLockService: AppLockService(keychainController: KeychainControllerMock(),
-                                                                                      appSettings: ServiceLocator.shared.settings),
-                                                       bugReportService: BugReportServiceMock(.init()),
-                                                       elementCallService: ElementCallServiceMock(.init()),
-                                                       timelineControllerFactory: TimelineControllerFactoryMock(.init()),
-                                                       appMediator: appMediator,
-                                                       appSettings: appSettings,
-                                                       appHooks: AppHooks(),
-                                                       analytics: ServiceLocator.shared.analytics,
-                                                       notificationManager: NotificationManagerMock(),
-                                                       isNewLogin: false)
+            let flowCoordinator = UserSessionFlowCoordinator(userSession: UserSessionMock(.init(clientProxy: clientProxy)),
+                                                             navigationRootCoordinator: navigationRootCoordinator,
+                                                             appLockService: AppLockService(keychainController: KeychainControllerMock(),
+                                                                                            appSettings: ServiceLocator.shared.settings),
+                                                             bugReportService: BugReportServiceMock(.init()),
+                                                             elementCallService: ElementCallServiceMock(.init()),
+                                                             timelineControllerFactory: TimelineControllerFactoryMock(.init()),
+                                                             appMediator: appMediator,
+                                                             appSettings: appSettings,
+                                                             appHooks: AppHooks(),
+                                                             analytics: ServiceLocator.shared.analytics,
+                                                             notificationManager: NotificationManagerMock(),
+                                                             isNewLogin: false)
             
             flowCoordinator.start()
             
@@ -729,6 +728,7 @@ class MockScreen: Identifiable {
             appSettings.hasRunNotificationPermissionsOnboarding = true
             appSettings.analyticsConsentState = .optedOut
             let navigationSplitCoordinator = NavigationSplitCoordinator(placeholderCoordinator: PlaceholderScreenCoordinator())
+            navigationRootCoordinator.setRootCoordinator(navigationSplitCoordinator)
             
             let clientProxy = ClientProxyMock(.init(userID: "@mock:client.com", roomSummaryProvider: RoomSummaryProviderMock(.init(state: .loaded(.mockRooms)))))
             
@@ -746,7 +746,7 @@ class MockScreen: Identifiable {
                                                         appSettings: ServiceLocator.shared.settings)
             
             let flowCoordinator = ChatsFlowCoordinator(userSession: UserSessionMock(.init(clientProxy: clientProxy)),
-                                                       navigationRootCoordinator: navigationRootCoordinator,
+                                                       navigationSplitCoordinator: navigationSplitCoordinator,
                                                        appLockService: AppLockService(keychainController: KeychainControllerMock(),
                                                                                       appSettings: ServiceLocator.shared.settings),
                                                        bugReportService: BugReportServiceMock(.init()),

--- a/ElementX/Sources/UITests/UITestsAppCoordinator.swift
+++ b/ElementX/Sources/UITests/UITestsAppCoordinator.swift
@@ -589,19 +589,19 @@ class MockScreen: Identifiable {
             let appMediator = AppMediatorMock.default
             appMediator.underlyingWindowManager = windowManager
             
-            let flowCoordinator = UserSessionFlowCoordinator(userSession: UserSessionMock(.init(clientProxy: clientProxy)),
-                                                             navigationRootCoordinator: navigationRootCoordinator,
-                                                             appLockService: AppLockService(keychainController: KeychainControllerMock(),
-                                                                                            appSettings: ServiceLocator.shared.settings),
-                                                             bugReportService: BugReportServiceMock(.init()),
-                                                             elementCallService: ElementCallServiceMock(.init()),
-                                                             timelineControllerFactory: TimelineControllerFactoryMock(.init()),
-                                                             appMediator: appMediator,
-                                                             appSettings: appSettings,
-                                                             appHooks: AppHooks(),
-                                                             analytics: ServiceLocator.shared.analytics,
-                                                             notificationManager: NotificationManagerMock(),
-                                                             isNewLogin: false)
+            let flowCoordinator = ChatsFlowCoordinator(userSession: UserSessionMock(.init(clientProxy: clientProxy)),
+                                                       navigationRootCoordinator: navigationRootCoordinator,
+                                                       appLockService: AppLockService(keychainController: KeychainControllerMock(),
+                                                                                      appSettings: ServiceLocator.shared.settings),
+                                                       bugReportService: BugReportServiceMock(.init()),
+                                                       elementCallService: ElementCallServiceMock(.init()),
+                                                       timelineControllerFactory: TimelineControllerFactoryMock(.init()),
+                                                       appMediator: appMediator,
+                                                       appSettings: appSettings,
+                                                       appHooks: AppHooks(),
+                                                       analytics: ServiceLocator.shared.analytics,
+                                                       notificationManager: NotificationManagerMock(),
+                                                       isNewLogin: false)
             
             flowCoordinator.start()
             
@@ -745,19 +745,19 @@ class MockScreen: Identifiable {
                                                         mediaProvider: MediaProviderMock(configuration: .init()),
                                                         appSettings: ServiceLocator.shared.settings)
             
-            let flowCoordinator = UserSessionFlowCoordinator(userSession: UserSessionMock(.init(clientProxy: clientProxy)),
-                                                             navigationRootCoordinator: navigationRootCoordinator,
-                                                             appLockService: AppLockService(keychainController: KeychainControllerMock(),
-                                                                                            appSettings: ServiceLocator.shared.settings),
-                                                             bugReportService: BugReportServiceMock(.init()),
-                                                             elementCallService: ElementCallServiceMock(.init()),
-                                                             timelineControllerFactory: TimelineControllerFactoryMock(.init(timelineController: timelineController)),
-                                                             appMediator: AppMediatorMock.default,
-                                                             appSettings: appSettings,
-                                                             appHooks: AppHooks(),
-                                                             analytics: ServiceLocator.shared.analytics,
-                                                             notificationManager: NotificationManagerMock(),
-                                                             isNewLogin: false)
+            let flowCoordinator = ChatsFlowCoordinator(userSession: UserSessionMock(.init(clientProxy: clientProxy)),
+                                                       navigationRootCoordinator: navigationRootCoordinator,
+                                                       appLockService: AppLockService(keychainController: KeychainControllerMock(),
+                                                                                      appSettings: ServiceLocator.shared.settings),
+                                                       bugReportService: BugReportServiceMock(.init()),
+                                                       elementCallService: ElementCallServiceMock(.init()),
+                                                       timelineControllerFactory: TimelineControllerFactoryMock(.init(timelineController: timelineController)),
+                                                       appMediator: AppMediatorMock.default,
+                                                       appSettings: appSettings,
+                                                       appHooks: AppHooks(),
+                                                       analytics: ServiceLocator.shared.analytics,
+                                                       notificationManager: NotificationManagerMock(),
+                                                       isNewLogin: false)
             
             flowCoordinator.start()
             

--- a/UnitTests/Sources/ChatsFlowCoordinatorTests.swift
+++ b/UnitTests/Sources/ChatsFlowCoordinatorTests.swift
@@ -15,12 +15,11 @@ class ChatsFlowCoordinatorTests: XCTestCase {
     var clientProxy: ClientProxyMock!
     var timelineControllerFactory: TimelineControllerFactoryMock!
     var chatsFlowCoordinator: ChatsFlowCoordinator!
-    var navigationRootCoordinator: NavigationRootCoordinator!
+    var splitCoordinator: NavigationSplitCoordinator!
     var notificationManager: NotificationManagerMock!
     
     var cancellables = Set<AnyCancellable>()
     
-    var splitCoordinator: NavigationSplitCoordinator? { navigationRootCoordinator.rootCoordinator as? NavigationSplitCoordinator }
     var detailCoordinator: CoordinatorProtocol? { splitCoordinator?.detailCoordinator }
     var detailNavigationStack: NavigationStackCoordinator? { detailCoordinator as? NavigationStackCoordinator }
     
@@ -29,12 +28,12 @@ class ChatsFlowCoordinatorTests: XCTestCase {
         clientProxy = ClientProxyMock(.init(userID: "hi@bob", roomSummaryProvider: RoomSummaryProviderMock(.init(state: .loaded(.mockRooms)))))
         timelineControllerFactory = TimelineControllerFactoryMock(.init())
         
-        navigationRootCoordinator = NavigationRootCoordinator()
+        splitCoordinator = NavigationSplitCoordinator(placeholderCoordinator: PlaceholderScreenCoordinator())
         
         notificationManager = NotificationManagerMock()
         
         chatsFlowCoordinator = ChatsFlowCoordinator(userSession: UserSessionMock(.init(clientProxy: clientProxy)),
-                                                    navigationRootCoordinator: navigationRootCoordinator,
+                                                    navigationSplitCoordinator: splitCoordinator,
                                                     appLockService: AppLockServiceMock(),
                                                     bugReportService: BugReportServiceMock(.init()),
                                                     elementCallService: ElementCallServiceMock(.init()),

--- a/UnitTests/Sources/ChatsFlowCoordinatorTests.swift
+++ b/UnitTests/Sources/ChatsFlowCoordinatorTests.swift
@@ -11,10 +11,10 @@ import Combine
 @testable import ElementX
 
 @MainActor
-class UserSessionFlowCoordinatorTests: XCTestCase {
+class ChatsFlowCoordinatorTests: XCTestCase {
     var clientProxy: ClientProxyMock!
     var timelineControllerFactory: TimelineControllerFactoryMock!
-    var userSessionFlowCoordinator: UserSessionFlowCoordinator!
+    var chatsFlowCoordinator: ChatsFlowCoordinator!
     var navigationRootCoordinator: NavigationRootCoordinator!
     var notificationManager: NotificationManagerMock!
     
@@ -33,21 +33,21 @@ class UserSessionFlowCoordinatorTests: XCTestCase {
         
         notificationManager = NotificationManagerMock()
         
-        userSessionFlowCoordinator = UserSessionFlowCoordinator(userSession: UserSessionMock(.init(clientProxy: clientProxy)),
-                                                                navigationRootCoordinator: navigationRootCoordinator,
-                                                                appLockService: AppLockServiceMock(),
-                                                                bugReportService: BugReportServiceMock(.init()),
-                                                                elementCallService: ElementCallServiceMock(.init()),
-                                                                timelineControllerFactory: timelineControllerFactory,
-                                                                appMediator: AppMediatorMock.default,
-                                                                appSettings: ServiceLocator.shared.settings,
-                                                                appHooks: AppHooks(),
-                                                                analytics: ServiceLocator.shared.analytics,
-                                                                notificationManager: notificationManager,
-                                                                isNewLogin: false)
+        chatsFlowCoordinator = ChatsFlowCoordinator(userSession: UserSessionMock(.init(clientProxy: clientProxy)),
+                                                    navigationRootCoordinator: navigationRootCoordinator,
+                                                    appLockService: AppLockServiceMock(),
+                                                    bugReportService: BugReportServiceMock(.init()),
+                                                    elementCallService: ElementCallServiceMock(.init()),
+                                                    timelineControllerFactory: timelineControllerFactory,
+                                                    appMediator: AppMediatorMock.default,
+                                                    appSettings: ServiceLocator.shared.settings,
+                                                    appHooks: AppHooks(),
+                                                    analytics: ServiceLocator.shared.analytics,
+                                                    notificationManager: notificationManager,
+                                                    isNewLogin: false)
         
-        let deferred = deferFulfillment(userSessionFlowCoordinator.statePublisher) { $0 == .roomList(roomListSelectedRoomID: nil) }
-        userSessionFlowCoordinator.start()
+        let deferred = deferFulfillment(chatsFlowCoordinator.statePublisher) { $0 == .roomList(roomListSelectedRoomID: nil) }
+        chatsFlowCoordinator.start()
         try await deferred.fulfill()
     }
     
@@ -128,8 +128,8 @@ class UserSessionFlowCoordinatorTests: XCTestCase {
         XCTAssertTrue(detailNavigationStack?.rootCoordinator is RoomDetailsScreenCoordinator)
         XCTAssertNotNil(detailCoordinator)
         
-        let unexpectedFulfillment = deferFailure(userSessionFlowCoordinator.statePublisher, timeout: 1) { _ in true }
-        userSessionFlowCoordinator.handleAppRoute(.roomDetails(roomID: "1"), animated: true)
+        let unexpectedFulfillment = deferFailure(chatsFlowCoordinator.statePublisher, timeout: 1) { _ in true }
+        chatsFlowCoordinator.handleAppRoute(.roomDetails(roomID: "1"), animated: true)
         try await unexpectedFulfillment.fulfill()
         
         XCTAssertTrue(detailNavigationStack?.rootCoordinator is RoomDetailsScreenCoordinator)
@@ -151,8 +151,8 @@ class UserSessionFlowCoordinatorTests: XCTestCase {
         XCTAssertTrue(detailNavigationStack?.rootCoordinator is RoomScreenCoordinator)
         XCTAssertNotNil(detailCoordinator)
         
-        let unexpectedFulfillment = deferFailure(userSessionFlowCoordinator.statePublisher, timeout: 1) { _ in true }
-        userSessionFlowCoordinator.handleAppRoute(.roomDetails(roomID: "1"), animated: true)
+        let unexpectedFulfillment = deferFailure(chatsFlowCoordinator.statePublisher, timeout: 1) { _ in true }
+        chatsFlowCoordinator.handleAppRoute(.roomDetails(roomID: "1"), animated: true)
         try await unexpectedFulfillment.fulfill()
         
         XCTAssertTrue(detailNavigationStack?.rootCoordinator is RoomScreenCoordinator)
@@ -192,7 +192,7 @@ class UserSessionFlowCoordinatorTests: XCTestCase {
         XCTAssertEqual(detailNavigationStack?.stackCoordinators.count, 0)
         XCTAssertNotNil(detailCoordinator)
         
-        userSessionFlowCoordinator.handleAppRoute(.childRoom(roomID: "2", via: []), animated: true)
+        chatsFlowCoordinator.handleAppRoute(.childRoom(roomID: "2", via: []), animated: true)
         try await Task.sleep(for: .milliseconds(100))
         XCTAssertTrue(detailNavigationStack?.rootCoordinator is RoomScreenCoordinator)
         XCTAssertEqual(detailNavigationStack?.stackCoordinators.count, 1)
@@ -215,7 +215,7 @@ class UserSessionFlowCoordinatorTests: XCTestCase {
         XCTAssertEqual(timelineControllerFactory.buildTimelineControllerRoomProxyInitialFocussedEventIDTimelineItemFactoryMediaProviderReceivedArguments?.initialFocussedEventID, "1")
         
         // A child event route should push a new room screen onto the stack and focus on the event.
-        userSessionFlowCoordinator.handleAppRoute(.childEvent(eventID: "2", roomID: "2", via: []), animated: true)
+        chatsFlowCoordinator.handleAppRoute(.childEvent(eventID: "2", roomID: "2", via: []), animated: true)
         try await Task.sleep(for: .milliseconds(100))
         XCTAssertTrue(detailNavigationStack?.rootCoordinator is RoomScreenCoordinator)
         XCTAssertEqual(detailNavigationStack?.stackCoordinators.count, 1)
@@ -290,12 +290,12 @@ class UserSessionFlowCoordinatorTests: XCTestCase {
     
     // MARK: - Private
     
-    private func process(route: AppRoute, expectedState: UserSessionFlowCoordinatorStateMachine.State) async throws {
+    private func process(route: AppRoute, expectedState: ChatsFlowCoordinatorStateMachine.State) async throws {
         // Sometimes the state machine's state changes before the coordinators have updated the stack.
-        let delayedPublisher = userSessionFlowCoordinator.statePublisher.delay(for: .milliseconds(100), scheduler: DispatchQueue.main)
+        let delayedPublisher = chatsFlowCoordinator.statePublisher.delay(for: .milliseconds(100), scheduler: DispatchQueue.main)
         
         let deferred = deferFulfillment(delayedPublisher) { $0 == expectedState }
-        userSessionFlowCoordinator.handleAppRoute(route, animated: true)
+        chatsFlowCoordinator.handleAppRoute(route, animated: true)
         try await deferred.fulfill()
     }
 }

--- a/UnitTests/Sources/NavigationTabCoordinatorTests.swift
+++ b/UnitTests/Sources/NavigationTabCoordinatorTests.swift
@@ -1,0 +1,123 @@
+//
+// Copyright 2022-2024 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+// Please see LICENSE files in the repository root for full details.
+//
+
+import XCTest
+
+@testable import ElementX
+
+@MainActor
+class NavigationTabCoordinatorTests: XCTestCase {
+    private var navigationTabCoordinator: NavigationTabCoordinator!
+    
+    override func setUp() {
+        navigationTabCoordinator = NavigationTabCoordinator()
+    }
+    
+    func testTabs() {
+        XCTAssertTrue(navigationTabCoordinator.tabCoordinators.isEmpty)
+        
+        let someCoordinator = SomeTestCoordinator()
+        navigationTabCoordinator.setTabs([.init(coordinator: someCoordinator, title: "Whatever", icon: \.help, selectedIcon: \.helpSolid)])
+        assertCoordinatorsEqual(navigationTabCoordinator.tabCoordinators, [someCoordinator])
+        
+        let chatsCoordinator = SomeTestCoordinator()
+        let spacesCoordinator = SomeTestCoordinator()
+        navigationTabCoordinator.setTabs([
+            .init(coordinator: chatsCoordinator, title: "Chats", icon: \.chat, selectedIcon: \.chatSolid),
+            .init(coordinator: spacesCoordinator, title: "Spaces", icon: \.space, selectedIcon: \.spaceSolid)
+        ])
+        assertCoordinatorsEqual(navigationTabCoordinator.tabCoordinators, [chatsCoordinator, spacesCoordinator])
+    }
+    
+    func testSingleSheet() {
+        let tabCoordinator = SomeTestCoordinator()
+        navigationTabCoordinator.setTabs([.init(coordinator: tabCoordinator, title: "Tab", icon: \.help, selectedIcon: \.helpSolid)])
+        
+        let coordinator = SomeTestCoordinator()
+        navigationTabCoordinator.setSheetCoordinator(coordinator)
+        
+        assertCoordinatorsEqual(navigationTabCoordinator.tabCoordinators, [tabCoordinator])
+        assertCoordinatorsEqual(coordinator, navigationTabCoordinator.sheetCoordinator)
+        
+        navigationTabCoordinator.setSheetCoordinator(nil)
+        
+        assertCoordinatorsEqual(navigationTabCoordinator.tabCoordinators, [tabCoordinator])
+        XCTAssertNil(navigationTabCoordinator.sheetCoordinator)
+    }
+    
+    func testMultipleSheets() {
+        let tabCoordinator = SomeTestCoordinator()
+        navigationTabCoordinator.setTabs([.init(coordinator: tabCoordinator, title: "Tab", icon: \.help, selectedIcon: \.helpSolid)])
+        
+        let sheetCoordinator = SomeTestCoordinator()
+        navigationTabCoordinator.setSheetCoordinator(sheetCoordinator)
+        
+        assertCoordinatorsEqual(navigationTabCoordinator.tabCoordinators, [tabCoordinator])
+        assertCoordinatorsEqual(sheetCoordinator, navigationTabCoordinator.sheetCoordinator)
+        
+        let someOtherSheetCoordinator = SomeTestCoordinator()
+        navigationTabCoordinator.setSheetCoordinator(someOtherSheetCoordinator)
+        
+        assertCoordinatorsEqual(navigationTabCoordinator.tabCoordinators, [tabCoordinator])
+        assertCoordinatorsEqual(someOtherSheetCoordinator, navigationTabCoordinator.sheetCoordinator)
+    }
+    
+    func testTabDismissalCallbacks() {
+        let chatsCoordinator = SomeTestCoordinator()
+        let spacesCoordinator = SomeTestCoordinator()
+        
+        let expectation = expectation(description: "Wait for callback")
+        expectation.expectedFulfillmentCount = 2
+        
+        navigationTabCoordinator.setTabs([
+            .init(coordinator: chatsCoordinator, title: "Chats", icon: \.chat, selectedIcon: \.chatSolid) { expectation.fulfill() },
+            .init(coordinator: spacesCoordinator, title: "Spaces", icon: \.space, selectedIcon: \.spaceSolid) { expectation.fulfill() }
+        ])
+        assertCoordinatorsEqual(navigationTabCoordinator.tabCoordinators, [chatsCoordinator, spacesCoordinator])
+        
+        navigationTabCoordinator.setTabs([.init(coordinator: SomeTestCoordinator(), title: "Whatever", icon: \.help, selectedIcon: \.helpSolid)])
+        waitForExpectations(timeout: 1.0)
+    }
+    
+    func testSheetDismissalCallback() {
+        let coordinator = SomeTestCoordinator()
+        let expectation = expectation(description: "Wait for callback")
+        navigationTabCoordinator.setSheetCoordinator(coordinator) {
+            expectation.fulfill()
+        }
+        
+        navigationTabCoordinator.setSheetCoordinator(nil)
+        waitForExpectations(timeout: 1.0)
+    }
+    
+    // MARK: - Private
+    
+    private func assertCoordinatorsEqual(_ lhs: CoordinatorProtocol?, _ rhs: CoordinatorProtocol?) {
+        guard let lhs = lhs as? SomeTestCoordinator,
+              let rhs = rhs as? SomeTestCoordinator else {
+            XCTFail("Coordinators are not the same")
+            return
+        }
+        
+        XCTAssertEqual(lhs.id, rhs.id)
+    }
+    
+    private func assertCoordinatorsEqual(_ lhs: [CoordinatorProtocol], _ rhs: [CoordinatorProtocol]) {
+        guard lhs.count == rhs.count else {
+            XCTFail("Coordinators are not the same")
+            return
+        }
+        
+        for (index, coordinator) in lhs.enumerated() {
+            assertCoordinatorsEqual(coordinator, rhs[index])
+        }
+    }
+}
+
+private class SomeTestCoordinator: CoordinatorProtocol {
+    let id = UUID()
+}

--- a/project.yml
+++ b/project.yml
@@ -72,7 +72,7 @@ packages:
     # path: ../matrix-rust-sdk
   Compound:
     url: https://github.com/element-hq/compound-ios
-    revision: 089904dc1aeb3bacce3b7bb757b7637274e46008
+    revision: afc59afb1b1e4f4960e2f2a15e52d4e2e33fc889
     # path: ../compound-ios
   AnalyticsEvents:
     url: https://github.com/matrix-org/matrix-analytics-events


### PR DESCRIPTION
With this PR, the `TabView` becomes part of the hierarchy, but is hard-coded as hidden until we're ready to show it (it will be reactive based on whether or not the user is a member of any spaces).

The commits basically explain themselves but just as a summary:
- Add a NavigationTabCoordinator to manage a set of tabs.
- Rename UserSessionFlowCoordinator to ChatsFlowCoordinator
- Make a basic UserSessionFlowCoordinator that embeds the ChatsFlowCoordinator into a tab.
- Move onboarding, verification and logout handling from the Chats flow into the UserSession flow.

Neither the implementation of the `NavigationTabCoordinator` nor the `UserSessionFlowCoordinator` are complete (the former needs badges, tab visibility and programmatic tab switching, the latter needs a state machine and improved route handling), but this PR was large enough that it seemed worthwhile opening now.

**Note:** This PR sure ain't a large as +13,901, the diff is just being dumb. Definitely review the commits individually I guess 😅

| iPhone | iPad |
| - | - |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-30 at 16 02 04" src="https://github.com/user-attachments/assets/a5e19629-8562-4b49-bfe5-24e54805fdfc" /> | <img width="2420" height="1668" alt="Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-07-30 at 16 00 02" src="https://github.com/user-attachments/assets/40b5fc30-c591-4a45-9849-5d4b0609f17c" /> |
