### PR TITLE
Actually fix the bug where the token couldn't be refreshed when the cached `/versions` has expired.

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -9429,7 +9429,7 @@
 			repositoryURL = "https://github.com/element-hq/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 25.11.03;
+				version = 25.11.04;
 			};
 		};
 		701C7BEF8F70F7A83E852DCC /* XCRemoteSwiftPackageReference "GZIP" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/matrix-rust-components-swift",
       "state" : {
-        "revision" : "0c991f498db5d7f8296472f28bd933b249382717",
-        "version" : "25.11.3"
+        "revision" : "07de744e8b4b6868fca9da6de1ed7443f50a6b38",
+        "version" : "25.11.4"
       }
     },
     {

--- a/project.yml
+++ b/project.yml
@@ -71,7 +71,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/element-hq/matrix-rust-components-swift
-    exactVersion: 25.11.03
+    exactVersion: 25.11.04
     # path: ../matrix-rust-sdk
   Compound:
     path: compound-ios


### PR DESCRIPTION
By updating the SDK again 😄