### PR TITLE
Improve supported share types

### DIFF
--- a/ElementX/Sources/Other/Extensions/NSItemProvider.swift
+++ b/ElementX/Sources/Other/Extensions/NSItemProvider.swift
@@ -125,6 +125,18 @@ extension NSItemProvider {
         let supportedContentTypes = registeredContentTypes
             .filter { isMimeTypeSupported($0.preferredMIMEType) || isIdentifierSupported($0.identifier) }
         
+        // If we can't find any supported types try to fallback to the first with
+        // a valid extension. Return nil otherwise.
+        guard !supportedContentTypes.isEmpty else {
+            for type in registeredContentTypes {
+                if let fileExtension = type.preferredFilenameExtension {
+                    return .init(type: type, fileExtension: fileExtension)
+                }
+            }
+            
+            return nil
+        }
+        
         // Have .jpeg take priority over .heic
         if supportedContentTypes.contains(.jpeg) {
             guard let fileExtension = preferredFileExtension(for: .jpeg) else {

--- a/ElementX/Sources/Other/Extensions/NSItemProvider.swift
+++ b/ElementX/Sources/Other/Extensions/NSItemProvider.swift
@@ -171,7 +171,10 @@ extension NSItemProvider {
             return false
         }
         
-        return mimeType.hasPrefix("image/") || mimeType.hasPrefix("video/") || mimeType.hasPrefix("application/")
+        return mimeType.hasPrefix("application/") ||
+            mimeType.hasPrefix("audio/") ||
+            mimeType.hasPrefix("image/") ||
+            mimeType.hasPrefix("video/")
     }
 }
 


### PR DESCRIPTION
* Add support for `audio/*` mime types on pasting/sharing/drag&dropping files
* Fallback to the first type with a valid extension when sharing media and no supported content types can be found

Fixes #3652