### PR TITLE
Permalink from/to threads

### DIFF
--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -173,6 +173,9 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
                             if case .thread(threadRootEventID: threadRootEventID, _) = stateMachine.state, let threadCoordinator = childThreads.last {
                                 threadCoordinator.focusOnEvent(eventID: eventID)
                             } else {
+                                if childThreads.isEmpty {
+                                    roomScreenCoordinator?.focusOnEvent(.init(eventID: eventID, shouldSetPin: false))
+                                }
                                 stateMachine.tryEvent(.presentThread(threadRootEventID: threadRootEventID, focusEventID: eventID))
                             }
                         } else if !childThreads.isEmpty {
@@ -260,7 +263,7 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
                     guard flowParameters.appSettings.threadsEnabled, let threadRootEventID = event.threadRootEventId() else {
                         break
                     }
-                    stateMachine.tryEvent(.presentRoom(presentationAction: nil), userInfo: EventUserInfo(animated: animated))
+                    stateMachine.tryEvent(.presentRoom(presentationAction: .eventFocus(.init(eventID: threadRootEventID, shouldSetPin: false))), userInfo: EventUserInfo(animated: animated))
                     stateMachine.tryEvent(.presentThread(threadRootEventID: threadRootEventID, focusEventID: focusEvent.eventID), userInfo: EventUserInfo(animated: false))
                     return
                 case .failure:

--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -173,8 +173,9 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
                             if case .thread(threadRootEventID: threadRootEventID, _) = stateMachine.state, let threadCoordinator = childThreads.last {
                                 threadCoordinator.focusOnEvent(eventID: eventID)
                             } else {
+                                // If we are showing the room timeline, we want to focus the thread root
                                 if childThreads.isEmpty {
-                                    roomScreenCoordinator?.focusOnEvent(.init(eventID: eventID, shouldSetPin: false))
+                                    roomScreenCoordinator?.focusOnEvent(.init(eventID: threadRootEventID, shouldSetPin: false))
                                 }
                                 stateMachine.tryEvent(.presentThread(threadRootEventID: threadRootEventID, focusEventID: eventID))
                             }

--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinatorStateMachine.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinatorStateMachine.swift
@@ -48,7 +48,7 @@ extension RoomFlowCoordinator {
         case initial
         case joinRoomScreen
         case room
-        case thread(itemID: TimelineItemIdentifier)
+        case thread(threadRootEventID: String, previousState: State)
         case roomDetails(isRoot: Bool)
         case roomDetailsEditScreen
         case notificationSettings
@@ -95,7 +95,7 @@ extension RoomFlowCoordinator {
         case presentRoom(presentationAction: PresentationAction?)
         case dismissFlow
         
-        case presentThread(itemID: TimelineItemIdentifier)
+        case presentThread(threadRootEventID: String, focusEventID: String?)
         case dismissThread
         
         case presentReportContent(itemID: TimelineItemIdentifier, senderID: String)
@@ -216,10 +216,12 @@ extension RoomFlowCoordinator {
                 return previousState
                 
             // Thread
-            case (.room, .presentThread(let itemID)):
-                return .thread(itemID: itemID)
-            case (.thread, .dismissThread):
-                return .room
+            case (.room, .presentThread(let threadRootEventID, _)):
+                return .thread(threadRootEventID: threadRootEventID, previousState: fromState)
+            case (.thread, .presentThread(let threadRootEventID, _)):
+                return .thread(threadRootEventID: threadRootEventID, previousState: fromState)
+            case (.thread(_, let previousState), .dismissThread):
+                return previousState
                 
             case (.thread, .presentReportContent(let itemID, let senderID)):
                 return .reportContent(itemID: itemID, senderID: senderID, previousState: fromState)

--- a/ElementX/Sources/Mocks/ClientProxyMock.swift
+++ b/ElementX/Sources/Mocks/ClientProxyMock.swift
@@ -97,11 +97,11 @@ extension ClientProxyMock {
         roomForIdentifierClosure = { [weak self] identifier in
             if let room = self?.roomSummaryProvider.roomListPublisher.value.first(where: { $0.id == identifier }) {
                 let roomProxy = await JoinedRoomProxyMock(.init(id: room.id, name: room.name))
-                roomProxy.loadOrFetchEventForReturnValue = .success(TimelineEventSDKMock())
+                roomProxy.loadOrFetchEventDetailsForReturnValue = .success(TimelineEventSDKMock())
                 return .joined(roomProxy)
             } else if let spaceRoomProxy = configuration.joinedSpaceRooms.first(where: { $0.id == identifier }) {
                 let roomProxy = await JoinedRoomProxyMock(.init(id: spaceRoomProxy.id, name: spaceRoomProxy.name))
-                roomProxy.loadOrFetchEventForReturnValue = .success(TimelineEventSDKMock())
+                roomProxy.loadOrFetchEventDetailsForReturnValue = .success(TimelineEventSDKMock())
                 return .joined(roomProxy)
             } else {
                 return nil

--- a/ElementX/Sources/Mocks/ClientProxyMock.swift
+++ b/ElementX/Sources/Mocks/ClientProxyMock.swift
@@ -96,11 +96,15 @@ extension ClientProxyMock {
         
         roomForIdentifierClosure = { [weak self] identifier in
             if let room = self?.roomSummaryProvider.roomListPublisher.value.first(where: { $0.id == identifier }) {
-                await .joined(JoinedRoomProxyMock(.init(id: room.id, name: room.name)))
+                let roomProxy = await JoinedRoomProxyMock(.init(id: room.id, name: room.name))
+                roomProxy.loadOrFetchEventForReturnValue = .success(TimelineEventSDKMock())
+                return .joined(roomProxy)
             } else if let spaceRoomProxy = configuration.joinedSpaceRooms.first(where: { $0.id == identifier }) {
-                await .joined(JoinedRoomProxyMock(.init(id: spaceRoomProxy.id, name: spaceRoomProxy.name)))
+                let roomProxy = await JoinedRoomProxyMock(.init(id: spaceRoomProxy.id, name: spaceRoomProxy.name))
+                roomProxy.loadOrFetchEventForReturnValue = .success(TimelineEventSDKMock())
+                return .joined(roomProxy)
             } else {
-                nil
+                return nil
             }
         }
         

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -6483,17 +6483,17 @@ class JoinedRoomProxyMock: JoinedRoomProxyProtocol, @unchecked Sendable {
             return threadTimelineEventIDReturnValue
         }
     }
-    //MARK: - getThreadRootEventID
+    //MARK: - loadOrFetchEvent
 
-    var getThreadRootEventIDForUnderlyingCallsCount = 0
-    var getThreadRootEventIDForCallsCount: Int {
+    var loadOrFetchEventForUnderlyingCallsCount = 0
+    var loadOrFetchEventForCallsCount: Int {
         get {
             if Thread.isMainThread {
-                return getThreadRootEventIDForUnderlyingCallsCount
+                return loadOrFetchEventForUnderlyingCallsCount
             } else {
                 var returnValue: Int? = nil
                 DispatchQueue.main.sync {
-                    returnValue = getThreadRootEventIDForUnderlyingCallsCount
+                    returnValue = loadOrFetchEventForUnderlyingCallsCount
                 }
 
                 return returnValue!
@@ -6501,29 +6501,29 @@ class JoinedRoomProxyMock: JoinedRoomProxyProtocol, @unchecked Sendable {
         }
         set {
             if Thread.isMainThread {
-                getThreadRootEventIDForUnderlyingCallsCount = newValue
+                loadOrFetchEventForUnderlyingCallsCount = newValue
             } else {
                 DispatchQueue.main.sync {
-                    getThreadRootEventIDForUnderlyingCallsCount = newValue
+                    loadOrFetchEventForUnderlyingCallsCount = newValue
                 }
             }
         }
     }
-    var getThreadRootEventIDForCalled: Bool {
-        return getThreadRootEventIDForCallsCount > 0
+    var loadOrFetchEventForCalled: Bool {
+        return loadOrFetchEventForCallsCount > 0
     }
-    var getThreadRootEventIDForReceivedEventID: String?
-    var getThreadRootEventIDForReceivedInvocations: [String] = []
+    var loadOrFetchEventForReceivedEventID: String?
+    var loadOrFetchEventForReceivedInvocations: [String] = []
 
-    var getThreadRootEventIDForUnderlyingReturnValue: Result<String?, RoomProxyError>!
-    var getThreadRootEventIDForReturnValue: Result<String?, RoomProxyError>! {
+    var loadOrFetchEventForUnderlyingReturnValue: Result<TimelineEvent, RoomProxyError>!
+    var loadOrFetchEventForReturnValue: Result<TimelineEvent, RoomProxyError>! {
         get {
             if Thread.isMainThread {
-                return getThreadRootEventIDForUnderlyingReturnValue
+                return loadOrFetchEventForUnderlyingReturnValue
             } else {
-                var returnValue: Result<String?, RoomProxyError>? = nil
+                var returnValue: Result<TimelineEvent, RoomProxyError>? = nil
                 DispatchQueue.main.sync {
-                    returnValue = getThreadRootEventIDForUnderlyingReturnValue
+                    returnValue = loadOrFetchEventForUnderlyingReturnValue
                 }
 
                 return returnValue!
@@ -6531,26 +6531,26 @@ class JoinedRoomProxyMock: JoinedRoomProxyProtocol, @unchecked Sendable {
         }
         set {
             if Thread.isMainThread {
-                getThreadRootEventIDForUnderlyingReturnValue = newValue
+                loadOrFetchEventForUnderlyingReturnValue = newValue
             } else {
                 DispatchQueue.main.sync {
-                    getThreadRootEventIDForUnderlyingReturnValue = newValue
+                    loadOrFetchEventForUnderlyingReturnValue = newValue
                 }
             }
         }
     }
-    var getThreadRootEventIDForClosure: ((String) async -> Result<String?, RoomProxyError>)?
+    var loadOrFetchEventForClosure: ((String) async -> Result<TimelineEvent, RoomProxyError>)?
 
-    func getThreadRootEventID(for eventID: String) async -> Result<String?, RoomProxyError> {
-        getThreadRootEventIDForCallsCount += 1
-        getThreadRootEventIDForReceivedEventID = eventID
+    func loadOrFetchEvent(for eventID: String) async -> Result<TimelineEvent, RoomProxyError> {
+        loadOrFetchEventForCallsCount += 1
+        loadOrFetchEventForReceivedEventID = eventID
         DispatchQueue.main.async {
-            self.getThreadRootEventIDForReceivedInvocations.append(eventID)
+            self.loadOrFetchEventForReceivedInvocations.append(eventID)
         }
-        if let getThreadRootEventIDForClosure = getThreadRootEventIDForClosure {
-            return await getThreadRootEventIDForClosure(eventID)
+        if let loadOrFetchEventForClosure = loadOrFetchEventForClosure {
+            return await loadOrFetchEventForClosure(eventID)
         } else {
-            return getThreadRootEventIDForReturnValue
+            return loadOrFetchEventForReturnValue
         }
     }
     //MARK: - messageFilteredTimeline

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -6483,17 +6483,17 @@ class JoinedRoomProxyMock: JoinedRoomProxyProtocol, @unchecked Sendable {
             return threadTimelineEventIDReturnValue
         }
     }
-    //MARK: - loadOrFetchEvent
+    //MARK: - loadOrFetchEventDetails
 
-    var loadOrFetchEventForUnderlyingCallsCount = 0
-    var loadOrFetchEventForCallsCount: Int {
+    var loadOrFetchEventDetailsForUnderlyingCallsCount = 0
+    var loadOrFetchEventDetailsForCallsCount: Int {
         get {
             if Thread.isMainThread {
-                return loadOrFetchEventForUnderlyingCallsCount
+                return loadOrFetchEventDetailsForUnderlyingCallsCount
             } else {
                 var returnValue: Int? = nil
                 DispatchQueue.main.sync {
-                    returnValue = loadOrFetchEventForUnderlyingCallsCount
+                    returnValue = loadOrFetchEventDetailsForUnderlyingCallsCount
                 }
 
                 return returnValue!
@@ -6501,29 +6501,29 @@ class JoinedRoomProxyMock: JoinedRoomProxyProtocol, @unchecked Sendable {
         }
         set {
             if Thread.isMainThread {
-                loadOrFetchEventForUnderlyingCallsCount = newValue
+                loadOrFetchEventDetailsForUnderlyingCallsCount = newValue
             } else {
                 DispatchQueue.main.sync {
-                    loadOrFetchEventForUnderlyingCallsCount = newValue
+                    loadOrFetchEventDetailsForUnderlyingCallsCount = newValue
                 }
             }
         }
     }
-    var loadOrFetchEventForCalled: Bool {
-        return loadOrFetchEventForCallsCount > 0
+    var loadOrFetchEventDetailsForCalled: Bool {
+        return loadOrFetchEventDetailsForCallsCount > 0
     }
-    var loadOrFetchEventForReceivedEventID: String?
-    var loadOrFetchEventForReceivedInvocations: [String] = []
+    var loadOrFetchEventDetailsForReceivedEventID: String?
+    var loadOrFetchEventDetailsForReceivedInvocations: [String] = []
 
-    var loadOrFetchEventForUnderlyingReturnValue: Result<TimelineEvent, RoomProxyError>!
-    var loadOrFetchEventForReturnValue: Result<TimelineEvent, RoomProxyError>! {
+    var loadOrFetchEventDetailsForUnderlyingReturnValue: Result<TimelineEvent, RoomProxyError>!
+    var loadOrFetchEventDetailsForReturnValue: Result<TimelineEvent, RoomProxyError>! {
         get {
             if Thread.isMainThread {
-                return loadOrFetchEventForUnderlyingReturnValue
+                return loadOrFetchEventDetailsForUnderlyingReturnValue
             } else {
                 var returnValue: Result<TimelineEvent, RoomProxyError>? = nil
                 DispatchQueue.main.sync {
-                    returnValue = loadOrFetchEventForUnderlyingReturnValue
+                    returnValue = loadOrFetchEventDetailsForUnderlyingReturnValue
                 }
 
                 return returnValue!
@@ -6531,26 +6531,26 @@ class JoinedRoomProxyMock: JoinedRoomProxyProtocol, @unchecked Sendable {
         }
         set {
             if Thread.isMainThread {
-                loadOrFetchEventForUnderlyingReturnValue = newValue
+                loadOrFetchEventDetailsForUnderlyingReturnValue = newValue
             } else {
                 DispatchQueue.main.sync {
-                    loadOrFetchEventForUnderlyingReturnValue = newValue
+                    loadOrFetchEventDetailsForUnderlyingReturnValue = newValue
                 }
             }
         }
     }
-    var loadOrFetchEventForClosure: ((String) async -> Result<TimelineEvent, RoomProxyError>)?
+    var loadOrFetchEventDetailsForClosure: ((String) async -> Result<TimelineEvent, RoomProxyError>)?
 
-    func loadOrFetchEvent(for eventID: String) async -> Result<TimelineEvent, RoomProxyError> {
-        loadOrFetchEventForCallsCount += 1
-        loadOrFetchEventForReceivedEventID = eventID
+    func loadOrFetchEventDetails(for eventID: String) async -> Result<TimelineEvent, RoomProxyError> {
+        loadOrFetchEventDetailsForCallsCount += 1
+        loadOrFetchEventDetailsForReceivedEventID = eventID
         DispatchQueue.main.async {
-            self.loadOrFetchEventForReceivedInvocations.append(eventID)
+            self.loadOrFetchEventDetailsForReceivedInvocations.append(eventID)
         }
-        if let loadOrFetchEventForClosure = loadOrFetchEventForClosure {
-            return await loadOrFetchEventForClosure(eventID)
+        if let loadOrFetchEventDetailsForClosure = loadOrFetchEventDetailsForClosure {
+            return await loadOrFetchEventDetailsForClosure(eventID)
         } else {
-            return loadOrFetchEventForReturnValue
+            return loadOrFetchEventDetailsForReturnValue
         }
     }
     //MARK: - messageFilteredTimeline

--- a/ElementX/Sources/Mocks/TimelineControllerFactoryMock.swift
+++ b/ElementX/Sources/Mocks/TimelineControllerFactoryMock.swift
@@ -10,6 +10,7 @@ import Foundation
 extension TimelineControllerFactoryMock {
     struct Configuration {
         var timelineController: TimelineControllerProtocol?
+        var threadTimelineController: TimelineControllerProtocol?
     }
     
     convenience init(_ configuration: Configuration) {
@@ -20,5 +21,15 @@ extension TimelineControllerFactoryMock {
             timelineController.timelineItems = RoomTimelineItemFixtures.largeChunk
             return timelineController
         }()
+        
+        buildThreadTimelineControllerEventIDRoomProxyTimelineItemFactoryMediaProviderClosure = { threadRootEventID, _, _, _ in
+            if let threadTimelineController = configuration.threadTimelineController {
+                return .success(threadTimelineController)
+            } else {
+                let timelineController = MockTimelineController(timelineKind: .thread(rootEventID: threadRootEventID))
+                timelineController.timelineItems = RoomTimelineItemFixtures.largeChunk
+                return .success(timelineController)
+            }
+        }
     }
 }

--- a/ElementX/Sources/Screens/ThreadTimelineScreen/ThreadTimelineScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/ThreadTimelineScreen/ThreadTimelineScreenCoordinator.swift
@@ -13,6 +13,7 @@ import WysiwygComposer
 struct ThreadTimelineScreenCoordinatorParameters {
     let userSession: UserSessionProtocol
     let roomProxy: JoinedRoomProxyProtocol
+    let focussedEventID: String?
     let timelineController: TimelineControllerProtocol
     let mediaPlayerProvider: MediaPlayerProviderProtocol
     let emojiProvider: EmojiProviderProtocol
@@ -58,6 +59,7 @@ final class ThreadTimelineScreenCoordinator: CoordinatorProtocol {
         viewModel = ThreadTimelineScreenViewModel(roomProxy: parameters.roomProxy, userSession: parameters.userSession)
         
         timelineViewModel = TimelineViewModel(roomProxy: parameters.roomProxy,
+                                              focussedEventID: parameters.focussedEventID,
                                               timelineController: parameters.timelineController,
                                               userSession: parameters.userSession,
                                               mediaPlayerProvider: parameters.mediaPlayerProvider,
@@ -154,5 +156,9 @@ final class ThreadTimelineScreenCoordinator: CoordinatorProtocol {
         return AnyView(ThreadTimelineScreen(context: viewModel.context,
                                             timelineContext: timelineViewModel.context,
                                             composerToolbar: composerToolbar))
+    }
+    
+    func focusOnEvent(eventID: String) {
+        Task { await timelineViewModel.focusOnEvent(eventID: eventID) }
     }
 }

--- a/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
@@ -190,7 +190,7 @@ class JoinedRoomProxy: JoinedRoomProxyProtocol {
         }
     }
     
-    func loadOrFetchEvent(for eventID: String) async -> Result<TimelineEvent, RoomProxyError> {
+    func loadOrFetchEventDetails(for eventID: String) async -> Result<TimelineEvent, RoomProxyError> {
         do {
             let event = try await room.loadOrFetchEvent(eventId: eventID)
             return .success(event)

--- a/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
@@ -190,10 +190,10 @@ class JoinedRoomProxy: JoinedRoomProxyProtocol {
         }
     }
     
-    func getThreadRootEventID(for eventID: String) async -> Result<String?, RoomProxyError> {
+    func loadOrFetchEvent(for eventID: String) async -> Result<TimelineEvent, RoomProxyError> {
         do {
             let event = try await room.loadOrFetchEvent(eventId: eventID)
-            return .success(event.threadRootEventId())
+            return .success(event)
         } catch {
             MXLog.error("Failed fetching the event with id: \(eventID) with error: \(error)")
             return .failure(.sdkError(error))

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -97,7 +97,7 @@ protocol JoinedRoomProxyProtocol: RoomProxyProtocol {
     
     func threadTimeline(eventID: String) async -> Result<TimelineProxyProtocol, RoomProxyError>
     
-    func loadOrFetchEvent(for eventID: String) async -> Result<TimelineEvent, RoomProxyError>
+    func loadOrFetchEventDetails(for eventID: String) async -> Result<TimelineEvent, RoomProxyError>
     
     func messageFilteredTimeline(focus: TimelineFocus,
                                  allowedMessageTypes: [TimelineAllowedMessageType],

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -97,7 +97,7 @@ protocol JoinedRoomProxyProtocol: RoomProxyProtocol {
     
     func threadTimeline(eventID: String) async -> Result<TimelineProxyProtocol, RoomProxyError>
     
-    func getThreadRootEventID(for eventID: String) async -> Result<String?, RoomProxyError>
+    func loadOrFetchEvent(for eventID: String) async -> Result<TimelineEvent, RoomProxyError>
     
     func messageFilteredTimeline(focus: TimelineFocus,
                                  allowedMessageTypes: [TimelineAllowedMessageType],

--- a/UnitTests/Sources/RoomFlowCoordinatorTests.swift
+++ b/UnitTests/Sources/RoomFlowCoordinatorTests.swift
@@ -235,7 +235,7 @@ class RoomFlowCoordinatorTests: XCTestCase {
         
         var mockedEvent = TimelineEventSDKMock()
         mockedEvent.threadRootEventIdReturnValue = "1"
-        roomProxy.loadOrFetchEventForReturnValue = .success(mockedEvent)
+        roomProxy.loadOrFetchEventDetailsForReturnValue = .success(mockedEvent)
         
         clientProxy.roomForIdentifierClosure = { _ in
             .joined(roomProxy)
@@ -258,7 +258,7 @@ class RoomFlowCoordinatorTests: XCTestCase {
         // From the thread screen, navigate to another threaded event in the same room, but in a different thread.
         mockedEvent = TimelineEventSDKMock()
         mockedEvent.threadRootEventIdReturnValue = "4"
-        roomProxy.loadOrFetchEventForReturnValue = .success(mockedEvent)
+        roomProxy.loadOrFetchEventDetailsForReturnValue = .success(mockedEvent)
         try await process(route: .childEvent(eventID: "5", roomID: "1", via: []))
         XCTAssert(navigationStackCoordinator.rootCoordinator is RoomScreenCoordinator)
         XCTAssertEqual(navigationStackCoordinator.stackCoordinators.count, 2)
@@ -274,7 +274,7 @@ class RoomFlowCoordinatorTests: XCTestCase {
         
         mockedEvent = TimelineEventSDKMock()
         mockedEvent.threadRootEventIdReturnValue = "1"
-        roomProxy.loadOrFetchEventForReturnValue = .success(mockedEvent)
+        roomProxy.loadOrFetchEventDetailsForReturnValue = .success(mockedEvent)
         
         clientProxy.roomForIdentifierClosure = { _ in
             .joined(roomProxy)
@@ -291,7 +291,7 @@ class RoomFlowCoordinatorTests: XCTestCase {
         // From the thread screen, navigate to an event of the same room that is not threaded
         mockedEvent = TimelineEventSDKMock()
         mockedEvent.threadRootEventIdReturnValue = nil
-        roomProxy.loadOrFetchEventForReturnValue = .success(mockedEvent)
+        roomProxy.loadOrFetchEventDetailsForReturnValue = .success(mockedEvent)
         
         try await process(route: .childEvent(eventID: "3", roomID: "2", via: []))
         XCTAssert(navigationStackCoordinator.rootCoordinator is RoomScreenCoordinator)
@@ -377,7 +377,7 @@ class RoomFlowCoordinatorTests: XCTestCase {
         
         try await fulfillment.fulfill()
     }
-        
+    
     // MARK: - Private
     
     private func process(route: AppRoute) async throws {


### PR DESCRIPTION
fixes #4546 

https://github.com/user-attachments/assets/44fbebf2-594e-4cb1-92c3-1592e90c558b

This PR allows to open permalinks from/to threads, specifically...
- If the permalink is opened in a thread, and belongs to the same thread, will just focus directly on the item itself: Room -> Thread -> focus on event
- If the permalink is opened in a thread, and belongs to another thread, it will open a new thread and will just focus directly on the item itself (without updating the room original focus, to keep a consistent navigation): Room -> Thread  1 -> Thread  2-> focus on event
- if the permalink is opened in a thread, and belongs to the the same room but is not a threaded message, it will open the same room again and focus the event: Room 1 -> Thread 1 -> Room 1 -> focus on event
- if the permalink is opened anywhere and belongs to another room, it will open the new room, focus the thread root and then open the thread and focus on the event: Any Room/Thread 1 -> Room 2 -> focus on root event -> Thread 2 -> focus on event

Also this PR allows us to check if the event id exists or can be fetched or not, which allows us to throw errors in case of an invalid event or if there are issues in getting it, while still navigating to the appropriate room.