### PR TITLE
Use single typeText call to speed up tests execution

### DIFF
--- a/ElementX/Sources/Other/Extensions/XCUIElement.swift
+++ b/ElementX/Sources/Other/Extensions/XCUIElement.swift
@@ -23,9 +23,8 @@ extension XCUIElement {
         let deleteString = String(repeating: XCUIKeyboardKey.delete.rawValue, count: currentValue.count)
         typeText(deleteString)
         
-        for character in text {
-            typeText(String(character))
-        }
+        // Note: In the past, we had to type chars one by one to avoid CI flakiness
+        typeText(text)
     }
     
     func tap(_ point: UnitPoint) {


### PR DESCRIPTION
## Summary
- Replace character-by-character typing with a single typeText call in clearAndTypeText
- Keep note documenting prior CI flakiness context

## Testing
- The CI will tell --> It fails but for already existing reasons.
