### PR TITLE
Unban correctly depends on kick PL + removed Change Settings permission

### DIFF
--- a/ElementX/Sources/Screens/ManageRoomMemberSheet/View/ManageRoomMemberSheetView.swift
+++ b/ElementX/Sources/Screens/ManageRoomMemberSheet/View/ManageRoomMemberSheetView.swift
@@ -40,25 +40,33 @@ struct ManageRoomMemberSheetView: View {
             
             Section {
                 if context.viewState.permissions.canKick {
-                    ListRow(label: .default(title: L10n.screenBottomSheetManageRoomMemberRemove,
-                                            icon: \.close,
-                                            role: .destructive),
-                            kind: .button {
-                                context.send(viewAction: .kick)
-                            })
-                            .disabled(context.viewState.isKickDisabled)
+                    // Unbanning requires only the kick permission according to the specs.
+                    if context.viewState.isMemberBanned {
+                        ListRow(label: .default(title: L10n.screenBottomSheetManageRoomMemberUnban,
+                                                icon: \.restart,
+                                                role: .destructive),
+                                kind: .button {
+                                    context.send(viewAction: .unban)
+                                })
+                                .disabled(context.viewState.isBanUnbanDisabled)
+                    } else {
+                        ListRow(label: .default(title: L10n.screenBottomSheetManageRoomMemberRemove,
+                                                icon: \.close,
+                                                role: .destructive),
+                                kind: .button {
+                                    context.send(viewAction: .kick)
+                                })
+                                .disabled(context.viewState.isKickDisabled)
+                    }
                 }
                 
-                if context.viewState.permissions.canBan {
-                    let title = context.viewState.isMemberBanned ? L10n.screenBottomSheetManageRoomMemberUnban : L10n.screenBottomSheetManageRoomMemberBan
-                    let icon: KeyPath<CompoundIcons, Image> = context.viewState.isMemberBanned ? \.restart : \.block
-                    let action: ManageRoomMemberSheetViewAction = context.viewState.isMemberBanned ? .unban : .ban
-                    
-                    ListRow(label: .default(title: title,
-                                            icon: icon,
+                if context.viewState.permissions.canBan,
+                   !context.viewState.isMemberBanned {
+                    ListRow(label: .default(title: L10n.screenBottomSheetManageRoomMemberBan,
+                                            icon: \.block,
                                             role: .destructive),
                             kind: .button {
-                                context.send(viewAction: action)
+                                context.send(viewAction: .ban)
                             })
                             .disabled(context.viewState.isBanUnbanDisabled)
                 }
@@ -81,7 +89,7 @@ struct ManageRoomMemberSheetView_Previews: PreviewProvider, TestablePreview {
     
     static let banOnlyViewModel = ManageRoomMemberSheetViewModel.mock(canKick: false)
     
-    static let unbanOnlyViewModel = ManageRoomMemberSheetViewModel.mock(canKick: false, memberIsBanned: true)
+    static let unbanOnlyViewModel = ManageRoomMemberSheetViewModel.mock(canKick: true, memberIsBanned: true)
     
     static var previews: some View {
         ManageRoomMemberSheetView(context: allActionsViewModel.context)

--- a/ElementX/Sources/Screens/RoomChangePermissionsScreen/RoomChangePermissionsScreenModels.swift
+++ b/ElementX/Sources/Screens/RoomChangePermissionsScreen/RoomChangePermissionsScreenModels.swift
@@ -114,10 +114,7 @@ extension RoomChangePermissionsScreenViewState {
                     settings[group] = [
                         RoomPermissionsSetting(title: L10n.screenRoomChangePermissionsManageSpaceRooms,
                                                value: currentPermissions.spaceChild,
-                                               keyPath: \.spaceChild),
-                        RoomPermissionsSetting(title: L10n.screenRoomChangePermissionsChangeSettings,
-                                               value: currentPermissions.stateDefault,
-                                               keyPath: \.stateDefault)
+                                               keyPath: \.spaceChild)
                     ]
                 }
             }

--- a/ElementX/Sources/Screens/RoomMemberListScreen/RoomMembersListScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomMemberListScreen/RoomMembersListScreenViewModel.swift
@@ -192,21 +192,6 @@ class RoomMembersListScreenViewModel: RoomMembersListScreenViewModelType, RoomMe
         actionsSubject.send(.selectMember(member))
     }
     
-    // MARK: - Member Management
-    
-    private func unbanMember(_ member: RoomMemberDetails) async {
-        let indicatorTitle = L10n.screenRoomMemberListUnbanningUser(member.name ?? member.id)
-        showManageMemberIndicator(title: indicatorTitle)
-        
-        switch await roomProxy.unbanUser(member.id) {
-        case .success:
-            hideManageMemberIndicator(title: indicatorTitle)
-            analytics.trackRoomModeration(action: .UnbanMember, role: nil)
-        case .failure:
-            showManageMemberFailure(title: indicatorTitle)
-        }
-    }
-    
     // MARK: - Indicators
     
     private static let setupMembersLoadingIndicatorIdentifier = "\(RoomMembersListScreenViewModel.self)-SetupMembers"

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/roomChangePermissionsScreen.Space-iPad-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/roomChangePermissionsScreen.Space-iPad-en-GB.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ede0ef34fec7165f9678614439897fda33d029ff99667fec93a3f5ae01d75d70
-size 158135
+oid sha256:81b67f260876237de89d66e411a8f2d5805553c76d2af3a60c5c0a778b45d888
+size 150830

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/roomChangePermissionsScreen.Space-iPad-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/roomChangePermissionsScreen.Space-iPad-pseudo.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6c2230071e4620ec198241c091cd684bfcbfcd0a4c112bf37b48916a9f5e76d6
-size 182805
+oid sha256:b83181a11827d4f93d0279330da617eaac4f826a78d2ca329721f5e63ac7e678
+size 173819

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/roomChangePermissionsScreen.Space-iPhone-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/roomChangePermissionsScreen.Space-iPhone-en-GB.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:794a750882e3ee230958cf75f114fa43ed91f6d84efd0ca2a2f68da92b51a949
-size 101987
+oid sha256:6ec9b480383e4590866fc36ff9efddceaec9d60687a7ed330cf6141b37096094
+size 95294

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/roomChangePermissionsScreen.Space-iPhone-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/roomChangePermissionsScreen.Space-iPhone-pseudo.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7c5cf4c712bbfa686cbcb70d13ad4041e701e4ab85b9974cfec847966aa5cc27
-size 139111
+oid sha256:37d6d26d83d9801753cfef539e0e76ca30fb202d74bbb5a7dbd37a315337c55e
+size 127665


### PR DESCRIPTION
fixes #4876 
fixes #4877 

Seems that to unban you just need the kick permission, this PR takes care of it + removes a setting we are not sure about implementing on mobile as of right now.