### PR TITLE
Add "Translate" to TimelineItemMenuActions

### DIFF
--- a/ElementX/Resources/Localizations/be.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/be.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "Паўтарыць";
 "action_retry_decryption" = "Паўтарыць расшыфроўку";
 "action_save" = "Захаваць";
+"action_translate" = "Перакласці";
 "action_search" = "Пошук";
 "action_select_all" = "Select all";
 "action_send" = "Адправіць";

--- a/ElementX/Resources/Localizations/bg.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/bg.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "Повторен опит";
 "action_retry_decryption" = "Повторен опит за разшифроване";
 "action_save" = "Запазване";
+"action_translate" = "Превод";
 "action_search" = "Търсене";
 "action_select_all" = "Select all";
 "action_send" = "Изпращане";

--- a/ElementX/Resources/Localizations/cs.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/cs.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "Zkusit znovu";
 "action_retry_decryption" = "Opakovat dešifrování";
 "action_save" = "Uložit";
+"action_translate" = "Přeložit";
 "action_search" = "Hledat";
 "action_select_all" = "Vybrat vše";
 "action_send" = "Odeslat";

--- a/ElementX/Resources/Localizations/cy.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/cy.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "Ceisio eto";
 "action_retry_decryption" = "Cynnig arall ar ddadgryptio";
 "action_save" = "Cadw";
+"action_translate" = "Cyfieithu";
 "action_search" = "Chwilio";
 "action_select_all" = "Dewis y cyfan";
 "action_send" = "Anfon";

--- a/ElementX/Resources/Localizations/da.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/da.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "Prøv igen";
 "action_retry_decryption" = "Prøv at dekryptere igen";
 "action_save" = "Gem";
+"action_translate" = "Oversæt";
 "action_search" = "Søg";
 "action_select_all" = "Vælg alle";
 "action_send" = "Send";

--- a/ElementX/Resources/Localizations/de.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/de.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "Erneut versuchen";
 "action_retry_decryption" = "Entschlüsselung wiederholen";
 "action_save" = "Speichern";
+"action_translate" = "Übersetzen";
 "action_search" = "Suchen";
 "action_select_all" = "Alles auswählen";
 "action_send" = "Senden";

--- a/ElementX/Resources/Localizations/el.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/el.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "Επανάληψη";
 "action_retry_decryption" = "Επανάληψη αποκρυπτογράφησης";
 "action_save" = "Αποθήκευση";
+"action_translate" = "Μετάφραση";
 "action_search" = "Αναζήτηση";
 "action_select_all" = "Select all";
 "action_send" = "Αποστολή";

--- a/ElementX/Resources/Localizations/en-US.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en-US.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "Retry";
 "action_retry_decryption" = "Retry decryption";
 "action_save" = "Save";
+"action_translate" = "Translate";
 "action_search" = "Search";
 "action_select_all" = "Select all";
 "action_send" = "Send";

--- a/ElementX/Resources/Localizations/en.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "Retry";
 "action_retry_decryption" = "Retry decryption";
 "action_save" = "Save";
+"action_translate" = "Translate";
 "action_search" = "Search";
 "action_select_all" = "Select all";
 "action_send" = "Send";

--- a/ElementX/Resources/Localizations/es.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/es.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "Reintentar";
 "action_retry_decryption" = "Reintentar descifrado";
 "action_save" = "Guardar";
+"action_translate" = "Traducir";
 "action_search" = "Buscar";
 "action_select_all" = "Select all";
 "action_send" = "Enviar";

--- a/ElementX/Resources/Localizations/et.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/et.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "Proovi uuesti";
 "action_retry_decryption" = "Proovi dekrüptimist uuesti";
 "action_save" = "Salvesta";
+"action_translate" = "Tõlgi";
 "action_search" = "Otsi";
 "action_select_all" = "Vali kõik";
 "action_send" = "Saada";

--- a/ElementX/Resources/Localizations/eu.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/eu.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "Saiatu berriro";
 "action_retry_decryption" = "Saiatu berriro deszifratzen";
 "action_save" = "Gorde";
+"action_translate" = "Itzuli";
 "action_search" = "Bilatu";
 "action_select_all" = "Select all";
 "action_send" = "Bidali";

--- a/ElementX/Resources/Localizations/fa.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/fa.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "تلاش دوباره";
 "action_retry_decryption" = "تلاش دوباره برای رمزگشایی";
 "action_save" = "ذخیره";
