### PR TITLE
WIP: Add server login integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -79,6 +79,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - server: default
+            host_secret: INTEGRATION_TESTS_HOST
+            username_secret: INTEGRATION_TESTS_USERNAME
+            password_secret: INTEGRATION_TESTS_PASSWORD
           - server: lts
             host_secret: INTEGRATION_TESTS_LTS_HOST
             username_secret: INTEGRATION_TESTS_LTS_USERNAME

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -70,10 +70,56 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: integrationtests
 
+  build_server_login_tests:
+    name: Build for Server Login Tests
+    runs-on: macos-26
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Cache Swift tools build
+        uses: actions/cache@v4
+        with:
+          path: .build
+          key: tools-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
+          restore-keys: tools-${{ runner.os }}-
+
+      - name: Setup environment
+        run:
+          source ci_scripts/ci_common.sh && setup_github_actions_environment
+
+      - name: Build tests
+        run: |
+          set -o pipefail
+          xcodebuild build-for-testing \
+            -scheme IntegrationTests \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.1' \
+            -derivedDataPath DerivedData \
+            -enableCodeCoverage NO \
+            | xcbeautify
+
+      - name: Archive build products
+        run: |
+          cd DerivedData/Build/Products
+          tar -czf build-products.tar.gz *.xctestrun Debug-iphonesimulator/
+
+      - name: Upload build products
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: server-login-build-products
+          path: DerivedData/Build/Products/build-products.tar.gz
+          retention-days: 1
+
   server_login_tests:
     name: Server Login Tests (${{ matrix.server }})
     runs-on: macos-26
-    timeout-minutes: 45
+    timeout-minutes: 30
+    needs: build_server_login_tests
 
     strategy:
       fail-fast: false
@@ -101,17 +147,60 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          fetch-depth: 1
+
+      - name: Cache Swift tools build
+        uses: actions/cache@v4
+        with:
+          path: .build
+          key: tools-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
+          restore-keys: tools-${{ runner.os }}-
 
       - name: Setup environment
         run:
           source ci_scripts/ci_common.sh && setup_github_actions_environment
 
+      - name: Download build products
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: server-login-build-products
+          path: DerivedData/Build/Products
+
+      - name: Extract build products
+        run: |
+          cd DerivedData/Build/Products
+          tar -xzf build-products.tar.gz
+
+      - name: Delete old log files
+        run: find '/Users/Shared' -name 'console*' -delete 2>/dev/null || true
+
       - name: Run tests
