### PR TITLE
Fix a retain cycle in the `SecureBackupController` `remoteBackupStateTask`

### DIFF
--- a/ElementX/Sources/Services/SecureBackup/SecureBackupController.swift
+++ b/ElementX/Sources/Services/SecureBackup/SecureBackupController.swift
@@ -189,7 +189,9 @@ class SecureBackupController: SecureBackupControllerProtocol {
     // MARK: - Private
     
     private func updateBackupStateFromRemote(retry: Bool = true) {
-        remoteBackupStateTask = Task {
+        remoteBackupStateTask = Task { [weak self] in
+            guard let self else { return }
+            
             do {
                 MXLog.info("Checking if backup exists on the server")
                 let backupExists = try await self.encryption.backupExistsOnServer()


### PR DESCRIPTION
Try to prevent closure crashes we've been seeing in sentry

https://sentry.tools.element.io/organizations/element/issues/9655394/?project=44&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=freq