### PR TITLE
Unable to open rooms because of missing bug reporting completion handling

### DIFF
--- a/ElementX/Sources/FlowCoordinators/ChatsTabFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/ChatsTabFlowCoordinator.swift
@@ -212,6 +212,14 @@ class ChatsTabFlowCoordinator: FlowCoordinatorProtocol {
                                                                                       userIndicatorController: flowParameters.userIndicatorController,
                                                                                       bugReportService: flowParameters.bugReportService,
                                                                                       userSession: userSession))
+                bugReportFlowCoordinator?.actionsPublisher.sink { [weak self] action in
+                    switch action {
+                    case .complete:
+                        self?.stateMachine.processEvent(.dismissedFeedbackScreen)
+                    }
+                }
+                .store(in: &cancellables)
+                
                 bugReportFlowCoordinator?.start()
             case (.feedbackScreen, .dismissedFeedbackScreen, .roomList):
                 break


### PR DESCRIPTION
Not much to it really, the state machine logs said it all:

```
2026-02-03T07:25:40.233643Z  INFO elementx: Transitioning from `initial` to `restoringSession` with event `startWithExistingSession` | AppCoordinatorStateMachine.swift:93 | spans: root
2026-02-03T07:25:41.513616Z  INFO elementx: Transitioning from `restoringSession` to `signedIn` with event `createdUserSession` | AppCoordinatorStateMachine.swift:93 | spans: root
2026-02-03T07:25:41.677629Z  INFO elementx: Transitioning from `initial` to `roomList(detailState: nil)` with event `start` | ChatsTabFlowCoordinatorStateMachine.swift:229 | spans: root
2026-02-03T07:25:50.698913Z  INFO elementx: Transitioning from `roomList(detailState: nil)` to `feedbackScreen(detailState: nil)` with event `feedbackScreen` | ChatsTabFlowCoordinatorStateMachine.swift:229 | spans: root
2026-02-03T07:26:06.343832Z ERROR elementx: Failed transition from equal states: feedbackScreen(detailState: nil) | ChatsTabFlowCoordinator.swift:292 | spans: root
2026-02-03T07:26:07.590987Z ERROR elementx: Failed transition from equal states: feedbackScreen(detailState: nil) | ChatsTabFlowCoordinator.swift:292 | spans: root
2026-02-03T07:26:07.826106Z ERROR elementx: Failed transition from equal states: feedbackScreen(detailState: nil) | ChatsTabFlowCoordinator.swift:292 | spans: root
2026-02-03T07:26:08.190817Z ERROR elementx: Failed transition from equal states: feedbackScreen(detailState: nil) | ChatsTabFlowCoordinator.swift:292 | spans: root
2026-02-03T07:26:08.375687Z ERROR elementx: Failed transition from equal states: feedbackScreen(detailState: nil) | ChatsTabFlowCoordinator.swift:292 | spans: root
2026-02-03T07:26:08.524726Z ERROR elementx: Failed transition from equal states: feedbackScreen(detailState: nil) | ChatsTabFlowCoordinator.swift:292 | spans: root
2026-02-03T07:26:08.692401Z ERROR elementx: Failed transition from equal states: feedbackScreen(detailState: nil) | ChatsTabFlowCoordinator.swift:292 | spans: root
2026-02-03T07:26:08.841693Z ERROR elementx: Failed transition from equal states: feedbackScreen(detailState: nil) | ChatsTabFlowCoordinator.swift:292 | spans: root
```