### PR TITLE
Fix for the settings badge being clipped in the home screen

### DIFF
--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
@@ -59,9 +59,9 @@ struct HomeScreen: View {
                                 avatarSize: .user(on: .chats),
                                 mediaProvider: context.mediaProvider)
                 .accessibilityIdentifier(A11yIdentifiers.homeScreen.userAvatar)
+                .clipShape(.circle)
                 .overlayBadge(10, isBadged: context.viewState.requiresExtraAccountSetup)
                 .compositingGroup()
-                .clipShape(.circle)
         }
         .accessibilityLabel(L10n.commonSettings)
     }


### PR DESCRIPTION
Name says it all
