### PR TITLE
Set a custom user agent on the Element Call web view

### DIFF
--- a/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
+++ b/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
@@ -123,6 +123,8 @@ private struct CallView: UIViewRepresentable {
             webView.navigationDelegate = self
             webView.isInspectable = true
             
+            webView.customUserAgent = UserAgentBuilder.makeASCIIUserAgent()
+            
             // https://stackoverflow.com/a/77963877/730924
             webView.allowsLinkPreview = true
             


### PR DESCRIPTION
This patch replaces the default User-Agent header with the common one.

The old User-Agent:
```
Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148
```
The new one:
```
Element X/26.01.1 (Simulator (iPhone 17 Pro); iOS 26.2; Scale/3.00)
```

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
- [x] No UI changes
