### PR TITLE
Fake an actual title bar on macOS Tahoe.

### DIFF
--- a/ElementX/Sources/Application/Application.swift
+++ b/ElementX/Sources/Application/Application.swift
@@ -33,6 +33,12 @@ struct Application: App {
         WindowGroup {
             appCoordinator.toPresentable()
                 .statusBarHidden(shouldHideStatusBar)
+                .overlay(alignment: .top) {
+                    if #available(iOS 26, *), ProcessInfo.processInfo.isiOSAppOnMac {
+                        // Fake an old-school titlebar to reduce the "floaty-ness" of everything with liquid glass.
+                        Divider().ignoresSafeArea()
+                    }
+                }
                 .environment(\.openURL, OpenURLAction { url in
                     if appCoordinator.handleDeepLink(url, isExternalURL: false) {
                         return .handled


### PR DESCRIPTION
Not necessarily a permanent change, but doing this to help (ever so slightly) with the ridiculous amount of space added above the sidebar by Tahoe.

| Before | After |
| - | - |
| <img width="938" height="724" alt="Screenshot 2026-01-19 at 5 34 39 pm" src="https://github.com/user-attachments/assets/bdcf0ffa-ec16-4d6b-9bf4-82a1ac515f2e" /> | <img width="938" height="724" alt="Screenshot 2026-01-19 at 5 33 34 pm" src="https://github.com/user-attachments/assets/0c1af4ea-f0f7-442d-8af0-5e1bc268eafd" /> |

It would be much nicer if Apple would merge the tab bar into the title bar where it's meant to go, but so far I've only ever seen that working when building a true macOS app.