-        run: swift run -q tools ci server-login-tests
+        run: |
+          set -o pipefail
+          xcodebuild test-without-building \
+            -xctestrun DerivedData/Build/Products/*.xctestrun \
+            -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.1' \
+            -only-testing:IntegrationTests/ServerLoginTests \
+            -resultBundlePath test_output/IntegrationTests.xcresult \
+            | xcbeautify
         env:
           INTEGRATION_TESTS_HOST: ${{ secrets[matrix.host_secret] }}
           INTEGRATION_TESTS_USERNAME: ${{ secrets[matrix.username_secret] }}
           INTEGRATION_TESTS_PASSWORD: ${{ secrets[matrix.password_secret] }}
+
+      - name: Check logs are set to trace level
+        run: |
+          if ! grep ' TRACE ' /Users/Shared -qR 2>/dev/null; then
+            echo "❌ Logs are not set to the trace level."
+            exit 1
+          fi
+          echo "✅ Trace level logging verified."
+
+      - name: Zip test results
+        if: always()
+        run: |
+          cd test_output
+          zip -r IntegrationTests.xcresult.zip IntegrationTests.xcresult
 
       - name: Archive artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -13,6 +13,7 @@ jobs:
     name: Integration Tests
     runs-on: macos-26
     timeout-minutes: 45
+    needs: build
 
     concurrency:
       # Only allow a single run of this workflow on each branch, automatically cancelling older runs.
@@ -23,13 +24,34 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          fetch-depth: 1
+
+      - name: Cache Swift tools build
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: .build
+          key: tools-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
+          restore-keys: tools-${{ runner.os }}-
 
       - name: Setup environment
         run:
           source ci_scripts/ci_common.sh && setup_github_actions_environment
 
+      - name: Download build products
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: integration-tests-build-products
+          path: DerivedData/Build/Products
+
+      - name: Extract build products
+        run: |
+          cd DerivedData/Build/Products
+          tar -xzf build-products.tar.gz
+
       - name: Run tests
-        run: swift run -q tools ci integration-tests
+        run: |
+          XCTESTRUN=$(ls DerivedData/Build/Products/*.xctestrun)
+          swift run -q tools ci integration-tests --xctestrun-path "$XCTESTRUN"
         env:
           INTEGRATION_TESTS_HOST: ${{ secrets.INTEGRATION_TESTS_HOST }}
           INTEGRATION_TESTS_USERNAME: ${{ secrets.INTEGRATION_TESTS_USERNAME }}
@@ -70,8 +92,8 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: integrationtests
 
-  build_server_login_tests:
-    name: Build for Server Login Tests
+  build:
+    name: Build Integration Tests
     runs-on: macos-26
     timeout-minutes: 30
 
@@ -93,15 +115,7 @@ jobs:
           source ci_scripts/ci_common.sh && setup_github_actions_environment
 
       - name: Build tests
-        run: |
-          set -o pipefail
-          xcodebuild build-for-testing \
-            -scheme IntegrationTests \
-            -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.1' \
-            -derivedDataPath DerivedData \
-            -enableCodeCoverage NO \
-            | xcbeautify
+        run: swift run -q tools ci build --scheme IntegrationTests
 
       - name: Archive build products
         run: |
@@ -111,7 +125,7 @@ jobs:
       - name: Upload build products
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: server-login-build-products
+          name: integration-tests-build-products
           path: DerivedData/Build/Products/build-products.tar.gz
           retention-days: 1
 
@@ -120,7 +134,7 @@ jobs:
     runs-on: macos-26
     environment: integration-tests
     timeout-minutes: 30
-    needs: build_server_login_tests
+    needs: build
 
     strategy:
       fail-fast: false
@@ -164,7 +178,7 @@ jobs:
       - name: Download build products
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
-          name: server-login-build-products
+          name: integration-tests-build-products
           path: DerivedData/Build/Products
 
       - name: Extract build products
@@ -172,36 +186,14 @@ jobs:
           cd DerivedData/Build/Products
           tar -xzf build-products.tar.gz
 
-      - name: Delete old log files
-        run: find '/Users/Shared' -name 'console*' -delete 2>/dev/null || true
-
       - name: Run tests
         run: |
-          set -o pipefail
-          xcodebuild test-without-building \
-            -xctestrun DerivedData/Build/Products/*.xctestrun \
-            -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.1' \
-            -only-testing:IntegrationTests/ServerLoginTests \
-            -resultBundlePath test_output/IntegrationTests.xcresult \
-            | xcbeautify
+          XCTESTRUN=$(ls DerivedData/Build/Products/*.xctestrun)
+          swift run -q tools ci server-login-tests --xctestrun-path "$XCTESTRUN"
         env:
           INTEGRATION_TESTS_HOST: ${{ secrets[matrix.host_secret] }}
           INTEGRATION_TESTS_USERNAME: ${{ secrets[matrix.username_secret] }}
           INTEGRATION_TESTS_PASSWORD: ${{ secrets[matrix.password_secret] }}
-
-      - name: Check logs are set to trace level
-        run: |
-          if ! grep ' TRACE ' /Users/Shared -qR 2>/dev/null; then
-            echo "❌ Logs are not set to the trace level."
-            exit 1
-          fi
-          echo "✅ Trace level logging verified."
-
-      - name: Zip test results
-        if: always()
-        run: |
-          cd test_output
-          zip -r IntegrationTests.xcresult.zip IntegrationTests.xcresult
 
       - name: Archive artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -82,7 +82,7 @@ jobs:
           fetch-depth: 1
 
       - name: Cache Swift tools build
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .build
           key: tools-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
@@ -118,6 +118,7 @@ jobs:
   server_login_tests:
     name: Server Login Tests (${{ matrix.server }})
     runs-on: macos-26
+    environment: integration-tests
     timeout-minutes: 30
     needs: build_server_login_tests
 
@@ -150,7 +151,7 @@ jobs:
           fetch-depth: 1
 
       - name: Cache Swift tools build
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .build
           key: tools-${{ runner.os }}-${{ hashFiles('Package.resolved') }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -69,3 +69,52 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: integrationtests
+
+  server_login_tests:
+    name: Server Login Tests (${{ matrix.server }})
+    runs-on: macos-26
+    timeout-minutes: 45
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - server: lts
+            host_secret: INTEGRATION_TESTS_LTS_HOST
+            username_secret: INTEGRATION_TESTS_LTS_USERNAME
+            password_secret: INTEGRATION_TESTS_LTS_PASSWORD
+          - server: lts-1
+            host_secret: INTEGRATION_TESTS_LTS_1_HOST
+            username_secret: INTEGRATION_TESTS_LTS_1_USERNAME
+            password_secret: INTEGRATION_TESTS_LTS_1_PASSWORD
+
+    concurrency:
+      # Only allow a single run of this workflow on each branch, automatically cancelling older runs.
+      group: server-login-tests-${{ matrix.server }}-${{ github.head_ref }}
+      cancel-in-progress: false
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup environment
+        run:
+          source ci_scripts/ci_common.sh && setup_github_actions_environment
+
+      - name: Run tests
+        run: swift run -q tools ci server-login-tests
+        env:
+          INTEGRATION_TESTS_HOST: ${{ secrets[matrix.host_secret] }}
+          INTEGRATION_TESTS_USERNAME: ${{ secrets[matrix.username_secret] }}
+          INTEGRATION_TESTS_PASSWORD: ${{ secrets[matrix.password_secret] }}
+
+      - name: Archive artifacts
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        # We only care about artefacts if the tests fail
+        if: failure()
+        with:
+          name: Results (${{ matrix.server }})
+          path: test_output/IntegrationTests.xcresult.zip
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,6 +1,6 @@
 --swiftversion 5.6
 
---exclude **/Sources/**/Generated,vendor,**/Package.swift,Secrets/**
+--exclude **/Sources/**/Generated,vendor,**/Package.swift,Secrets/**,DerivedData
 
 --disable wrapMultiLineStatementBraces
 --disable hoistPatternLet

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -312,6 +312,7 @@
 		3467FEE8210D301FF1B77001 /* UserIndicatorControllerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7893780A1FD6E3F38B3E9049 /* UserIndicatorControllerMock.swift */; };
 		34ADC506C929D10B138EBA51 /* AdvancedSettingsScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C58159916ABD7F454CE689 /* AdvancedSettingsScreenCoordinator.swift */; };
 		34C752A73717C691582DC6C7 /* UnsupportedRoomTimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B8500C152BC59445647DA8 /* UnsupportedRoomTimelineItem.swift */; };
