### PR TITLE
Fix last owner not prompted to promote on leave

### DIFF
--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -363,7 +363,7 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
                    ownMember.role.isOwner {
                     await roomProxy.updateMembers()
                     var isLastOwner = true
-                    for member in roomProxy.membersPublisher.value where member.userID != roomProxy.ownUserID {
+                    for member in roomProxy.membersPublisher.value where member.userID != roomProxy.ownUserID && member.membership == .join {
                         if member.role.isOwner {
                             isLastOwner = false
                             break

--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
@@ -177,7 +177,7 @@ class RoomDetailsScreenViewModel: RoomDetailsScreenViewModelType, RoomDetailsScr
         
         if !roomProxy.isDirectOneToOneRoom, state.accountOwner?.role.isOwner == true {
             var isLastOwner = true
-            for member in roomProxy.membersPublisher.value where member.userID != roomProxy.ownUserID {
+            for member in roomProxy.membersPublisher.value where member.userID != roomProxy.ownUserID && member.membership == .join {
                 if member.role.isOwner {
                     isLastOwner = false
                     break


### PR DESCRIPTION
fixes #4603 

The check to verify if the user is the last owner of the room, did not filter out non joined members, which meant that if the last owner tried to leave after the creator that promoted them left the room, the creator would still be accounted as another owner in the room, and the last owner won't be prompted to promote a new one.
