### PR TITLE
Fix a bug where the app wouldn't retry when the server rate-limits its requests.

### DIFF
--- a/ElementX/Sources/Other/Extensions/ClientBuilder.swift
+++ b/ElementX/Sources/Other/Extensions/ClientBuilder.swift
@@ -27,7 +27,7 @@ extension ClientBuilder {
             .setSessionDelegate(sessionDelegate: sessionDelegate)
             .userAgent(userAgent: UserAgentBuilder.makeASCIIUserAgent())
             .threadsEnabled(enabled: threadsEnabled, threadSubscriptions: threadsEnabled)
-            .requestConfig(config: .init(retryLimit: 0,
+            .requestConfig(config: .init(retryLimit: 3, // Must be non-zero for the SDK to retry API calls when rate-limited.
                                          timeout: requestTimeout,
                                          maxConcurrentRequests: nil,
                                          maxRetryTime: maxRequestRetryTime))


### PR DESCRIPTION
… by changing the retry limit to 3. We'll see how this goes in Nightlies as [other `5xx` errors](https://github.com/matrix-org/matrix-rust-sdk/blob/8f4ac73ca9b627627fa164d815430a13cb7e215f/crates/matrix-sdk/src/error.rs#L251) are also re-tried, so we may need to report these to the SDK team if they don't make sense.

Related to https://github.com/element-hq/element-meta/issues/3017 as this was seen when adding/removing children to/from a space.