### PR TITLE
Update Roles & Permissions UI test snapshots.

### DIFF
--- a/UITests/Sources/__Snapshots__/Application/roomRolesAndPermissions.testFlow-iPad-18-5-en-GB-2.png
+++ b/UITests/Sources/__Snapshots__/Application/roomRolesAndPermissions.testFlow-iPad-18-5-en-GB-2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a1b4649fcece1c1ae5c7ab9e5f73c34533dbde046e575eb9073fdb2ac14a2eab
-size 203091
+oid sha256:561ac3a36fa31f5fafb29f281ef86d0bd5328a3dfb6c2fb31f35ccbc18a5c404
+size 239958

--- a/UITests/Sources/__Snapshots__/Application/roomRolesAndPermissions.testFlow-iPhone-18-5-en-GB-2.png
+++ b/UITests/Sources/__Snapshots__/Application/roomRolesAndPermissions.testFlow-iPhone-18-5-en-GB-2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9df4fe228cfaaad395ce544b68e721f5f35f5edb7a0a89c70e92c287f6077897
-size 220310
+oid sha256:f61b7a66ef03eed0c04bc699d9973793d24699ca1d505d4d6d9a7b80bda63d9f
+size 289521


### PR DESCRIPTION
The behaviour of the moderation screen changed in #4372 so that admins are now shown as (non-demotable) moderators at the top of the change moderators screen.

UI tests run: https://github.com/element-hq/element-x-ios/actions/runs/16876727395