### PR TITLE
Disable the cross-fade animation on the split view detail.

### DIFF
--- a/ElementX/Sources/Application/Navigation/NavigationCoordinators.swift
+++ b/ElementX/Sources/Application/Navigation/NavigationCoordinators.swift
@@ -400,7 +400,7 @@ private struct NavigationSplitCoordinatorView: View {
                 .id(module.id)
         }
         .animation(.elementDefault, value: navigationSplitCoordinator.sidebarModule)
-        .animation(.elementDefault, value: navigationSplitCoordinator.detailModule)
+        .animation(.noAnimation, value: navigationSplitCoordinator.detailModule) // Don't crossfade the detail transition on iPad.
     }
 }
 


### PR DESCRIPTION
#4085 fixed a bug when changing the detail from a room to a space, but in the process it inadvertently introduced a crossfade animation when selecting a room. The animation is somewhat stuttery so this PR disables it again. Before and after:

https://github.com/user-attachments/assets/91fc8d70-4183-4c81-b658-100f01c9d601

https://github.com/user-attachments/assets/f98f6e14-e40c-46e8-85c6-21946ea34674
