### PR TITLE
Fix for permalinks not working

### DIFF
--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -6483,6 +6483,76 @@ class JoinedRoomProxyMock: JoinedRoomProxyProtocol, @unchecked Sendable {
             return threadTimelineEventIDReturnValue
         }
     }
+    //MARK: - getThreadRootEventID
+
+    var getThreadRootEventIDForUnderlyingCallsCount = 0
+    var getThreadRootEventIDForCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return getThreadRootEventIDForUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = getThreadRootEventIDForUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                getThreadRootEventIDForUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    getThreadRootEventIDForUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var getThreadRootEventIDForCalled: Bool {
+        return getThreadRootEventIDForCallsCount > 0
+    }
+    var getThreadRootEventIDForReceivedEventID: String?
+    var getThreadRootEventIDForReceivedInvocations: [String] = []
+
+    var getThreadRootEventIDForUnderlyingReturnValue: Result<String?, RoomProxyError>!
+    var getThreadRootEventIDForReturnValue: Result<String?, RoomProxyError>! {
+        get {
+            if Thread.isMainThread {
+                return getThreadRootEventIDForUnderlyingReturnValue
+            } else {
+                var returnValue: Result<String?, RoomProxyError>? = nil
+                DispatchQueue.main.sync {
+                    returnValue = getThreadRootEventIDForUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                getThreadRootEventIDForUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    getThreadRootEventIDForUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    var getThreadRootEventIDForClosure: ((String) async -> Result<String?, RoomProxyError>)?
+
+    func getThreadRootEventID(for eventID: String) async -> Result<String?, RoomProxyError> {
+        getThreadRootEventIDForCallsCount += 1
+        getThreadRootEventIDForReceivedEventID = eventID
+        DispatchQueue.main.async {
+            self.getThreadRootEventIDForReceivedInvocations.append(eventID)
+        }
+        if let getThreadRootEventIDForClosure = getThreadRootEventIDForClosure {
+            return await getThreadRootEventIDForClosure(eventID)
+        } else {
+            return getThreadRootEventIDForReturnValue
+        }
+    }
     //MARK: - messageFilteredTimeline
 
     var messageFilteredTimelineFocusAllowedMessageTypesPresentationUnderlyingCallsCount = 0

--- a/ElementX/Sources/Other/Pills/MessageText.swift
+++ b/ElementX/Sources/Other/Pills/MessageText.swift
@@ -148,7 +148,6 @@ struct MessageText: UIViewRepresentable {
             if case .link(let url) = textItem.content {
                 return .init(title: defaultAction.title,
                              image: defaultAction.image,
-                             identifier: defaultAction.identifier,
                              discoverabilityTitle: defaultAction.discoverabilityTitle,
                              attributes: defaultAction.attributes,
                              state: defaultAction.state) { [weak self] _ in

--- a/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
@@ -190,6 +190,16 @@ class JoinedRoomProxy: JoinedRoomProxyProtocol {
         }
     }
     
+    func getThreadRootEventID(for eventID: String) async -> Result<String?, RoomProxyError> {
+        do {
+            let event = try await room.loadOrFetchEvent(eventId: eventID)
+            return .success(event.threadRootEventId())
+        } catch {
+            MXLog.error("Failed fetching the event with id: \(eventID) with error: \(error)")
+            return .failure(.sdkError(error))
+        }
+    }
+    
     func messageFilteredTimeline(focus: TimelineFocus,
                                  allowedMessageTypes: [TimelineAllowedMessageType],
                                  presentation: TimelineKind.MediaPresentation) async -> Result<any TimelineProxyProtocol, RoomProxyError> {

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -97,6 +97,8 @@ protocol JoinedRoomProxyProtocol: RoomProxyProtocol {
     
     func threadTimeline(eventID: String) async -> Result<TimelineProxyProtocol, RoomProxyError>
     
+    func getThreadRootEventID(for eventID: String) async -> Result<String?, RoomProxyError>
+    
     func messageFilteredTimeline(focus: TimelineFocus,
                                  allowedMessageTypes: [TimelineAllowedMessageType],
                                  presentation: TimelineKind.MediaPresentation) async -> Result<TimelineProxyProtocol, RoomProxyError>


### PR DESCRIPTION
Also includes a function to get the thread root id from an event (if available).

The issue was caused because we were using for the new custom action, the same identifier of the default action, which made iOS use always the default action instead of the custom one.
