### PR TITLE
Change icon size and container in message bubbles

### DIFF
--- a/ElementX/Sources/Screens/Timeline/View/Replies/TimelineReplyView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Replies/TimelineReplyView.swift
@@ -175,7 +175,7 @@ struct TimelineReplyView: View {
                         .aspectRatio(contentMode: .fit)
                         .padding(8.0)
                 case .icon(let keyPath):
-                    CompoundIcon(keyPath, size: .small, relativeTo: .body)
+                    CompoundIcon(keyPath, size: .medium, relativeTo: .body)
                 }
             }
         }

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/FileRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/FileRoomTimelineView.swift
@@ -90,9 +90,9 @@ struct MediaFileRoomTimelineContent: View {
             .foregroundStyle(.compound.textPrimary)
             .lineLimit(2)
         } icon: {
-            CompoundIcon(icon, size: .xSmall, relativeTo: .body)
+            CompoundIcon(icon, size: .medium, relativeTo: .body)
                 .foregroundColor(.compound.iconPrimary)
-                .scaledPadding(8)
+                .scaledPadding(6)
                 .background(.compound.iconOnSolidPrimary,
                             in: RoundedRectangle(cornerRadius: 4, style: .continuous))
         }


### PR DESCRIPTION
- Container size = 36x36px
- Icon size = 24x24px

### Pull Request Checklist

- [ ] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
