### PR TITLE
Disable video on call join and update call button icon

### DIFF
--- a/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
@@ -157,6 +157,9 @@ class CallScreenViewModel: CallScreenViewModelType, CallScreenViewModelProtocol 
            decodedMessage.hasLoaded {
             // This means that the call room was joined succesfully, we can stop the timeout task
             timeoutTask = nil
+            if !state.isGenericCallLink {
+                await setVideoEnabled(false)
+            }
         }
         await widgetDriver.handleMessage(message)
     }
@@ -254,6 +257,14 @@ class CallScreenViewModel: CallScreenViewModelType, CallScreenViewModelProtocol 
         let message = ElementCallWidgetMessage(direction: .toWidget,
                                                action: .mediaState,
                                                data: .init(audioEnabled: enabled),
+                                               widgetId: widgetDriver.widgetID)
+        await postMessageToWidget(message)
+    }
+
+    private func setVideoEnabled(_ enabled: Bool) async {
+        let message = ElementCallWidgetMessage(direction: .toWidget,
+                                               action: .mediaState,
+                                               data: .init(videoEnabled: enabled),
                                                widgetId: widgetDriver.widgetID)
         await postMessageToWidget(message)
     }

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
@@ -183,7 +183,7 @@ struct RoomScreen: View {
             Button {
                 context.send(viewAction: .displayCall)
             } label: {
-                CompoundIcon(\.videoCallSolid)
+                CompoundIcon(\.voiceCallSolid)
             }
             .accessibilityLabel(L10n.a11yStartCall)
             .accessibilityIdentifier(A11yIdentifiers.roomScreen.joinCall)


### PR DESCRIPTION
### Changes

- **CallScreenViewModel**: Automatically disable video when joining a non-generic call link by sending a `mediaState` message to the widget with `videoEnabled: false`
- **RoomScreen**: Change the call button icon from `videoCallSolid` to `voiceCallSolid` to better reflect the default call behavior

### Motivation

These changes ensure that video is disabled by default when users join calls (except for generic call links), and update the UI to accurately represent that calls start in voice-only mode.

### Testing

- Existing call flow tests should cover the new `setVideoEnabled` method
- Icon change is a simple UI update with no functional impact

### Checklist

- [ ] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.

https://claude.ai/code/session_01CqEb8iPEFgYkzihWPdaCYm