+"action_translate" = "ترجمه";
 "action_search" = "جست‌وجو";
 "action_select_all" = "گزینش همه";
 "action_send" = "فرستادن";

--- a/ElementX/Resources/Localizations/fi.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/fi.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "Yritä uudelleen";
 "action_retry_decryption" = "Yritä salauksen purkamista uudelleen";
 "action_save" = "Tallenna";
+"action_translate" = "Käännä";
 "action_search" = "Hae";
 "action_select_all" = "Valitse kaikki";
 "action_send" = "Lähetä";

--- a/ElementX/Resources/Localizations/fr.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/fr.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "Réessayer";
 "action_retry_decryption" = "Réessayer le déchiffrement";
 "action_save" = "Enregistrer";
+"action_translate" = "Traduire";
 "action_search" = "Rechercher";
 "action_select_all" = "Tout sélectionner";
 "action_send" = "Envoyer";

--- a/ElementX/Resources/Localizations/hu.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/hu.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "Újra";
 "action_retry_decryption" = "Visszafejtés újbóli megpróbálása";
 "action_save" = "Mentés";
+"action_translate" = "Fordítás";
 "action_search" = "Keresés";
 "action_select_all" = "Összes kijelölése";
 "action_send" = "Küldés";

--- a/ElementX/Resources/Localizations/id.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/id.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "Coba lagi";
 "action_retry_decryption" = "Coba dekripsi ulang";
 "action_save" = "Simpan";
+"action_translate" = "Terjemahkan";
 "action_search" = "Cari";
 "action_select_all" = "Select all";
 "action_send" = "Kirim";

--- a/ElementX/Resources/Localizations/it.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/it.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "Riprova";
 "action_retry_decryption" = "Riprova la decrittazione";
 "action_save" = "Salva";
+"action_translate" = "Traduci";
 "action_search" = "Ricerca";
 "action_select_all" = "Seleziona tutti";
 "action_send" = "Invia";

--- a/ElementX/Resources/Localizations/ka.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/ka.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "ხელახლა ცდა";
 "action_retry_decryption" = "გაშიფვრის ხელახლა ცდა";
 "action_save" = "შენახვა";
+"action_translate" = "თარგმნა";
 "action_search" = "ძიება";
 "action_select_all" = "Select all";
 "action_send" = "გაგზავნა";

--- a/ElementX/Resources/Localizations/ko.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/ko.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "재시도";
 "action_retry_decryption" = "복호화 재시도";
 "action_save" = "저장";
+"action_translate" = "번역";
 "action_search" = "검색";
 "action_select_all" = "Select all";
 "action_send" = "보내기";

--- a/ElementX/Resources/Localizations/lt.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/lt.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "Bandyti dar kartą";
 "action_retry_decryption" = "Pakartoti iššifravimą";
 "action_save" = "Išsaugoti";
+"action_translate" = "Išversti";
 "action_search" = "Ieškoti";
 "action_select_all" = "Select all";
 "action_send" = "Siųsti";

--- a/ElementX/Resources/Localizations/nb.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/nb.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "Prøv på nytt";
 "action_retry_decryption" = "Prøv dekryptering på nytt";
 "action_save" = "Lagre";
+"action_translate" = "Oversett";
 "action_search" = "Søke";
 "action_select_all" = "Velg alle";
 "action_send" = "Sende";

--- a/ElementX/Resources/Localizations/nl.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/nl.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "Opnieuw proberen";
 "action_retry_decryption" = "Decryptie opnieuw proberen";
 "action_save" = "Opslaan";
+"action_translate" = "Vertalen";
 "action_search" = "Zoeken";
 "action_select_all" = "Select all";
 "action_send" = "Verzenden";

--- a/ElementX/Resources/Localizations/pl.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/pl.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "Spróbuj ponownie";
 "action_retry_decryption" = "Ponów próbę odszyfrowania";
 "action_save" = "Zapisz";
+"action_translate" = "Przetłumacz";
 "action_search" = "Szukaj";
 "action_select_all" = "Zaznacz wszystko";
 "action_send" = "Wyślij";

--- a/ElementX/Resources/Localizations/pt-BR.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/pt-BR.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "Tentar novamente";
 "action_retry_decryption" = "Tentar descriptografar novamente";
 "action_save" = "Salvar";
+"action_translate" = "Traduzir";
 "action_search" = "Pesquisar";
 "action_select_all" = "Selecionar tudo";
 "action_send" = "Enviar";

