### PR TITLE
Cancel still-running danger workflows when a new one starts

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [ labeled, synchronize, opened, reopened ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel any running old workflow runs with the same git branch/tag if a new run starts.
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Danger


### PR DESCRIPTION
Helps limit the number of MacOS runners that are taken up when rapidly iterating on a PR.

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
