### PR TITLE
Have fastlane's xcbeautify use a special github actions formatter and reporter.

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -26,7 +26,8 @@ lane :unit_tests do |options|
     ensure_devices_found: true,
     result_bundle: true,
     number_of_retries: 3,
-    reset_simulator: reset_simulator
+    reset_simulator: reset_simulator,
+    xcodebuild_formatter: "xcbeautify --is-ci --renderer github-actions"
   )
   
   if !options[:skip_previews]
@@ -41,7 +42,8 @@ lane :unit_tests do |options|
       ensure_devices_found: true,
       result_bundle: true,
       number_of_retries: 3,
-      reset_simulator: reset_simulator
+      reset_simulator: reset_simulator,
+      xcodebuild_formatter: "xcbeautify --is-ci --renderer github-actions"
     )
   end
   
@@ -86,7 +88,8 @@ lane :ui_tests do |options|
     result_bundle: true,
     only_testing: test_to_run,
     number_of_retries: 3,
-    reset_simulator: reset_simulator
+    reset_simulator: reset_simulator,
+    xcodebuild_formatter: "xcbeautify --is-ci --renderer github-actions"
   )
 end
 
@@ -100,7 +103,8 @@ lane :accessibility_tests do |options|
     prelaunch_simulator: false,
     result_bundle: true,
     number_of_retries: 0,
-    reset_simulator: reset_simulator
+    reset_simulator: reset_simulator,
+    xcodebuild_formatter: "xcbeautify --is-ci --renderer github-actions"
   )
 end
 
@@ -115,7 +119,8 @@ lane :integration_tests do
     device: "iPhone 17 (#{simulator_version})",
     ensure_devices_found: true,
     result_bundle: true,
-    reset_simulator: reset_simulator
+    reset_simulator: reset_simulator,
+    xcodebuild_formatter: "xcbeautify --is-ci --renderer github-actions"
   )
 end
 


### PR DESCRIPTION
> --is-ci Print test result too under quiet/quieter flag.

Not particularly sure it's useful in this case but it can't hurt. We might want to play with quiet/quieter as well

> xcbeautify features an integrated GitHub Actions renderer that harnesses [workflow commands](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions) to highlight warnings, errors, and results directly within the GitHub user interface. To utilize this function, simply run xcbeautify and add the --renderer github-actions flag during execution.