### PR TITLE
Fix a bug where the image upload screen was unintentionally dismissed for some failures.

### DIFF
--- a/ElementX/Sources/Screens/MediaUploadPreviewScreen/MediaUploadPreviewScreenViewModel.swift
+++ b/ElementX/Sources/Screens/MediaUploadPreviewScreen/MediaUploadPreviewScreenViewModel.swift
@@ -62,7 +62,6 @@ class MediaUploadPreviewScreenViewModel: MediaUploadPreviewScreenViewModelType, 
             Task {
                 defer { stopLoading() }
                 
-                var shouldDismissOnCompletion = true
                 switch await processingTask.value {
                 case .success(let mediaInfos):
                     for mediaInfo in mediaInfos {
@@ -70,22 +69,19 @@ class MediaUploadPreviewScreenViewModel: MediaUploadPreviewScreenViewModelType, 
                         case .success:
                             caption = nil // Set the caption only on the first uploaded file.
                         case .failure(let error):
-                            MXLog.error("Failed processing media to upload with error: \(error)")
-                            showError(label: L10n.screenMediaUploadPreviewErrorFailedProcessing)
+                            MXLog.error("Failed sending media with error: \(error)")
+                            showError(label: L10n.screenMediaUploadPreviewErrorFailedSending)
                         }
                     }
+                    
+                    actionsSubject.send(.dismiss)
                 case .failure(.maxUploadSizeUnknown):
                     showAlert(.maxUploadSizeUnknown)
-                    shouldDismissOnCompletion = false
                 case .failure(.maxUploadSizeExceeded(let limit)):
                     showAlert(.maxUploadSizeExceeded(limit: limit))
                 case .failure(let error):
                     MXLog.error("Failed processing media to upload with error: \(error)")
                     showError(label: L10n.screenMediaUploadPreviewErrorFailedProcessing)
-                }
-                
-                if shouldDismissOnCompletion {
-                    actionsSubject.send(.dismiss)
                 }
             }
         case .cancel:


### PR DESCRIPTION
@stefanceriu and I were working on #4358 and #4359 at the same time and it looks like something went wrong when the former rebased on the latter. I've added dismissal checks in the relevant tests and a bunch more test cases.

Fixes #4408.

https://github.com/user-attachments/assets/b9aa70dd-644e-4ca9-91e8-47a3ca6ad13e
