### PR TITLE
Hide the Translate action on macOS in favour of selecting the text.

### DIFF
--- a/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenuActionProvider.swift
+++ b/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenuActionProvider.swift
@@ -91,7 +91,12 @@ struct TimelineItemMenuActionProvider {
 
         if item.isCopyable {
             actions.append(.copy)
-            actions.append(.translate)
+            
+            if !ProcessInfo.processInfo.isiOSAppOnMac {
+                // As of macOS 26.2, the sheet isn't presented, but it is easy enough
+                // to select some text and right click on Mac anyway so hide this one.
+                actions.append(.translate)
+            }
         } else if item.hasMediaCaption {
             actions.append(.copyCaption)
         }


### PR DESCRIPTION
The sheet is never presented on macOS, but it's also easy enough to translate something by selecting the text anyway.