### PR TITLE
Add multiple window support for mac and iPad OS

### DIFF
--- a/ElementX/Sources/AccessibilityTests/AccessibilityTestsAppCoordinator.swift
+++ b/ElementX/Sources/AccessibilityTests/AccessibilityTestsAppCoordinator.swift
@@ -13,8 +13,12 @@ import SwiftUI
 class AccessibilityTestsAppCoordinator: AppCoordinatorProtocol {
     var windowManager: any SecureWindowManagerProtocol
     
-    func handleDeepLink(_ url: URL, isExternalURL: Bool) -> Bool {
+    func handleDeepLink(_ url: URL, isExternalURL: Bool, windowType: WindowManagerWindowType?) -> Bool {
         fatalError("Not implemented")
+    }
+    
+    func handleAppRoute(_ appRoute: AppRoute, windowType: WindowManagerWindowType?) {
+        fatalError("Not implemented.")
     }
     
     func handlePotentialPhishingAttempt(url: URL, openURLAction: @escaping (URL) -> Void) -> Bool {

--- a/ElementX/Sources/AccessibilityTests/AccessibilityTestsAppCoordinator.swift
+++ b/ElementX/Sources/AccessibilityTests/AccessibilityTestsAppCoordinator.swift
@@ -13,11 +13,11 @@ import SwiftUI
 class AccessibilityTestsAppCoordinator: AppCoordinatorProtocol {
     var windowManager: any SecureWindowManagerProtocol
     
-    func handleDeepLink(_ url: URL, isExternalURL: Bool, windowType: WindowManagerWindowType?) -> Bool {
+    func handleDeepLink(_ url: URL, isExternalURL: Bool, windowType: SecondaryWindowType?) -> Bool {
         fatalError("Not implemented")
     }
     
-    func handleAppRoute(_ appRoute: AppRoute, windowType: WindowManagerWindowType?) {
+    func handleAppRoute(_ appRoute: AppRoute, windowType: SecondaryWindowType?) {
         fatalError("Not implemented.")
     }
     

--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -188,6 +188,12 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
                 }
             }
             .store(in: &cancellables)
+        
+        windowManager.auxiliaryWindowsEnabled = !appLockService.isEnabled
+        appLockService.isEnabledPublisher.sink { [weak windowManager] appLockEnabled in
+            windowManager?.auxiliaryWindowsEnabled = !appLockEnabled
+        }
+        .store(in: &cancellables)
     }
     
     func start() {

--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -793,6 +793,8 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
             fatalError("User session not setup")
         }
         
+        windowManager.closeAllAuxiliaryWindows()
+        
         showLoadingIndicator()
         
         stopSync(isBackgroundTask: false)

--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -176,7 +176,7 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
             .sink { [weak self] action in
                 switch action {
                 case .startCall(let roomID, let isVoiceCall):
-                    self?.handleAppRoute(.call(roomID: roomID, isVoiceCall: isVoiceCall))
+                    self?.handleAppRoute(.call(roomID: roomID, isVoiceCall: isVoiceCall), windowType: nil)
                 case .receivedIncomingCallRequest:
                     // When reporting a VoIP call through the CXProvider's `reportNewIncomingVoIPPushPayload`
                     // the UIApplication states don't change and syncing is neither started nor ran on
@@ -233,14 +233,41 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
                                                     secondaryButton: .init(title: L10n.actionContinue) { openURLAction(confirmationParameters.internalURL) })
         return true
     }
+    
+    func handleAppRoute(_ appRoute: AppRoute, windowType: WindowManagerWindowType?) {
+        if let windowType {
+            windowManager.handleRoute(appRoute, windowType: windowType)
+            return
+        }
+        
+        var handled = false
+        
+        switch appRoute {
+        case .accountProvisioningLink:
+            if let authenticationFlowCoordinator {
+                authenticationFlowCoordinator.handleAppRoute(appRoute, animated: appMediator.appState == .active)
+                handled = true
+            }
+        default:
+            if let userSessionFlowCoordinator {
+                userSessionFlowCoordinator.handleAppRoute(appRoute, animated: appMediator.appState == .active)
+                handled = true
+            }
+        }
+        
+        if !handled {
+            storedAppRoute = appRoute
+        }
+    }
 
-    func handleDeepLink(_ url: URL, isExternalURL: Bool) -> Bool {
+    func handleDeepLink(_ url: URL, isExternalURL: Bool, windowType: WindowManagerWindowType?) -> Bool {
         // Parse into an AppRoute to redirect these in a type safe way.
         
         if let route = appRouteURLParser.route(from: url) {
             switch route {
             case .accountProvisioningLink:
-                handleAppRoute(route)
+                handleAppRoute(route,
+                               windowType: windowType)
             case .genericCallLink(let url):
                 if let userSessionFlowCoordinator {
                     userSessionFlowCoordinator.handleAppRoute(route, animated: true)
@@ -249,33 +276,43 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
                 }
             case .userProfile(let userID):
                 if isExternalURL {
-                    handleAppRoute(route)
+                    handleAppRoute(route,
+                                   windowType: windowType)
                 } else {
-                    handleAppRoute(.roomMemberDetails(userID: userID))
+                    handleAppRoute(.roomMemberDetails(userID: userID),
+                                   windowType: windowType)
                 }
             case .room(let roomID, let via):
                 if isExternalURL {
-                    handleAppRoute(route)
+                    handleAppRoute(route,
+                                   windowType: windowType)
                 } else {
-                    handleAppRoute(.childRoom(roomID: roomID, via: via))
+                    handleAppRoute(.childRoom(roomID: roomID, via: via),
+                                   windowType: windowType)
                 }
             case .roomAlias(let alias):
                 if isExternalURL {
-                    handleAppRoute(route)
+                    handleAppRoute(route,
+                                   windowType: windowType)
                 } else {
-                    handleAppRoute(.childRoomAlias(alias))
+                    handleAppRoute(.childRoomAlias(alias),
+                                   windowType: windowType)
                 }
             case .event(let eventID, let roomID, let via):
                 if isExternalURL {
-                    handleAppRoute(route)
+                    handleAppRoute(route,
+                                   windowType: windowType)
                 } else {
-                    handleAppRoute(.childEvent(eventID: eventID, roomID: roomID, via: via))
+                    handleAppRoute(.childEvent(eventID: eventID, roomID: roomID, via: via),
+                                   windowType: windowType)
                 }
             case .eventOnRoomAlias(let eventID, let alias):
                 if isExternalURL {
-                    handleAppRoute(route)
+                    handleAppRoute(route,
+                                   windowType: windowType)
                 } else {
-                    handleAppRoute(.childEventOnRoomAlias(eventID: eventID, alias: alias))
+                    handleAppRoute(.childEventOnRoomAlias(eventID: eventID, alias: alias),
+                                   windowType: windowType)
                 }
             case .share(let payload):
                 guard isExternalURL else {
@@ -284,7 +321,8 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
                 }
                 
                 do {
-                    try handleAppRoute(.share(payload.withDefaultTemporaryDirectory()))
+                    try handleAppRoute(.share(payload.withDefaultTemporaryDirectory()),
+                                       windowType: windowType)
                 } catch {
                     MXLog.error("Failed moving payload out of the app group container: \(error)")
                 }
@@ -309,7 +347,7 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
         }
         
         MXLog.info("Starting call in room: \(roomIdentifier)")
-        handleAppRoute(AppRoute.call(roomID: roomIdentifier, isVoiceCall: false))
+        handleAppRoute(AppRoute.call(roomID: roomIdentifier, isVoiceCall: false), windowType: nil)
     }
     
     // MARK: - AuthenticationFlowCoordinatorDelegate
@@ -363,15 +401,15 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
             } else {
                 storedRoomsToAwait = [roomID]
             }
-            handleAppRoute(.room(roomID: roomID, via: []))
+            handleAppRoute(.room(roomID: roomID, via: []), windowType: nil)
         } else if appSettings.threadsEnabled, let threadRootEventID = content.threadRootEventID {
-            handleAppRoute(.thread(roomID: roomID, threadRootEventID: threadRootEventID, focusEventID: eventID))
+            handleAppRoute(.thread(roomID: roomID, threadRootEventID: threadRootEventID, focusEventID: eventID), windowType: nil)
         } else if let eventID {
             // Only track main timeline event deeplinking
             ServiceLocator.shared.analytics.signpost.startTransaction(.notificationToMessage)
-            handleAppRoute(.event(eventID: eventID, roomID: roomID, via: []))
+            handleAppRoute(.event(eventID: eventID, roomID: roomID, via: []), windowType: nil)
         } else {
-            handleAppRoute(.room(roomID: roomID, via: []))
+            handleAppRoute(.room(roomID: roomID, via: []), windowType: nil)
         }
     }
     
@@ -904,27 +942,6 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
             }
         }
         .store(in: &cancellables)
-    }
-    
-    private func handleAppRoute(_ appRoute: AppRoute) {
-        var handled = false
-        
-        switch appRoute {
-        case .accountProvisioningLink:
-            if let authenticationFlowCoordinator {
-                authenticationFlowCoordinator.handleAppRoute(appRoute, animated: appMediator.appState == .active)
-                handled = true
-            }
-        default:
-            if let userSessionFlowCoordinator {
-                userSessionFlowCoordinator.handleAppRoute(appRoute, animated: appMediator.appState == .active)
-                handled = true
-            }
-        }
-        
-        if !handled {
-            storedAppRoute = appRoute
-        }
     }
     
     private func clearCache() {

--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -189,9 +189,9 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
             }
             .store(in: &cancellables)
         
-        windowManager.auxiliaryWindowsEnabled = !appLockService.isEnabled
+        windowManager.secondaryWindowsEnabled = !appLockService.isEnabled
         appLockService.isEnabledPublisher.sink { [weak windowManager] appLockEnabled in
-            windowManager?.auxiliaryWindowsEnabled = !appLockEnabled
+            windowManager?.secondaryWindowsEnabled = !appLockEnabled
         }
         .store(in: &cancellables)
     }
@@ -240,7 +240,7 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
         return true
     }
     
