### PR TITLE
Disallow tapping on reply details in a pinned events timeline

### DIFF
--- a/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemBubbledStylerView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemBubbledStylerView.swift
@@ -200,7 +200,9 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
                     .cornerRadius(8)
                     .layoutPriority(TimelineBubbleLayout.Priority.visibleQuote)
                     .onTapGesture {
-                        context.send(viewAction: .focusOnEventID(replyDetails.eventID))
+                        if context.viewState.timelineKind != .pinned {
+                            context.send(viewAction: .focusOnEventID(replyDetails.eventID))
+                        }
                     }
                 
                 // Add a fixed width reply bubble that is used for layout calculations but won't be rendered.


### PR DESCRIPTION
fixes #4750 

Since the pinned events timeline is a non continuous one, we need to disable the reply details tap action in it, or this could make the pinned timeline get overlapped with the normal one