### PR TITLE
MSC4075 Use expirationTS to define the call ringing window

### DIFF
--- a/ElementX/Sources/Services/ElementCall/ElementCallService.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallService.swift
@@ -163,6 +163,19 @@ class ElementCallService: NSObject, ElementCallServiceProtocol, PKPushRegistryDe
         let callID = CallID(callKitID: UUID(), roomID: roomID, rtcNotificationID: rtcNotificationID)
         incomingCallID = callID
         
+        guard let expirationTimestamp = payload.dictionaryPayload[ElementCallServiceNotificationKey.expirationTimestampMillis.rawValue] as? UInt64 else {
+            MXLog.error("Something went wrong, missing expiration timestamp for incoming voip call: \(payload)")
+            return
+        }
+        let nowTimestampMillis = UInt64(Date().timeIntervalSince1970 * 1000)
+        
+        guard nowTimestampMillis > expirationTimestamp else {
+            MXLog.warning("Call expired for room \(roomID), ignoring incoming push")
+            return
+        }
+        
+        let ringDurationMillis = min(expirationTimestamp - nowTimestampMillis, 90000)
+        
         let roomDisplayName = payload.dictionaryPayload[ElementCallServiceNotificationKey.roomDisplayName.rawValue] as? String
         
         let update = CXCallUpdate()
@@ -182,7 +195,7 @@ class ElementCallService: NSObject, ElementCallServiceProtocol, PKPushRegistryDe
         }
         
         endUnansweredCallTask = Task { [weak self] in
-            try? await Task.sleep(for: .seconds(90))
+            try? await Task.sleep(for: .milliseconds(ringDurationMillis))
             
             guard let self, !Task.isCancelled else {
                 return

--- a/ElementX/Sources/Services/ElementCall/ElementCallServiceConstants.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallServiceConstants.swift
@@ -13,6 +13,8 @@ enum ElementCallServiceNotificationKey: String {
     /// When an incoming call is set to ring, there will be a `m.rtc.notification`event  (MSC4075).
     /// Keep the notification event id as it is needed to decline calls (MSC4310).
     case rtcNotifyEventID
+    /// The local timestamp in millis at which the incoming call should stop ringing.
+    case expirationTimestampMillis
 }
 
 let ElementCallServiceNotificationDiscardDelta = 15.0

--- a/NSE/Sources/NotificationHandler.swift
+++ b/NSE/Sources/NotificationHandler.swift
@@ -124,10 +124,11 @@ class NotificationHandler {
                 }
                 
                 return .processedShouldDiscard
-            case .rtcNotification(let notificationType, _):
+            case .rtcNotification(let notificationType, let expirationTimestamp):
                 return await handleCallNotification(notificationType: notificationType,
                                                     rtcNotifyEventID: event.eventId(),
                                                     timestamp: event.timestamp(),
+                                                    expirationTimestamp: expirationTimestamp,
                                                     roomID: itemProxy.roomID,
                                                     roomDisplayName: itemProxy.roomDisplayName)
             case .callAnswer,
@@ -156,6 +157,7 @@ class NotificationHandler {
     private func handleCallNotification(notificationType: RtcNotificationType,
                                         rtcNotifyEventID: String,
                                         timestamp: Timestamp,
+                                        expirationTimestamp: Timestamp,
                                         roomID: String,
                                         roomDisplayName: String) async -> NotificationProcessingResult {
         // Handle incoming VoIP calls, show the native OS call screen
@@ -209,7 +211,8 @@ class NotificationHandler {
         
         let payload = [ElementCallServiceNotificationKey.roomID.rawValue: roomID,
                        ElementCallServiceNotificationKey.roomDisplayName.rawValue: roomDisplayName,
-                       ElementCallServiceNotificationKey.rtcNotifyEventID.rawValue: rtcNotifyEventID]
+                       ElementCallServiceNotificationKey.expirationTimestampMillis.rawValue: expirationTimestamp,
+                       ElementCallServiceNotificationKey.rtcNotifyEventID.rawValue: rtcNotifyEventID] as [String: Any]
         
         do {
             try await CXProvider.reportNewIncomingVoIPPushPayload(payload)


### PR DESCRIPTION
### Pull Request Checklist

As per MSC4075

> Notify events that are older than lifetime are ignored (using the sender_ts timestamp).
Otherwise a client syncing for the first time would ring for outdated call events. In general ringing only makes sense in "real time". Any client which is not able to receive the event in the lifetime period should not ring to prohibit annoying/misleading/irrelevant/outdated rings.

- [ ] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
