### PR TITLE
Add default sound to APNS payload for eventIdOnly pushes

### DIFF
--- a/ElementX/Sources/Services/Notification/Manager/APNSPayload.swift
+++ b/ElementX/Sources/Services/Notification/Manager/APNSPayload.swift
@@ -21,10 +21,12 @@ struct APSAlert: Encodable {
 struct APSInfo: Encodable {
     let mutableContent: Int
     let alert: APSAlert
+    let sound: String?
 
     enum CodingKeys: String, CodingKey {
         case mutableContent = "mutable-content"
         case alert
+        case sound
     }
 }
 

--- a/ElementX/Sources/Services/Notification/Manager/NotificationManager.swift
+++ b/ElementX/Sources/Services/Notification/Manager/NotificationManager.swift
@@ -166,7 +166,8 @@ final class NotificationManager: NSObject, NotificationManagerProtocol {
         do {
             let defaultPayload = APNSPayload(aps: APSInfo(mutableContent: 1,
                                                           alert: APSAlert(locKey: "Notification",
-                                                                          locArgs: [])),
+                                                                          locArgs: []),
+                                                          sound: "default"),
                                              pusherNotificationClientIdentifier: clientProxy.pusherNotificationClientIdentifier)
 
             let configuration = try await PusherConfiguration(identifiers: .init(pushkey: deviceToken.base64EncodedString(),

--- a/UnitTests/Sources/NotificationManager/NotificationManagerTests.swift
+++ b/UnitTests/Sources/NotificationManager/NotificationManagerTests.swift
@@ -92,7 +92,8 @@ final class NotificationManagerTests {
         #expect(data.format == .eventIdOnly)
         let defaultPayload = APNSPayload(aps: APSInfo(mutableContent: 1,
                                                       alert: APSAlert(locKey: "Notification",
-                                                                      locArgs: [])),
+                                                                      locArgs: []),
+                                                      sound: "default"),
                                          pusherNotificationClientIdentifier: nil)
         #expect(try data.defaultPayload == (defaultPayload.toJsonString()))
     }


### PR DESCRIPTION
*vibecoded pr | i do not know what i'm doing exactly*
following the issue https://github.com/element-hq/element-x-ios/issues/5132
and their counterpart on continuwuity
https://forgejo.ellis.link/continuwuation/continuwuity/issues/1533
https://forgejo.ellis.link/continuwuation/continuwuity/issues/1424

This PR ensures that incoming push notifications utilizing the eventIdOnly format are no longer silent by explicitly including the sound: "default" key in the APNS payload during pusher registration.

Previously, the APSInfo structure omitted the sound property, causing iOS to treat these background pushes as silent notifications, especially since some homeservers (continuwuity) discard the tweaks field when the event_id_only flag is used.