### PR TITLE
Fix some app route navigation bugs.

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -5,7 +5,6 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
-import Algorithms
 import Combine
 import Foundation
 import MatrixRustSDK

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -5,6 +5,7 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+import Algorithms
 import Combine
 import Foundation
 import MatrixRustSDK


### PR DESCRIPTION
A couple of bugs have been notice with the latest release:
- Opening a notification would update the stack with an animated pop.
- Opening a permalink from the timeline wouldn't push the room as a child.

The regression was introduced by #4390 which naively made the user session flow coordinator clear the existing route before presenting the new one (whereas it should only by clearing any sheets). I need to revisit this as it seems too error prone