### PR TITLE
Correctly handle span tags and data attributes

### DIFF
--- a/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilder.swift
+++ b/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilder.swift
@@ -40,7 +40,7 @@ struct AttributedStringBuilder: AttributedStringBuilderProtocol {
     private let cacheKey: String
     private let mentionBuilder: MentionBuilderProtocol
     
-    private static let attributeMSC4286 = "data-msc4286-external-payment-details"
+    private static let attributeMSC4286 = "msc4286-external-payment-details"
     private static let cacheDispatchQueue = DispatchQueue(label: "io.element.elementx.attributed_string_builder_v2_cache")
     private static var caches: [String: LRUCache<String, AttributedString>] = [:]
 
@@ -225,7 +225,7 @@ struct AttributedStringBuilder: AttributedStringBuilderProtocol {
                 }
                 
             case "span":
-                if childElement.dataset()[Self.attributeMSC4286] != nil {
+                if childElement.dataset()[Self.attributeMSC4286] == nil {
                     content = attributedString(element: childElement, documentBody: documentBody, preserveFormatting: preserveFormatting, listTag: listTag, listIndex: &childIndex, indentLevel: indentLevel)
                 }
                 

--- a/UnitTests/Sources/AttributedStringBuilderTests.swift
+++ b/UnitTests/Sources/AttributedStringBuilderTests.swift
@@ -1016,17 +1016,31 @@ class AttributedStringBuilderTests: XCTestCase {
     }
 
     func testMxExternalPaymentDetailsRemoved() {
-        let htmlString = "This is visible<span data-msc4286-external-payment-details>. But text is hidden <a href=\"https://matrix.org\">and this link too</a></span>"
+        var htmlString = "This is visible.<span data-msc4286-external-payment-details> But this is hidden <a href=\"https://matrix.org\">and this link too</a></span>"
         
         guard let attributedString = attributedStringBuilder.fromHTML(htmlString) else {
             XCTFail("Could not build the attributed string")
             return
         }
         
-        XCTAssertEqual(String(attributedString.characters), "This is visible")
+        XCTAssertEqual(String(attributedString.characters), "This is visible.")
         
         for run in attributedString.runs where run.link != nil {
             XCTFail("No link expected, but found one")
+            return
+        }
+        
+        htmlString = "This is visible.<span> And this text <a href=\"https://matrix.org\">and link</a> are visible too.</span>"
+        
+        guard let attributedString = attributedStringBuilder.fromHTML(htmlString) else {
+            XCTFail("Could not build the attributed string")
+            return
+        }
+        
+        XCTAssertEqual(String(attributedString.characters), "This is visible. And this text and link are visible too.")
+        
+        guard attributedString.runs.first(where: { $0.link != nil })?.link != nil else {
+            XCTFail("Couldn't find the link")
             return
         }
     }


### PR DESCRIPTION
By correctly matching the msc4286 data attribute and adding a test to make sure this doesn't happen again.