### PR TITLE
add attribute for spoilers

### DIFF
--- a/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilder.swift
+++ b/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilder.swift
@@ -32,6 +32,7 @@ extension NSAttributedString.Key {
     static let MatrixEventOnRoomAlias: NSAttributedString.Key = .init(rawValue: EventOnRoomAliasAttribute.name)
     static let MatrixAllUsersMention: NSAttributedString.Key = .init(rawValue: AllUsersMentionAttribute.name)
     static let CodeBlock: NSAttributedString.Key = .init(rawValue: CodeBlockAttribute.name)
+    static let MatrixSpoiler: NSAttributedString.Key = .init(rawValue: SpoilerAttribute.name)
 }
 
 struct AttributedStringBuilder: AttributedStringBuilderProtocol {

--- a/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilderV2.swift
+++ b/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilderV2.swift
@@ -16,6 +16,7 @@ struct AttributedStringBuilderV2: AttributedStringBuilderProtocol {
     private let mentionBuilder: MentionBuilderProtocol
     
     private static let attributeMSC4286 = "data-msc4286-external-payment-details"
+    private static let attributeMSC2010 = "mx-spoiler"
     private static let cacheDispatchQueue = DispatchQueue(label: "io.element.elementx.attributed_string_builder_v2_cache")
     private static var caches: [String: LRUCache<String, AttributedString>] = [:]
 
@@ -202,6 +203,10 @@ struct AttributedStringBuilderV2: AttributedStringBuilderProtocol {
             case "span":
                 if childElement.dataset()[Self.attributeMSC4286] != nil {
                     content = attributedString(element: childElement, documentBody: documentBody, preserveFormatting: preserveFormatting, listTag: listTag, listIndex: &childIndex, indentLevel: indentLevel)
+                }
+                if childElement.dataset()[Self.attributeMSC2010] != nil {
+                    content = attributedString(element: childElement, documentBody: documentBody, preserveFormatting: preserveFormatting, listTag: listTag, listIndex: &childIndex, indentLevel: indentLevel)
+                    content.addAttribute(.MatrixSpoiler, value: true, range: NSRange(location: 0, length: content.length))
                 }
                 
             case "ul", "ol":

--- a/ElementX/Sources/Other/HTMLParsing/ElementXAttributeScope.swift
+++ b/ElementX/Sources/Other/HTMLParsing/ElementXAttributeScope.swift
@@ -67,6 +67,11 @@ enum CodeBlockAttribute: AttributedStringKey {
     static let name = "MXCodeBlockAttribute"
 }
 
+enum SpoilerAttribute: AttributedStringKey {
+    typealias Value = Bool
+    static let name = "MXSpoilerAttribute"
+}
+
 // periphery: ignore - required to make NSAttributedString to AttributedString conversion even if not used directly
 extension AttributeScopes {
     struct ElementXAttributes: AttributeScope {

--- a/ElementX/Sources/Other/HTMLParsing/HTMLFixtures.swift
+++ b/ElementX/Sources/Other/HTMLParsing/HTMLFixtures.swift
@@ -17,6 +17,8 @@ enum HTMLFixtures: String, CaseIterable {
     case codeBlocks
     case unorderedList
     case orderedList
+    case entirelySpoilered
+    case partiallySpoilered
     
     var rawValue: String {
         switch self {
@@ -110,6 +112,14 @@ enum HTMLFixtures: String, CaseIterable {
             <li>Starburst</li>
             <li>Skittles</li>
             </ol>
+            """
+        case .partiallySpoilered:
+            """
+            partially <span data-mx-spoiler>spoilered</span>
+            """
+        case .entirelySpoilered:
+            """
+            <span data-mx-spoiler>entirely spoilered</span>
             """
         }
     }

--- a/ElementX/Sources/Other/Pills/MessageText.swift
+++ b/ElementX/Sources/Other/Pills/MessageText.swift
@@ -203,6 +203,8 @@ struct MessageText_Previews: PreviewProvider, TestablePreview {
         """
     
     private static let htmlStringWithList = "<p>This is a list</p>\n<ul>\n<li>One</li>\n<li>Two</li>\n<li>And number 3</li>\n</ul>\n"
+    
+    private static let htmlStringWithSpoiler = "partially <span data-mx-spoiler>spoilered</span>"
 
     private static let attributedStringBuilder = AttributedStringBuilder(mentionBuilder: MentionBuilder())
     
@@ -231,6 +233,11 @@ struct MessageText_Previews: PreviewProvider, TestablePreview {
             MessageText(attributedString: attributedString)
                 .border(Color.purple)
                 .previewDisplayName("With list")
+        }
+        if let attributedString = attributedStringBuilder.fromHTML(htmlStringWithSpoiler) {
+            MessageText(attributedString: attributedString)
+                .border(Color.purple)
+                .previewDisplayName("With spoiler")
         }
     }
 }


### PR DESCRIPTION
Hi, this is a start to #2839. I've never done iOS development before (outside of playing around with the templates in Xcode years ago) but I tried to follow what was already there. Currently the string has the spoilered parts get marked with the attribute but I have no idea how to actually hide them (I'm guessing I need a pill thing?). 

Currently:
Element Web
<img width="444" height="262" alt="CleanShot 2025-10-20 at 16 56 27@2x" src="https://github.com/user-attachments/assets/d87d61d2-ee4f-4b02-8167-f130fc66efca" />

Current Element X (spoilered text is shown as nothing)
<img width="270" height="196" alt="CleanShot 2025-10-20 at 16 57 39@2x" src="https://github.com/user-attachments/assets/07536818-9031-4021-93e6-4b826a4a64ce" />

This pull request currently (spoilered text is shown plain)
<img width="438" height="240" alt="CleanShot 2025-10-20 at 16 57 55@2x" src="https://github.com/user-attachments/assets/efcedd14-2d98-4341-a328-26c503533595" />

Leaving this as a draft for now while I figure out how to make it actually appear hidden. Also guessing maybe stuff for notifications would need changed to hide spoilered text? Any advice would be appreciated! 


### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