-    func handleAppRoute(_ appRoute: AppRoute, windowType: WindowManagerWindowType?) {
+    func handleAppRoute(_ appRoute: AppRoute, windowType: SecondaryWindowType?) {
         if let windowType {
             windowManager.handleRoute(appRoute, windowType: windowType)
             return
@@ -266,7 +266,7 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
         }
     }
 
-    func handleDeepLink(_ url: URL, isExternalURL: Bool, windowType: WindowManagerWindowType?) -> Bool {
+    func handleDeepLink(_ url: URL, isExternalURL: Bool, windowType: SecondaryWindowType?) -> Bool {
         // Parse into an AppRoute to redirect these in a type safe way.
         
         if let route = appRouteURLParser.route(from: url) {
@@ -799,7 +799,7 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
             fatalError("User session not setup")
         }
         
-        windowManager.closeAllAuxiliaryWindows()
+        windowManager.closeAllSecondaryWindows()
         
         showLoadingIndicator()
         

--- a/ElementX/Sources/Application/AppCoordinatorProtocol.swift
+++ b/ElementX/Sources/Application/AppCoordinatorProtocol.swift
@@ -12,9 +12,9 @@ import Foundation
 protocol AppCoordinatorProtocol: CoordinatorProtocol {
     var windowManager: SecureWindowManagerProtocol { get }
     
-    @discardableResult func handleDeepLink(_ url: URL, isExternalURL: Bool, windowType: WindowManagerWindowType?) -> Bool
+    @discardableResult func handleDeepLink(_ url: URL, isExternalURL: Bool, windowType: SecondaryWindowType?) -> Bool
     
-    func handleAppRoute(_ appRoute: AppRoute, windowType: WindowManagerWindowType?)
+    func handleAppRoute(_ appRoute: AppRoute, windowType: SecondaryWindowType?)
     
     func handlePotentialPhishingAttempt(url: URL, openURLAction: @escaping (URL) -> Void) -> Bool
     

--- a/ElementX/Sources/Application/AppCoordinatorProtocol.swift
+++ b/ElementX/Sources/Application/AppCoordinatorProtocol.swift
@@ -12,7 +12,9 @@ import Foundation
 protocol AppCoordinatorProtocol: CoordinatorProtocol {
     var windowManager: SecureWindowManagerProtocol { get }
     
-    @discardableResult func handleDeepLink(_ url: URL, isExternalURL: Bool) -> Bool
+    @discardableResult func handleDeepLink(_ url: URL, isExternalURL: Bool, windowType: WindowManagerWindowType?) -> Bool
+    
+    func handleAppRoute(_ appRoute: AppRoute, windowType: WindowManagerWindowType?)
     
     func handlePotentialPhishingAttempt(url: URL, openURLAction: @escaping (URL) -> Void) -> Bool
     

--- a/ElementX/Sources/Application/Application.swift
+++ b/ElementX/Sources/Application/Application.swift
@@ -81,7 +81,7 @@ struct Application: App {
         // This is invoked in response of the WindowManager receiving a register
         // coordinator request and invoking the `OpenWindowAction` with which
         // it's configured in the task above.
-        WindowGroup(for: WindowManagerWindowType.self) { $type in
+        WindowGroup(for: SecondaryWindowType.self) { $type in
             if let type {
                 appCoordinator.windowManager.windowForType(type)
                     .environment(\.openURL, openURLAction(appCoordinator: appCoordinator, windowType: type))
@@ -91,7 +91,7 @@ struct Application: App {
         .windowResizability(.contentSize)
     }
     
-    private func openURLAction(appCoordinator: AppCoordinatorProtocol, windowType: WindowManagerWindowType?) -> OpenURLAction {
+    private func openURLAction(appCoordinator: AppCoordinatorProtocol, windowType: SecondaryWindowType?) -> OpenURLAction {
         .init { url in
             if appCoordinator.handleDeepLink(url, isExternalURL: false, windowType: windowType) {
                 return .handled

--- a/ElementX/Sources/Application/Application.swift
+++ b/ElementX/Sources/Application/Application.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct Application: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @Environment(\.openURL) private var openURL
+    @Environment(\.openWindow) private var openWindow
     
     private var appCoordinator: AppCoordinatorProtocol!
 
@@ -39,19 +40,7 @@ struct Application: App {
                         Divider().ignoresSafeArea()
                     }
                 }
-                .environment(\.openURL, OpenURLAction { url in
-                    if appCoordinator.handleDeepLink(url, isExternalURL: false) {
-                        return .handled
-                    }
-                    
-                    if appCoordinator.handlePotentialPhishingAttempt(url: url, openURLAction: { url in
-                        openURL(url, isExternalURL: false)
-                    }) {
-                        return .handled
-                    }
-
-                    return .systemAction
-                })
+                .environment(\.openURL, openURLAction(appCoordinator: appCoordinator, windowType: nil))
                 .onOpenURL { url in
                     openURL(url, isExternalURL: true)
                 }
@@ -62,14 +51,42 @@ struct Application: App {
                 }
                 .task {
                     appCoordinator.start()
+                    appCoordinator.windowManager.configure(with: openWindow)
                 }
+        }
+        .handlesExternalEvents(matching: ["*"])
+        
+        // This is invoked in response of the WindowManager receiving a register
+        // coordinator request and invoking the `OpenWindowAction` with which
+        // it's configured in the task above.
+        WindowGroup(for: WindowManagerWindowType.self) { $type in
+            if let type {
+                appCoordinator.windowManager.windowForType(type)
+                    .environment(\.openURL, openURLAction(appCoordinator: appCoordinator, windowType: type))
+            }
+        }
+    }
+    
+    private func openURLAction(appCoordinator: AppCoordinatorProtocol, windowType: WindowManagerWindowType?) -> OpenURLAction {
+        .init { url in
+            if appCoordinator.handleDeepLink(url, isExternalURL: false, windowType: windowType) {
+                return .handled
+            }
+            
+            if appCoordinator.handlePotentialPhishingAttempt(url: url, openURLAction: { url in
+                openURL(url, isExternalURL: false)
+            }) {
+                return .handled
+            }
+            
+            return .systemAction
         }
     }
     
     // MARK: - Private
     
     private func openURL(_ url: URL, isExternalURL: Bool) {
-        if !appCoordinator.handleDeepLink(url, isExternalURL: isExternalURL) {
+        if !appCoordinator.handleDeepLink(url, isExternalURL: isExternalURL, windowType: nil) {
             openURLInSystemBrowser(url)
         }
     }

--- a/ElementX/Sources/Application/Application.swift
+++ b/ElementX/Sources/Application/Application.swift
@@ -64,6 +64,13 @@ struct Application: App {
                 }
                 .keyboardShortcut(",", modifiers: .command)
             }
+            
+            CommandGroup(after: .windowArrangement) {
+                Button("Global Search") {
+                    appCoordinator.handleAppRoute(.globalSearch, windowType: nil)
+                }
+                .keyboardShortcut("k", modifiers: [.command])
+            }
         }
         
         // This is invoked in response of the WindowManager receiving a register

--- a/ElementX/Sources/Application/Application.swift
+++ b/ElementX/Sources/Application/Application.swift
@@ -82,7 +82,7 @@ struct Application: App {
                     .environment(\.openURL, openURLAction(appCoordinator: appCoordinator, windowType: type))
             }
         }
-        .defaultSize(width: 400, height: 800)
+        .defaultSize(width: ProcessInfo.processInfo.isiOSAppOnMac ? 600 : 400, height: 800)
         .windowResizability(.contentSize)
     }
     

--- a/ElementX/Sources/Application/Application.swift
+++ b/ElementX/Sources/Application/Application.swift
@@ -58,6 +58,11 @@ struct Application: App {
         }
         .handlesExternalEvents(matching: ["*"])
         .commands {
+            CommandGroup(replacing: .newItem) {
+                Button(L10n.actionStartChat) { }
+                    .disabled(true)
+            }
+            
             CommandGroup(replacing: .appSettings) {
                 Button(L10n.commonSettings) {
                     appCoordinator.handleAppRoute(.settings, windowType: nil)

--- a/ElementX/Sources/Application/Application.swift
+++ b/ElementX/Sources/Application/Application.swift
@@ -55,6 +55,14 @@ struct Application: App {
                 }
         }
         .handlesExternalEvents(matching: ["*"])
+        .commands {
+            CommandGroup(replacing: .appSettings) {
+                Button(L10n.commonSettings) {
+                    appCoordinator.handleAppRoute(.settings, windowType: nil)
+                }
+                .keyboardShortcut(",", modifiers: .command)
+            }
+        }
         
         // This is invoked in response of the WindowManager receiving a register
         // coordinator request and invoking the `OpenWindowAction` with which

--- a/ElementX/Sources/Application/Application.swift
+++ b/ElementX/Sources/Application/Application.swift
@@ -13,6 +13,7 @@ struct Application: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @Environment(\.openURL) private var openURL
     @Environment(\.openWindow) private var openWindow
+    @Environment(\.dismissWindow) private var dismissWindow
     
     private var appCoordinator: AppCoordinatorProtocol!
 
@@ -51,7 +52,8 @@ struct Application: App {
                 }
                 .task {
                     appCoordinator.start()
-                    appCoordinator.windowManager.configure(with: openWindow)
+                    appCoordinator.windowManager.configure(withOpenWinddowAction: openWindow,
+                                                           dismissWindowAction: dismissWindow)
                 }
         }
         .handlesExternalEvents(matching: ["*"])

--- a/ElementX/Sources/Application/Application.swift
+++ b/ElementX/Sources/Application/Application.swift
@@ -73,6 +73,8 @@ struct Application: App {
                     .environment(\.openURL, openURLAction(appCoordinator: appCoordinator, windowType: type))
             }
         }
+        .defaultSize(width: 400, height: 800)
+        .windowResizability(.contentSize)
     }
     
     private func openURLAction(appCoordinator: AppCoordinatorProtocol, windowType: WindowManagerWindowType?) -> OpenURLAction {

--- a/ElementX/Sources/Application/Navigation/AppRoutes.swift
+++ b/ElementX/Sources/Application/Navigation/AppRoutes.swift
@@ -53,6 +53,8 @@ enum AppRoute: Hashable {
     case transferOwnership(roomID: String)
     /// A thread within a room, only to be used to handle tap on notification for threaded events.
     case thread(roomID: String, threadRootEventID: String, focusEventID: String?)
+    /// The global search screen
+    case globalSearch
     
     /// Whether or not the route should be handled by the authentication flow.
     var isAuthenticationRoute: Bool {

--- a/ElementX/Sources/Application/Windowing/SceneDelegate.swift
+++ b/ElementX/Sources/Application/Windowing/SceneDelegate.swift
@@ -16,6 +16,6 @@ class SceneDelegate: NSObject, UIWindowSceneDelegate {
     
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = scene as? UIWindowScene else { return }
-        Self.windowManager.configure(with: windowScene)
+        Self.windowManager.configure(withScene: windowScene, session: session)
     }
 }

--- a/ElementX/Sources/Application/Windowing/WindowManager.swift
+++ b/ElementX/Sources/Application/Windowing/WindowManager.swift
@@ -20,6 +20,7 @@ class WindowManager: SecureWindowManagerProtocol {
     private(set) var alternateWindow: UIWindow!
     
     private(set) var openWindowAction: OpenWindowAction!
+    private(set) var dismissWindowAction: DismissWindowAction!
         
     var windows: [UIWindow] {
         [mainWindow, overlayWindow, globalSearchWindow, alternateWindow]
@@ -58,13 +59,23 @@ class WindowManager: SecureWindowManagerProtocol {
         delegate?.windowManagerDidConfigureWindows(self)
     }
     
-    func configure(with openWindowAction: OpenWindowAction) {
+    func configure(withOpenWinddowAction openWindowAction: OpenWindowAction,
+                   dismissWindowAction: DismissWindowAction) {
         self.openWindowAction = openWindowAction
+        self.dismissWindowAction = dismissWindowAction
     }
     
     func registerCoordinator(_ coordinator: CoordinatorProtocol, flowCoordinator: FlowCoordinatorProtocol?, forWindowType type: WindowManagerWindowType) {
         coordinators[type] = (coordinator, flowCoordinator)
         openWindowAction(value: type)
+    }
+    
+    func closeAllAuxiliaryWindows() {
+        for key in coordinators.keys {
+            dismissWindowAction(value: key)
+        }
+        
+        coordinators.removeAll()
     }
     
     func windowForType(_ type: WindowManagerWindowType) -> AnyView {

--- a/ElementX/Sources/Application/Windowing/WindowManager.swift
+++ b/ElementX/Sources/Application/Windowing/WindowManager.swift
@@ -74,31 +74,6 @@ class WindowManager: SecureWindowManagerProtocol {
         self.dismissWindowAction = dismissWindowAction
     }
     
-    func registerCoordinator(_ coordinator: CoordinatorProtocol, flowCoordinator: FlowCoordinatorProtocol?, forWindowType type: WindowManagerWindowType) {
-        coordinators[type] = (coordinator, flowCoordinator)
-        openWindowAction(value: type)
-    }
-    
-    func closeAllAuxiliaryWindows() {
-        for key in coordinators.keys {
-            dismissWindowAction(value: key)
-        }
-        
-        coordinators.removeAll()
-    }
-    
-    func windowForType(_ type: WindowManagerWindowType) -> AnyView {
-        guard let coordinator = coordinators[type]?.coordinator else {
-            return AnyView(InstantlyDismissingWindow())
-        }
-        
-        // This behaves strangely and gets called late but cleans up enough
-        // and is self contained enough to be just good .. enough
-        return AnyView(coordinator.toPresentable().onDisappear { [weak self] in
-            self?.coordinators[type] = nil
-        })
-    }
-    
     func handleRoute(_ appRoute: AppRoute, windowType: WindowManagerWindowType) {
         if let flowCoordinator = coordinators[windowType]?.flowCoordinator {
             flowCoordinator.handleAppRoute(appRoute, animated: true)
@@ -167,6 +142,8 @@ class WindowManager: SecureWindowManagerProtocol {
         mainWindow.makeKey()
     }
     
+    // MARK: - OrientationManager
+    
     func setOrientation(_ orientation: UIInterfaceOrientationMask) {
         mainScene?.requestGeometryUpdate(.iOS(interfaceOrientations: orientation))
     }
@@ -175,8 +152,35 @@ class WindowManager: SecureWindowManagerProtocol {
         appDelegate.orientationLock = orientation
     }
     
+    // MARK: - Auxiliary window support
+    
+    func windowForType(_ type: WindowManagerWindowType) -> AnyView {
+        guard let coordinator = coordinators[type]?.coordinator else {
+            return AnyView(InstantlyDismissingWindow())
+        }
+        
+        // This behaves strangely and gets called late but cleans up enough
+        // and is self contained enough to be just good .. enough
+        return AnyView(coordinator.toPresentable().onDisappear { [weak self] in
+            self?.coordinators[type] = nil
+        })
+    }
+    
+    func registerCoordinator(_ coordinator: CoordinatorProtocol, flowCoordinator: FlowCoordinatorProtocol?, forWindowType type: WindowManagerWindowType) {
+        coordinators[type] = (coordinator, flowCoordinator)
+        openWindowAction(value: type)
+    }
+    
     func closeAuxiliaryWindow(forType type: WindowManagerWindowType) {
         dismissWindowAction(value: type)
+    }
+    
+    func closeAllAuxiliaryWindows() {
+        for key in coordinators.keys {
+            dismissWindowAction(value: key)
+        }
+        
+        coordinators.removeAll()
     }
 }
 

--- a/ElementX/Sources/Application/Windowing/WindowManager.swift
+++ b/ElementX/Sources/Application/Windowing/WindowManager.swift
@@ -18,6 +18,8 @@ class WindowManager: SecureWindowManagerProtocol {
     private(set) var overlayWindow: UIWindow!
     private(set) var globalSearchWindow: UIWindow!
     private(set) var alternateWindow: UIWindow!
+    
+    private(set) var openWindowAction: OpenWindowAction!
         
     var windows: [UIWindow] {
         [mainWindow, overlayWindow, globalSearchWindow, alternateWindow]
@@ -28,6 +30,8 @@ class WindowManager: SecureWindowManagerProtocol {
     @CancellableTask private var switchTask: Task<Void, Error>?
     /// A duration that allows window switching to wait a couple of frames to avoid a transition through black.
     private let windowHideDelay = Duration.milliseconds(33)
+    
+    private var coordinators: [WindowManagerWindowType: (coordinator: CoordinatorProtocol, flowCoordinator: FlowCoordinatorProtocol?)] = [:]
     
     init(appDelegate: AppDelegate) {
         self.appDelegate = appDelegate
@@ -52,6 +56,29 @@ class WindowManager: SecureWindowManagerProtocol {
         alternateWindow.tintColor = .compound.textActionPrimary
         
         delegate?.windowManagerDidConfigureWindows(self)
+    }
+    
+    func configure(with openWindowAction: OpenWindowAction) {
+        self.openWindowAction = openWindowAction
+    }
+    
+    func registerCoordinator(_ coordinator: CoordinatorProtocol, flowCoordinator: FlowCoordinatorProtocol?, forWindowType type: WindowManagerWindowType) {
+        coordinators[type] = (coordinator, flowCoordinator)
+        openWindowAction(value: type)
+    }
+    
+    func windowForType(_ type: WindowManagerWindowType) -> AnyView? {
+        guard let coordinator = coordinators[type]?.coordinator else {
+            return nil
+        }
+        
+        return coordinator.toPresentable()
+    }
+    
+    func handleRoute(_ appRoute: AppRoute, windowType: WindowManagerWindowType) {
+        if let flowCoordinator = coordinators[windowType]?.flowCoordinator {
+            flowCoordinator.handleAppRoute(appRoute, animated: true)
+        }
     }
     
     func switchToMain() {

--- a/ElementX/Sources/Application/Windowing/WindowManager.swift
+++ b/ElementX/Sources/Application/Windowing/WindowManager.swift
@@ -11,7 +11,8 @@ import SwiftUI
 
 class WindowManager: SecureWindowManagerProtocol {
     private let appDelegate: AppDelegate
-    weak var windowScene: UIWindowScene?
+    weak var mainScene: UIWindowScene?
+    weak var mainSession: UISceneSession?
     weak var delegate: SecureWindowManagerDelegate?
     
     private(set) var mainWindow: UIWindow!
@@ -38,28 +39,30 @@ class WindowManager: SecureWindowManagerProtocol {
         self.appDelegate = appDelegate
     }
     
-    func configure(with windowScene: UIWindowScene) {
+    func configure(withScene scene: UIWindowScene, session: UISceneSession) {
         // This gets called for all opened windows, we're only interested in the
         // first call, for the main window (works with state restoration too).
         guard mainWindow == nil else {
             return
         }
         
-        self.windowScene = windowScene
-        mainWindow = windowScene.keyWindow
+        mainScene = scene
+        mainSession = session
+        
+        mainWindow = scene.keyWindow
         mainWindow.tintColor = .compound.textActionPrimary
         
-        overlayWindow = PassthroughWindow(windowScene: windowScene)
+        overlayWindow = PassthroughWindow(windowScene: scene)
         overlayWindow.tintColor = .compound.textActionPrimary
         overlayWindow.backgroundColor = .clear
         overlayWindow.isHidden = false
         
-        globalSearchWindow = UIWindow(windowScene: windowScene)
+        globalSearchWindow = UIWindow(windowScene: scene)
         globalSearchWindow.tintColor = .compound.textActionPrimary
         globalSearchWindow.backgroundColor = .clear
         globalSearchWindow.isHidden = true
         
-        alternateWindow = UIWindow(windowScene: windowScene)
+        alternateWindow = UIWindow(windowScene: scene)
         alternateWindow.tintColor = .compound.textActionPrimary
         
         delegate?.windowManagerDidConfigureWindows(self)
@@ -144,8 +147,15 @@ class WindowManager: SecureWindowManagerProtocol {
             return
         }
         
+        if let mainSession {
+            let request = UISceneSessionActivationRequest(session: mainSession)
+            UIApplication.shared.activateSceneSession(for: request) { error in
+                MXLog.error("Failed to focus window with error: \(error)")
+            }
+        }
+        
         globalSearchWindow.isHidden = false
-        globalSearchWindow.makeKey()
+        globalSearchWindow.makeKeyAndVisible()
     }
     
     func hideGlobalSearch() {
@@ -158,7 +168,7 @@ class WindowManager: SecureWindowManagerProtocol {
     }
     
     func setOrientation(_ orientation: UIInterfaceOrientationMask) {
-        windowScene?.requestGeometryUpdate(.iOS(interfaceOrientations: orientation))
+        mainScene?.requestGeometryUpdate(.iOS(interfaceOrientations: orientation))
     }
     
     func lockOrientation(_ orientation: UIInterfaceOrientationMask) {

--- a/ElementX/Sources/Application/Windowing/WindowManager.swift
+++ b/ElementX/Sources/Application/Windowing/WindowManager.swift
@@ -39,6 +39,12 @@ class WindowManager: SecureWindowManagerProtocol {
     }
     
     func configure(with windowScene: UIWindowScene) {
+        // This gets called for all opened windows, we're only interested in the
+        // first call, for the main window (works with state restoration too).
+        guard mainWindow == nil else {
+            return
+        }
+        
         self.windowScene = windowScene
         mainWindow = windowScene.keyWindow
         mainWindow.tintColor = .compound.textActionPrimary

--- a/ElementX/Sources/Application/Windowing/WindowManager.swift
+++ b/ElementX/Sources/Application/Windowing/WindowManager.swift
@@ -67,9 +67,9 @@ class WindowManager: SecureWindowManagerProtocol {
         openWindowAction(value: type)
     }
     
-    func windowForType(_ type: WindowManagerWindowType) -> AnyView? {
+    func windowForType(_ type: WindowManagerWindowType) -> AnyView {
         guard let coordinator = coordinators[type]?.coordinator else {
-            return nil
+            return AnyView(InstantlyDismissingWindow())
         }
         
         return coordinator.toPresentable()
@@ -177,5 +177,18 @@ private class PassthroughWindow: UIWindow {
             // If the returned view is the `UIHostingController`'s view, ignore.
             return rootViewController.view == hitView ? nil : hitView
         }
+    }
+}
+
+/// Whenever restoring an app SwiftUI tries to restore its windows as well
+/// which we're generally not prepared for so use this to just close them instead
+private struct InstantlyDismissingWindow: View {
+    @Environment(\.dismissWindow) var dismissWindow
+    
+    var body: some View {
+        Rectangle()
+            .task {
+                dismissWindow()
+            }
     }
 }

--- a/ElementX/Sources/Application/Windowing/WindowManager.swift
+++ b/ElementX/Sources/Application/Windowing/WindowManager.swift
@@ -23,10 +23,10 @@ class WindowManager: SecureWindowManagerProtocol {
     private(set) var openWindowAction: OpenWindowAction!
     private(set) var dismissWindowAction: DismissWindowAction!
     
-    var auxiliaryWindowsEnabled = true {
+    var secondaryWindowsEnabled = true {
         didSet {
-            if auxiliaryWindowsEnabled == false {
-                closeAllAuxiliaryWindows()
+            if secondaryWindowsEnabled == false {
+                closeAllSecondaryWindows()
             }
         }
     }
@@ -41,7 +41,7 @@ class WindowManager: SecureWindowManagerProtocol {
     /// A duration that allows window switching to wait a couple of frames to avoid a transition through black.
     private let windowHideDelay = Duration.milliseconds(33)
     
-    private var coordinators: [WindowManagerWindowType: (coordinator: CoordinatorProtocol, flowCoordinator: FlowCoordinatorProtocol?)] = [:]
+    private var coordinators: [SecondaryWindowType: (coordinator: CoordinatorProtocol, flowCoordinator: FlowCoordinatorProtocol?)] = [:]
     
     init(appDelegate: AppDelegate) {
         self.appDelegate = appDelegate
@@ -82,7 +82,7 @@ class WindowManager: SecureWindowManagerProtocol {
         self.dismissWindowAction = dismissWindowAction
     }
     
-    func handleRoute(_ appRoute: AppRoute, windowType: WindowManagerWindowType) {
+    func handleRoute(_ appRoute: AppRoute, windowType: SecondaryWindowType) {
         if let flowCoordinator = coordinators[windowType]?.flowCoordinator {
             flowCoordinator.handleAppRoute(appRoute, animated: true)
         }
@@ -160,9 +160,9 @@ class WindowManager: SecureWindowManagerProtocol {
         appDelegate.orientationLock = orientation
     }
     
-    // MARK: - Auxiliary window support
+    // MARK: - Secondary window support
     
-    func windowForType(_ type: WindowManagerWindowType) -> AnyView {
+    func windowForType(_ type: SecondaryWindowType) -> AnyView {
         guard let coordinator = coordinators[type]?.coordinator else {
             return AnyView(InstantlyDismissingWindow())
         }
@@ -174,9 +174,9 @@ class WindowManager: SecureWindowManagerProtocol {
         })
     }
     
-    func registerCoordinator(_ coordinator: CoordinatorProtocol, flowCoordinator: FlowCoordinatorProtocol?, forWindowType type: WindowManagerWindowType) {
-        if auxiliaryWindowsEnabled == false {
-            MXLog.error("Cannot register coordinator, auxiliary windows are disabled.")
+    func registerCoordinator(_ coordinator: CoordinatorProtocol, flowCoordinator: FlowCoordinatorProtocol?, forWindowType type: SecondaryWindowType) {
+        if secondaryWindowsEnabled == false {
+            MXLog.error("Cannot register coordinator, secondary windows are disabled.")
             return
         }
         
@@ -184,11 +184,11 @@ class WindowManager: SecureWindowManagerProtocol {
         openWindowAction(value: type)
     }
     
-    func closeAuxiliaryWindow(forType type: WindowManagerWindowType) {
+    func closeSecondaryWindow(forType type: SecondaryWindowType) {
         dismissWindowAction(value: type)
     }
     
-    func closeAllAuxiliaryWindows() {
+    func closeAllSecondaryWindows() {
         for key in coordinators.keys {
             dismissWindowAction(value: key)
         }

--- a/ElementX/Sources/Application/Windowing/WindowManager.swift
+++ b/ElementX/Sources/Application/Windowing/WindowManager.swift
@@ -22,6 +22,14 @@ class WindowManager: SecureWindowManagerProtocol {
     
     private(set) var openWindowAction: OpenWindowAction!
     private(set) var dismissWindowAction: DismissWindowAction!
+    
+    var auxiliaryWindowsEnabled = true {
+        didSet {
+            if auxiliaryWindowsEnabled == false {
+                closeAllAuxiliaryWindows()
+            }
+        }
+    }
         
     var windows: [UIWindow] {
         [mainWindow, overlayWindow, globalSearchWindow, alternateWindow]
@@ -167,6 +175,11 @@ class WindowManager: SecureWindowManagerProtocol {
     }
     
     func registerCoordinator(_ coordinator: CoordinatorProtocol, flowCoordinator: FlowCoordinatorProtocol?, forWindowType type: WindowManagerWindowType) {
+        if auxiliaryWindowsEnabled == false {
+            MXLog.error("Cannot register coordinator, auxiliary windows are disabled.")
+            return
+        }
+        
         coordinators[type] = (coordinator, flowCoordinator)
         openWindowAction(value: type)
     }

--- a/ElementX/Sources/Application/Windowing/WindowManager.swift
+++ b/ElementX/Sources/Application/Windowing/WindowManager.swift
@@ -89,7 +89,11 @@ class WindowManager: SecureWindowManagerProtocol {
             return AnyView(InstantlyDismissingWindow())
         }
         
-        return coordinator.toPresentable()
+        // This behaves strangely and gets called late but cleans up enough
+        // and is self contained enough to be just good .. enough
+        return AnyView(coordinator.toPresentable().onDisappear { [weak self] in
+            self?.coordinators[type] = nil
+        })
     }
     
     func handleRoute(_ appRoute: AppRoute, windowType: WindowManagerWindowType) {

--- a/ElementX/Sources/Application/Windowing/WindowManager.swift
+++ b/ElementX/Sources/Application/Windowing/WindowManager.swift
@@ -174,6 +174,10 @@ class WindowManager: SecureWindowManagerProtocol {
     func lockOrientation(_ orientation: UIInterfaceOrientationMask) {
         appDelegate.orientationLock = orientation
     }
+    
+    func closeAuxiliaryWindow(forType type: WindowManagerWindowType) {
+        dismissWindowAction(value: type)
+    }
 }
 
 private class PassthroughWindow: UIWindow {

--- a/ElementX/Sources/Application/Windowing/WindowManagerProtocol.swift
+++ b/ElementX/Sources/Application/Windowing/WindowManagerProtocol.swift
@@ -29,7 +29,7 @@ protocol SecureWindowManagerProtocol: WindowManagerProtocol {
     
     func handleRoute(_ appRoute: AppRoute, windowType: WindowManagerWindowType)
     
-    func windowForType(_ type: WindowManagerWindowType) -> AnyView?
+    func windowForType(_ type: WindowManagerWindowType) -> AnyView
     
     /// Shows the main and overlay window combo, hiding the alternate window.
     func switchToMain()

--- a/ElementX/Sources/Application/Windowing/WindowManagerProtocol.swift
+++ b/ElementX/Sources/Application/Windowing/WindowManagerProtocol.swift
@@ -64,6 +64,8 @@ protocol WindowManagerProtocol: AnyObject, OrientationManagerProtocol {
     
     // MARK: - Auxiliary window support
     
+    var auxiliaryWindowsEnabled: Bool { get set }
+    
     /// Register a coordinator and it's respective flow (if any) within the WindowManager which in turn
     /// invokes the Application's `OpenWindowAction`
     func registerCoordinator(_ coordinator: CoordinatorProtocol,

--- a/ElementX/Sources/Application/Windowing/WindowManagerProtocol.swift
+++ b/ElementX/Sources/Application/Windowing/WindowManagerProtocol.swift
@@ -8,6 +8,11 @@
 
 import SwiftUI
 
+enum WindowManagerWindowType: Hashable, Codable {
+    case room(roomID: String)
+    case settings
+}
+
 protocol SecureWindowManagerDelegate: AnyObject {
     /// The window manager has configured its windows.
     func windowManagerDidConfigureWindows(_ windowManager: SecureWindowManagerProtocol)
@@ -19,6 +24,12 @@ protocol SecureWindowManagerProtocol: WindowManagerProtocol {
     
     /// Configures the window manager to operate on the supplied scene.
     func configure(with windowScene: UIWindowScene)
+    
+    func configure(with openWindowAction: OpenWindowAction)
+    
+    func handleRoute(_ appRoute: AppRoute, windowType: WindowManagerWindowType)
+    
+    func windowForType(_ type: WindowManagerWindowType) -> AnyView?
     
     /// Shows the main and overlay window combo, hiding the alternate window.
     func switchToMain()
@@ -42,6 +53,8 @@ protocol WindowManagerProtocol: AnyObject, OrientationManagerProtocol {
     
     /// All the windows being managed
     var windows: [UIWindow] { get }
+    
+    func registerCoordinator(_ coordinator: CoordinatorProtocol, flowCoordinator: FlowCoordinatorProtocol?, forWindowType type: WindowManagerWindowType)
     
     /// Makes the global search window key. Used to get automatic text field focus.
     func showGlobalSearch()

--- a/ElementX/Sources/Application/Windowing/WindowManagerProtocol.swift
+++ b/ElementX/Sources/Application/Windowing/WindowManagerProtocol.swift
@@ -8,7 +8,7 @@
 
 import SwiftUI
 
-enum WindowManagerWindowType: Hashable, Codable {
+enum SecondaryWindowType: Hashable, Codable {
     case room(roomID: String)
     case settings
 }
@@ -27,7 +27,7 @@ protocol SecureWindowManagerProtocol: WindowManagerProtocol {
     
     func configure(withOpenWinddowAction openWindowAction: OpenWindowAction, dismissWindowAction: DismissWindowAction)
     
-    func handleRoute(_ appRoute: AppRoute, windowType: WindowManagerWindowType)
+    func handleRoute(_ appRoute: AppRoute, windowType: SecondaryWindowType)
     
     /// Shows the main and overlay window combo, hiding the alternate window.
     func switchToMain()
@@ -35,10 +35,10 @@ protocol SecureWindowManagerProtocol: WindowManagerProtocol {
     /// Shows the alternate window, hiding the main and overlay combo.
     func switchToAlternate()
     
-    // MARK: - Auxiliary window support
+    // MARK: - Secondary window support
     
-    /// Used by the Application to retrieve the root view for an auxiliary window
-    func windowForType(_ type: WindowManagerWindowType) -> AnyView
+    /// Used by the Application to retrieve the root view for an secondary window
+    func windowForType(_ type: SecondaryWindowType) -> AnyView
 }
 
 /// A window manager that supports switching between a main app window with an overlay and
@@ -62,21 +62,21 @@ protocol WindowManagerProtocol: AnyObject, OrientationManagerProtocol {
     
     func hideGlobalSearch()
     
-    // MARK: - Auxiliary window support
+    // MARK: - Secondary window support
     
-    var auxiliaryWindowsEnabled: Bool { get set }
+    var secondaryWindowsEnabled: Bool { get set }
     
     /// Register a coordinator and it's respective flow (if any) within the WindowManager which in turn
     /// invokes the Application's `OpenWindowAction`
     func registerCoordinator(_ coordinator: CoordinatorProtocol,
                              flowCoordinator: FlowCoordinatorProtocol?,
-                             forWindowType type: WindowManagerWindowType)
+                             forWindowType type: SecondaryWindowType)
     
     /// Closes any window previously opened by registering a coordinator
-    func closeAllAuxiliaryWindows()
+    func closeAllSecondaryWindows()
     
     /// Closes a previously opened window for the given type.
-    func closeAuxiliaryWindow(forType type: WindowManagerWindowType)
+    func closeSecondaryWindow(forType type: SecondaryWindowType)
 }
 
 // sourcery: AutoMockable

--- a/ElementX/Sources/Application/Windowing/WindowManagerProtocol.swift
+++ b/ElementX/Sources/Application/Windowing/WindowManagerProtocol.swift
@@ -23,7 +23,7 @@ protocol SecureWindowManagerProtocol: WindowManagerProtocol {
     var delegate: SecureWindowManagerDelegate? { get set }
     
     /// Configures the window manager to operate on the supplied scene.
-    func configure(with windowScene: UIWindowScene)
+    func configure(withScene scene: UIWindowScene, session: UISceneSession)
     
     func configure(withOpenWinddowAction openWindowAction: OpenWindowAction, dismissWindowAction: DismissWindowAction)
     

--- a/ElementX/Sources/Application/Windowing/WindowManagerProtocol.swift
+++ b/ElementX/Sources/Application/Windowing/WindowManagerProtocol.swift
@@ -62,6 +62,9 @@ protocol WindowManagerProtocol: AnyObject, OrientationManagerProtocol {
     func showGlobalSearch()
     
     func hideGlobalSearch()
+    
+    /// Closes a previously opened window for the given type.
+    func closeAuxiliaryWindow(forType type: WindowManagerWindowType)
 }
 
 // sourcery: AutoMockable

--- a/ElementX/Sources/Application/Windowing/WindowManagerProtocol.swift
+++ b/ElementX/Sources/Application/Windowing/WindowManagerProtocol.swift
@@ -25,7 +25,7 @@ protocol SecureWindowManagerProtocol: WindowManagerProtocol {
     /// Configures the window manager to operate on the supplied scene.
     func configure(with windowScene: UIWindowScene)
     
-    func configure(with openWindowAction: OpenWindowAction)
+    func configure(withOpenWinddowAction openWindowAction: OpenWindowAction, dismissWindowAction: DismissWindowAction)
     
     func handleRoute(_ appRoute: AppRoute, windowType: WindowManagerWindowType)
     
@@ -55,6 +55,8 @@ protocol WindowManagerProtocol: AnyObject, OrientationManagerProtocol {
     var windows: [UIWindow] { get }
     
     func registerCoordinator(_ coordinator: CoordinatorProtocol, flowCoordinator: FlowCoordinatorProtocol?, forWindowType type: WindowManagerWindowType)
+    
+    func closeAllAuxiliaryWindows()
     
     /// Makes the global search window key. Used to get automatic text field focus.
     func showGlobalSearch()

--- a/ElementX/Sources/Application/Windowing/WindowManagerProtocol.swift
+++ b/ElementX/Sources/Application/Windowing/WindowManagerProtocol.swift
@@ -29,13 +29,16 @@ protocol SecureWindowManagerProtocol: WindowManagerProtocol {
     
     func handleRoute(_ appRoute: AppRoute, windowType: WindowManagerWindowType)
     
-    func windowForType(_ type: WindowManagerWindowType) -> AnyView
-    
     /// Shows the main and overlay window combo, hiding the alternate window.
     func switchToMain()
     
     /// Shows the alternate window, hiding the main and overlay combo.
     func switchToAlternate()
+    
+    // MARK: - Auxiliary window support
+    
+    /// Used by the Application to retrieve the root view for an auxiliary window
+    func windowForType(_ type: WindowManagerWindowType) -> AnyView
 }
 
 /// A window manager that supports switching between a main app window with an overlay and
@@ -54,14 +57,21 @@ protocol WindowManagerProtocol: AnyObject, OrientationManagerProtocol {
     /// All the windows being managed
     var windows: [UIWindow] { get }
     
-    func registerCoordinator(_ coordinator: CoordinatorProtocol, flowCoordinator: FlowCoordinatorProtocol?, forWindowType type: WindowManagerWindowType)
-    
-    func closeAllAuxiliaryWindows()
-    
     /// Makes the global search window key. Used to get automatic text field focus.
     func showGlobalSearch()
     
     func hideGlobalSearch()
+    
+    // MARK: - Auxiliary window support
+    
+    /// Register a coordinator and it's respective flow (if any) within the WindowManager which in turn
+    /// invokes the Application's `OpenWindowAction`
+    func registerCoordinator(_ coordinator: CoordinatorProtocol,
+                             flowCoordinator: FlowCoordinatorProtocol?,
+                             forWindowType type: WindowManagerWindowType)
+    
+    /// Closes any window previously opened by registering a coordinator
+    func closeAllAuxiliaryWindows()
     
     /// Closes a previously opened window for the given type.
     func closeAuxiliaryWindow(forType type: WindowManagerWindowType)

--- a/ElementX/Sources/FlowCoordinators/ChatsTabFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/ChatsTabFlowCoordinator.swift
@@ -321,7 +321,11 @@ class ChatsTabFlowCoordinator: FlowCoordinatorProtocol {
             if case .space = detailState {
                 dismissRoomFlow(animated: animated)
             }
-            startRoomFlow(roomID: roomID, via: via, entryPoint: entryPoint, animated: animated)
+            startRoomFlow(roomID: roomID,
+                          via: via,
+                          entryPoint: entryPoint,
+                          detached: false,
+                          animated: animated)
         }
         actionsSubject.send(.hideCallScreenOverlay) // Turn any active call into a PiP so that navigation from a notification is visible to the user.
     }
@@ -393,6 +397,8 @@ class ChatsTabFlowCoordinator: FlowCoordinatorProtocol {
                 switch action {
                 case .presentRoom(let roomID):
                     handleAppRoute(.room(roomID: roomID, via: []), animated: true)
+                case .detachRoom(let roomID):
+                    startRoomFlow(roomID: roomID, via: [], entryPoint: .room, detached: true, animated: true)
                 case .presentRoomDetails(let roomID):
                     handleAppRoute(.roomDetails(roomID: roomID), animated: true)
                 case .presentReportRoom(let roomID):
@@ -516,8 +522,10 @@ class ChatsTabFlowCoordinator: FlowCoordinatorProtocol {
     private func startRoomFlow(roomID: String,
                                via: [String],
                                entryPoint: RoomFlowCoordinatorEntryPoint,
+                               detached: Bool,
                                animated: Bool) {
-        let navigationStackCoordinator = NavigationStackCoordinator(navigationSplitCoordinator: navigationSplitCoordinator)
+        let navigationStackCoordinator = NavigationStackCoordinator(navigationSplitCoordinator: detached ? nil : navigationSplitCoordinator)
+        
         let coordinator = RoomFlowCoordinator(roomID: roomID,
                                               isChildFlow: false,
                                               navigationStackCoordinator: navigationStackCoordinator,
@@ -539,9 +547,14 @@ class ChatsTabFlowCoordinator: FlowCoordinatorProtocol {
         }
         .store(in: &cancellables)
         
-        roomFlowCoordinator = coordinator
-        
-        navigationSplitCoordinator.setDetailCoordinator(navigationStackCoordinator, animated: animated)
+        if detached {
+            flowParameters.windowManager.registerCoordinator(navigationStackCoordinator,
+                                                             flowCoordinator: coordinator,
+                                                             forWindowType: .room(roomID: roomID))
+        } else {
+            roomFlowCoordinator = coordinator
+            navigationSplitCoordinator.setDetailCoordinator(navigationStackCoordinator, animated: animated)
+        }
         
         switch entryPoint {
         case .room:

--- a/ElementX/Sources/FlowCoordinators/ChatsTabFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/ChatsTabFlowCoordinator.swift
@@ -170,6 +170,8 @@ class ChatsTabFlowCoordinator: FlowCoordinatorProtocol {
             } else {
                 stateMachine.processEvent(.presentTransferOwnershipScreen(roomID: roomID))
             }
+        case .globalSearch:
+            presentGlobalSearch()
         case .accountProvisioningLink, .settings, .chatBackupSettings, .call, .genericCallLink:
             break // These routes cannot be handled.
         }
@@ -422,8 +424,6 @@ class ChatsTabFlowCoordinator: FlowCoordinatorProtocol {
                     stateMachine.processEvent(.startEncryptionResetFlow)
                 case .presentStartChatScreen:
                     stateMachine.processEvent(.startStartChatFlow)
-                case .presentGlobalSearch:
-                    presentGlobalSearch()
                 case .logout:
                     actionsSubject.send(.logout)
                 case .presentDeclineAndBlock(let userID, let roomID):

--- a/ElementX/Sources/FlowCoordinators/EncryptionSettingsFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/EncryptionSettingsFlowCoordinator.swift
@@ -83,7 +83,8 @@ class EncryptionSettingsFlowCoordinator: FlowCoordinatorProtocol {
         case .roomList, .room, .roomAlias, .childRoom, .childRoomAlias,
              .roomDetails, .roomMemberDetails, .userProfile, .thread,
              .event, .eventOnRoomAlias, .childEvent, .childEventOnRoomAlias,
-             .call, .genericCallLink, .settings, .share, .transferOwnership:
+             .call, .genericCallLink, .settings, .share, .transferOwnership,
+             .globalSearch:
             // These routes aren't in this flow so clear the entire stack.
             clearRoute(animated: animated)
         case .chatBackupSettings:

--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -199,7 +199,7 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
             }
         case .roomAlias, .childRoomAlias, .eventOnRoomAlias, .childEventOnRoomAlias:
             break // These are converted to a room ID route one level above.
-        case .accountProvisioningLink, .roomList, .userProfile, .call, .genericCallLink, .settings, .chatBackupSettings:
+        case .accountProvisioningLink, .roomList, .userProfile, .call, .genericCallLink, .settings, .chatBackupSettings, .globalSearch:
             break // These routes can't be handled.
         case .transferOwnership(let roomID):
             guard self.roomID == roomID else { fatalError("Navigation route doesn't belong to this room flow.") }

--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -887,7 +887,7 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
             // iPhone the compact module diffs call the dismissal callback and we present a blank space flow 🙈
             if spaceRoomListProxy == nil {
                 navigationStackCoordinator.setRootCoordinator(nil, animated: false)
-                flowParameters.windowManager.closeAuxiliaryWindow(forType: .room(roomID: roomID))
+                flowParameters.windowManager.closeSecondaryWindow(forType: .room(roomID: roomID))
             }
         }
         

--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -887,7 +887,7 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
             // iPhone the compact module diffs call the dismissal callback and we present a blank space flow 🙈
             if spaceRoomListProxy == nil {
                 navigationStackCoordinator.setRootCoordinator(nil, animated: false)
-                flowParameters.windowManager.closeAuxiliaryWindow(forType: .room(roomID: roomProxy.id))
+                flowParameters.windowManager.closeAuxiliaryWindow(forType: .room(roomID: roomID))
             }
         }
         

--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -887,6 +887,7 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
             // iPhone the compact module diffs call the dismissal callback and we present a blank space flow 🙈
             if spaceRoomListProxy == nil {
                 navigationStackCoordinator.setRootCoordinator(nil, animated: false)
+                flowParameters.windowManager.closeAuxiliaryWindow(forType: .room(roomID: roomProxy.id))
             }
         }
         

--- a/ElementX/Sources/FlowCoordinators/RoomMembersFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomMembersFlowCoordinator.swift
@@ -120,7 +120,7 @@ final class RoomMembersFlowCoordinator: FlowCoordinatorProtocol {
             break // These are converted to a room ID route one level above.
         case .accountProvisioningLink, .roomList, .room, .roomDetails, .event,
              .userProfile, .call, .genericCallLink, .settings, .chatBackupSettings,
-             .share, .transferOwnership, .thread:
+             .share, .transferOwnership, .thread, .globalSearch:
             break
         }
     }

--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -122,10 +122,14 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
         case .accountProvisioningLink:
             break // We always ignore this flow when logged in.
         case .settings, .chatBackupSettings:
-            if stateMachine.state != .settingsScreen {
-                stateMachine.tryEvent(.showSettingsScreen)
+            if ProcessInfo.processInfo.isiOSAppOnMac {
+                startSettingsFlow(detached: true)
+            } else {
+                if stateMachine.state != .settingsScreen {
+                    stateMachine.tryEvent(.showSettingsScreen)
+                }
+                settingsFlowCoordinator?.handleAppRoute(appRoute, animated: animated)
             }
-            settingsFlowCoordinator?.handleAppRoute(appRoute, animated: animated)
         case .call(let roomID, let isVoiceCall):
             Task { await presentCallScreen(roomID: roomID, isVoiceCall: isVoiceCall) }
         case .genericCallLink(let url):
@@ -179,7 +183,7 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
         }
         
         stateMachine.addRoutes(event: .showSettingsScreen, transitions: [.tabBar => .settingsScreen]) { [weak self] _ in
-            self?.startSettingsFlow()
+            self?.startSettingsFlow(detached: false)
         }
         stateMachine.addRoutes(event: .dismissedSettingsScreen, transitions: [.settingsScreen => .tabBar]) { [weak self] _ in
             self?.settingsFlowCoordinator = nil
@@ -303,7 +307,7 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
     
     // MARK: - Settings
     
-    private func startSettingsFlow() {
+    private func startSettingsFlow(detached: Bool) {
         let navigationStackCoordinator = NavigationStackCoordinator()
         let coordinator = SettingsFlowCoordinator(appLockService: appLockService,
                                                   navigationStackCoordinator: navigationStackCoordinator,
@@ -331,11 +335,18 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
         }
         .store(in: &cancellables)
         
-        settingsFlowCoordinator = coordinator
         coordinator.handleAppRoute(.settings, animated: false)
         
-        navigationTabCoordinator.setSheetCoordinator(navigationStackCoordinator) { [weak self] in
-            self?.stateMachine.tryEvent(.dismissedSettingsScreen)
+        if detached {
+            flowParameters.windowManager.registerCoordinator(navigationStackCoordinator,
+                                                             flowCoordinator: coordinator,
+                                                             forWindowType: .settings)
+        } else {
+            settingsFlowCoordinator = coordinator
+            
+            navigationTabCoordinator.setSheetCoordinator(navigationStackCoordinator) { [weak self] in
+                self?.stateMachine.tryEvent(.dismissedSettingsScreen)
+            }
         }
     }
     

--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -137,7 +137,7 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
         case .roomList, .room, .roomAlias, .childRoom, .childRoomAlias,
              .roomDetails, .roomMemberDetails, .userProfile,
              .event, .eventOnRoomAlias, .childEvent, .childEventOnRoomAlias,
-             .share, .transferOwnership, .thread:
+             .share, .transferOwnership, .thread, .globalSearch:
             clearPresentedSheets(animated: animated) // Make sure the presented route is visible.
             chatsTabFlowCoordinator.handleAppRoute(appRoute, animated: animated)
             if navigationTabCoordinator.selectedTab != .chats {

--- a/ElementX/Sources/Mocks/AppMediatorMock.swift
+++ b/ElementX/Sources/Mocks/AppMediatorMock.swift
@@ -17,8 +17,8 @@ extension AppMediatorMock {
         mock.underlyingNetworkMonitor = NetworkMonitorMock.default
         
         let windowManagerMock = WindowManagerMock()
-        windowManagerMock.closeAllAuxiliaryWindowsClosure = { }
-        windowManagerMock.closeAuxiliaryWindowForTypeClosure = { _ in }
+        windowManagerMock.closeAllSecondaryWindowsClosure = { }
+        windowManagerMock.closeSecondaryWindowForTypeClosure = { _ in }
         mock.underlyingWindowManager = windowManagerMock
         
         return mock

--- a/ElementX/Sources/Mocks/AppMediatorMock.swift
+++ b/ElementX/Sources/Mocks/AppMediatorMock.swift
@@ -14,8 +14,12 @@ extension AppMediatorMock {
         
         mock.underlyingAppState = .active
         mock.requestAuthorizationIfNeededUnderlyingReturnValue = true
-        mock.underlyingWindowManager = WindowManagerMock()
         mock.underlyingNetworkMonitor = NetworkMonitorMock.default
+        
+        let windowManagerMock = WindowManagerMock()
+        windowManagerMock.closeAllAuxiliaryWindowsClosure = { }
+        windowManagerMock.closeAuxiliaryWindowForTypeClosure = { _ in }
+        mock.underlyingWindowManager = windowManagerMock
         
         return mock
     }

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -21217,6 +21217,47 @@ class WindowManagerMock: WindowManagerProtocol, @unchecked Sendable {
     var alternateWindow: UIWindow!
     var windows: [UIWindow] = []
 
+    //MARK: - registerCoordinator
+
+    var registerCoordinatorFlowCoordinatorForWindowTypeUnderlyingCallsCount = 0
+    var registerCoordinatorFlowCoordinatorForWindowTypeCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return registerCoordinatorFlowCoordinatorForWindowTypeUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = registerCoordinatorFlowCoordinatorForWindowTypeUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                registerCoordinatorFlowCoordinatorForWindowTypeUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    registerCoordinatorFlowCoordinatorForWindowTypeUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var registerCoordinatorFlowCoordinatorForWindowTypeCalled: Bool {
+        return registerCoordinatorFlowCoordinatorForWindowTypeCallsCount > 0
+    }
+    var registerCoordinatorFlowCoordinatorForWindowTypeReceivedArguments: (coordinator: CoordinatorProtocol, flowCoordinator: FlowCoordinatorProtocol?, type: WindowManagerWindowType)?
+    var registerCoordinatorFlowCoordinatorForWindowTypeReceivedInvocations: [(coordinator: CoordinatorProtocol, flowCoordinator: FlowCoordinatorProtocol?, type: WindowManagerWindowType)] = []
+    var registerCoordinatorFlowCoordinatorForWindowTypeClosure: ((CoordinatorProtocol, FlowCoordinatorProtocol?, WindowManagerWindowType) -> Void)?
+
+    func registerCoordinator(_ coordinator: CoordinatorProtocol, flowCoordinator: FlowCoordinatorProtocol?, forWindowType type: WindowManagerWindowType) {
+        registerCoordinatorFlowCoordinatorForWindowTypeCallsCount += 1
+        registerCoordinatorFlowCoordinatorForWindowTypeReceivedArguments = (coordinator: coordinator, flowCoordinator: flowCoordinator, type: type)
+        DispatchQueue.main.async {
+            self.registerCoordinatorFlowCoordinatorForWindowTypeReceivedInvocations.append((coordinator: coordinator, flowCoordinator: flowCoordinator, type: type))
+        }
+        registerCoordinatorFlowCoordinatorForWindowTypeClosure?(coordinator, flowCoordinator, type)
+    }
     //MARK: - showGlobalSearch
 
     var showGlobalSearchUnderlyingCallsCount = 0

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -21258,6 +21258,41 @@ class WindowManagerMock: WindowManagerProtocol, @unchecked Sendable {
         }
         registerCoordinatorFlowCoordinatorForWindowTypeClosure?(coordinator, flowCoordinator, type)
     }
+    //MARK: - closeAllAuxiliaryWindows
+
+    var closeAllAuxiliaryWindowsUnderlyingCallsCount = 0
+    var closeAllAuxiliaryWindowsCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return closeAllAuxiliaryWindowsUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = closeAllAuxiliaryWindowsUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                closeAllAuxiliaryWindowsUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    closeAllAuxiliaryWindowsUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var closeAllAuxiliaryWindowsCalled: Bool {
+        return closeAllAuxiliaryWindowsCallsCount > 0
+    }
+    var closeAllAuxiliaryWindowsClosure: (() -> Void)?
+
+    func closeAllAuxiliaryWindows() {
+        closeAllAuxiliaryWindowsCallsCount += 1
+        closeAllAuxiliaryWindowsClosure?()
+    }
     //MARK: - showGlobalSearch
 
     var showGlobalSearchUnderlyingCallsCount = 0

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -21321,8 +21321,13 @@ class WindowManagerMock: WindowManagerProtocol, @unchecked Sendable {
     }
     var showGlobalSearchCalled: Bool {
         return showGlobalSearchCallsCount > 0
+    var closeAuxiliaryWindowForTypeCalled: Bool {
+        return closeAuxiliaryWindowForTypeCallsCount > 0
     }
     var showGlobalSearchClosure: (() -> Void)?
+    var closeAuxiliaryWindowForTypeReceivedType: WindowManagerWindowType?
+    var closeAuxiliaryWindowForTypeReceivedInvocations: [WindowManagerWindowType] = []
+    var closeAuxiliaryWindowForTypeClosure: ((WindowManagerWindowType) -> Void)?
 
     func showGlobalSearch() {
         showGlobalSearchCallsCount += 1

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -21216,6 +21216,11 @@ class WindowManagerMock: WindowManagerProtocol, @unchecked Sendable {
     var globalSearchWindow: UIWindow!
     var alternateWindow: UIWindow!
     var windows: [UIWindow] = []
+    var auxiliaryWindowsEnabled: Bool {
+        get { return underlyingAuxiliaryWindowsEnabled }
+        set(value) { underlyingAuxiliaryWindowsEnabled = value }
+    }
+    var underlyingAuxiliaryWindowsEnabled: Bool!
 
     //MARK: - showGlobalSearch
 

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -21216,11 +21216,11 @@ class WindowManagerMock: WindowManagerProtocol, @unchecked Sendable {
     var globalSearchWindow: UIWindow!
     var alternateWindow: UIWindow!
     var windows: [UIWindow] = []
-    var auxiliaryWindowsEnabled: Bool {
-        get { return underlyingAuxiliaryWindowsEnabled }
-        set(value) { underlyingAuxiliaryWindowsEnabled = value }
+    var secondaryWindowsEnabled: Bool {
+        get { return underlyingSecondaryWindowsEnabled }
+        set(value) { underlyingSecondaryWindowsEnabled = value }
     }
-    var underlyingAuxiliaryWindowsEnabled: Bool!
+    var underlyingSecondaryWindowsEnabled: Bool!
 
     //MARK: - showGlobalSearch
 
@@ -21321,11 +21321,11 @@ class WindowManagerMock: WindowManagerProtocol, @unchecked Sendable {
     var registerCoordinatorFlowCoordinatorForWindowTypeCalled: Bool {
         return registerCoordinatorFlowCoordinatorForWindowTypeCallsCount > 0
     }
-    var registerCoordinatorFlowCoordinatorForWindowTypeReceivedArguments: (coordinator: CoordinatorProtocol, flowCoordinator: FlowCoordinatorProtocol?, type: WindowManagerWindowType)?
-    var registerCoordinatorFlowCoordinatorForWindowTypeReceivedInvocations: [(coordinator: CoordinatorProtocol, flowCoordinator: FlowCoordinatorProtocol?, type: WindowManagerWindowType)] = []
-    var registerCoordinatorFlowCoordinatorForWindowTypeClosure: ((CoordinatorProtocol, FlowCoordinatorProtocol?, WindowManagerWindowType) -> Void)?
+    var registerCoordinatorFlowCoordinatorForWindowTypeReceivedArguments: (coordinator: CoordinatorProtocol, flowCoordinator: FlowCoordinatorProtocol?, type: SecondaryWindowType)?
+    var registerCoordinatorFlowCoordinatorForWindowTypeReceivedInvocations: [(coordinator: CoordinatorProtocol, flowCoordinator: FlowCoordinatorProtocol?, type: SecondaryWindowType)] = []
+    var registerCoordinatorFlowCoordinatorForWindowTypeClosure: ((CoordinatorProtocol, FlowCoordinatorProtocol?, SecondaryWindowType) -> Void)?
 
-    func registerCoordinator(_ coordinator: CoordinatorProtocol, flowCoordinator: FlowCoordinatorProtocol?, forWindowType type: WindowManagerWindowType) {
+    func registerCoordinator(_ coordinator: CoordinatorProtocol, flowCoordinator: FlowCoordinatorProtocol?, forWindowType type: SecondaryWindowType) {
         registerCoordinatorFlowCoordinatorForWindowTypeCallsCount += 1
         registerCoordinatorFlowCoordinatorForWindowTypeReceivedArguments = (coordinator: coordinator, flowCoordinator: flowCoordinator, type: type)
         DispatchQueue.main.async {
@@ -21333,17 +21333,17 @@ class WindowManagerMock: WindowManagerProtocol, @unchecked Sendable {
         }
         registerCoordinatorFlowCoordinatorForWindowTypeClosure?(coordinator, flowCoordinator, type)
     }
-    //MARK: - closeAllAuxiliaryWindows
+    //MARK: - closeAllSecondaryWindows
 
-    var closeAllAuxiliaryWindowsUnderlyingCallsCount = 0
-    var closeAllAuxiliaryWindowsCallsCount: Int {
+    var closeAllSecondaryWindowsUnderlyingCallsCount = 0
+    var closeAllSecondaryWindowsCallsCount: Int {
         get {
             if Thread.isMainThread {
-                return closeAllAuxiliaryWindowsUnderlyingCallsCount
+                return closeAllSecondaryWindowsUnderlyingCallsCount
             } else {
                 var returnValue: Int? = nil
                 DispatchQueue.main.sync {
-                    returnValue = closeAllAuxiliaryWindowsUnderlyingCallsCount
+                    returnValue = closeAllSecondaryWindowsUnderlyingCallsCount
                 }
 
                 return returnValue!
@@ -21351,34 +21351,34 @@ class WindowManagerMock: WindowManagerProtocol, @unchecked Sendable {
         }
         set {
             if Thread.isMainThread {
-                closeAllAuxiliaryWindowsUnderlyingCallsCount = newValue
+                closeAllSecondaryWindowsUnderlyingCallsCount = newValue
             } else {
                 DispatchQueue.main.sync {
-                    closeAllAuxiliaryWindowsUnderlyingCallsCount = newValue
+                    closeAllSecondaryWindowsUnderlyingCallsCount = newValue
                 }
             }
         }
     }
-    var closeAllAuxiliaryWindowsCalled: Bool {
-        return closeAllAuxiliaryWindowsCallsCount > 0
+    var closeAllSecondaryWindowsCalled: Bool {
+        return closeAllSecondaryWindowsCallsCount > 0
     }
-    var closeAllAuxiliaryWindowsClosure: (() -> Void)?
+    var closeAllSecondaryWindowsClosure: (() -> Void)?
 
-    func closeAllAuxiliaryWindows() {
-        closeAllAuxiliaryWindowsCallsCount += 1
-        closeAllAuxiliaryWindowsClosure?()
+    func closeAllSecondaryWindows() {
+        closeAllSecondaryWindowsCallsCount += 1
+        closeAllSecondaryWindowsClosure?()
     }
-    //MARK: - closeAuxiliaryWindow
+    //MARK: - closeSecondaryWindow
 
-    var closeAuxiliaryWindowForTypeUnderlyingCallsCount = 0
-    var closeAuxiliaryWindowForTypeCallsCount: Int {
+    var closeSecondaryWindowForTypeUnderlyingCallsCount = 0
+    var closeSecondaryWindowForTypeCallsCount: Int {
         get {
             if Thread.isMainThread {
-                return closeAuxiliaryWindowForTypeUnderlyingCallsCount
+                return closeSecondaryWindowForTypeUnderlyingCallsCount
             } else {
                 var returnValue: Int? = nil
                 DispatchQueue.main.sync {
-                    returnValue = closeAuxiliaryWindowForTypeUnderlyingCallsCount
+                    returnValue = closeSecondaryWindowForTypeUnderlyingCallsCount
                 }
 
                 return returnValue!
@@ -21386,28 +21386,28 @@ class WindowManagerMock: WindowManagerProtocol, @unchecked Sendable {
         }
         set {
             if Thread.isMainThread {
-                closeAuxiliaryWindowForTypeUnderlyingCallsCount = newValue
+                closeSecondaryWindowForTypeUnderlyingCallsCount = newValue
             } else {
                 DispatchQueue.main.sync {
-                    closeAuxiliaryWindowForTypeUnderlyingCallsCount = newValue
+                    closeSecondaryWindowForTypeUnderlyingCallsCount = newValue
                 }
             }
         }
     }
-    var closeAuxiliaryWindowForTypeCalled: Bool {
-        return closeAuxiliaryWindowForTypeCallsCount > 0
+    var closeSecondaryWindowForTypeCalled: Bool {
+        return closeSecondaryWindowForTypeCallsCount > 0
     }
-    var closeAuxiliaryWindowForTypeReceivedType: WindowManagerWindowType?
-    var closeAuxiliaryWindowForTypeReceivedInvocations: [WindowManagerWindowType] = []
-    var closeAuxiliaryWindowForTypeClosure: ((WindowManagerWindowType) -> Void)?
+    var closeSecondaryWindowForTypeReceivedType: SecondaryWindowType?
+    var closeSecondaryWindowForTypeReceivedInvocations: [SecondaryWindowType] = []
+    var closeSecondaryWindowForTypeClosure: ((SecondaryWindowType) -> Void)?
 
-    func closeAuxiliaryWindow(forType type: WindowManagerWindowType) {
-        closeAuxiliaryWindowForTypeCallsCount += 1
-        closeAuxiliaryWindowForTypeReceivedType = type
+    func closeSecondaryWindow(forType type: SecondaryWindowType) {
+        closeSecondaryWindowForTypeCallsCount += 1
+        closeSecondaryWindowForTypeReceivedType = type
         DispatchQueue.main.async {
-            self.closeAuxiliaryWindowForTypeReceivedInvocations.append(type)
+            self.closeSecondaryWindowForTypeReceivedInvocations.append(type)
         }
-        closeAuxiliaryWindowForTypeClosure?(type)
+        closeSecondaryWindowForTypeClosure?(type)
     }
     //MARK: - setOrientation
 

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -21217,6 +21217,76 @@ class WindowManagerMock: WindowManagerProtocol, @unchecked Sendable {
     var alternateWindow: UIWindow!
     var windows: [UIWindow] = []
 
+    //MARK: - showGlobalSearch
+
+    var showGlobalSearchUnderlyingCallsCount = 0
+    var showGlobalSearchCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return showGlobalSearchUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = showGlobalSearchUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                showGlobalSearchUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    showGlobalSearchUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var showGlobalSearchCalled: Bool {
+        return showGlobalSearchCallsCount > 0
+    }
+    var showGlobalSearchClosure: (() -> Void)?
+
+    func showGlobalSearch() {
+        showGlobalSearchCallsCount += 1
+        showGlobalSearchClosure?()
+    }
+    //MARK: - hideGlobalSearch
+
+    var hideGlobalSearchUnderlyingCallsCount = 0
+    var hideGlobalSearchCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return hideGlobalSearchUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = hideGlobalSearchUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                hideGlobalSearchUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    hideGlobalSearchUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var hideGlobalSearchCalled: Bool {
+        return hideGlobalSearchCallsCount > 0
+    }
+    var hideGlobalSearchClosure: (() -> Void)?
+
+    func hideGlobalSearch() {
+        hideGlobalSearchCallsCount += 1
+        hideGlobalSearchClosure?()
+    }
     //MARK: - registerCoordinator
 
     var registerCoordinatorFlowCoordinatorForWindowTypeUnderlyingCallsCount = 0
@@ -21293,17 +21363,17 @@ class WindowManagerMock: WindowManagerProtocol, @unchecked Sendable {
         closeAllAuxiliaryWindowsCallsCount += 1
         closeAllAuxiliaryWindowsClosure?()
     }
-    //MARK: - showGlobalSearch
+    //MARK: - closeAuxiliaryWindow
 
-    var showGlobalSearchUnderlyingCallsCount = 0
-    var showGlobalSearchCallsCount: Int {
+    var closeAuxiliaryWindowForTypeUnderlyingCallsCount = 0
+    var closeAuxiliaryWindowForTypeCallsCount: Int {
         get {
             if Thread.isMainThread {
-                return showGlobalSearchUnderlyingCallsCount
+                return closeAuxiliaryWindowForTypeUnderlyingCallsCount
             } else {
                 var returnValue: Int? = nil
                 DispatchQueue.main.sync {
-                    returnValue = showGlobalSearchUnderlyingCallsCount
+                    returnValue = closeAuxiliaryWindowForTypeUnderlyingCallsCount
                 }
 
                 return returnValue!
@@ -21311,62 +21381,28 @@ class WindowManagerMock: WindowManagerProtocol, @unchecked Sendable {
         }
         set {
             if Thread.isMainThread {
-                showGlobalSearchUnderlyingCallsCount = newValue
+                closeAuxiliaryWindowForTypeUnderlyingCallsCount = newValue
             } else {
                 DispatchQueue.main.sync {
-                    showGlobalSearchUnderlyingCallsCount = newValue
+                    closeAuxiliaryWindowForTypeUnderlyingCallsCount = newValue
                 }
             }
         }
     }
-    var showGlobalSearchCalled: Bool {
-        return showGlobalSearchCallsCount > 0
     var closeAuxiliaryWindowForTypeCalled: Bool {
         return closeAuxiliaryWindowForTypeCallsCount > 0
     }
-    var showGlobalSearchClosure: (() -> Void)?
     var closeAuxiliaryWindowForTypeReceivedType: WindowManagerWindowType?
     var closeAuxiliaryWindowForTypeReceivedInvocations: [WindowManagerWindowType] = []
     var closeAuxiliaryWindowForTypeClosure: ((WindowManagerWindowType) -> Void)?
 
-    func showGlobalSearch() {
-        showGlobalSearchCallsCount += 1
-        showGlobalSearchClosure?()
-    }
-    //MARK: - hideGlobalSearch
-
-    var hideGlobalSearchUnderlyingCallsCount = 0
-    var hideGlobalSearchCallsCount: Int {
-        get {
-            if Thread.isMainThread {
-                return hideGlobalSearchUnderlyingCallsCount
-            } else {
-                var returnValue: Int? = nil
-                DispatchQueue.main.sync {
-                    returnValue = hideGlobalSearchUnderlyingCallsCount
-                }
-
-                return returnValue!
-            }
+    func closeAuxiliaryWindow(forType type: WindowManagerWindowType) {
+        closeAuxiliaryWindowForTypeCallsCount += 1
+        closeAuxiliaryWindowForTypeReceivedType = type
+        DispatchQueue.main.async {
+            self.closeAuxiliaryWindowForTypeReceivedInvocations.append(type)
         }
-        set {
-            if Thread.isMainThread {
-                hideGlobalSearchUnderlyingCallsCount = newValue
-            } else {
-                DispatchQueue.main.sync {
-                    hideGlobalSearchUnderlyingCallsCount = newValue
-                }
-            }
-        }
-    }
-    var hideGlobalSearchCalled: Bool {
-        return hideGlobalSearchCallsCount > 0
-    }
-    var hideGlobalSearchClosure: (() -> Void)?
-
-    func hideGlobalSearch() {
-        hideGlobalSearchCallsCount += 1
-        hideGlobalSearchClosure?()
+        closeAuxiliaryWindowForTypeClosure?(type)
     }
     //MARK: - setOrientation
 

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenCoordinator.swift
@@ -21,6 +21,7 @@ struct HomeScreenCoordinatorParameters {
 
 enum HomeScreenCoordinatorAction {
     case presentRoom(roomIdentifier: String)
+    case detachRoom(roomIdentifier: String)
     case presentRoomDetails(roomIdentifier: String)
     case presentReportRoom(roomIdentifier: String)
     case presentDeclineAndBlock(userID: String, roomID: String)
@@ -65,6 +66,8 @@ final class HomeScreenCoordinator: CoordinatorProtocol {
                 switch action {
                 case .presentRoom(let roomIdentifier):
                     actionsSubject.send(.presentRoom(roomIdentifier: roomIdentifier))
+                case .detachRoom(let roomIdentifier):
+                    actionsSubject.send(.detachRoom(roomIdentifier: roomIdentifier))
                 case .presentRoomDetails(roomIdentifier: let roomIdentifier):
                     actionsSubject.send(.presentRoomDetails(roomIdentifier: roomIdentifier))
                 case .presentReportRoom(let roomIdentifier):

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenCoordinator.swift
@@ -34,7 +34,6 @@ enum HomeScreenCoordinatorAction {
     case presentRecoveryKeyScreen
     case presentEncryptionResetScreen
     case presentStartChatScreen
-    case presentGlobalSearch
     case logout
 }
 
@@ -90,8 +89,6 @@ final class HomeScreenCoordinator: CoordinatorProtocol {
                     actionsSubject.send(.presentEncryptionResetScreen)
                 case .presentStartChatScreen:
                     actionsSubject.send(.presentStartChatScreen)
-                case .presentGlobalSearch:
-                    actionsSubject.send(.presentGlobalSearch)
                 case .logout:
                     actionsSubject.send(.logout)
                 case .transferOwnership(let roomIdentifier):

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
@@ -12,6 +12,7 @@ import UIKit
 
 enum HomeScreenViewModelAction {
     case presentRoom(roomIdentifier: String)
+    case detachRoom(roomIdentifier: String)
     case presentRoomDetails(roomIdentifier: String)
     case presentReportRoom(roomIdentifier: String)
     case presentDeclineAndBlock(userID: String, roomID: String)
@@ -30,6 +31,7 @@ enum HomeScreenViewModelAction {
 
 enum HomeScreenViewAction {
     case selectRoom(roomIdentifier: String)
+    case detachRoom(roomIdentifier: String)
     case showRoomDetails(roomIdentifier: String)
     case leaveRoom(roomIdentifier: String)
     case confirmLeaveRoom(roomIdentifier: String)

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
@@ -25,7 +25,6 @@ enum HomeScreenViewModelAction {
     case presentSettingsScreen
     case presentFeedbackScreen
     case presentStartChatScreen
-    case presentGlobalSearch
     case logout
 }
 
@@ -44,7 +43,6 @@ enum HomeScreenViewAction {
     case skipRecoveryKeyConfirmation
     case dismissNewSoundBanner
     case updateVisibleItemRange(Range<Int>)
-    case globalSearch
     case spaceFilters
     case markRoomAsUnread(roomIdentifier: String)
     case markRoomAsRead(roomIdentifier: String)

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -173,6 +173,8 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
         switch viewAction {
         case .selectRoom(let roomIdentifier):
             actionsSubject.send(.presentRoom(roomIdentifier: roomIdentifier))
+        case .detachRoom(let roomIdentifier):
+            actionsSubject.send(.detachRoom(roomIdentifier: roomIdentifier))
         case .showRoomDetails(let roomIdentifier):
             actionsSubject.send(.presentRoomDetails(roomIdentifier: roomIdentifier))
         case .leaveRoom(let roomIdentifier):

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -199,8 +199,6 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
             roomSummaryProvider?.updateVisibleRange(range)
         case .startChat:
             actionsSubject.send(.presentStartChatScreen)
-        case .globalSearch:
-            actionsSubject.send(.presentGlobalSearch)
         case .spaceFilters:
             if spaceFilterSubject.value != nil {
                 spaceFilterSubject.send(nil)

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreenContent.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreenContent.swift
@@ -99,12 +99,6 @@ struct HomeScreenContent: View {
                     scrollView.setContentOffset(oldOffset, animated: false)
                 }
             }
-            .background {
-                Button("") {
-                    context.send(viewAction: .globalSearch)
-                }
-                .keyboardShortcut(KeyEquivalent("k"), modifiers: [.command])
-            }
             .overlay {
                 if context.viewState.shouldShowEmptyFilterState {
                     RoomListFiltersEmptyStateView(state: context.filtersState)

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreenRoomList.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreenRoomList.swift
@@ -9,6 +9,8 @@
 import SwiftUI
 
 struct HomeScreenRoomList: View {
+    @Environment(\.supportsMultipleWindows) private var supportsMultipleWindows
+    
     @ObservedObject var context: HomeScreenViewModel.Context
     
     var body: some View {
@@ -38,7 +40,7 @@ struct HomeScreenRoomList: View {
                         context.send(viewAction: .detachRoom(roomIdentifier: room.id))
                     })
                     .contextMenu {
-                        if !UIDevice.current.isPhone {
+                        if supportsMultipleWindows {
                             Button {
                                 context.send(viewAction: .detachRoom(roomIdentifier: room.id))
                             } label: {

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreenRoomList.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreenRoomList.swift
@@ -34,7 +34,18 @@ struct HomeScreenRoomList: View {
                 let isSelected = context.viewState.selectedRoomID == room.id
                 
                 HomeScreenRoomCell(room: room, isSelected: isSelected, mediaProvider: context.mediaProvider, action: context.send)
+                    .simultaneousGesture(TapGesture(count: 2).onEnded {
+                        context.send(viewAction: .detachRoom(roomIdentifier: room.id))
+                    })
                     .contextMenu {
+                        if !UIDevice.current.isPhone {
+                            Button {
+                                context.send(viewAction: .detachRoom(roomIdentifier: room.id))
+                            } label: {
+                                Label("Open in new window", icon: \.popOut)
+                            }
+                        }
+                        
                         if room.badges.isDotShown {
                             Button {
                                 context.send(viewAction: .markRoomAsRead(roomIdentifier: room.id))

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreenRoomList.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreenRoomList.swift
@@ -40,14 +40,6 @@ struct HomeScreenRoomList: View {
                         context.send(viewAction: .detachRoom(roomIdentifier: room.id))
                     })
                     .contextMenu {
-                        if supportsMultipleWindows {
-                            Button {
-                                context.send(viewAction: .detachRoom(roomIdentifier: room.id))
-                            } label: {
-                                Label("Open in new window", icon: \.popOut)
-                            }
-                        }
-                        
                         if room.badges.isDotShown {
                             Button {
                                 context.send(viewAction: .markRoomAsRead(roomIdentifier: room.id))
@@ -59,6 +51,14 @@ struct HomeScreenRoomList: View {
                                 context.send(viewAction: .markRoomAsUnread(roomIdentifier: room.id))
                             } label: {
                                 Label(L10n.screenRoomlistMarkAsUnread, icon: \.markAsUnread)
+                            }
+                        }
+                        
+                        if supportsMultipleWindows {
+                            Button {
+                                context.send(viewAction: .detachRoom(roomIdentifier: room.id))
+                            } label: {
+                                Label("Open in new window", icon: \.spotlight)
                             }
                         }
                         

--- a/ElementX/Sources/Screens/Settings/SettingsScreen/View/SettingsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/SettingsScreen/View/SettingsScreen.swift
@@ -40,6 +40,7 @@ struct SettingsScreen: View {
         .compoundList()
         .navigationTitle(L10n.commonSettings)
         .navigationBarTitleDisplayMode(.inline)
+        .toolbarVisibility(ProcessInfo.processInfo.isiOSAppOnMac ? .hidden : .automatic, for: .navigationBar)
         .toolbar { toolbar }
     }
     

--- a/ElementX/Sources/UITests/UITestsAppCoordinator.swift
+++ b/ElementX/Sources/UITests/UITestsAppCoordinator.swift
@@ -65,11 +65,11 @@ class UITestsAppCoordinator: AppCoordinatorProtocol, SecureWindowManagerDelegate
         fatalError("Not implemented.")
     }
     
-    func handleDeepLink(_ url: URL, isExternalURL: Bool, windowType: WindowManagerWindowType?) -> Bool {
+    func handleDeepLink(_ url: URL, isExternalURL: Bool, windowType: SecondaryWindowType?) -> Bool {
         fatalError("Not implemented.")
     }
     
-    func handleAppRoute(_ appRoute: AppRoute, windowType: WindowManagerWindowType?) {
+    func handleAppRoute(_ appRoute: AppRoute, windowType: SecondaryWindowType?) {
         fatalError("Not implemented.")
     }
     

--- a/ElementX/Sources/UITests/UITestsAppCoordinator.swift
+++ b/ElementX/Sources/UITests/UITestsAppCoordinator.swift
@@ -65,7 +65,11 @@ class UITestsAppCoordinator: AppCoordinatorProtocol, SecureWindowManagerDelegate
         fatalError("Not implemented.")
     }
     
-    func handleDeepLink(_ url: URL, isExternalURL: Bool) -> Bool {
+    func handleDeepLink(_ url: URL, isExternalURL: Bool, windowType: WindowManagerWindowType?) -> Bool {
+        fatalError("Not implemented.")
+    }
+    
+    func handleAppRoute(_ appRoute: AppRoute, windowType: WindowManagerWindowType?) {
         fatalError("Not implemented.")
     }
     

--- a/ElementX/Sources/UnitTests/UnitTestsAppCoordinator.swift
+++ b/ElementX/Sources/UnitTests/UnitTestsAppCoordinator.swift
@@ -50,11 +50,11 @@ class UnitTestsAppCoordinator: AppCoordinatorProtocol {
         fatalError("Not implemented.")
     }
     
-    func handleDeepLink(_ url: URL, isExternalURL: Bool, windowType: WindowManagerWindowType?) -> Bool {
+    func handleDeepLink(_ url: URL, isExternalURL: Bool, windowType: SecondaryWindowType?) -> Bool {
         fatalError("Not implemented.")
     }
     
-    func handleAppRoute(_ appRoute: AppRoute, windowType: WindowManagerWindowType?) {
+    func handleAppRoute(_ appRoute: AppRoute, windowType: SecondaryWindowType?) {
         fatalError("Not implemented.")
     }
     

--- a/ElementX/Sources/UnitTests/UnitTestsAppCoordinator.swift
+++ b/ElementX/Sources/UnitTests/UnitTestsAppCoordinator.swift
@@ -50,7 +50,11 @@ class UnitTestsAppCoordinator: AppCoordinatorProtocol {
         fatalError("Not implemented.")
     }
     
-    func handleDeepLink(_ url: URL, isExternalURL: Bool) -> Bool {
+    func handleDeepLink(_ url: URL, isExternalURL: Bool, windowType: WindowManagerWindowType?) -> Bool {
+        fatalError("Not implemented.")
+    }
+    
+    func handleAppRoute(_ appRoute: AppRoute, windowType: WindowManagerWindowType?) {
         fatalError("Not implemented.")
     }
     

--- a/ElementX/SupportingFiles/Info.plist
+++ b/ElementX/SupportingFiles/Info.plist
@@ -80,6 +80,11 @@
 		<string>INSendMessageIntent</string>
 		<string>INStartCallIntent</string>
 	</array>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+	</dict>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>

--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -67,6 +67,9 @@ targets:
             ]
           }
         ]
+        UIApplicationSceneManifest: {
+          UIApplicationSupportsMultipleScenes: true
+        }
         UISupportedInterfaceOrientations: [
           UIInterfaceOrientationPortrait,
           UIInterfaceOrientationPortraitUpsideDown,

--- a/UnitTests/Sources/HomeScreenViewModelTests.swift
+++ b/UnitTests/Sources/HomeScreenViewModelTests.swift
@@ -488,8 +488,6 @@ extension HomeScreenViewModelAction: @retroactive Equatable {
             true
         case (.presentStartChatScreen, .presentStartChatScreen):
             true
-        case (.presentGlobalSearch, .presentGlobalSearch):
-            true
         case (.logout, .logout):
             true
         default:


### PR DESCRIPTION
This takes avantage of our neatly decoupled architecture to do the following:

Once the app starts the WindowManager is configured with SwiftUI's environment `OpenWindowAction`. It can then be used to register coordinators (that provide the toPresentable view) and an optional flow coordinator (as most of the screens are part of a flow, especially rooms). 
Once a coordinator is registed, the WindowManager invokes the `OpenWindowAction` which in turn makes the Application call its newly introduced `WindowManagerWindowType` `WindowGroup`'s block to instantiate a new visual window rooting that view.

The WindowManager is also responsible for wrapping the presentable in a disappearance block and clean up the coordinator stack. 

The rest lies in various tweaks like disabling multi window when the pin lock is enabled, closing windows when leaving rooms, focusing the main window when opening global search (cmd+k) etc.

As presented in http://youtube.com/watch?v=Bo7GaLRhtc0&t=1790s

<img width="877" height="572" alt="Screenshot 2026-03-31 at 19 33 24" src="https://github.com/user-attachments/assets/55c37c44-2552-4779-9ec4-271dd61ae686" />
