### PR TITLE
Change Signposter 'Homeserver' performance tag to 'homeserver'

### DIFF
--- a/ElementX/Sources/Services/Analytics/Signposter.swift
+++ b/ElementX/Sources/Services/Analytics/Signposter.swift
@@ -51,7 +51,7 @@ class Signposter {
     }
     
     enum TagName: String {
-        case homeserver = "homeserver"
+        case homeserver
     }
     
     // MARK: - Transactions


### PR DESCRIPTION
The spec was misleading. We fixed it in https://github.com/element-hq/element-meta/pull/3132.