### PR TITLE
Fix proxies by reverting the change that introduced schemes.

### DIFF
--- a/ElementX/Sources/Other/Extensions/URL.swift
+++ b/ElementX/Sources/Other/Extensions/URL.swift
@@ -114,49 +114,22 @@ extension URL {
         }
         
         MXLog.info("Found \(String(describing: proxies?.count)) proxies, using the first one.")
-    
-        if proxyType == kCFProxyTypeAutoConfigurationURL as String {
-            MXLog.info("Found proxy auto configuration")
+        MXLog.info("Proxy type is \(proxyType)")
             
-            if let pacURL = firstProxy[kCFProxyAutoConfigurationURLKey] as? String {
-                MXLog.info("Retrieved global PAC URL: \(pacURL)")
-                return pacURL
-            } else {
-                MXLog.info("Failed retrieving PAC URL")
-            }
-        } else {
-            MXLog.info("Proxy type found as \(proxyType)")
-            
-            guard let host = firstProxy[kCFProxyHostNameKey] as? String else {
-                MXLog.error("Found proxy with invalid host name")
-                return nil
-            }
-            
-            let port = firstProxy[kCFProxyPortNumberKey] as? Int
-            
-            let scheme: String? = if proxyType == kCFProxyTypeHTTP as String {
-                "http"
-            } else if proxyType == kCFProxyTypeHTTPS as String {
-                "https"
-            } else if proxyType == kCFProxyTypeSOCKS as String {
-                "socks"
-            } else {
-                nil
-            }
-            
-            var components = URLComponents()
-            components.scheme = scheme
-            components.host = host
-            components.port = port
-            
-            MXLog.info("Found proxy components: \(String(describing: scheme)), \(host), \(String(describing: port))")
-            
-            MXLog.info("Retrieved global proxy: \(String(describing: components.url))")
-            
-            return components.url?.absoluteString
+        guard let host = firstProxy[kCFProxyHostNameKey] as? String else {
+            MXLog.error("Found proxy with invalid host name")
+            return nil
         }
-    
-        return nil
+        
+        let port = firstProxy[kCFProxyPortNumberKey] as? Int
+        
+        MXLog.info("Found proxy host: \(host), port: \(String(describing: port))")
+        
+        if let port {
+            return "\(host):\(port)"
+        } else {
+            return host
+        }
     }
     
     // MARK: Mocks


### PR DESCRIPTION
This partially reverts #4440, keeping the logging but returning the same value as before (with a leniency for not having a port).