### PR TITLE
Update Element Call to 0.15.0.

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -9274,7 +9274,7 @@
 			repositoryURL = "https://github.com/element-hq/element-call-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 0.14.1;
+				version = 0.15.0;
 			};
 		};
 		821C67C9A7F8CC3FD41B28B4 /* XCRemoteSwiftPackageReference "emojibase-bindings" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/element-call-swift",
       "state" : {
-        "revision" : "85121ce5278518d52e0347d84308611007e13480",
-        "version" : "0.14.1"
+        "revision" : "deab02926b07c276514149e1a63e60d284f31878",
+        "version" : "0.15.0"
       }
     },
     {

--- a/project.yml
+++ b/project.yml
@@ -80,7 +80,7 @@ packages:
     # path: ../matrix-analytics-events
   EmbeddedElementCall:
     url: https://github.com/element-hq/element-call-swift
-    exactVersion: 0.14.1
+    exactVersion: 0.15.0
   Emojibase:
     url: https://github.com/matrix-org/emojibase-bindings
     minorVersion: 1.4.2


### PR DESCRIPTION
Ready for today's release, (which is probably going to happen tomorrow given #4445 timed out on CI).