+		34DBE24749DF3FA946C2EE11 /* ServerLoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503C375DC6A10DC236E8CC16 /* ServerLoginTests.swift */; };
 		34F1261CEF6D6A00D559B520 /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFD5EB0B0EEA4549FB49784 /* SettingsScreen.swift */; };
 		352C439BE0F75E101EF11FB1 /* RoomScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2886615BEBAE33A0AA4D5F8 /* RoomScreenModels.swift */; };
 		355B11D08CE0CEF97A813236 /* AppRoutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A9E3FBE8A66B5A17AD7F74 /* AppRoutes.swift */; };
@@ -2037,6 +2038,7 @@
 		4FCB2126C091EEF2454B4D56 /* RoomFlowCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomFlowCoordinatorTests.swift; sourceTree = "<group>"; };
 		4FDD775CFD72DD2D3C8A8390 /* NotificationSettingsProxyProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsProxyProtocol.swift; sourceTree = "<group>"; };
 		502F986D57158674172C58E3 /* AppLockSetupSettingsScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockSetupSettingsScreenModels.swift; sourceTree = "<group>"; };
+		503C375DC6A10DC236E8CC16 /* ServerLoginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerLoginTests.swift; sourceTree = "<group>"; };
 		505208F28007C0FEC14E1FF0 /* HomeScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenViewModelTests.swift; sourceTree = "<group>"; };
 		505ADA084C0B38A0C4AD2574 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		5098DA7799946A61E34A2373 /* FileRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileRoomTimelineItem.swift; sourceTree = "<group>"; };
@@ -4371,6 +4373,7 @@
 			children = (
 				D33116993D54FADC0C721C1F /* Application.swift */,
 				D1BC84BA0AF11C2128D58ABD /* Common.swift */,
