### PR TITLE
Make sure the integration tests stop when running out of WAS retries 🙈

### DIFF
--- a/IntegrationTests/Sources/Common.swift
+++ b/IntegrationTests/Sources/Common.swift
@@ -8,10 +8,14 @@
 
 import XCTest
 
+enum IntegrationTestsError: Error {
+    case webAuthenticationSessionFailure
+}
+
 extension XCUIApplication {
     private var doesNotExistPredicate: NSPredicate { NSPredicate(format: "exists == 0") }
     
-    func login(currentTestCase: XCTestCase) {
+    func login(currentTestCase: XCTestCase) throws {
         let getStartedButton = buttons[A11yIdentifiers.authenticationStartScreen.signIn]
         
         XCTAssertTrue(getStartedButton.waitForExistence(timeout: 10.0))
@@ -55,6 +59,7 @@ extension XCUIApplication {
             remainingAttempts -= 1
             if remainingAttempts <= 0 {
                 XCTFail("Failed to present the web authentication session.")
+                throw IntegrationTestsError.webAuthenticationSessionFailure
             }
             
             if alerts.count > 0 {

--- a/IntegrationTests/Sources/UserFlowTests.swift
+++ b/IntegrationTests/Sources/UserFlowTests.swift
@@ -8,15 +8,16 @@
 
 import XCTest
 
+@MainActor
 class UserFlowTests: XCTestCase {
     private static let integrationTestsRoomName = "Element X iOS Integration Tests"
     private static let integrationTestsMessage = "Go down in flames!"
     
     private var app: XCUIApplication!
     
-    override func setUp() {
+    override func setUp() async throws {
         app = Application.launch()
-        app.login(currentTestCase: self)
+        try app.login(currentTestCase: self)
     }
     
     func testUserFlow() {


### PR DESCRIPTION
I noticed that an apparently failed run actually completed successfully even though the WAS failure was being handled.

<img width="1331" height="108" alt="Screenshot 2025-11-11 at 11 39 35 am" src="https://github.com/user-attachments/assets/bf46bd50-dd32-4436-ad41-6d7316fa5c8d" />

A bit more debugging and the answer became clear:

<img width="217" height="54" alt="618878B5-8F39-4AA6-85C1-A2C5D033C58F" src="https://github.com/user-attachments/assets/01ef5cb3-4de8-42b0-afd5-6f9a330d5500" />
