### PR TITLE
Make the space list bloom height match the room list.

### DIFF
--- a/AccessibilityTests/Sources/GeneratedAccessibilityTests.swift
+++ b/AccessibilityTests/Sources/GeneratedAccessibilityTests.swift
@@ -63,6 +63,10 @@ extension AccessibilityTests {
         try await performAccessibilityAudit(named: "BlockedUsersScreen_Previews")
     }
 
+    func testBloomModifier() async throws {
+        try await performAccessibilityAudit(named: "BloomModifier_Previews")
+    }
+
     func testBugReportScreen() async throws {
         try await performAccessibilityAudit(named: "BugReportScreen_Previews")
     }

--- a/ElementX/Sources/Other/TestablePreview/TestablePreviewsDictionary.swift
+++ b/ElementX/Sources/Other/TestablePreview/TestablePreviewsDictionary.swift
@@ -23,6 +23,7 @@ enum TestablePreviewsDictionary {
         "BadgeLabel_Previews" : BadgeLabel_Previews.self,
         "BigIcon_Previews" : BigIcon_Previews.self,
         "BlockedUsersScreen_Previews" : BlockedUsersScreen_Previews.self,
+        "BloomModifier_Previews" : BloomModifier_Previews.self,
         "BugReportScreen_Previews" : BugReportScreen_Previews.self,
         "CallInviteRoomTimelineView_Previews" : CallInviteRoomTimelineView_Previews.self,
         "CallNotificationRoomTimelineView_Previews" : CallNotificationRoomTimelineView_Previews.self,

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
@@ -25,7 +25,7 @@ struct HomeScreen: View {
             .toolbar { toolbar }
             .background(Color.compound.bgCanvasDefault.ignoresSafeArea())
             .track(screen: .Home)
-            .bloom()
+            .toolbarBloom(hasSearchBar: true)
             .sentryTrace("\(Self.self)")
     }
     

--- a/ElementX/Sources/Screens/Spaces/SpaceListScreen/View/SpaceListScreen.swift
+++ b/ElementX/Sources/Screens/Spaces/SpaceListScreen/View/SpaceListScreen.swift
@@ -22,7 +22,7 @@ struct SpaceListScreen: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar { toolbar }
         .background(Color.compound.bgCanvasDefault.ignoresSafeArea())
-        .bloom()
+        .toolbarBloom(hasSearchBar: true)
         .onAppear { context.send(viewAction: .screenAppeared) }
         .sheet(isPresented: $context.isPresentingFeatureAnnouncement) {
             SpacesAnnouncementSheetView(context: context)

--- a/PreviewTests/Sources/GeneratedPreviewTests.swift
+++ b/PreviewTests/Sources/GeneratedPreviewTests.swift
@@ -95,6 +95,12 @@ extension PreviewTests {
         }
     }
 
+    func testBloomModifier() async throws {
+        for (index, preview) in BloomModifier_Previews._allPreviews.enumerated() {
+            try await assertSnapshots(matching: preview, step: index)
+        }
+    }
+
     func testBugReportScreen() async throws {
         for (index, preview) in BugReportScreen_Previews._allPreviews.enumerated() {
             try await assertSnapshots(matching: preview, step: index)

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/bloomModifier.Chats-iPad-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/bloomModifier.Chats-iPad-en-GB.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:158498fc55b72583eddb12a90533550bc4311ab5421c087d66147dcbe91333a7
+size 115492

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/bloomModifier.Chats-iPad-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/bloomModifier.Chats-iPad-pseudo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57a4f1a8ca8f11a67078c3263e3c560666dcdf572c0db5695a8c1384557019db
+size 115791

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/bloomModifier.Chats-iPhone-16-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/bloomModifier.Chats-iPhone-16-en-GB.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3346489010c047b4286e29afd4113880342d1b73e99e8d1390e2c448863c362e
+size 52946

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/bloomModifier.Chats-iPhone-16-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/bloomModifier.Chats-iPhone-16-pseudo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:988d6d27125778fde9a803e8099a6f13c287dede58a2a6244883377ea1076375
+size 54858

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/bloomModifier.Spaces-iPad-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/bloomModifier.Spaces-iPad-en-GB.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b35be286bc9ca52ad0e02cb0bee9c9b72973a3968eee457d4c584ccf23ff633
+size 112203

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/bloomModifier.Spaces-iPad-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/bloomModifier.Spaces-iPad-pseudo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b35be286bc9ca52ad0e02cb0bee9c9b72973a3968eee457d4c584ccf23ff633
+size 112203

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/bloomModifier.Spaces-iPhone-16-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/bloomModifier.Spaces-iPhone-16-en-GB.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23f8d1c80181c9634198ae5488cb665e606db61d363d0ebe6e54644fc2ff2a55
+size 50960

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/bloomModifier.Spaces-iPhone-16-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/bloomModifier.Spaces-iPhone-16-pseudo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb3072779e29a9f67a8f580c7c07f46c0ab11e603605ce1fef31d6d502df2a0b
+size 51525


### PR DESCRIPTION
As the toolbar doesn't have a search field in the spaces tab, the safe area is smaller which results in a shorter bloom. This PR fixes that.