### PR TITLE
Allow redacting the collocutor's messages in DMs (again)

### DIFF
--- a/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenuActionProvider.swift
+++ b/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenuActionProvider.swift
@@ -159,6 +159,6 @@ struct TimelineItemMenuActionProvider {
     }
     
     private func canRedactItem(_ item: EventBasedTimelineItemProtocol) -> Bool {
-        item.isOutgoing ? canCurrentUserRedactSelf : canCurrentUserRedactOthers && !isDM
+        item.isOutgoing ? canCurrentUserRedactSelf : canCurrentUserRedactOthers
     }
 }


### PR DESCRIPTION
This reverts https://github.com/element-hq/element-x-ios/pull/2368 as the behavior didn't make it to any of our other clients.

This was initially made as part of this story https://github.com/element-hq/element-meta/issues/1705