### PR TITLE
Add a stale bot for X-Needs-Info issues.

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/stale@997185467fa4f803885201cee163a9f38240193d # v10.1.1
+      - uses: actions/stale@v10
         with:
           only-labels: "X-Needs-Info"
           days-before-issue-stale: 30


### PR DESCRIPTION
This should only act upon issues with the `X-Needs-Info` label. It will also automatically remove the label when there's a response.

Before merging we need to double check all existing issues and remove the label from any that do not need it any more.