### PR TITLE
Fix notification and call delivery reliability

### DIFF
--- a/ElementX/Sources/Services/ElementCall/ElementCallService.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallService.swift
@@ -194,7 +194,8 @@ class ElementCallService: NSObject, ElementCallServiceProtocol, PKPushRegistryDe
             return
         }
         
-        let ringDuration: Duration = .seconds(min(expirationDate.timeIntervalSince1970 - nowDate.timeIntervalSince1970, 90))
+        let rawDuration = expirationDate.timeIntervalSince1970 - nowDate.timeIntervalSince1970
+        let ringDuration: Duration = .seconds(min(max(rawDuration, 15), 90))
         
         let roomDisplayName = payload.dictionaryPayload[ElementCallServiceNotificationKey.roomDisplayName.rawValue] as? String
         
@@ -267,12 +268,13 @@ class ElementCallService: NSObject, ElementCallServiceProtocol, PKPushRegistryDe
         
         // And delay ending the call so that the app has enough time
         // to get deeplinked into
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+            guard let self else { return }
             // Then end the and call rely on `setupCallSession` to create a new one
             provider.reportCall(with: incomingCallID.callKitID, endedAt: nil, reason: .remoteEnded)
-            
-            self.actionsSubject.send(.startCall(roomID: incomingCallID.roomID))
-            self.endUnansweredCallTask?.cancel()
+
+            actionsSubject.send(.startCall(roomID: incomingCallID.roomID))
+            endUnansweredCallTask?.cancel()
         }
     }
     
@@ -412,9 +414,11 @@ class ElementCallService: NSObject, ElementCallServiceProtocol, PKPushRegistryDe
     }
     
     private func reportEndedCall(incomingCallID: CallID, reason: CXCallEndedReason) {
+        incomingCallRoomInfoCancellable = nil
         declineListenerHandle?.cancel()
         declineListenerHandle = nil
         endUnansweredCallTask?.cancel()
+        self.incomingCallID = nil
         callProvider.reportCall(with: incomingCallID.callKitID, endedAt: nil, reason: reason)
     }
 }

--- a/ElementX/Sources/Services/ElementCall/ElementCallServiceConstants.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallServiceConstants.swift
@@ -18,4 +18,4 @@ enum ElementCallServiceNotificationKey: String {
     case expirationDate
 }
 
-let ElementCallServiceNotificationDiscardDelta = 15.0
+let ElementCallServiceNotificationDiscardDelta = 25.0

--- a/NSE/Sources/NotificationHandler.swift
+++ b/NSE/Sources/NotificationHandler.swift
@@ -182,10 +182,12 @@ class NotificationHandler {
         // Check to see if a call is still ongoing
         if let room = userSession.roomForIdentifier(roomID) { // Try to get call details from the room info
             if !room.hasActiveRoomCall() { // If I don't have an active call wait a bit and make sure
+                var hasResumed = false
                 let expiringTask = ExpiringTaskRunner {
                     await withCheckedContinuation { [weak self] continuation in
                         self?.roomInfoObservationToken = room.subscribeToRoomInfoUpdates(listener: SDKListener { info in
-                            if info.hasRoomCall {
+                            if info.hasRoomCall, !hasResumed {
+                                hasResumed = true
                                 MXLog.info("Received room info update and the room has an active call now.")
                                 continuation.resume()
                             } else {

--- a/NSE/Sources/NotificationServiceExtension.swift
+++ b/NSE/Sources/NotificationServiceExtension.swift
@@ -164,6 +164,7 @@ class NotificationServiceExtension: UNNotificationServiceExtension {
             await notificationHandler?.processEvent(eventID, roomID: roomID)
         } catch {
             MXLog.error("Failed creating user session with error: \(error)")
+            contentHandler(mutableContent)
         }
     }
     


### PR DESCRIPTION
Several bugs caused push notifications and incoming calls to be silently dropped or immediately dismissed under common real-world conditions:

- NSE: guard `withCheckedContinuation` in `handleCallNotification` against multiple resumes when rapid room-info updates arrive with hasRoomCall=true (undefined behaviour / crash in debug builds)

- NSE: call `contentHandler(mutableContent)` immediately when `NSEUserSession` init throws, so the notification is delivered right away instead of waiting up to 30 s for the iOS extension timeout

- ElementCallService: guarantee a minimum ring duration of 15 s so that calls whose expiration date was reached during NSE processing still appear on-screen rather than vanishing the instant CallKit shows them

- ElementCallServiceConstants: raise `ElementCallServiceNotificationDiscardDelta` from 15 s to 25 s — NSE session creation can take 10-20 s on a loaded device, leaving no margin before valid calls were downgraded to plain notifications

- ElementCallService: use `[weak self]` in the `asyncAfter` closure of `CXAnswerCallAction` to avoid a 1-second retain cycle

- ElementCallService: in `reportEndedCall`, cancel `incomingCallRoomInfoCancellable` and nil out `incomingCallID` so that duplicate `reportCall` invocations and stale state after a remote cancellation / answer-elsewhere are prevented

https://claude.ai/code/session_018tw6cP7FTXXUSF5YiPSEAV

### Pull Request Checklist

- [ ] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
