### PR TITLE
Disable PostHog's swizzling.

### DIFF
--- a/ElementX/Sources/Services/Analytics/PHGPostHogConfiguration.swift
+++ b/ElementX/Sources/Services/Analytics/PHGPostHogConfiguration.swift
@@ -15,6 +15,9 @@ extension PostHogConfig {
         postHogConfiguration.captureScreenViews = false
         postHogConfiguration.surveys = false
         
+        // We only want to track the events provided by the AnalyticsEvents package
+        postHogConfiguration.enableSwizzling = false
+        
         return postHogConfiguration
     }
 }


### PR DESCRIPTION
There's a new option available since https://github.com/PostHog/posthog-ios/pull/388. As we only want to track the events provided by https://github.com/matrix-org/matrix-analytics-events and we aren't using any of the additional features swizzling brings, it seems reasonable to disable it.