### PR TITLE
Improve canSee Sec & Privacy check.

### DIFF
--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
@@ -292,7 +292,8 @@ class RoomDetailsScreenViewModel: RoomDetailsScreenViewModelType, RoomDetailsScr
             state.canBanUsers = powerLevels.canOwnUserBan()
             state.canJoinCall = powerLevels.canOwnUserJoinCall()
             state.canEditRolesOrPermissions = powerLevels.canOwnUserEditRolesAndPermissions()
-            state.canEditSecurityAndPrivacy = powerLevels.canOwnUserEditSecurityAndPrivacy()
+            state.canEditSecurityAndPrivacy = powerLevels.canOwnUserEditSecurityAndPrivacy(isSpace: roomInfo.isSpace,
+                                                                                           joinRule: roomInfo.joinRule)
         }
     }
     

--- a/ElementX/Sources/Services/Room/RoomPowerLevelProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomPowerLevelProxyProtocol.swift
@@ -46,7 +46,18 @@ extension RoomPowerLevelsProxyProtocol {
     }
     
     /// Can own user edit any of the security and privacy settings.
-    func canOwnUserEditSecurityAndPrivacy() -> Bool {
-        canOwnUser(sendStateEvent: .roomEncryption) || canOwnUser(sendStateEvent: .roomAliases) || canOwnUser(sendStateEvent: .roomJoinRules) || canOwnUser(sendStateEvent: .roomHistoryVisibility)
+    func canOwnUserEditSecurityAndPrivacy(isSpace: Bool, joinRule: JoinRule?) -> Bool {
+        let canOwnUserChangeAddress = switch joinRule {
+        case .knockRestricted, .knock, .public:
+            canOwnUser(sendStateEvent: .roomAliases)
+        default:
+            false
+        }
+        
+        return if isSpace {
+            canOwnUser(sendStateEvent: .roomJoinRules) || canOwnUserChangeAddress
+        } else {
+            canOwnUser(sendStateEvent: .roomEncryption) || canOwnUser(sendStateEvent: .roomJoinRules) || canOwnUser(sendStateEvent: .roomHistoryVisibility) || canOwnUserChangeAddress
+        }
     }
 }


### PR DESCRIPTION
In this way the screen is only displayed if at least one option is available given the context of the JoinRule or if the room is also a space.