### PR TITLE
Joining a space from the room flow.

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -367,6 +367,7 @@
 		41DFDD212D1BE57CA50D783B /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 0DD568A494247444A4B56031 /* Kingfisher */; };
 		41F553349AF44567184822D8 /* APNSPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D670124FC3E84F23A62CCF /* APNSPayload.swift */; };
 		4219391CD2351E410554B3E8 /* AggregratedReaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B858A61F2A570DFB8DE570A7 /* AggregratedReaction.swift */; };
+		42239FD59394A086E046C9BF /* Backports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76A46ABD27628CB5FC402541 /* Backports.swift */; };
 		422E8D182CA688D4565CD1E1 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B21E611DADDEF00307E7AC /* String.swift */; };
 		4295E5F850897710A51AE114 /* GeoURI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190EC7285D3CFEF0D3011BCF /* GeoURI.swift */; };
 		42995EA68E194B19DAD6AEEF /* test_rotated_image.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 723B055A57857BFF0F18D9CB /* test_rotated_image.jpg */; };
@@ -2098,6 +2099,7 @@
 		753B4C6C0EDDCBF0708DC384 /* TimelineItemSendInfoLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineItemSendInfoLabel.swift; sourceTree = "<group>"; };
 		75821CD31A4BD02B99C327A4 /* DataProtectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataProtectionManager.swift; sourceTree = "<group>"; };
 		76310030C831D4610A705603 /* URLComponentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLComponentsTests.swift; sourceTree = "<group>"; };
+		76A46ABD27628CB5FC402541 /* Backports.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Backports.swift; sourceTree = "<group>"; };
 		7720ACAC6155AB7F9C70B546 /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = nb; path = nb.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		7773CBFDBD458E0B7E270507 /* PillView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PillView.swift; sourceTree = "<group>"; };
 		780258F1B9D15E30549FF4BE /* NotificationSettingsEditScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsEditScreenViewModel.swift; sourceTree = "<group>"; };
@@ -2995,6 +2997,7 @@
 		052CC920F473C10B509F9FC1 /* SwiftUI */ = {
 			isa = PBXGroup;
 			children = (
+				76A46ABD27628CB5FC402541 /* Backports.swift */,
 				693E16574C6F7F9FA1015A8C /* Search.swift */,
 				832397B5C3D00A4BF52C5F0B /* ShouldScrollOnKeyboardDidShow.swift */,
 				D1D97BAF04AA150C0EF03021 /* VerificationBadge.swift */,
@@ -7579,6 +7582,7 @@
 				0B05A35FF5D1ED9E8A0B41A7 /* AuthenticationStartScreenViewModelProtocol.swift in Sources */,
 				4AAA8606FBA290E23D15422E /* AvatarHeaderView.swift in Sources */,
 				1621BF6316FFFEF5AE067C77 /* Avatars.swift in Sources */,
+				42239FD59394A086E046C9BF /* Backports.swift in Sources */,
 				7A25D6926A2C01DB8D0D67A5 /* BadgeLabel.swift in Sources */,
 				A4B0BAD62A12ED76BD611B79 /* BadgeView.swift in Sources */,
 				2B52B2A5A6496C5C0F952776 /* BannedRoomProxy.swift in Sources */,

--- a/ElementX/Sources/Application/Navigation/NavigationTabCoordinator.swift
+++ b/ElementX/Sources/Application/Navigation/NavigationTabCoordinator.swift
@@ -307,6 +307,7 @@ private struct NavigationTabCoordinatorView<Tag: Hashable>: View {
                     .toolbar(module.details.barVisibility(in: horizontalSizeClass), for: .tabBar)
             }
         }
+        .backportTabBarMinimizeBehaviorOnScrollDown()
         .introspect(.tabView, on: .supportedVersions, customize: configureAppearance)
         .sheet(item: $navigationTabCoordinator.sheetModule) { module in
             module.coordinator?.toPresentable()

--- a/ElementX/Sources/Application/Settings/AppSettings.swift
+++ b/ElementX/Sources/Application/Settings/AppSettings.swift
@@ -381,7 +381,7 @@ final class AppSettings {
     @UserPreference(key: UserDefaultsKeys.threadsEnabled, defaultValue: false, storageType: .userDefaults(store))
     var threadsEnabled
     
-    @UserPreference(key: UserDefaultsKeys.spacesEnabled, defaultValue: false, storageType: .userDefaults(store))
+    @UserPreference(key: UserDefaultsKeys.spacesEnabled, defaultValue: true, storageType: .userDefaults(store))
     var spacesEnabled
     
     @UserPreference(key: UserDefaultsKeys.nextGenHTMLParserEnabled, defaultValue: true, storageType: .userDefaults(store))

--- a/ElementX/Sources/FlowCoordinators/ChatsFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/ChatsFlowCoordinator.swift
@@ -469,6 +469,8 @@ class ChatsFlowCoordinator: FlowCoordinatorProtocol {
                 actionsSubject.send(.showCallScreen(roomProxy: roomProxy))
             case .verifyUser(let userID):
                 actionsSubject.send(.sessionVerification(.userInitiator(userID: userID)))
+            case .continueWithSpaceFlow(let spaceRoomListProxy):
+                stateMachine.processEvent(.startSpaceFlow, userInfo: .init(animated: false, spaceRoomListProxy: spaceRoomListProxy))
             case .finished:
                 stateMachine.processEvent(.deselectRoom)
             }

--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinatorStateMachine.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinatorStateMachine.swift
@@ -84,11 +84,13 @@ extension RoomFlowCoordinator {
     struct EventUserInfo {
         let animated: Bool
         var timelineController: TimelineControllerProtocol?
+        var spaceRoomListProxy: SpaceRoomListProxyProtocol?
     }
 
     enum Event: EventType {
         case presentJoinRoomScreen(via: [String])
         case dismissJoinRoomScreen
+        case joinedSpace
         
         case presentRoom(presentationAction: PresentationAction?)
         case dismissFlow
@@ -320,6 +322,8 @@ extension RoomFlowCoordinator {
             case (_, .presentJoinRoomScreen):
                 return .joinRoomScreen
             case (_, .dismissJoinRoomScreen):
+                return .complete
+            case (_, .joinedSpace):
                 return .complete
                 
             case (.joinRoomScreen, .presentDeclineAndBlockScreen):

--- a/ElementX/Sources/Other/SwiftUI/Backports.swift
+++ b/ElementX/Sources/Other/SwiftUI/Backports.swift
@@ -1,0 +1,19 @@
+//
+// Copyright 2025 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+// Please see LICENSE files in the repository root for full details.
+//
+
+import SwiftUI
+
+extension View {
+    @ViewBuilder
+    func backportTabBarMinimizeBehaviorOnScrollDown() -> some View {
+        if #available(iOS 26.0, *) {
+            tabBarMinimizeBehavior(.onScrollDown)
+        } else {
+            self
+        }
+    }
+}

--- a/ElementX/Sources/Screens/Spaces/SpaceScreen/SpaceScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Spaces/SpaceScreen/SpaceScreenCoordinator.swift
@@ -22,6 +22,7 @@ enum SpaceScreenCoordinatorAction {
     case selectSpace(SpaceRoomListProxyProtocol)
     case selectUnjoinedSpace(SpaceRoomProxyProtocol)
     case selectRoom(roomID: String)
+    case leftSpace
 }
 
 final class SpaceScreenCoordinator: CoordinatorProtocol {
@@ -57,6 +58,8 @@ final class SpaceScreenCoordinator: CoordinatorProtocol {
                 actionsSubject.send(.selectUnjoinedSpace(spaceRoomProxy))
             case .selectRoom(let roomID):
                 actionsSubject.send(.selectRoom(roomID: roomID))
+            case .leftSpace:
+                actionsSubject.send(.leftSpace)
             }
         }
         .store(in: &cancellables)

--- a/ElementX/Sources/Screens/Spaces/SpaceScreen/SpaceScreenModels.swift
+++ b/ElementX/Sources/Screens/Spaces/SpaceScreen/SpaceScreenModels.swift
@@ -11,10 +11,13 @@ enum SpaceScreenViewModelAction {
     case selectSpace(SpaceRoomListProxyProtocol)
     case selectUnjoinedSpace(SpaceRoomProxyProtocol)
     case selectRoom(roomID: String)
+    case leftSpace
 }
 
 struct SpaceScreenViewState: BindableState {
     let space: SpaceRoomProxyProtocol
+    
+    var permalink: URL?
     
     var isPaginating = false
     var rooms: [SpaceRoomProxyProtocol]
@@ -30,4 +33,5 @@ struct SpaceScreenViewStateBindings { }
 
 enum SpaceScreenViewAction {
     case spaceAction(SpaceRoomCell.Action)
+    case leaveSpace
 }

--- a/ElementX/Sources/Screens/Spaces/SpaceScreen/View/SpaceScreen.swift
+++ b/ElementX/Sources/Screens/Spaces/SpaceScreen/View/SpaceScreen.swift
@@ -42,6 +42,7 @@ struct SpaceScreen: View {
         }
     }
     
+    @ToolbarContentBuilder
     var toolbar: some ToolbarContent {
         // Use the same trick as the RoomScreen for a leading title view that
         // also hides the navigation title.
@@ -49,6 +50,22 @@ struct SpaceScreen: View {
             RoomHeaderView(roomName: context.viewState.spaceName,
                            roomAvatar: context.viewState.space.avatar,
                            mediaProvider: context.mediaProvider)
+        }
+        
+        ToolbarItemGroup(placement: .secondaryAction) {
+            if let permalink = context.viewState.permalink {
+                Section {
+                    ShareLink(item: permalink) {
+                        Label(L10n.actionShare, icon: \.shareIos)
+                    }
+                }
+            }
+            
+            Section {
+                Button(role: .destructive) { context.send(viewAction: .leaveSpace) } label: {
+                    Label(L10n.actionLeaveSpace, icon: \.leave)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
- Adds the more menu with a quick leave implementation for now (DEBUG only).
- Handles RoomFlowCoordinator replacement in the ChatsFlowCoordinator so you can join a space by opening the JoinRoomScreen for an invite.
- Enables tab bar minimisation on iOS 26.
- Enables the spaces feature flag by default.

Closes #4488.