### PR TITLE
Download en and en-US when running download-strings

### DIFF
--- a/localazy.json
+++ b/localazy.json
@@ -8,7 +8,7 @@
         "output": "ElementX/Resources/Localizations/${iosLprojFolder}/Localizable.strings",
         "excludeKeys": ["REGEX:.*_android"],
         "conditions": [
-          "equals: ${langIosStrings}, en | equals: ${file}, content.json"
+          "equals: ${languageCode}, en | equals: ${file}, content.json"
         ],
         "filterPlurals": true,
         "replacements": {
@@ -24,7 +24,7 @@
         "output": "ElementX/Resources/Localizations/${iosLprojFolder}/Localizable.stringsdict",
         "excludeKeys": ["REGEX:.*_android"],
         "conditions": [
-          "equals: ${langIosStrings}, en | equals: ${file}, content.json"
+          "equals: ${languageCode}, en | equals: ${file}, content.json"
         ],
         "replacements": {
           "%s": "%@",
@@ -40,7 +40,7 @@
         "changeExtension": "strings",
         "output": "ElementX/Resources/Localizations/${iosLprojFolder}/${file}",
         "conditions": [
-          "equals: ${langIosStrings}, en | equals: ${file}, InfoPlist.json"
+          "equals: ${languageCode}, en | equals: ${file}, InfoPlist.json"
         ]
       },
 


### PR DESCRIPTION
Completely my mistake, I didn't realise the effect when I made it `en` only, but given that `en-US` is used for the pseudo-language snapshots, this will make life easier for us during development.