### PR TITLE
Handle the edge case of one or more non parent joined spaces present in the existing allowed list

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -9570,7 +9570,7 @@
 			repositoryURL = "https://github.com/element-hq/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 25.12.10;
+				version = 25.12.11;
 			};
 		};
 		701C7BEF8F70F7A83E852DCC /* XCRemoteSwiftPackageReference "GZIP" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/matrix-rust-components-swift",
       "state" : {
-        "revision" : "ae9a08f7faebb5cd2af7fe29860378009066a27e",
-        "version" : "25.12.10"
+        "revision" : "8efbdc808f699f6df830f552a2b302e91d45431a",
+        "version" : "25.12.11"
       }
     },
     {

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -16568,6 +16568,76 @@ class SpaceServiceProxyMock: SpaceServiceProxyProtocol, @unchecked Sendable {
             return spaceRoomListSpaceIDReturnValue
         }
     }
+    //MARK: - spaceForIdentifier
+
+    var spaceForIdentifierSpaceIDUnderlyingCallsCount = 0
+    var spaceForIdentifierSpaceIDCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return spaceForIdentifierSpaceIDUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = spaceForIdentifierSpaceIDUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                spaceForIdentifierSpaceIDUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    spaceForIdentifierSpaceIDUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var spaceForIdentifierSpaceIDCalled: Bool {
+        return spaceForIdentifierSpaceIDCallsCount > 0
+    }
+    var spaceForIdentifierSpaceIDReceivedSpaceID: String?
+    var spaceForIdentifierSpaceIDReceivedInvocations: [String] = []
+
+    var spaceForIdentifierSpaceIDUnderlyingReturnValue: Result<SpaceRoomProxyProtocol?, SpaceServiceProxyError>!
+    var spaceForIdentifierSpaceIDReturnValue: Result<SpaceRoomProxyProtocol?, SpaceServiceProxyError>! {
+        get {
+            if Thread.isMainThread {
+                return spaceForIdentifierSpaceIDUnderlyingReturnValue
+            } else {
+                var returnValue: Result<SpaceRoomProxyProtocol?, SpaceServiceProxyError>? = nil
+                DispatchQueue.main.sync {
+                    returnValue = spaceForIdentifierSpaceIDUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                spaceForIdentifierSpaceIDUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    spaceForIdentifierSpaceIDUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    var spaceForIdentifierSpaceIDClosure: ((String) async -> Result<SpaceRoomProxyProtocol?, SpaceServiceProxyError>)?
+
+    func spaceForIdentifier(spaceID: String) async -> Result<SpaceRoomProxyProtocol?, SpaceServiceProxyError> {
+        spaceForIdentifierSpaceIDCallsCount += 1
+        spaceForIdentifierSpaceIDReceivedSpaceID = spaceID
+        DispatchQueue.main.async {
+            self.spaceForIdentifierSpaceIDReceivedInvocations.append(spaceID)
+        }
+        if let spaceForIdentifierSpaceIDClosure = spaceForIdentifierSpaceIDClosure {
+            return await spaceForIdentifierSpaceIDClosure(spaceID)
+        } else {
+            return spaceForIdentifierSpaceIDReturnValue
+        }
+    }
     //MARK: - leaveSpace
 
     var leaveSpaceSpaceIDUnderlyingCallsCount = 0

--- a/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
@@ -23265,6 +23265,81 @@ open class SpaceServiceSDKMock: MatrixRustSDK.SpaceService, @unchecked Sendable 
         }
     }
 
+    //MARK: - getSpaceRoom
+
+    open var getSpaceRoomRoomIdThrowableError: Error?
+    var getSpaceRoomRoomIdUnderlyingCallsCount = 0
+    open var getSpaceRoomRoomIdCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return getSpaceRoomRoomIdUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = getSpaceRoomRoomIdUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                getSpaceRoomRoomIdUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    getSpaceRoomRoomIdUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    open var getSpaceRoomRoomIdCalled: Bool {
+        return getSpaceRoomRoomIdCallsCount > 0
+    }
+    open var getSpaceRoomRoomIdReceivedRoomId: String?
+    open var getSpaceRoomRoomIdReceivedInvocations: [String] = []
+
+    var getSpaceRoomRoomIdUnderlyingReturnValue: SpaceRoom?
+    open var getSpaceRoomRoomIdReturnValue: SpaceRoom? {
+        get {
+            if Thread.isMainThread {
+                return getSpaceRoomRoomIdUnderlyingReturnValue
+            } else {
+                var returnValue: SpaceRoom?? = nil
+                DispatchQueue.main.sync {
+                    returnValue = getSpaceRoomRoomIdUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                getSpaceRoomRoomIdUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    getSpaceRoomRoomIdUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    open var getSpaceRoomRoomIdClosure: ((String) async throws -> SpaceRoom?)?
+
+    open override func getSpaceRoom(roomId: String) async throws -> SpaceRoom? {
+        if let error = getSpaceRoomRoomIdThrowableError {
+            throw error
+        }
+        getSpaceRoomRoomIdCallsCount += 1
+        getSpaceRoomRoomIdReceivedRoomId = roomId
+        DispatchQueue.main.async {
+            self.getSpaceRoomRoomIdReceivedInvocations.append(roomId)
+        }
+        if let getSpaceRoomRoomIdClosure = getSpaceRoomRoomIdClosure {
+            return try await getSpaceRoomRoomIdClosure(roomId)
+        } else {
+            return getSpaceRoomRoomIdReturnValue
+        }
+    }
+
     //MARK: - joinedParentsOfChild
 
     open var joinedParentsOfChildChildIdThrowableError: Error?

--- a/ElementX/Sources/Mocks/SpaceServiceProxyMock.swift
+++ b/ElementX/Sources/Mocks/SpaceServiceProxyMock.swift
@@ -34,6 +34,9 @@ extension SpaceServiceProxyMock {
             .success(LeaveSpaceHandleProxy(spaceID: spaceID,
                                            leaveHandle: LeaveSpaceHandleSDKMock(.init(rooms: configuration.leaveSpaceRooms))))
         }
+        spaceForIdentifierSpaceIDClosure = { spaceID in
+            .success(configuration.joinedSpaces.first { $0.id == spaceID })
+        }
     }
 }
 

--- a/ElementX/Sources/Screens/ManageAuthorizedSpacesScreen/ManageAuthorizedSpacesScreenModels.swift
+++ b/ElementX/Sources/Screens/ManageAuthorizedSpacesScreen/ManageAuthorizedSpacesScreenModels.swift
@@ -37,7 +37,7 @@ enum ManageAuthorizedSpacesScreenViewAction {
 }
 
 struct AuthorizedSpacesSelection {
-    let joinedParentSpaces: [SpaceRoomProxyProtocol]
+    let joinedSpaces: [SpaceRoomProxyProtocol]
     let unknownSpacesIDs: [String]
     let initialSelectedIDs: Set<String>
     let selectedIDs: PassthroughSubject<Set<String>, Never> = .init()

--- a/ElementX/Sources/Screens/ManageAuthorizedSpacesScreen/View/ManageAuthorizedSpacesScreen.swift
+++ b/ElementX/Sources/Screens/ManageAuthorizedSpacesScreen/View/ManageAuthorizedSpacesScreen.swift
@@ -15,8 +15,8 @@ struct ManageAuthorizedSpacesScreen: View {
         Form {
             header
             
-            if !context.viewState.authorizedSpacesSelection.joinedParentSpaces.isEmpty {
-                joinedParentsSection
+            if !context.viewState.authorizedSpacesSelection.joinedSpaces.isEmpty {
+                joinedSpacesSection
             }
             
             if !context.viewState.authorizedSpacesSelection.unknownSpacesIDs.isEmpty {
@@ -46,9 +46,9 @@ struct ManageAuthorizedSpacesScreen: View {
         }
     }
     
-    private var joinedParentsSection: some View {
+    private var joinedSpacesSection: some View {
         Section {
-            ForEach(context.viewState.authorizedSpacesSelection.joinedParentSpaces, id: \.id) { space in
+            ForEach(context.viewState.authorizedSpacesSelection.joinedSpaces, id: \.id) { space in
                 ListRow(label: .avatar(title: space.name,
                                        description: space.canonicalAlias,
                                        icon: avatar(space: space)),
@@ -102,7 +102,7 @@ struct ManageAuthorizedSpacesScreen: View {
 // MARK: - Previews
 
 struct ManageAuthorizedSpacesScreen_Previews: PreviewProvider, TestablePreview {
-    static let viewModel = ManageAuthorizedSpacesScreenViewModel(authorizedSpacesSelection: .init(joinedParentSpaces: .mockJoinedSpaces2,
+    static let viewModel = ManageAuthorizedSpacesScreenViewModel(authorizedSpacesSelection: .init(joinedSpaces: .mockJoinedSpaces2,
                                                                                                   unknownSpacesIDs: ["!unknown-space-id-1",
                                                                                                                      "!unknown-space-id-2",
                                                                                                                      "!unknown-space-id-3"],

--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenModels.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenModels.swift
@@ -38,11 +38,12 @@ struct SecurityAndPrivacyScreenViewState: BindableState {
     var canEditJoinRule = false
     var canEnableEncryption = false
     var canEditHistoryVisibility = false
-    var joinedParentSpaces: [SpaceRoomProxyProtocol] = []
+    /// The union of joined parent spaces and the joined spaces in the current access type
+    var selectableJoinedSpaces: [SpaceRoomProxyProtocol] = []
     
     /// The count of the intersection between the set of joined parent spaces and the set of spaces in the current access type
     var selectableSpacesCount: Int {
-        Set(joinedParentSpaces.map(\.id) + currentSettings.accessType.spaceIDs).count
+        Set(selectableJoinedSpaces.map(\.id) + currentSettings.accessType.spaceIDs).count
     }
     
     private var hasChanges: Bool {
@@ -85,8 +86,8 @@ struct SecurityAndPrivacyScreenViewState: BindableState {
     var spaceMembersDescription: String {
         if isSpaceMembersOptionSelectable {
             switch spaceSelection {
-            case .singleJoined(let joinedParentSpace):
-                L10n.screenSecurityAndPrivacyRoomAccessSpaceMembersOptionSingleParentDescription(joinedParentSpace.name)
+            case .singleJoined(let joinedSpace):
+                L10n.screenSecurityAndPrivacyRoomAccessSpaceMembersOptionSingleParentDescription(joinedSpace.name)
             case .singleUnknown(let id):
                 L10n.screenSecurityAndPrivacyRoomAccessSpaceMembersOptionSingleParentDescription(id)
             case .multiple, .empty:
@@ -100,8 +101,8 @@ struct SecurityAndPrivacyScreenViewState: BindableState {
     var askToJoinWithSpaceMembersDescription: String {
         if isAskToJoinWithSpaceMembersOptionSelectable {
             switch spaceSelection {
-            case .singleJoined(let joinedParentSpace):
-                L10n.screenSecurityAndPrivacyAskToJoinSingleSpaceMembersOptionDescription(joinedParentSpace.name)
+            case .singleJoined(let joinedSpace):
+                L10n.screenSecurityAndPrivacyAskToJoinSingleSpaceMembersOptionDescription(joinedSpace.name)
             case .singleUnknown(let id):
                 L10n.screenSecurityAndPrivacyAskToJoinSingleSpaceMembersOptionDescription(id)
             case .multiple, .empty:
@@ -140,17 +141,17 @@ struct SecurityAndPrivacyScreenViewState: BindableState {
             .empty
         } else if selectableSpacesCount > 1 {
             .multiple
-        } else if let joinedParent = joinedParentSpaces.first {
+        } else if let joinedSpace = selectableJoinedSpaces.first {
             if currentSettings.accessType.isSpaceMembers || currentSettings.accessType.isAskToJoinWithSpaceMembers {
                 if currentSettings.accessType.spaceIDs.isEmpty {
                     // Edge case where the access type is already space members, but it does not contain any id
                     // So if the user wants to add their own parent they need to do it from the selection menu
                     .multiple
                 } else {
-                    .singleJoined(joinedParent)
+                    .singleJoined(joinedSpace)
                 }
             } else {
-                .singleJoined(joinedParent)
+                .singleJoined(joinedSpace)
             }
         } else if let unknownSpaceID = currentSettings.accessType.spaceIDs.first {
             // The space is not joined by the user but is currently selected

--- a/ElementX/Sources/Services/Spaces/SpaceServiceProxy.swift
+++ b/ElementX/Sources/Services/Spaces/SpaceServiceProxy.swift
@@ -40,6 +40,15 @@ class SpaceServiceProxy: SpaceServiceProxyProtocol {
         }
     }
     
+    func spaceForIdentifier(spaceID: String) async -> Result<SpaceRoomProxyProtocol?, SpaceServiceProxyError> {
+        do {
+            return try await .success(spaceService.getSpaceRoom(roomId: spaceID).map(SpaceRoomProxy.init))
+        } catch {
+            MXLog.error("Failed getting space room for \(spaceID): \(error)")
+            return .failure(.sdkError(error))
+        }
+    }
+    
     func leaveSpace(spaceID: String) async -> Result<LeaveSpaceHandleProxy, SpaceServiceProxyError> {
         do {
             return try await .success(.init(spaceID: spaceID, leaveHandle: spaceService.leaveSpace(spaceId: spaceID)))

--- a/ElementX/Sources/Services/Spaces/SpaceServiceProxyProtocol.swift
+++ b/ElementX/Sources/Services/Spaces/SpaceServiceProxyProtocol.swift
@@ -18,6 +18,8 @@ protocol SpaceServiceProxyProtocol {
     var joinedSpacesPublisher: CurrentValuePublisher<[SpaceRoomProxyProtocol], Never> { get }
     
     func spaceRoomList(spaceID: String) async -> Result<SpaceRoomListProxyProtocol, SpaceServiceProxyError>
+    /// Returns a joined space given its identifier
+    func spaceForIdentifier(spaceID: String) async -> Result<SpaceRoomProxyProtocol?, SpaceServiceProxyError>
     func leaveSpace(spaceID: String) async -> Result<LeaveSpaceHandleProxy, SpaceServiceProxyError>
     /// Returns all the parent spaces of a child that user has joined.
     func joinedParents(childID: String) async -> Result<[SpaceRoomProxyProtocol], SpaceServiceProxyError>

--- a/project.yml
+++ b/project.yml
@@ -71,7 +71,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/element-hq/matrix-rust-components-swift
-    exactVersion: 25.12.10
+    exactVersion: 25.12.11
     # path: ../matrix-rust-sdk
   Compound:
     path: compound-ios


### PR DESCRIPTION
This applies to both the `restricted` and `knockRestricted` join rules.
Essentially what was happening is that if the existing room access type contains a space that is not a parent of the room, but is still joined by the current user trying to edit its join rule, we displayed such space as unknown.
However since the user is actually part of that space, they should be able to visualise their display name, and it should appear in the list of the spaces they are a member of.

So we added a new API that checks the availability of a joined space room given their id, and we cross check with all the ids that were not resolved to not be joined parents, and if is at least a joined room, we add it to the selection list.
We still only allow by default to add in the allowed list spaces that are joined and parent of the room plus any other value available on the current allowed list, the only difference is that if one of these values is a joined space, we display its info to the user

This PR also updates the SDK to use the newly defined `getSpace` function.
I also renamed joinedParents to joinedSpaces, since now that list could also contain a non parent joined space.