### PR TITLE
`RoomList::entriesWithDynamicAdaptersWith` has been removed

### DIFF
--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
@@ -90,12 +90,11 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
         self.roomList = roomList
         
         do {
-            listUpdatesSubscriptionResult = roomList.entriesWithDynamicAdaptersWith(pageSize: UInt32(roomListPageSize),
-                                                                                    enableLatestEventSorter: true,
-                                                                                    listener: SDKListener { [weak self] updates in
-                                                                                        guard let self else { return }
-                                                                                        diffsPublisher.send(updates)
-                                                                                    })
+            listUpdatesSubscriptionResult = roomList.entriesWithDynamicAdapters(pageSize: UInt32(roomListPageSize),
+                                                                                listener: SDKListener { [weak self] updates in
+                                                                                     guard let self else { return }
+                                                                                      diffsPublisher.send(updates)
+                                                                                })
             
             // Forces the listener above to be called with the current state
             setFilter(.all(filters: []))


### PR DESCRIPTION
This patch replaces `entriesWithDynamicAdaptersWith` by `entriesWithDynamicAdapters`. The latest event sorter is always enabled now.

See https://github.com/matrix-org/matrix-rust-sdk/pull/6309.

Note: the Rust SDK must be updated.

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
