### PR TITLE
Set trust requirement even if `setEncryption` is `false`.

### DIFF
--- a/ElementX/Sources/Other/Extensions/ClientBuilder.swift
+++ b/ElementX/Sources/Other/Extensions/ClientBuilder.swift
@@ -43,23 +43,18 @@ extension ClientBuilder {
                 .backupDownloadStrategy(backupDownloadStrategy: .afterDecryptionFailure)
                 .enableShareHistoryOnInvite(enableShareHistoryOnInvite: enableKeyShareOnInvite)
                 .autoEnableBackups(autoEnableBackups: true)
-                
-            if enableOnlySignedDeviceIsolationMode {
-                builder = builder
-                    .roomKeyRecipientStrategy(strategy: .identityBasedStrategy)
-            } else {
-                builder = builder
-                    .roomKeyRecipientStrategy(strategy: .errorOnVerifiedUserProblem)
-            }
         }
 
-        // Set trust requirement even if `setupEncryption` is false.
+        // Set recipient strategy and trust requirement even if `setupEncryption` is false to ensure messages
+        // from insecure devices aren't displayed in push notifications.
         // See https://github.com/element-hq/element-x-ios/issues/4702.
         if enableOnlySignedDeviceIsolationMode {
             builder = builder
+                .roomKeyRecipientStrategy(strategy: .identityBasedStrategy)
                 .decryptionSettings(decryptionSettings: .init(senderDeviceTrustRequirement: .crossSignedOrLegacy))
         } else {
             builder = builder
+                .roomKeyRecipientStrategy(strategy: .errorOnVerifiedUserProblem)
                 .decryptionSettings(decryptionSettings: .init(senderDeviceTrustRequirement: .untrusted))
         }
         


### PR DESCRIPTION
- Calls `builder.decryptionSettings` with sender trust requirement, even if `setEncryption` is false`.
- Fixes https://github.com/element-hq/element-x-ios/issues/4702

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
