### PR TITLE
FF to enable/disable focussing the event on notification tap

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -347,6 +347,7 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
             return
         }
         
+        let eventID = appSettings.focusEventOnNotificationTap ? content.eventID : nil
         if content.categoryIdentifier == NotificationConstants.Category.invite {
             if let userSession {
                 userSession.clientProxy.roomsToAwait.insert(roomID)
@@ -355,8 +356,8 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
             }
             handleAppRoute(.room(roomID: roomID, via: []))
         } else if appSettings.threadsEnabled, let threadRootEventID = content.threadRootEventID {
-            handleAppRoute(.thread(roomID: roomID, threadRootEventID: threadRootEventID, focusEventID: content.eventID))
-        } else if let eventID = content.eventID {
+            handleAppRoute(.thread(roomID: roomID, threadRootEventID: threadRootEventID, focusEventID: eventID))
+        } else if let eventID {
             handleAppRoute(.event(eventID: eventID, roomID: roomID, via: []))
         } else {
             handleAppRoute(.room(roomID: roomID, via: []))

--- a/ElementX/Sources/Application/Settings/AppSettings.swift
+++ b/ElementX/Sources/Application/Settings/AppSettings.swift
@@ -66,6 +66,7 @@ final class AppSettings {
         case linkPreviewsEnabled
         case latestEventSorterEnabled
         case spaceSettingsEnabled
+        case focusEventOnNotificationTap
         
         // Doug's tweaks 🔧
         case hideUnreadMessagesBadge
@@ -389,6 +390,9 @@ final class AppSettings {
     
     @UserPreference(key: UserDefaultsKeys.threadsEnabled, defaultValue: false, storageType: .userDefaults(store))
     var threadsEnabled
+    
+    @UserPreference(key: UserDefaultsKeys.focusEventOnNotificationTap, defaultValue: false, storageType: .userDefaults(store))
+    var focusEventOnNotificationTap
     
     @UserPreference(key: UserDefaultsKeys.spaceSettingsEnabled, defaultValue: false, storageType: .userDefaults(store))
     var spaceSettingsEnabled

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
@@ -43,6 +43,7 @@ protocol DeveloperOptionsProtocol: AnyObject {
     var enableOnlySignedDeviceIsolationMode: Bool { get set }
     var enableKeyShareOnInvite: Bool { get set }
     var hideQuietNotificationAlerts: Bool { get set }
+    var focusEventOnNotificationTap: Bool { get set }
     
     var hideUnreadMessagesBadge: Bool { get set }
     var elementCallBaseURLOverride: URL? { get set }

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
@@ -121,6 +121,9 @@ struct DeveloperOptionsScreen: View {
                     Text("Hide quiet alerts")
                     Text("The badge count will still be updated")
                 }
+                Toggle(isOn: $context.focusEventOnNotificationTap) {
+                    Text("Focus event on notification tap")
+                }
             }
             
             Section {


### PR DESCRIPTION
Name says it all!
This has been done because focussing an event is still a bit too slow, which while okay when tapping a permalink, could be quite a bother when tapping a notification.
We still allow threads to be opened from notifications, we will just avoid focussing events regardless if it is in a thread or not.