### PR TITLE
Adopt the new tracing configuration that allows maximum size and age limits on all logs.

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -9837,7 +9837,7 @@
 			repositoryURL = "https://github.com/element-hq/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 26.02.10;
+				version = 26.02.13;
 			};
 		};
 		701C7BEF8F70F7A83E852DCC /* XCRemoteSwiftPackageReference "GZIP" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/matrix-rust-components-swift",
       "state" : {
-        "revision" : "b4a065799c4b73d3c7c345ab13e701344568bd91",
-        "version" : "26.2.10"
+        "revision" : "113131fa5f779a22319b61525c3126ba63045fa0",
+        "version" : "26.2.13"
       }
     },
     {

--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -134,7 +134,6 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
         bugReportService = BugReportService(rageshakeURLPublisher: appSettings.bugReportRageshakeURL.publisher,
                                             applicationID: appSettings.bugReportApplicationID,
                                             sdkGitSHA: sdkGitSha(),
-                                            maxUploadSize: appSettings.bugReportMaxUploadSize,
                                             appHooks: appHooks)
         
         Self.setupSentry(bugReportService: bugReportService, appSettings: appSettings)

--- a/ElementX/Sources/Application/Settings/AppSettings.swift
+++ b/ElementX/Sources/Application/Settings/AppSettings.swift
@@ -313,8 +313,6 @@ final class AppSettings {
     let bugReportSentryRustURL: URL? = Secrets.sentryRustDSN.map { URL(string: $0)! } // swiftlint:disable:this force_unwrapping
     /// The name allocated by the bug report server
     private(set) var bugReportApplicationID = "element-x-ios"
-    /// The maximum size of the upload request. Default value is just below CloudFlare's max request size.
-    let bugReportMaxUploadSize = 50 * 1024 * 1024
     
     // MARK: - Analytics
     

--- a/ElementX/Sources/Application/TargetConfiguration.swift
+++ b/ElementX/Sources/Application/TargetConfiguration.swift
@@ -25,10 +25,12 @@ enum Target: String {
         }
     }
     
-    var logFilePrefix: String? {
+    var logFilePrefix: String {
         switch self {
-        case .mainApp: nil
-        default: rawValue
+        case .mainApp:
+            "console"
+        default:
+            rawValue
         }
     }
     

--- a/UnitTests/Sources/BugReportServiceTests.swift
+++ b/UnitTests/Sources/BugReportServiceTests.swift
@@ -55,7 +55,6 @@ class BugReportServiceTests: XCTestCase {
         let service = BugReportService(rageshakeURLPublisher: urlPublisher.asCurrentValuePublisher(),
                                        applicationID: "mock_app_id",
                                        sdkGitSHA: "1234",
-                                       maxUploadSize: ServiceLocator.shared.settings.bugReportMaxUploadSize,
                                        session: .mock,
                                        appHooks: AppHooks())
         XCTAssertTrue(service.isEnabled)
@@ -67,7 +66,6 @@ class BugReportServiceTests: XCTestCase {
         let service = BugReportService(rageshakeURLPublisher: urlPublisher.asCurrentValuePublisher(),
                                        applicationID: "mock_app_id",
                                        sdkGitSHA: "1234",
-                                       maxUploadSize: ServiceLocator.shared.settings.bugReportMaxUploadSize,
                                        session: .mock,
                                        appHooks: AppHooks())
         XCTAssertFalse(service.isEnabled)
@@ -79,7 +77,6 @@ class BugReportServiceTests: XCTestCase {
         let service = BugReportService(rageshakeURLPublisher: urlPublisher.asCurrentValuePublisher(),
                                        applicationID: "mock_app_id",
                                        sdkGitSHA: "1234",
-                                       maxUploadSize: ServiceLocator.shared.settings.bugReportMaxUploadSize,
                                        session: .mock,
                                        appHooks: AppHooks())
 
@@ -107,7 +104,6 @@ class BugReportServiceTests: XCTestCase {
         let service = BugReportService(rageshakeURLPublisher: appSettings.bugReportRageshakeURL.publisher,
                                        applicationID: "mock_app_id",
                                        sdkGitSHA: "1234",
-                                       maxUploadSize: ServiceLocator.shared.settings.bugReportMaxUploadSize,
                                        session: .mock,
                                        appHooks: AppHooks())
         XCTAssertTrue(service.isEnabled)
@@ -138,31 +134,6 @@ class BugReportServiceTests: XCTestCase {
         let defaultConfigurationResponse = try await service.submitBugReport(bugReport, progressListener: progressSubject).get()
         
         XCTAssertEqual(defaultConfigurationResponse.reportURL, initialURL.absoluteString.replacingOccurrences(of: "submit", with: "123"))
-    }
-    
-    func testLogsMaxSize() {
-        // Given a new set of logs
-        var logs = BugReportService.Logs(maxFileSize: 1000)
-        XCTAssertEqual(logs.zippedSize, 0)
-        XCTAssertEqual(logs.originalSize, 0)
-        XCTAssertTrue(logs.files.isEmpty)
-        
-        // When adding new files within the size limit
-        logs.appendFile(at: .homeDirectory, zippedSize: 250, originalSize: 1000)
-        logs.appendFile(at: .picturesDirectory, zippedSize: 500, originalSize: 2000)
-        
-        // Then the logs should be included
-        XCTAssertEqual(logs.zippedSize, 750)
-        XCTAssertEqual(logs.originalSize, 3000)
-        XCTAssertEqual(logs.files, [.homeDirectory, .picturesDirectory])
-        
-        // When adding a new file larger that will exceed the size limit
-        logs.appendFile(at: .homeDirectory, zippedSize: 500, originalSize: 2000)
-        
-        // Then the files shouldn't be included.
-        XCTAssertEqual(logs.zippedSize, 750)
-        XCTAssertEqual(logs.originalSize, 3000)
-        XCTAssertEqual(logs.files, [.homeDirectory, .picturesDirectory])
     }
 }
 

--- a/UnitTests/Sources/LoggingTests.swift
+++ b/UnitTests/Sources/LoggingTests.swift
@@ -19,8 +19,9 @@ class LoggingTests: XCTestCase {
         Tracing.logsDirectoryOverride = nil
         try reloadTracingFileWriter(configuration: .init(path: URL.appGroupLogsDirectory.path(percentEncoded: false),
                                                          filePrefix: "console-tests",
-                                                         fileSuffix: "log",
-                                                         maxFiles: 100))
+                                                         fileSuffix: ".log",
+                                                         maxTotalSizeBytes: 1000,
+                                                         maxAgeSeconds: 1000))
     }
     
     func testFileLogging() throws {
@@ -343,8 +344,9 @@ class LoggingTests: XCTestCase {
         if redirectTracingFileWriter {
             try reloadTracingFileWriter(configuration: .init(path: testDirectory.path(percentEncoded: false),
                                                              filePrefix: "console",
-                                                             fileSuffix: "log",
-                                                             maxFiles: 100))
+                                                             fileSuffix: ".log",
+                                                             maxTotalSizeBytes: 1000,
+                                                             maxAgeSeconds: 1000))
         }
     }
 }

--- a/project.yml
+++ b/project.yml
@@ -73,7 +73,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/element-hq/matrix-rust-components-swift
-    exactVersion: 26.02.10
+    exactVersion: 26.02.13
     # path: ../matrix-rust-sdk
   Compound:
     path: compound-ios


### PR DESCRIPTION
Set that 100Mb and a week and remove previous rageshake uploading checks as they are no longer required.