### PR TITLE
More iOS 26 tweaks

### DIFF
--- a/ElementX/Sources/Other/Extensions/Observable.swift
+++ b/ElementX/Sources/Other/Extensions/Observable.swift
@@ -14,37 +14,25 @@ extension Observable {
     ///
     /// - Parameter property: The key path to the property you would like to observe.
     func observe<Value>(_ property: KeyPath<Self, Value>) -> AsyncStream<Value> {
-        if #available(iOS 26, *) {
-            let observations = Observations { self[keyPath: property] }
-            return AsyncStream { continuation in
-                let task = Task {
-                    for await value in observations {
-                        continuation.yield(value)
+        AsyncStream { continuation in
+            let isActive = Mutex(true)
+            
+            @Sendable func observe() {
+                let value = withObservationTracking {
+                    self[keyPath: property]
+                } onChange: {
+                    // Handle the update on the next run loop as this is willSet not didSet.
+                    DispatchQueue.main.async {
+                        guard isActive.withLock({ $0 }) else { return }
+                        observe()
                     }
                 }
-                continuation.onTermination = { _ in task.cancel() }
+                continuation.yield(value)
             }
-        } else {
-            return AsyncStream { continuation in
-                let isActive = Mutex(true)
-                
-                @Sendable func observe() {
-                    let value = withObservationTracking {
-                        self[keyPath: property]
-                    } onChange: {
-                        // Handle the update on the next run loop as this is willSet not didSet.
-                        DispatchQueue.main.async {
-                            guard isActive.withLock({ $0 }) else { return }
-                            observe()
-                        }
-                    }
-                    continuation.yield(value)
-                }
-                
-                continuation.onTermination = { _ in isActive.withLock { $0 = false } }
-                
-                observe()
-            }
+            
+            continuation.onTermination = { _ in isActive.withLock { $0 = false } }
+            
+            observe()
         }
     }
 }

--- a/ElementX/Sources/Other/Pills/MessageText.swift
+++ b/ElementX/Sources/Other/Pills/MessageText.swift
@@ -146,7 +146,12 @@ struct MessageText: UIViewRepresentable {
         
         func textView(_ textView: UITextView, primaryActionFor textItem: UITextItem, defaultAction: UIAction) -> UIAction? {
             if case .link(let url) = textItem.content {
-                return .init(title: defaultAction.title) { [weak self] _ in
+                return .init(title: defaultAction.title,
+                             image: defaultAction.image,
+                             identifier: defaultAction.identifier,
+                             discoverabilityTitle: defaultAction.discoverabilityTitle,
+                             attributes: defaultAction.attributes,
+                             state: defaultAction.state) { [weak self] _ in
                     self?.openURLAction.callAsFunction(url)
                 }
             }

--- a/ElementX/Sources/Screens/MediaEventsTimelineScreen/View/MediaEventsTimelineScreen.swift
+++ b/ElementX/Sources/Screens/MediaEventsTimelineScreen/View/MediaEventsTimelineScreen.swift
@@ -47,20 +47,32 @@ struct MediaEventsTimelineScreen: View {
         if context.viewState.shouldShowEmptyState {
             emptyState
         } else {
-            ScrollView {
-                Group {
-                    switch context.viewState.bindings.screenMode {
-                    case .media:
-                        mediaContent
-                    case .files:
-                        filesContent
-                    }
-                    
-                    header
-                }
+            if #available(iOS 26, *) {
+                scrollView
+                    // Remove the glass effect of iOS 26+
+                    // A flipped table view will always trigger it
+                    // since the nav bar thinks is always at the bottom.
+                    .scrollEdgeEffectHidden()
+            } else {
+                scrollView
             }
-            .scaleEffect(.init(width: 1, height: -1))
         }
+    }
+    
+    private var scrollView: some View {
+        ScrollView {
+            Group {
+                switch context.viewState.bindings.screenMode {
+                case .media:
+                    mediaContent
+                case .files:
+                    filesContent
+                }
+                
+                header
+            }
+        }
+        .scaleEffect(.init(width: 1, height: -1))
     }
     
     @ViewBuilder

--- a/ElementX/Sources/Screens/MediaEventsTimelineScreen/View/MediaEventsTimelineScreen.swift
+++ b/ElementX/Sources/Screens/MediaEventsTimelineScreen/View/MediaEventsTimelineScreen.swift
@@ -223,9 +223,13 @@ struct MediaEventsTimelineScreen: View {
             }
         }
         
-        ToolbarItem(placement: .primaryAction) {
-            // Reserve the space trailing space to match the back button.
-            CompoundIcon(\.search).hidden()
+        if #available(iOS 26, *) {
+            ToolbarSpacer()
+        } else {
+            ToolbarItem(placement: .primaryAction) {
+                // Reserve the space trailing space to match the back button.
+                CompoundIcon(\.search).hidden()
+            }
         }
     }
     

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/mediaEventsTimelineScreen.Files-iPad-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/mediaEventsTimelineScreen.Files-iPad-en-GB.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ddf502478c371f79bbd567ed2d431b4fd076ada1185a521ef8fcd24f62546495
-size 65917
+oid sha256:d8c4495841c21003736a27ccaaa2db9063fb7e539a528de258940e41ede63b32
+size 145119

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/mediaEventsTimelineScreen.Files-iPad-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/mediaEventsTimelineScreen.Files-iPad-en-GB.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:75071eb534072ec77ecc5b1de2a5734fa8897b928879afb78715edd35045205e
-size 79003
+oid sha256:ddf502478c371f79bbd567ed2d431b4fd076ada1185a521ef8fcd24f62546495
+size 65917

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/mediaEventsTimelineScreen.Files-iPad-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/mediaEventsTimelineScreen.Files-iPad-pseudo.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a87b7650671cf502238ba03b9685f12fccb945bb8065125047ccc0ecd74c3e30
-size 67058
+oid sha256:ea63581e157dc93a9461cf3b4172493d14ea0097c763825fdeb89dc98ace7c4d
+size 147083

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/mediaEventsTimelineScreen.Files-iPad-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/mediaEventsTimelineScreen.Files-iPad-pseudo.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9beff0a1bf2dbb610f3da79b0fbc1601361464baacbd2ed364abbbb0141bae18
-size 79186
+oid sha256:a87b7650671cf502238ba03b9685f12fccb945bb8065125047ccc0ecd74c3e30
+size 67058

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/mediaEventsTimelineScreen.Files-iPhone-16-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/mediaEventsTimelineScreen.Files-iPhone-16-en-GB.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4b73526d79f5ad054c45f5ef5dd80153de1898885e1a7356feb825f9b910faa4
-size 21577
+oid sha256:cf5a10b363a7e9b2a60734ba4fb1cf05d1e109b24ca8904b83950a980318ef9f
+size 86785

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/mediaEventsTimelineScreen.Files-iPhone-16-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/mediaEventsTimelineScreen.Files-iPhone-16-en-GB.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:482fc4aee7d5674a7b0ddd889c367d307a9be74f2cb19cb997e45dc3643b9ee9
-size 29542
+oid sha256:4b73526d79f5ad054c45f5ef5dd80153de1898885e1a7356feb825f9b910faa4
+size 21577

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/mediaEventsTimelineScreen.Files-iPhone-16-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/mediaEventsTimelineScreen.Files-iPhone-16-pseudo.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:482fc4aee7d5674a7b0ddd889c367d307a9be74f2cb19cb997e45dc3643b9ee9
-size 29542
+oid sha256:4b73526d79f5ad054c45f5ef5dd80153de1898885e1a7356feb825f9b910faa4
+size 21577

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/mediaEventsTimelineScreen.Files-iPhone-16-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/mediaEventsTimelineScreen.Files-iPhone-16-pseudo.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4b73526d79f5ad054c45f5ef5dd80153de1898885e1a7356feb825f9b910faa4
-size 21577
+oid sha256:e403c0b0fbfe482f21792b9ee19a970ada917a027e8d28029eb7ebfda1e9cb0b
+size 87709

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/mediaEventsTimelineScreen.Media-iPhone-16-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/mediaEventsTimelineScreen.Media-iPhone-16-en-GB.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:482fc4aee7d5674a7b0ddd889c367d307a9be74f2cb19cb997e45dc3643b9ee9
-size 29542
+oid sha256:4b73526d79f5ad054c45f5ef5dd80153de1898885e1a7356feb825f9b910faa4
+size 21577

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/mediaEventsTimelineScreen.Media-iPhone-16-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/mediaEventsTimelineScreen.Media-iPhone-16-en-GB.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4b73526d79f5ad054c45f5ef5dd80153de1898885e1a7356feb825f9b910faa4
-size 21577
+oid sha256:04726d007194bed3efe35e12af0bf74dde9034e6b0a472df1f3f58850fe20a94
+size 810567

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/mediaEventsTimelineScreen.Media-iPhone-16-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/mediaEventsTimelineScreen.Media-iPhone-16-pseudo.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4b73526d79f5ad054c45f5ef5dd80153de1898885e1a7356feb825f9b910faa4
-size 21577
+oid sha256:1915a9043dc893e3b9ebb3061b7f12a67bf5886e7c97ed60c89cf44ce3afa924
+size 815253

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/mediaEventsTimelineScreen.Media-iPhone-16-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/mediaEventsTimelineScreen.Media-iPhone-16-pseudo.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:482fc4aee7d5674a7b0ddd889c367d307a9be74f2cb19cb997e45dc3643b9ee9
-size 29542
+oid sha256:4b73526d79f5ad054c45f5ef5dd80153de1898885e1a7356feb825f9b910faa4
+size 21577


### PR DESCRIPTION
- Fix for the caption not appearing the media preview
- Fix that prevents magnification to happen when longpressing
- Fix for an empty button appearing in the media timeline's nav bar
- Fix for the glass effect of the media timeline screen always being applied