### PR TITLE
Add a rounded rect border around space avatars

### DIFF
--- a/ElementX/Sources/Other/SwiftUI/Views/OverridableAvatarImage.swift
+++ b/ElementX/Sources/Other/SwiftUI/Views/OverridableAvatarImage.swift
@@ -14,7 +14,7 @@ struct OverridableAvatarImage: View {
     let url: URL?
     let name: String?
     let contentID: String
-    let isSpace: Bool
+    let shape: LoadableAvatarImage.Shape
     let avatarSize: Avatars.Size
     let mediaProvider: MediaProviderProtocol?
     
@@ -28,12 +28,12 @@ struct OverridableAvatarImage: View {
                 ProgressView()
             }
             .scaledFrame(size: avatarSize.value)
-            .clipAvatar(isSpace: isSpace, size: avatarSize.value)
+            .avatarShape(shape, size: avatarSize.value)
         } else {
             LoadableAvatarImage(url: url,
                                 name: name,
                                 contentID: contentID,
-                                isSpace: isSpace,
+                                shape: shape,
                                 avatarSize: avatarSize,
                                 mediaProvider: mediaProvider)
         }

--- a/ElementX/Sources/Other/SwiftUI/Views/RoomAvatarImage.swift
+++ b/ElementX/Sources/Other/SwiftUI/Views/RoomAvatarImage.swift
@@ -116,7 +116,7 @@ struct RoomAvatarImage: View {
             LoadableAvatarImage(url: avatarURL,
                                 name: name,
                                 contentID: id,
-                                isSpace: true,
+                                shape: .roundedRect,
                                 avatarSize: avatarSize,
                                 mediaProvider: mediaProvider,
                                 onTap: onAvatarTap)

--- a/ElementX/Sources/Screens/RoomDetailsEditScreen/View/RoomDetailsEditScreen.swift
+++ b/ElementX/Sources/Screens/RoomDetailsEditScreen/View/RoomDetailsEditScreen.swift
@@ -60,7 +60,7 @@ struct RoomDetailsEditScreen: View {
                                    url: context.viewState.avatarURL,
                                    name: context.viewState.initialName,
                                    contentID: context.viewState.roomID,
-                                   isSpace: context.viewState.isSpace,
+                                   shape: context.viewState.isSpace ? .roundedRect : .circle,
                                    avatarSize: .user(on: .memberDetails),
                                    mediaProvider: context.mediaProvider)
                 .accessibilityLabel(L10n.a11yEditAvatar)

--- a/ElementX/Sources/Screens/Settings/UserDetailsEditScreen/View/UserDetailsEditScreen.swift
+++ b/ElementX/Sources/Screens/Settings/UserDetailsEditScreen/View/UserDetailsEditScreen.swift
@@ -64,7 +64,7 @@ struct UserDetailsEditScreen: View {
                                    url: context.viewState.selectedAvatarURL,
                                    name: context.viewState.currentDisplayName,
                                    contentID: context.viewState.userID,
-                                   isSpace: false,
+                                   shape: .circle,
                                    avatarSize: .user(on: .editUserDetails),
                                    mediaProvider: context.mediaProvider)
                 .overlay(alignment: .bottomTrailing) {


### PR DESCRIPTION
.. and also refactor the LoadableAvatarImage to stop having knowledge of spaces and instead focus on generic shapes.

<img width="568" height="1084" alt="Screenshot 2026-02-10 at 14 13 33" src="https://github.com/user-attachments/assets/d6fe71d1-851a-4eb3-9ae1-f517e59d71dd" />
