### PR TITLE
Remove check for allowed provider when signing in using QR code

### DIFF
--- a/ElementX/Sources/Services/Authentication/AuthenticationService.swift
+++ b/ElementX/Sources/Services/Authentication/AuthenticationService.swift
@@ -179,20 +179,18 @@ class AuthenticationService: AuthenticationServiceProtocol {
             return progressSubject.asCurrentValuePublisher()
         }
         
-        // At some stage the SDK will have a `qrCodeData.intent` which we should check before continuing here.
-        // Note the equivalent check will also happen for linking a device by QR in the LinkNewDeviceService.
+        // n.b. We rely on the SDK checking that the intent of the QR is suitable for us to login with.
         
-        guard let scannedServerName = qrData.serverName() else {
+        // Future versions of the QR should always give us the baseUrl
+        guard let scannedServerNameOrBaseUrl = qrData.baseUrl() ?? qrData.serverName() else {
+            // With the older version of QR we treat the presence of serverName as meaning that the other device
+            // is not signed in.
             MXLog.error("The QR code is from a device that is not yet signed in.")
             progressSubject.send(completion: .failure(.qrCodeError(.deviceNotSignedIn)))
             return progressSubject.asCurrentValuePublisher()
         }
-        
-        if !appSettings.allowOtherAccountProviders, !appSettings.accountProviders.contains(scannedServerName) {
-            MXLog.error("The scanned device's server is not allowed: \(scannedServerName)")
-            progressSubject.send(completion: .failure(.qrCodeError(.providerNotAllowed(scannedProvider: scannedServerName, allowedProviders: appSettings.accountProviders))))
-            return progressSubject.asCurrentValuePublisher()
-        }
+
+        // n.b. We deliberatley don't check whether the received server is in our appSettings.accountProviders
         
         let listener = SDKListener { progress in
             guard let progress = QRLoginProgress(rustProgress: progress) else { return }
@@ -201,7 +199,7 @@ class AuthenticationService: AuthenticationServiceProtocol {
         
         Task {
             do {
-                let client = try await makeClient(homeserverAddress: scannedServerName)
+                let client = try await makeClient(homeserverAddress: scannedServerNameOrBaseUrl)
                 let qrCodeHandler = client.newLoginWithQrCodeHandler(oidcConfiguration: appSettings.oidcConfiguration.rustValue)
                 try await qrCodeHandler.scan(qrCodeData: qrData, progressListener: listener)
                 


### PR DESCRIPTION
This removes the check for whether the server name is allowed or not. This is based on discussion with @mxandreas and @pixlwave.

It also adds support for the QR code containing a base URL as well as a server name which will be required for the 2025 version of MSC4108.

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
