### PR TITLE
Fix key storage if it's broken

### DIFF
--- a/ElementX/Sources/Services/SecureBackup/SecureBackupController.swift
+++ b/ElementX/Sources/Services/SecureBackup/SecureBackupController.swift
@@ -147,7 +147,7 @@ class SecureBackupController: SecureBackupControllerProtocol {
     func confirmRecoveryKey(_ key: String) async -> Result<Void, SecureBackupControllerError> {
         do {
             MXLog.info("Confirming recovery key")
-            try await encryption.recover(recoveryKey: key)
+            try await encryption.recoverAndFixBackup(recoveryKey: key)
             return .success(())
         } catch {
             MXLog.info("Failed confirming recovery key with error: \(error)")


### PR DESCRIPTION
When recovering from Recovery, use the new `recoverAndFixBackup` method that fixes key storage if the public and private keys are out of sync.

Part of https://github.com/element-hq/element-meta/issues/3059
Depends on https://github.com/matrix-org/matrix-rust-sdk/pull/6252

Note: I don't have an iOS environment in which to build and test this, so please treat with caution.

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
