### PR TITLE
Make `.invited` the default history visibility of a dm

### DIFF
--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -516,7 +516,8 @@ class ClientProxy: ClientProxyProtocol {
                                                   preset: .trustedPrivateChat,
                                                   invite: [userID],
                                                   avatar: nil,
-                                                  powerLevelContentOverride: Self.roomCreationPowerLevelOverrides)
+                                                  powerLevelContentOverride: Self.roomCreationPowerLevelOverrides,
+                                                  historyVisibilityOverride: .invited)
             let roomID = try await client.createRoom(request: parameters)
             
             await waitForRoomToSync(roomID: roomID)


### PR DESCRIPTION
fixes #5047 