### PR TITLE
A11y audit improvements and fixes

### DIFF
--- a/ElementX/Sources/Other/MatrixEntityRegex.swift
+++ b/ElementX/Sources/Other/MatrixEntityRegex.swift
@@ -14,6 +14,7 @@ enum MatrixEntityRegex: String {
     case roomAlias
     case uri
     case allUsers
+    case legacyRoomID
     
     var rawValue: String {
         switch self {
@@ -23,6 +24,8 @@ enum MatrixEntityRegex: String {
             return "@[\\x21-\\x39\\x3B-\\x7F]+:" + MatrixEntityRegex.homeserver.rawValue
         case .roomAlias:
             return "#[A-Z0-9._%#@=+-]+:" + MatrixEntityRegex.homeserver.rawValue
+        case .legacyRoomID:
+            return "![A-Z0-9_\\-\\/]+:" + MatrixEntityRegex.homeserver.rawValue
         case .uri:
             return "matrix:(r|u|roomid)\\/[A-Z0-9\\-._~:/?#\\[\\]@!$&'()*+,;=%]*(?:\\?[A-Z0-9\\-._~:/?#\\[\\]@!$&'()*+,;=%]*)?"
         case .allUsers:
@@ -37,6 +40,7 @@ enum MatrixEntityRegex: String {
     static let uriRegex = try! NSRegularExpression(pattern: MatrixEntityRegex.uri.rawValue, options: .caseInsensitive)
     static let allUsersRegex = try! NSRegularExpression(pattern: MatrixEntityRegex.allUsers.rawValue)
     static let linkRegex = try! NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+    static let legacyRoomIDRegex = try! NSRegularExpression(pattern: MatrixEntityRegex.legacyRoomID.rawValue, options: .caseInsensitive)
     // swiftlint:enable force_try
     
     static func isMatrixHomeserver(_ homeserver: String) -> Bool {
@@ -61,6 +65,14 @@ enum MatrixEntityRegex: String {
         }
         
         return match.range.length == alias.count
+    }
+    
+    static func isLegacyMatrixRoomID(_ roomID: String) -> Bool {
+        guard let match = legacyRoomIDRegex.firstMatch(in: roomID) else {
+            return false
+        }
+        
+        return match.range.length == roomID.count
     }
     
     static func isMatrixURI(_ uri: String) -> Bool {

--- a/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewDetailsView.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewDetailsView.swift
@@ -44,6 +44,7 @@ struct TimelineMediaPreviewDetailsView: View {
                                         contentID: item.sender.id,
                                         avatarSize: .user(on: .mediaPreviewDetails),
                                         mediaProvider: context.mediaProvider)
+                        .accessibilityHidden(true)
                     
                     VStack(alignment: .leading, spacing: 0) {
                         if let displayName = item.sender.displayName {

--- a/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewRedactConfirmationView.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewRedactConfirmationView.swift
@@ -71,6 +71,7 @@ struct TimelineMediaPreviewRedactConfirmationView: View {
                         .aspectRatio(contentMode: .fill)
                     }
                     .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .accessibilityHidden(true)
             }
                 
             VStack(alignment: .leading, spacing: 4) {

--- a/ElementX/Sources/Screens/MediaEventsTimelineScreen/View/MediaEventsTimelineScreen.swift
+++ b/ElementX/Sources/Screens/MediaEventsTimelineScreen/View/MediaEventsTimelineScreen.swift
@@ -85,6 +85,7 @@ struct MediaEventsTimelineScreen: View {
                     ForEach(group.items) { item in
                         VStack(spacing: 20) {
                             Divider()
+                                .accessibilityHidden(true)
                             
                             Button {
                                 tappedItem(item)
@@ -92,7 +93,11 @@ struct MediaEventsTimelineScreen: View {
                                 viewForTimelineItem(item)
                                     .scaleEffect(CGSize(width: 1, height: -1))
                             }
+                            .accessibilityRepresentation {
+                                viewForTimelineItem(item)
+                            }
                         }
+                        .accessibilityElement(children: .combine)
                         .padding(.horizontal, 16)
                     }
                 } footer: {

--- a/ElementX/Sources/Screens/Spaces/Common/SpaceHeaderView.swift
+++ b/ElementX/Sources/Screens/Spaces/Common/SpaceHeaderView.swift
@@ -19,6 +19,7 @@ struct SpaceHeaderView: View {
             RoomAvatarImage(avatar: spaceRoomProxy.avatar,
                             avatarSize: .room(on: .spaceHeader),
                             mediaProvider: mediaProvider)
+                .accessibilityHidden(true)
             
             VStack(spacing: 8) {
                 Text(title)


### PR DESCRIPTION
- Hidden some unnecessary avatars from voice over
- Ignored element descriptions in a rendering test
- Better rendering of the accessibility representation for the files list 
- Added the legacy room id to the regex, so that we can also filter false positives of non human readable labels for them since we still use them in tests sometimes