--- a/ElementX/Resources/Localizations/pt.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/pt.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "Tentar novamente";
 "action_retry_decryption" = "Tentar decifragem novamente";
 "action_save" = "Guardar";
+"action_translate" = "Traduzir";
 "action_search" = "Pesquisar";
 "action_select_all" = "Selecionar tudo";
 "action_send" = "Enviar";

--- a/ElementX/Resources/Localizations/ro.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/ro.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "Reîncercați";
 "action_retry_decryption" = "Reîncercați decriptarea";
 "action_save" = "Salvați";
+"action_translate" = "Traduceți";
 "action_search" = "Căutați";
 "action_select_all" = "Selectați tot";
 "action_send" = "Trimiteți";

--- a/ElementX/Resources/Localizations/ru.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/ru.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "Повторить";
 "action_retry_decryption" = "Повторите расшифровку";
 "action_save" = "Сохранить";
+"action_translate" = "Перевести";
 "action_search" = "Поиск";
 "action_select_all" = "Выбрать все";
 "action_send" = "Отправить";

--- a/ElementX/Resources/Localizations/sk.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/sk.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "Skúsiť znova";
 "action_retry_decryption" = "Opakovať dešifrovanie";
 "action_save" = "Uložiť";
+"action_translate" = "Preložiť";
 "action_search" = "Hľadať";
 "action_select_all" = "Vybrať všetko";
 "action_send" = "Odoslať";

--- a/ElementX/Resources/Localizations/sv.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/sv.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "Försök igen";
 "action_retry_decryption" = "Försök att avkryptera igen";
 "action_save" = "Spara";
+"action_translate" = "Översätt";
 "action_search" = "Sök";
 "action_select_all" = "Select all";
 "action_send" = "Skicka";

--- a/ElementX/Resources/Localizations/tr.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/tr.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "Yeniden dene";
 "action_retry_decryption" = "Şifre çözmeyi tekrar deneyin";
 "action_save" = "Kaydet";
+"action_translate" = "Çevir";
 "action_search" = "Ara";
 "action_select_all" = "Select all";
 "action_send" = "Gönder";

--- a/ElementX/Resources/Localizations/uk.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/uk.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "Спробувати ще раз";
 "action_retry_decryption" = "Повторити спробу розшифрування";
 "action_save" = "Зберегти";
+"action_translate" = "Перекласти";
 "action_search" = "Шукати";
 "action_select_all" = "Select all";
 "action_send" = "Надіслати";

--- a/ElementX/Resources/Localizations/ur.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/ur.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "پھر کوشش کریں";
 "action_retry_decryption" = "رمزکشائی کی پھر کوشش کریں";
 "action_save" = "محفوظ کریں";
+"action_translate" = "ترجمہ کریں";
 "action_search" = "تلاش کریں";
 "action_select_all" = "Select all";
 "action_send" = "بھیجیں";

--- a/ElementX/Resources/Localizations/uz.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/uz.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "Qayta urinish";
 "action_retry_decryption" = "Shifrni ochishni qayta urinish";
 "action_save" = "Saqlash";
+"action_translate" = "Tarjima";
 "action_search" = "Qidirmoq";
 "action_select_all" = "Select all";
 "action_send" = "Yuborish";

--- a/ElementX/Resources/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/zh-Hans.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "重试";
 "action_retry_decryption" = "重试解密";
 "action_save" = "保存";
+"action_translate" = "翻译";
 "action_search" = "搜索";
 "action_select_all" = "全选";
 "action_send" = "发送";

--- a/ElementX/Resources/Localizations/zh-Hant-TW.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/zh-Hant-TW.lproj/Localizable.strings
@@ -133,6 +133,7 @@
 "action_retry" = "再試一次";
 "action_retry_decryption" = "再次嘗試解密";
 "action_save" = "儲存";
+"action_translate" = "翻譯";
 "action_search" = "搜尋";
 "action_select_all" = "選取全部";
 "action_send" = "傳送";

