### PR TITLE
Switch the ClientProxy's `roomForIdentifier` state publisher await to the `staticRoomSummaryProvider`

### DIFF
--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -16383,6 +16383,11 @@ class SpaceServiceProxyMock: SpaceServiceProxyProtocol, @unchecked Sendable {
     }
 }
 class StaticRoomSummaryProviderMock: StaticRoomSummaryProviderProtocol, @unchecked Sendable {
+    var statePublisher: CurrentValuePublisher<RoomSummaryProviderState, Never> {
+        get { return underlyingStatePublisher }
+        set(value) { underlyingStatePublisher = value }
+    }
+    var underlyingStatePublisher: CurrentValuePublisher<RoomSummaryProviderState, Never>!
     var roomListPublisher: CurrentValuePublisher<[RoomSummary], Never> {
         get { return underlyingRoomListPublisher }
         set(value) { underlyingRoomListPublisher = value }

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -591,8 +591,8 @@ class ClientProxy: ClientProxyProtocol {
             return room
         }
         
-        if !roomSummaryProvider.statePublisher.value.isLoaded {
-            _ = await roomSummaryProvider.statePublisher.values.first { $0.isLoaded }
+        if !staticRoomSummaryProvider.statePublisher.value.isLoaded {
+            _ = await staticRoomSummaryProvider.statePublisher.values.first { $0.isLoaded }
         }
         
         if shouldAwait {

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProviderProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProviderProtocol.swift
@@ -44,6 +44,9 @@ enum RoomSummaryProviderFilter: Equatable {
 
 // sourcery: AutoMockable
 protocol StaticRoomSummaryProviderProtocol {
+    /// Publishes the current state the summary provider is finding itself in
+    var statePublisher: CurrentValuePublisher<RoomSummaryProviderState, Never> { get }
+    
     /// Publishes the currently available room summaries
     var roomListPublisher: CurrentValuePublisher<[RoomSummary], Never> { get }
     
@@ -52,9 +55,6 @@ protocol StaticRoomSummaryProviderProtocol {
 
 // sourcery: AutoMockable
 protocol RoomSummaryProviderProtocol: StaticRoomSummaryProviderProtocol {
-    /// Publishes the current state the summary provider is finding itself in
-    var statePublisher: CurrentValuePublisher<RoomSummaryProviderState, Never> { get }
-        
     func updateVisibleRange(_ range: Range<Int>)
     
     func setFilter(_ filter: RoomSummaryProviderFilter)


### PR DESCRIPTION
… similar to the other methods.