### PR TITLE
Add timeouts to our GitHub actions.

### DIFF
--- a/.github/workflows/accessibility_tests.yml
+++ b/.github/workflows/accessibility_tests.yml
@@ -10,6 +10,7 @@ jobs:
   tests:
     name: Tests
     runs-on: macos-15
+    timeout-minutes: 120
 
     concurrency:
       # Only allow a single run of this workflow on each branch, automatically cancelling older runs.

--- a/.github/workflows/automatic-calendar-version.yml
+++ b/.github/workflows/automatic-calendar-version.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   automatic-calendar-version:
     runs-on: macos-15
+    timeout-minutes: 15
+    
     # Skip in forks
     if: github.repository == 'element-hq/element-x-ios'
     steps:

--- a/.github/workflows/compound-ios.yml
+++ b/.github/workflows/compound-ios.yml
@@ -15,6 +15,7 @@ jobs:
   tests:
 
     runs-on: macos-15
+    timeout-minutes: 15
 
     concurrency:
       # When running on develop, use the sha to allow all runs of this workflow to run concurrently.

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -8,6 +8,7 @@ jobs:
   build:
     name: Danger
     runs-on: macos-15
+    timeout-minutes: 15
 
     concurrency:
       # Only allow a single run of this workflow on each branch, automatically cancelling older runs.

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,6 +10,7 @@ jobs:
   integration_tests:
     name: Integration Tests
     runs-on: macos-15
+    timeout-minutes: 45
 
     concurrency:
       # Only allow a single run of this workflow on each branch, automatically cancelling older runs.

--- a/.github/workflows/translations-pr.yml
+++ b/.github/workflows/translations-pr.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   open-translations-pr:
     runs-on: macos-15
+    timeout-minutes: 15
+    
     # Skip in forks
     if: github.repository == 'element-hq/element-x-ios'
     steps:

--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -14,6 +14,7 @@ jobs:
   tests:
     name: Tests
     runs-on: macos-15
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -12,6 +12,7 @@ jobs:
   tests:
     name: Tests
     runs-on: macos-15
+    timeout-minutes: 60
 
     concurrency:
       # Only allow a single run of this workflow on each branch, automatically cancelling older runs.

--- a/.github/workflows/unit_tests_enterprise.yml
+++ b/.github/workflows/unit_tests_enterprise.yml
@@ -12,6 +12,7 @@ jobs:
   tests:
     name: Tests (Enterprise)
     runs-on: macos-15
+    timeout-minutes: 45
     
     # Skip in forks
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}


### PR DESCRIPTION
6 hours is way too long and eats up the runners.

In the long run it would be nice to have some kind of hang detection on the output from Fastlane, but for now this will help free up some runners.