### PR TITLE
Configure the video camera picker to record in high quality

### DIFF
--- a/ElementX/Sources/Screens/MediaPickerScreen/CameraPicker.swift
+++ b/ElementX/Sources/Screens/MediaPickerScreen/CameraPicker.swift
@@ -34,6 +34,7 @@ struct CameraPicker: UIViewControllerRepresentable {
         imagePicker.sourceType = .camera
         imagePicker.allowsEditing = false
         imagePicker.delegate = context.coordinator
+        imagePicker.videoQuality = .typeHigh
         
         if let mediaTypes = UIImagePickerController.availableMediaTypes(for: .camera) {
             imagePicker.mediaTypes = mediaTypes


### PR DESCRIPTION
as per [UIImagePickerController.QualityType.typeHigh](https://developer.apple.com/documentation/uikit/uiimagepickercontroller/qualitytype)