+				503C375DC6A10DC236E8CC16 /* ServerLoginTests.swift */,
 				21DD8599815136EFF5B73F38 /* UserFlowTests.swift */,
 			);
 			path = Sources;
@@ -9051,6 +9054,7 @@
 				1702981A8085BE4FB0EC001B /* Application.swift in Sources */,
 				388D39ED9FE1122EA6D76BF2 /* Common.swift in Sources */,
 				A439B456D0761D6541745CC3 /* NSRegularExpresion.swift in Sources */,
+				34DBE24749DF3FA946C2EE11 /* ServerLoginTests.swift in Sources */,
 				32B7891D937377A59606EDFC /* UserFlowTests.swift in Sources */,
 				B444F9C184A377C1B481F07F /* XCUIElement.swift in Sources */,
 			);

--- a/IntegrationTests/Sources/Common.swift
+++ b/IntegrationTests/Sources/Common.swift
@@ -75,7 +75,35 @@ extension XCUIApplication {
         XCTAssertTrue(webAuthenticationView.waitForExistence(timeout: 10.0))
         webAuthenticationView.tap(.top) // Tap the web view to properly focus the app again.
         
-        let webUsernameTextField = textFields["Username or Email"]
+        // The user may already be authenticated on MAS; sign them out.
+        // The button label varies by MAS version: "Sign out" or "Use another account".
+        let masLogoutPredicate = NSPredicate(format: "label == 'Sign out' OR label == 'Use another account'")
+        let masLogoutButton = webAuthenticationView.buttons.matching(masLogoutPredicate).firstMatch
+        if masLogoutButton.waitForExistence(timeout: 2.0) {
+            masLogoutButton.tap(.center)
+        }
+        
+        // Detect whether the server uses a Keycloak identity provider.
+        let keycloakLoginLink = webAuthenticationView.links["Continue with Keycloak"]
+        let usernameFieldLabel: String
+        let submitButtonLabel: String
+        if keycloakLoginLink.waitForExistence(timeout: 5.0) {
+            keycloakLoginLink.tap(.center)
+            
+            // Keycloak may also insist on an already-authenticated user; sign out if so.
+            let keycloakLogoutButton = webAuthenticationView.buttons.matching(masLogoutPredicate).firstMatch
+            if keycloakLogoutButton.waitForExistence(timeout: 2.0) {
+                keycloakLogoutButton.tap(.center)
+            }
+            
+            usernameFieldLabel = "Username or email"
+            submitButtonLabel = "Sign In"
+        } else {
+            usernameFieldLabel = "Username or Email"
+            submitButtonLabel = "Continue"
+        }
+        
+        let webUsernameTextField = textFields[usernameFieldLabel]
         XCTAssertTrue(webUsernameTextField.waitForExistence(timeout: 10.0))
         webUsernameTextField.clearAndTypeText(username, app: self)
         webAuthenticationView.buttons["Done"].firstMatch.tap() // Dismiss the keyboard so that the password text field is fully hittable.
@@ -83,9 +111,9 @@ extension XCUIApplication {
         let webPasswordTextField = secureTextFields["Password"]
         XCTAssertTrue(webPasswordTextField.waitForExistence(timeout: 10.0))
         webPasswordTextField.clearAndTypeText(password, app: self)
-        webAuthenticationView.buttons["Done"].firstMatch.tap() // Dismiss the keyboard so that the continue button is fully hittable.
+        webAuthenticationView.buttons["Done"].firstMatch.tap() // Dismiss the keyboard so that the submit button is fully hittable.
         
-        let webLoginButton = webAuthenticationView.buttons["Continue"]
+        let webLoginButton = webAuthenticationView.buttons[submitButtonLabel]
         XCTAssertTrue(webLoginButton.waitForExistence(timeout: 10.0))
         webLoginButton.tap(.center)
         

--- a/IntegrationTests/Sources/Common.swift
+++ b/IntegrationTests/Sources/Common.swift
@@ -159,7 +159,7 @@ extension XCUIApplication {
         logoutButton.tap(.center)
         
         // Confirm logout
-        let alertLogoutButton = alerts.firstMatch.buttons["Sign out"].firstMatch
+        let alertLogoutButton = alerts.firstMatch.buttons[A11yIdentifiers.alertInfo.primaryButton].firstMatch
         XCTAssertTrue(alertLogoutButton.waitForExistence(timeout: 10.0))
         alertLogoutButton.tap(.center)
         

--- a/IntegrationTests/Sources/ServerLoginTests.swift
+++ b/IntegrationTests/Sources/ServerLoginTests.swift
@@ -1,0 +1,25 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+// Please see LICENSE files in the repository root for full details.
+//
+
+import XCTest
+
+@MainActor
+class ServerLoginTests: XCTestCase {
+    private var app: XCUIApplication!
+    
+    override func setUp() async throws {
+        app = Application.launch()
+    }
+    
+    func testLogin() throws {
+        XCTAssertNotNil(app.homeserver, "INTEGRATION_TESTS_HOST environment variable must be set for this test to run.")
+
+        try app.login(currentTestCase: self)
+
+        app.logout()
+    }
+}

--- a/Tools/Sources/Commands/CI/Build.swift
+++ b/Tools/Sources/Commands/CI/Build.swift
@@ -1,0 +1,46 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+// Please see LICENSE files in the repository root for full details.
+//
+
+import ArgumentParser
+import Foundation
+
+struct Build: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "build",
+                                                    abstract: "Builds a scheme for testing without running tests.",
+                                                    discussion: """
+                                                    Runs xcodebuild build-for-testing and archives the build products so they
+                                                    can be shared across multiple test jobs via CI artifacts.
+                                                    """)
+
+    @Option(help: "The Xcode scheme to build.")
+    var scheme: String
+
+    @Option(help: "Device name for the destination.")
+    var device = "iPhone 17"
+
+    @Option(help: "iOS version for the simulator.")
+    var osVersion = "26.1"
+
+    @Option(help: "DerivedData path for the build output.")
+    var derivedDataPath = "DerivedData"
+
+    func run() async throws {
+        logger.info("\n🔨 Building \(scheme) for testing…\n")
+
+        var command = "set -o pipefail && xcodebuild build-for-testing"
+        command += " -scheme \(scheme)"
+        command += " -sdk iphonesimulator"
+        command += " -destination 'platform=iOS Simulator,name=\(device),OS=\(osVersion)'"
+        command += " -derivedDataPath \(derivedDataPath)"
+        command += " -skipPackagePluginValidation"
+        command += " | xcbeautify"
+
+        try await CI.run(.path("/bin/zsh"), ["-cu", command])
+
+        logger.info("\n✅ Build complete.\n")
+    }
+}

--- a/Tools/Sources/Commands/CI/CI.swift
+++ b/Tools/Sources/Commands/CI/CI.swift
@@ -10,6 +10,7 @@ struct CI: ParsableCommand {
                                                         UnitTests.self,
                                                         UITests.self,
                                                         IntegrationTests.self,
+                                                        ServerLoginTests.self,
                                                         RunTests.self,
                                                         ConfigureNightly.self,
                                                         ConfigureProduction.self,

--- a/Tools/Sources/Commands/CI/CI.swift
+++ b/Tools/Sources/Commands/CI/CI.swift
@@ -9,6 +9,7 @@ struct CI: ParsableCommand {
                                                         AccessibilityTests.self,
                                                         UnitTests.self,
                                                         UITests.self,
+                                                        Build.self,
                                                         IntegrationTests.self,
                                                         ServerLoginTests.self,
                                                         RunTests.self,

--- a/Tools/Sources/Commands/CI/IntegrationTests.swift
+++ b/Tools/Sources/Commands/CI/IntegrationTests.swift
@@ -15,6 +15,9 @@ struct IntegrationTests: AsyncParsableCommand {
     @Option(help: "iOS version for the simulator.")
     var osVersion = "26.1"
     
+    @Option(help: "Path to a .xctestrun file produced by build-for-testing. When provided, the build step is skipped.")
+    var xctestrunPath: String?
+    
     func run() async throws {
         // Delete old log files
         logger.info("🗑️ Deleting old log files…")
@@ -23,12 +26,16 @@ struct IntegrationTests: AsyncParsableCommand {
         var testsFailed = false
         do {
             logger.info("\n🧪 Running integration tests…\n")
-            try await RunTests.parse([
+            var args = [
                 "--scheme", "IntegrationTests",
                 "--device", device,
                 "--os-version", osVersion,
                 "--retries", "0"
-            ]).run()
+            ]
+            if let xctestrunPath {
+                args += ["--xctestrun-path", xctestrunPath]
+            }
+            try await RunTests.parse(args).run()
         } catch {
             testsFailed = true
             logger.error("\n❌ Integration tests failed.\n")

--- a/Tools/Sources/Commands/CI/RunTests.swift
+++ b/Tools/Sources/Commands/CI/RunTests.swift
@@ -14,8 +14,11 @@ struct RunTests: AsyncParsableCommand {
                                                         --create-simulator-type com.apple.CoreSimulator.SimDeviceType.iPhone-SE-3rd-generation
                                                     """)
     
-    @Option(help: "The Xcode scheme to test.")
-    var scheme: String
+    @Option(help: "The Xcode scheme to test. Required unless --xctestrun-path is provided.")
+    var scheme: String?
+    
+    @Option(help: "Path to a .xctestrun file. When provided, the build step is skipped (test-without-building).")
+    var xctestrunPath: String?
     
     @Option(help: "The simulator device name to run tests on (e.g. 'iPhone 17').")
     var device = "iPhone 17"
@@ -40,7 +43,7 @@ struct RunTests: AsyncParsableCommand {
     }
     
     private var resultBundlePath: String {
-        "test_output/\(scheme).xcresult"
+        "test_output/\(scheme ?? "IntegrationTests").xcresult"
     }
     
     private var formatter: String {
@@ -52,6 +55,10 @@ struct RunTests: AsyncParsableCommand {
     }
     
     func run() async throws {
+        guard scheme != nil || xctestrunPath != nil else {
+            throw ValidationError("Either --scheme or --xctestrun-path must be provided.")
+        }
+        
         if let createName = createSimulatorName {
             guard let createType = createSimulatorType else {
                 throw ValidationError("--create-simulator-type must be provided when --create-simulator-name is set.")
@@ -121,27 +128,44 @@ struct RunTests: AsyncParsableCommand {
     // MARK: - Test Running
     
     private func executeXcodeBuild() async throws {
-        var command = "set -o pipefail && xcodebuild test"
-        command += " -scheme \(scheme)"
-        command += " -sdk iphonesimulator"
-        command += " -destination 'platform=iOS Simulator,name=\(device),OS=\(osVersion),arch=arm64'"
-        command += " -resultBundlePath \(resultBundlePath)"
-        command += " -skipPackagePluginValidation"
-        
-        // Use xcodebuild's native retry support to re-run only failing tests
-        // instead of re-running the entire suite. retries=0 means no retries (single run).
-        if retries > 0 {
-            // -test-iterations is the total number of attempts (initial + retries)
-            command += " -retry-tests-on-failure"
-            command += " -test-iterations \(retries + 1)"
-        }
-        
-        if let testName {
-            command += " -only-testing:\(scheme)/\(testName)"
-        }
+        if let xctestrunPath {
+            var command = "set -o pipefail && xcodebuild test-without-building"
+            command += " -xctestrun \(xctestrunPath)"
+            command += " -destination 'platform=iOS Simulator,name=\(device),OS=\(osVersion),arch=arm64'"
+            command += " -resultBundlePath \(resultBundlePath)"
+            
+            if retries > 0 {
+                command += " -retry-tests-on-failure"
+                command += " -test-iterations \(retries + 1)"
+            }
+            
+            if let testName, let scheme {
+                command += " -only-testing:\(scheme)/\(testName)"
+            }
+            
+            command += " | \(formatter)"
+            try await CI.run(.path("/bin/zsh"), ["-cu", command])
+        } else {
+            guard let scheme else { return }
+            
+            var command = "set -o pipefail && xcodebuild test"
+            command += " -scheme \(scheme)"
+            command += " -sdk iphonesimulator"
+            command += " -destination 'platform=iOS Simulator,name=\(device),OS=\(osVersion),arch=arm64'"
+            command += " -resultBundlePath \(resultBundlePath)"
+            command += " -skipPackagePluginValidation"
+            
+            if retries > 0 {
+                command += " -retry-tests-on-failure"
+                command += " -test-iterations \(retries + 1)"
+            }
+            
+            if let testName {
+                command += " -only-testing:\(scheme)/\(testName)"
+            }
 
-        command += " | \(formatter)"
-
-        try await CI.run(.path("/bin/zsh"), ["-cu", command])
+            command += " | \(formatter)"
+            try await CI.run(.path("/bin/zsh"), ["-cu", command])
+        }
     }
 }

--- a/Tools/Sources/Commands/CI/ServerLoginTests.swift
+++ b/Tools/Sources/Commands/CI/ServerLoginTests.swift
@@ -58,9 +58,6 @@ struct ServerLoginTests: AsyncParsableCommand {
         await CI.zipResults(bundles: ["IntegrationTests.xcresult"],
                             outputName: "IntegrationTests.xcresult.zip")
         
-        await CI.collectCoverage(resultBundle: "IntegrationTests.xcresult", outputName: "server-login-cobertura.xml")
-        await CI.collectTestResults(resultBundle: "IntegrationTests.xcresult", outputName: "server-login-junit.xml")
-        
         if testsFailed {
             throw ExitCode.failure
         }

--- a/Tools/Sources/Commands/CI/ServerLoginTests.swift
+++ b/Tools/Sources/Commands/CI/ServerLoginTests.swift
@@ -23,6 +23,9 @@ struct ServerLoginTests: AsyncParsableCommand {
     @Option(help: "iOS version for the simulator.")
     var osVersion = "26.1"
     
+    @Option(help: "Path to a .xctestrun file produced by build-for-testing. When provided, the build step is skipped.")
+    var xctestrunPath: String?
+    
     func run() async throws {
         // Delete old log files
         logger.info("🗑️ Deleting old log files…")
@@ -31,13 +34,17 @@ struct ServerLoginTests: AsyncParsableCommand {
         var testsFailed = false
         do {
             logger.info("\n🧪 Running server login integration tests…\n")
-            try await RunTests.parse([
+            var args = [
                 "--scheme", "IntegrationTests",
                 "--device", device,
                 "--os-version", osVersion,
                 "--retries", "0",
                 "--test-name", "ServerLoginTests"
-            ]).run()
+            ]
+            if let xctestrunPath {
+                args += ["--xctestrun-path", xctestrunPath]
+            }
+            try await RunTests.parse(args).run()
         } catch {
             testsFailed = true
             logger.error("\n❌ Server login integration tests failed.\n")

--- a/Tools/Sources/Commands/CI/ServerLoginTests.swift
+++ b/Tools/Sources/Commands/CI/ServerLoginTests.swift
@@ -1,0 +1,70 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+// Please see LICENSE files in the repository root for full details.
+//
+
+import ArgumentParser
+import Foundation
+
+struct ServerLoginTests: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "server-login-tests",
+                                                    abstract: "Runs the server login integration test CI workflow.",
+                                                    discussion: """
+                                                    Runs a login test against an arbitrary server using INTEGRATION_TESTS_HOST/
+                                                    USERNAME/PASSWORD. Designed to be driven by a CI matrix so credentials
+                                                    for each server are injected at runtime.
+                                                    """)
+
+    @Option(help: "Device name for tests.")
+    var device = "iPhone 17"
+    
+    @Option(help: "iOS version for the simulator.")
+    var osVersion = "26.1"
+    
+    func run() async throws {
+        // Delete old log files
+        logger.info("🗑️ Deleting old log files…")
+        try await CI.run(.path("/bin/zsh"), ["-cu", "find '/Users/Shared' -name 'console*' -delete"])
+        
+        var testsFailed = false
+        do {
+            logger.info("\n🧪 Running server login integration tests…\n")
+            try await RunTests.parse([
+                "--scheme", "IntegrationTests",
+                "--device", device,
+                "--os-version", osVersion,
+                "--retries", "0",
+                "--test-name", "ServerLoginTests"
+            ]).run()
+        } catch {
+            testsFailed = true
+            logger.error("\n❌ Server login integration tests failed.\n")
+        }
+        
+        // Validate logs only when tests passed — log files won't be meaningful otherwise
+        if !testsFailed {
+            do {
+                logger.info("🔍 Checking logs are set to the trace level…")
+                try await CI.run(.path("/bin/zsh"), ["-cu", "grep ' TRACE ' /Users/Shared -qR"])
+                logger.info("✅ Trace level logging verified.")
+            } catch {
+                testsFailed = true
+                logger.error("❌ Logs are not set to the trace level.")
+            }
+        }
+        
+        await CI.zipResults(bundles: ["IntegrationTests.xcresult"],
+                            outputName: "IntegrationTests.xcresult.zip")
+        
+        await CI.collectCoverage(resultBundle: "IntegrationTests.xcresult", outputName: "server-login-cobertura.xml")
+        await CI.collectTestResults(resultBundle: "IntegrationTests.xcresult", outputName: "server-login-junit.xml")
+        
+        if testsFailed {
+            throw ExitCode.failure
+        }
+        
+        logger.info("\n✅ Server login integration tests passed.\n")
+    }
+}


### PR DESCRIPTION
Adds a `ServerLoginTests` class with a single `testLogin` method that verifies login works against a configurable server.

The `login` helper auto-detects whether the server uses a Keycloak identity provider (via the "Continue with Keycloak" link) and adapts the web UI interaction accordingly, so the same test works against any OIDC server. It also handles stale MAS sessions by looking for "Sign out" or "Use another account" buttons before attempting login.

A new `server-login-tests` CLI command runs only this test class. A GitHub Actions matrix job in the integration tests workflow feeds server-specific secrets as the standard `INTEGRATION_TESTS_HOST/USERNAME/PASSWORD` variables. The matrix currently covers three servers: default, lts, lts-1.