--- a/ElementX/Sources/Generated/Strings.swift
+++ b/ElementX/Sources/Generated/Strings.swift
@@ -342,6 +342,8 @@ internal enum L10n {
   internal static var actionTakePhoto: String { return L10n.tr("Localizable", "action_take_photo") }
   /// Tap for options
   internal static var actionTapForOptions: String { return L10n.tr("Localizable", "action_tap_for_options") }
+  /// Translate
+  internal static var actionTranslate: String { return L10n.tr("Localizable", "action_translate") }
   /// Try again
   internal static var actionTryAgain: String { return L10n.tr("Localizable", "action_try_again") }
   /// Unpin

--- a/ElementX/Sources/Screens/Timeline/TimelineInteractionHandler.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineInteractionHandler.swift
@@ -26,6 +26,7 @@ enum TimelineInteractionHandlerAction {
     
     case viewInRoomTimeline(eventID: String)
     case displayThread(itemID: TimelineItemIdentifier)
+    case showTranslation(text: String)
 }
 
 /// The interaction handler groups logic for dealing with various actions the user can take on a timeline's
@@ -198,6 +199,9 @@ class TimelineInteractionHandler {
             break // Handled inline in the media preview screen with a ShareLink.
         case .save:
             break // Handled inline in the media preview screen.
+        case .translate:
+            guard let messageTimelineItem = timelineItem as? EventBasedMessageTimelineItemProtocol else { return }
+            actionsSubject.send(.showTranslation(text: messageTimelineItem.body))
         }
         
         if action.switchToDefaultComposer {

--- a/ElementX/Sources/Screens/Timeline/TimelineModels.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineModels.swift
@@ -160,6 +160,9 @@ struct TimelineViewStateBindings {
     var readReceiptsSummaryInfo: ReadReceiptSummaryInfo?
     
     var manageMemberViewModel: ManageRoomMemberSheetViewModel?
+
+    var showTranslation = false
+    var textToBeTranslated: String?
 }
 
 struct TimelineItemActionMenuInfo: Equatable, Identifiable {

--- a/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
@@ -498,6 +498,9 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
                     Task { await self.viewInRoomTimeline(eventID: eventID) }
                 case .displayThread(let itemID):
                     actionsSubject.send(.displayThread(itemID: itemID))
+                case .showTranslation(let text):
+                    self.state.bindings.textToBeTranslated = text
+                    self.state.bindings.showTranslation = true
                 }
             }
             .store(in: &cancellables)

--- a/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenuAction.swift
+++ b/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenuAction.swift
@@ -57,6 +57,7 @@ struct TimelineItemMenuReaction: Hashable {
 
 enum TimelineItemMenuAction: Identifiable, Hashable {
     case copy
+    case translate
     case copyCaption
     case edit
     case addCaption
@@ -145,6 +146,8 @@ enum TimelineItemMenuAction: Identifiable, Hashable {
         switch self {
         case .copy:
             Label(L10n.actionCopyText, icon: \.copy)
+        case .translate:
+            Label(L10n.actionTranslate, systemSymbol: .translate)
         case .copyCaption:
             Label(L10n.actionCopyCaption, icon: \.copy)
         case .edit:

--- a/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenuActionProvider.swift
+++ b/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenuActionProvider.swift
@@ -91,6 +91,7 @@ struct TimelineItemMenuActionProvider {
 
         if item.isCopyable {
             actions.append(.copy)
+            actions.append(.translate)
         } else if item.hasMediaCaption {
             actions.append(.copyCaption)
         }

--- a/ElementX/Sources/Screens/Timeline/View/TimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineView.swift
@@ -7,6 +7,7 @@
 //
 
 import SwiftUI
+import Translation
 import WysiwygComposer
 
 struct TimelineView: View {
@@ -55,6 +56,7 @@ struct TimelineView: View {
                 ReadReceiptsSummaryView(orderedReadReceipts: $0.orderedReceipts)
                     .environmentObject(timelineContext)
             }
+            .translationPresentation(isPresented: $timelineContext.showTranslation, text: timelineContext.actionMenuInfo?.item.body ?? "")
             .onDrop(of: ["public.item", "public.file-url"], isTargeted: $dragOver) { providers -> Bool in
                 let supportedProviders = providers.filter(\.isSupportedForPasteOrDrop)
                 


### PR DESCRIPTION


https://github.com/user-attachments/assets/cfde29e1-2233-4efb-8fa8-9515d0b93578





> [!NOTE]
> Translated by AI

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
  > Don't see any `changlog.d` folder in this repo

**UI changes have been tested with:**
- [x] iPhone and iPad simulators in portrait and landscape orientations.
- [x] Dark mode enabled and disabled.
- [x] Various sizes of dynamic type.
- [ ] Voiceover enabled.
  > Don't have a paid developer account to run on a physical device, but this is basically the same with the "Copy" action.
