### PR TITLE
Automatically dismiss `UserDetailsEditScreen` when saving changes.

### DIFF
--- a/ElementX/Sources/Screens/Settings/UserDetailsEditScreen/UserDetailsEditScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Settings/UserDetailsEditScreen/UserDetailsEditScreenViewModel.swift
@@ -112,11 +112,11 @@ class UserDetailsEditScreenViewModel: UserDetailsEditScreenViewModelType, UserDe
         state.bindings.alertInfo = .init(id: .unsavedChanges,
                                          title: L10n.dialogUnsavedChangesTitle,
                                          message: L10n.dialogUnsavedChangesDescription,
-                                         primaryButton: .init(title: L10n.actionSave) { Task { await self.saveUserDetails(shouldDismiss: true) } },
+                                         primaryButton: .init(title: L10n.actionSave) { Task { await self.saveUserDetails() } },
                                          secondaryButton: .init(title: L10n.actionDiscard, role: .cancel) { self.actionsSubject.send(.dismiss) })
     }
     
-    private func saveUserDetails(shouldDismiss: Bool = false) async {
+    private func saveUserDetails() async {
         let userIndicatorID = UUID().uuidString
         defer {
             userIndicatorController.retractIndicatorWithId(userIndicatorID)
@@ -147,9 +147,7 @@ class UserDetailsEditScreenViewModel: UserDetailsEditScreenViewModelType, UserDe
                 try await group.waitForAll()
             }
             
-            if shouldDismiss {
-                actionsSubject.send(.dismiss)
-            }
+            actionsSubject.send(.dismiss)
         } catch {
             userIndicatorController.alertInfo = .init(id: .init(),
                                                       title: L10n.screenEditProfileErrorTitle,

--- a/UnitTests/Sources/UserDetailsEditScreenViewModelTests.swift
+++ b/UnitTests/Sources/UserDetailsEditScreenViewModelTests.swift
@@ -49,8 +49,7 @@ class UserDetailsEditScreenViewModelTests: XCTestCase {
     func testSave() async throws {
         setupViewModel()
         
-        // Saving shouldn't dismiss this screen (or trigger any other action).
-        let deferred = deferFailure(viewModel.actions, timeout: 1) { _ in true }
+        let deferred = deferFulfillment(viewModel.actions) { $0 == .dismiss }
         
         context.name = "name"
         context.send(viewAction: .save)


### PR DESCRIPTION
Android already does this, and without it we have a bug where the screen still considers there to be unsaved changes.