### PR TITLE
Label rageshakes from macOS and report the right operating system.

### DIFF
--- a/ElementX/Sources/Services/BugReport/BugReportService.swift
+++ b/ElementX/Sources/Services/BugReport/BugReportService.swift
@@ -91,6 +91,10 @@ class BugReportService: NSObject, BugReportServiceProtocol {
             bugReport.githubLabels.append("Nightly")
         }
         
+        if ProcessInfo.processInfo.isiOSAppOnMac {
+            bugReport.githubLabels.append("macOS")
+        }
+        
         for label in bugReport.githubLabels {
             params.append(MultipartFormData(key: "label", type: .text(value: label)))
         }
@@ -191,7 +195,12 @@ class BugReportService: NSObject, BugReportServiceProtocol {
     }
 
     private var os: String {
-        "\(UIDevice.current.systemName) \(UIDevice.current.systemVersion)"
+        if ProcessInfo.processInfo.isiOSAppOnMac {
+            // The other APIs report macOS's equivalent iOS version, so lets use the right one to get the macOS version.
+            "macOS \(ProcessInfo.processInfo.operatingSystemVersionString)"
+        } else {
+            "\(UIDevice.current.systemName) \(UIDevice.current.systemVersion)"
+        }
     }
 
     private func zipFiles(_ logFiles: [URL]) async -> Logs {


### PR DESCRIPTION
Tiny PR to tidy up rageshakes a bit. The operating system will be reported like so:

os: `macOS Version 15.6 (Build 24G84)`

Unfortunately this is localised, but at least it tells us the correct version.