### PR TITLE
Favour network over homeserver reachability when computing the offline indicator.

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -1077,7 +1077,8 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
                 
                 switch state {
                 case .loading:
-                    if self?.userSession?.clientProxy.homeserverReachabilityPublisher.value == .reachable {
+                    if self?.userSession?.clientProxy.homeserverReachabilityPublisher.value == .reachable,
+                       self?.appMediator.networkMonitor.reachabilityPublisher.value == .reachable {
                         ServiceLocator.shared.userIndicatorController.submitIndicator(.init(id: toastIdentifier, type: .toast(progress: .indeterminate), title: L10n.commonSyncing, persistent: true))
                     }
                 case .notLoading:

--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -246,16 +246,16 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
                 MXLog.info("Homeserver reachability: \(homeserverReachability)")
                 
                 guard let self else { return }
-                switch (homeserverReachability, networkReachability) {
-                case (.reachable, _):
+                switch (networkReachability, homeserverReachability) {
+                case (.reachable, .reachable):
                     flowParameters.userIndicatorController.retractIndicatorWithId(reachabilityNotificationID)
-                case (.unreachable, .unreachable):
-                    flowParameters.userIndicatorController.submitIndicator(.init(id: reachabilityNotificationID,
-                                                                                 title: L10n.commonOffline,
-                                                                                 persistent: true))
-                case (.unreachable, .reachable):
+                case (.reachable, .unreachable):
                     flowParameters.userIndicatorController.submitIndicator(.init(id: reachabilityNotificationID,
                                                                                  title: L10n.commonServerUnreachable,
+                                                                                 persistent: true))
+                case (.unreachable, _):
+                    flowParameters.userIndicatorController.submitIndicator(.init(id: reachabilityNotificationID,
+                                                                                 title: L10n.commonOffline,
                                                                                  persistent: true))
                 }
             }

--- a/UnitTests/Sources/UserSessionFlowCoordinatorTests.swift
+++ b/UnitTests/Sources/UserSessionFlowCoordinatorTests.swift
@@ -196,17 +196,18 @@ class UserSessionFlowCoordinatorTests: XCTestCase {
         homeserverReachabilitySubject.send(.reachable)
         try await Task.sleep(for: .milliseconds(100))
         
-        // Then the indicator should be hidden even if the network isn't reachable.
-        XCTAssertEqual(userIndicatorController.submitIndicatorDelayCallsCount, 2)
-        XCTAssertEqual(retractReachabilityIndicatorCallsCount, 2)
+        // Then there should still be an offline indicator (as we don't yet support air-gapped servers on iOS).
+        XCTAssertEqual(userIndicatorController.submitIndicatorDelayCallsCount, 3)
+        XCTAssertEqual(userIndicatorController.submitIndicatorDelayReceivedArguments?.indicator.title, L10n.commonOffline)
+        XCTAssertEqual(retractReachabilityIndicatorCallsCount, 1)
         
         // When the network becomes reachable again.
         networkReachabilitySubject.send(.reachable)
         try await Task.sleep(for: .milliseconds(100))
         
-        // Then nothing else should happen.
-        XCTAssertEqual(userIndicatorController.submitIndicatorDelayCallsCount, 2)
-        XCTAssertEqual(retractReachabilityIndicatorCallsCount, 3)
+        // Then the indicator should be hidden now as everything is back to normal
+        XCTAssertEqual(userIndicatorController.submitIndicatorDelayCallsCount, 3)
+        XCTAssertEqual(retractReachabilityIndicatorCallsCount, 2)
     }
     
     // MARK: - Helpers


### PR DESCRIPTION
For a whole host of reasons we don't support air-gapped operation anyway so that previous implementation was really an early "optimisation" on my part. The SDK is somewhat slow to tell us about the homeserver's reachability so the indicator wasn't really working.

Also adds an additional check against showing the syncing indicator although https://github.com/matrix-org/matrix-rust-sdk/pull/5914 can also help with that too.

Fixes #4786 although testing this is a pain as the simulator never transitions network reachability after going offline and when using a device, Xcode's debugger was detaching whenever I enabled or disabled Airplane mode.