### PR TITLE
Start, send and stop live location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ build
 
 ## Editors
 .nova
+.vscode
 
 ## Project specific
 test_output

--- a/ElementX/Resources/Localizations/en-US.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en-US.lproj/Localizable.strings
@@ -680,6 +680,13 @@
 "screen_media_upload_preview_item_count" = "Item %1$d of %2$d";
 "screen_media_upload_preview_optimize_image_quality_title" = "Optimize image quality";
 "screen_media_upload_preview_processing" = "Processing...";
+"screen_missing_key_backup_open_element_classic" = "Open Element Classic";
+"screen_missing_key_backup_step_1" = "Open Element Classic on your device";
+"screen_missing_key_backup_step_2" = "Go to \"Settings\" > \"Security &Privacy\"";
+"screen_missing_key_backup_step_3" = "In the section \"Cryptography Keys Management\", click on \"Encrypted Messages Recovery\"";
+"screen_missing_key_backup_step_4" = "Follow instructions";
+"screen_missing_key_backup_step_5" = "Done!";
+"screen_missing_key_backup_title" = "We need you to enable your key storage before processing to %1$@";
 "screen_onboarding_welcome_back" = "Welcome back";
 "screen_pinned_timeline_empty_state_description" = "Press on a message and choose “%1$@” to include here.";
 "screen_pinned_timeline_empty_state_headline" = "Pin important messages so that they can be easily discovered";
@@ -758,6 +765,7 @@
 "screen_security_and_privacy_room_visibility_section_footer" = "Addresses are a way to find and access rooms and spaces. This also ensures you can easily share them with others.";
 "screen_security_and_privacy_room_visibility_section_header" = "Visibility";
 "screen_security_and_privacy_title" = "Security & privacy";
+"screen_share_location_live_location_disclaimer_title" = "Your live location history will be stored in the room and visible to members after the session ends.";
 "screen_share_location_live_location_duration_picker_title" = "Choose how long to share your live location.";
 "screen_sharing_location_option_sheet_title" = "Sharing options";
 "screen_space_add_room_action" = "Room";

--- a/ElementX/Resources/Localizations/en.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Localizable.strings
@@ -680,6 +680,13 @@
 "screen_media_upload_preview_item_count" = "Item %1$d of %2$d";
 "screen_media_upload_preview_optimize_image_quality_title" = "Optimise image quality";
 "screen_media_upload_preview_processing" = "Processing...";
+"screen_missing_key_backup_open_element_classic" = "Open Element Classic";
+"screen_missing_key_backup_step_1" = "Open Element Classic on your device";
+"screen_missing_key_backup_step_2" = "Go to \"Settings\" > \"Security &Privacy\"";
+"screen_missing_key_backup_step_3" = "In the section \"Cryptography Keys Management\", click on \"Encrypted Messages Recovery\"";
+"screen_missing_key_backup_step_4" = "Follow instructions";
+"screen_missing_key_backup_step_5" = "Done!";
+"screen_missing_key_backup_title" = "We need you to enable your key storage before processing to %1$@";
 "screen_onboarding_welcome_back" = "Welcome back";
 "screen_pinned_timeline_empty_state_description" = "Press on a message and choose “%1$@” to include here.";
 "screen_pinned_timeline_empty_state_headline" = "Pin important messages so that they can be easily discovered";
@@ -758,6 +765,7 @@
 "screen_security_and_privacy_room_visibility_section_footer" = "Addresses are a way to find and access rooms and spaces. This also ensures you can easily share them with others.";
 "screen_security_and_privacy_room_visibility_section_header" = "Visibility";
 "screen_security_and_privacy_title" = "Security & privacy";
+"screen_share_location_live_location_disclaimer_title" = "Your live location history will be stored in the room and visible to members after the session ends.";
 "screen_share_location_live_location_duration_picker_title" = "Choose how long to share your live location.";
 "screen_sharing_location_option_sheet_title" = "Sharing options";
 "screen_space_add_room_action" = "Room";

--- a/ElementX/Sources/Application/Settings/AppSettings.swift
+++ b/ElementX/Sources/Application/Settings/AppSettings.swift
@@ -80,6 +80,7 @@ final class AppSettings {
         case focusEventOnNotificationTap
         case linkNewDeviceEnabled
         case liveLocationSharingEnabled
+        case liveLocationSharingTimeoutDatesByRoomID
         case floatingTimelineDateEnabled
         
         // Doug's tweaks 🔧
@@ -348,6 +349,9 @@ final class AppSettings {
     
     @UserPreference(key: UserDefaultsKeys.hasRequestedLocationAlwaysLocationAuthorization, defaultValue: false, storageType: .userDefaults(store))
     var hasRequestedLocationAlwaysLocationAuthorization
+    
+    @UserPreference(key: UserDefaultsKeys.liveLocationSharingTimeoutDatesByRoomID, defaultValue: [String: Date](), storageType: .userDefaults(store))
+    var liveLocationSharingTimeoutDatesByRoomID
     
     @UserPreference(key: UserDefaultsKeys.frequentlyUsedSystemEmojis, defaultValue: [FrequentlyUsedEmoji](), storageType: .userDefaults(store))
     var frequentlyUsedSystemEmojis

--- a/ElementX/Sources/Generated/Strings.swift
+++ b/ElementX/Sources/Generated/Strings.swift
@@ -2200,6 +2200,22 @@ internal enum L10n {
   internal static var screenMigrationMessage: String { return L10n.tr("Localizable", "screen_migration_message") }
   /// Setting up your account.
   internal static var screenMigrationTitle: String { return L10n.tr("Localizable", "screen_migration_title") }
+  /// Open Element Classic
+  internal static var screenMissingKeyBackupOpenElementClassic: String { return L10n.tr("Localizable", "screen_missing_key_backup_open_element_classic") }
+  /// Open Element Classic on your device
+  internal static var screenMissingKeyBackupStep1: String { return L10n.tr("Localizable", "screen_missing_key_backup_step_1") }
+  /// Go to "Settings" > "Security &Privacy"
+  internal static var screenMissingKeyBackupStep2: String { return L10n.tr("Localizable", "screen_missing_key_backup_step_2") }
+  /// In the section "Cryptography Keys Management", click on "Encrypted Messages Recovery"
+  internal static var screenMissingKeyBackupStep3: String { return L10n.tr("Localizable", "screen_missing_key_backup_step_3") }
+  /// Follow instructions
+  internal static var screenMissingKeyBackupStep4: String { return L10n.tr("Localizable", "screen_missing_key_backup_step_4") }
+  /// Done!
+  internal static var screenMissingKeyBackupStep5: String { return L10n.tr("Localizable", "screen_missing_key_backup_step_5") }
+  /// We need you to enable your key storage before processing to %1$@
+  internal static func screenMissingKeyBackupTitle(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "screen_missing_key_backup_title", String(describing: p1))
+  }
   /// You can change your settings later.
   internal static var screenNotificationOptinSubtitle: String { return L10n.tr("Localizable", "screen_notification_optin_subtitle") }
   /// Allow notifications and never miss a message
@@ -3183,6 +3199,8 @@ internal enum L10n {
   internal static var screenSessionVerificationWaitingToAcceptSubtitle: String { return L10n.tr("Localizable", "screen_session_verification_waiting_to_accept_subtitle") }
   /// Waiting to accept request
   internal static var screenSessionVerificationWaitingToAcceptTitle: String { return L10n.tr("Localizable", "screen_session_verification_waiting_to_accept_title") }
+  /// Your live location history will be stored in the room and visible to members after the session ends.
+  internal static var screenShareLocationLiveLocationDisclaimerTitle: String { return L10n.tr("Localizable", "screen_share_location_live_location_disclaimer_title") }
   /// Choose how long to share your live location.
   internal static var screenShareLocationLiveLocationDurationPickerTitle: String { return L10n.tr("Localizable", "screen_share_location_live_location_duration_picker_title") }
   /// Share location

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -10062,6 +10062,210 @@ class JoinedRoomProxyMock: JoinedRoomProxyProtocol, @unchecked Sendable {
             return clearDraftThreadRootEventIDReturnValue
         }
     }
+    //MARK: - startLiveLocationShare
+
+    var startLiveLocationShareDurationMillisUnderlyingCallsCount = 0
+    var startLiveLocationShareDurationMillisCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return startLiveLocationShareDurationMillisUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = startLiveLocationShareDurationMillisUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                startLiveLocationShareDurationMillisUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    startLiveLocationShareDurationMillisUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var startLiveLocationShareDurationMillisCalled: Bool {
+        return startLiveLocationShareDurationMillisCallsCount > 0
+    }
+    var startLiveLocationShareDurationMillisReceivedDurationMillis: UInt64?
+    var startLiveLocationShareDurationMillisReceivedInvocations: [UInt64] = []
+
+    var startLiveLocationShareDurationMillisUnderlyingReturnValue: Result<Void, RoomProxyError>!
+    var startLiveLocationShareDurationMillisReturnValue: Result<Void, RoomProxyError>! {
+        get {
+            if Thread.isMainThread {
+                return startLiveLocationShareDurationMillisUnderlyingReturnValue
+            } else {
+                var returnValue: Result<Void, RoomProxyError>? = nil
+                DispatchQueue.main.sync {
+                    returnValue = startLiveLocationShareDurationMillisUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                startLiveLocationShareDurationMillisUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    startLiveLocationShareDurationMillisUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    var startLiveLocationShareDurationMillisClosure: ((UInt64) async -> Result<Void, RoomProxyError>)?
+
+    func startLiveLocationShare(durationMillis: UInt64) async -> Result<Void, RoomProxyError> {
+        startLiveLocationShareDurationMillisCallsCount += 1
+        startLiveLocationShareDurationMillisReceivedDurationMillis = durationMillis
+        DispatchQueue.main.async {
+            self.startLiveLocationShareDurationMillisReceivedInvocations.append(durationMillis)
+        }
+        if let startLiveLocationShareDurationMillisClosure = startLiveLocationShareDurationMillisClosure {
+            return await startLiveLocationShareDurationMillisClosure(durationMillis)
+        } else {
+            return startLiveLocationShareDurationMillisReturnValue
+        }
+    }
+    //MARK: - sendLiveLocation
+
+    var sendLiveLocationGeoURIUnderlyingCallsCount = 0
+    var sendLiveLocationGeoURICallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return sendLiveLocationGeoURIUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = sendLiveLocationGeoURIUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                sendLiveLocationGeoURIUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    sendLiveLocationGeoURIUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var sendLiveLocationGeoURICalled: Bool {
+        return sendLiveLocationGeoURICallsCount > 0
+    }
+    var sendLiveLocationGeoURIReceivedGeoURI: GeoURI?
+    var sendLiveLocationGeoURIReceivedInvocations: [GeoURI] = []
+
+    var sendLiveLocationGeoURIUnderlyingReturnValue: Result<Void, RoomProxyError>!
+    var sendLiveLocationGeoURIReturnValue: Result<Void, RoomProxyError>! {
+        get {
+            if Thread.isMainThread {
+                return sendLiveLocationGeoURIUnderlyingReturnValue
+            } else {
+                var returnValue: Result<Void, RoomProxyError>? = nil
+                DispatchQueue.main.sync {
+                    returnValue = sendLiveLocationGeoURIUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                sendLiveLocationGeoURIUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    sendLiveLocationGeoURIUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    var sendLiveLocationGeoURIClosure: ((GeoURI) async -> Result<Void, RoomProxyError>)?
+
+    func sendLiveLocation(geoURI: GeoURI) async -> Result<Void, RoomProxyError> {
+        sendLiveLocationGeoURICallsCount += 1
+        sendLiveLocationGeoURIReceivedGeoURI = geoURI
+        DispatchQueue.main.async {
+            self.sendLiveLocationGeoURIReceivedInvocations.append(geoURI)
+        }
+        if let sendLiveLocationGeoURIClosure = sendLiveLocationGeoURIClosure {
+            return await sendLiveLocationGeoURIClosure(geoURI)
+        } else {
+            return sendLiveLocationGeoURIReturnValue
+        }
+    }
+    //MARK: - stopLiveLocationShare
+
+    var stopLiveLocationShareUnderlyingCallsCount = 0
+    var stopLiveLocationShareCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return stopLiveLocationShareUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = stopLiveLocationShareUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                stopLiveLocationShareUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    stopLiveLocationShareUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var stopLiveLocationShareCalled: Bool {
+        return stopLiveLocationShareCallsCount > 0
+    }
+
+    var stopLiveLocationShareUnderlyingReturnValue: Result<Void, RoomProxyError>!
+    var stopLiveLocationShareReturnValue: Result<Void, RoomProxyError>! {
+        get {
+            if Thread.isMainThread {
+                return stopLiveLocationShareUnderlyingReturnValue
+            } else {
+                var returnValue: Result<Void, RoomProxyError>? = nil
+                DispatchQueue.main.sync {
+                    returnValue = stopLiveLocationShareUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                stopLiveLocationShareUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    stopLiveLocationShareUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    var stopLiveLocationShareClosure: (() async -> Result<Void, RoomProxyError>)?
+
+    func stopLiveLocationShare() async -> Result<Void, RoomProxyError> {
+        stopLiveLocationShareCallsCount += 1
+        if let stopLiveLocationShareClosure = stopLiveLocationShareClosure {
+            return await stopLiveLocationShareClosure()
+        } else {
+            return stopLiveLocationShareReturnValue
+        }
+    }
 }
 class KeychainControllerMock: KeychainControllerProtocol, @unchecked Sendable {
 
@@ -11235,6 +11439,117 @@ class LiveLocationManagerMock: LiveLocationManagerProtocol, @unchecked Sendable 
         } else {
             return requestAlwaysAuthorizationIfPossibleReturnValue
         }
+    }
+    //MARK: - startLiveLocation
+
+    var startLiveLocationRoomIDDurationMillisUnderlyingCallsCount = 0
+    var startLiveLocationRoomIDDurationMillisCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return startLiveLocationRoomIDDurationMillisUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = startLiveLocationRoomIDDurationMillisUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                startLiveLocationRoomIDDurationMillisUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    startLiveLocationRoomIDDurationMillisUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var startLiveLocationRoomIDDurationMillisCalled: Bool {
+        return startLiveLocationRoomIDDurationMillisCallsCount > 0
+    }
+    var startLiveLocationRoomIDDurationMillisReceivedArguments: (roomID: String, durationMillis: UInt64)?
+    var startLiveLocationRoomIDDurationMillisReceivedInvocations: [(roomID: String, durationMillis: UInt64)] = []
+
+    var startLiveLocationRoomIDDurationMillisUnderlyingReturnValue: Result<Void, LiveLocationManagerError>!
+    var startLiveLocationRoomIDDurationMillisReturnValue: Result<Void, LiveLocationManagerError>! {
+        get {
+            if Thread.isMainThread {
+                return startLiveLocationRoomIDDurationMillisUnderlyingReturnValue
+            } else {
+                var returnValue: Result<Void, LiveLocationManagerError>? = nil
+                DispatchQueue.main.sync {
+                    returnValue = startLiveLocationRoomIDDurationMillisUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                startLiveLocationRoomIDDurationMillisUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    startLiveLocationRoomIDDurationMillisUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    var startLiveLocationRoomIDDurationMillisClosure: ((String, UInt64) async -> Result<Void, LiveLocationManagerError>)?
+
+    func startLiveLocation(roomID: String, durationMillis: UInt64) async -> Result<Void, LiveLocationManagerError> {
+        startLiveLocationRoomIDDurationMillisCallsCount += 1
+        startLiveLocationRoomIDDurationMillisReceivedArguments = (roomID: roomID, durationMillis: durationMillis)
+        DispatchQueue.main.async {
+            self.startLiveLocationRoomIDDurationMillisReceivedInvocations.append((roomID: roomID, durationMillis: durationMillis))
+        }
+        if let startLiveLocationRoomIDDurationMillisClosure = startLiveLocationRoomIDDurationMillisClosure {
+            return await startLiveLocationRoomIDDurationMillisClosure(roomID, durationMillis)
+        } else {
+            return startLiveLocationRoomIDDurationMillisReturnValue
+        }
+    }
+    //MARK: - stopLiveLocation
+
+    var stopLiveLocationRoomIDUnderlyingCallsCount = 0
+    var stopLiveLocationRoomIDCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return stopLiveLocationRoomIDUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = stopLiveLocationRoomIDUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                stopLiveLocationRoomIDUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    stopLiveLocationRoomIDUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var stopLiveLocationRoomIDCalled: Bool {
+        return stopLiveLocationRoomIDCallsCount > 0
+    }
+    var stopLiveLocationRoomIDReceivedRoomID: String?
+    var stopLiveLocationRoomIDReceivedInvocations: [String] = []
+    var stopLiveLocationRoomIDClosure: ((String) async -> Void)?
+
+    func stopLiveLocation(roomID: String) async {
+        stopLiveLocationRoomIDCallsCount += 1
+        stopLiveLocationRoomIDReceivedRoomID = roomID
+        DispatchQueue.main.async {
+            self.stopLiveLocationRoomIDReceivedInvocations.append(roomID)
+        }
+        await stopLiveLocationRoomIDClosure?(roomID)
     }
 }
 class MediaLoaderMock: MediaLoaderProtocol, @unchecked Sendable {

--- a/ElementX/Sources/Mocks/LiveLocationManagerMock.swift
+++ b/ElementX/Sources/Mocks/LiveLocationManagerMock.swift
@@ -21,5 +21,6 @@ extension LiveLocationManagerMock {
         underlyingAuthorizationStatus = .init(authorizationStatusSubject)
         
         requestAlwaysAuthorizationIfPossibleReturnValue = configuration.requestAlwaysAuthorizationIfPossibleReturnValue
+        startLiveLocationRoomIDDurationMillisReturnValue = .success(())
     }
 }

--- a/ElementX/Sources/Screens/LocationSharing/LocationSharingScreenModels.swift
+++ b/ElementX/Sources/Screens/LocationSharing/LocationSharingScreenModels.swift
@@ -10,9 +10,11 @@ import CoreLocation
 import Foundation
 import MatrixRustSDK
 
-enum LocationSharingViewError: Error, Hashable {
+enum LocationSharingViewAlert: Hashable {
     case missingAuthorization
     case missingAlwaysAuthorization
+    case liveLocationDisclaimer
+    case liveLocationDurationSelection
     case mapError(MapLibreError)
 }
 
@@ -130,12 +132,12 @@ struct LocationSharingScreenBindings {
             return nil
         }
         set {
-            alertInfo = newValue.map { AlertInfo(locationSharingViewError: .mapError($0)) }
+            alertInfo = newValue.map { AlertInfo(alertID: .mapError($0)) }
         }
     }
     
     /// Information describing the currently displayed alert.
-    var alertInfo: AlertInfo<LocationSharingViewError>?
+    var alertInfo: AlertInfo<LocationSharingViewAlert>?
 
     var showShareSheet = false
 }
@@ -148,30 +150,42 @@ enum LocationSharingScreenViewAction {
     case userDidPan
 }
 
-extension AlertInfo where T == LocationSharingViewError {
-    init(locationSharingViewError error: LocationSharingViewError,
+extension AlertInfo where T == LocationSharingViewAlert {
+    init(alertID: LocationSharingViewAlert,
          primaryButton: AlertButton = AlertButton(title: L10n.actionOk, action: nil),
-         secondaryButton: AlertButton? = nil) {
-        switch error {
+         secondaryButton: AlertButton? = nil,
+         verticalButtons: [AlertButton]? = nil) {
+        switch alertID {
         case .missingAuthorization:
-            self.init(id: error,
+            self.init(id: alertID,
                       title: L10n.dialogAllowAccess,
                       message: L10n.dialogPermissionLocationDescriptionIos(InfoPlistReader.main.bundleDisplayName),
                       primaryButton: primaryButton,
                       secondaryButton: secondaryButton)
         case .missingAlwaysAuthorization:
-            self.init(id: error,
+            self.init(id: alertID,
                       title: L10n.dialogAllowAccess,
                       message: L10n.dialogPermissionLiveLocationDescriptionIos(InfoPlistReader.main.bundleDisplayName),
                       primaryButton: primaryButton,
                       secondaryButton: secondaryButton)
+        case .liveLocationDisclaimer:
+            self.init(id: alertID,
+                      title: L10n.screenShareLocationLiveLocationDisclaimerTitle,
+                      primaryButton: primaryButton,
+                      secondaryButton: secondaryButton)
+        case .liveLocationDurationSelection:
+            self.init(id: alertID,
+                      title: L10n.screenShareLocationLiveLocationDurationPickerTitle,
+                      primaryButton: primaryButton,
+                      secondaryButton: nil,
+                      verticalButtons: verticalButtons)
         case .mapError(.failedLoadingMap):
-            self.init(id: error,
+            self.init(id: alertID,
                       title: L10n.errorFailedLoadingMap(InfoPlistReader.main.bundleDisplayName),
                       primaryButton: primaryButton,
                       secondaryButton: secondaryButton)
         case .mapError(.failedLocatingUser):
-            self.init(id: error,
+            self.init(id: alertID,
                       title: L10n.errorFailedLocatingUser(InfoPlistReader.main.bundleDisplayName),
                       primaryButton: primaryButton,
                       secondaryButton: secondaryButton)

--- a/ElementX/Sources/Screens/LocationSharing/LocationSharingScreenViewModel.swift
+++ b/ElementX/Sources/Screens/LocationSharing/LocationSharingScreenViewModel.swift
@@ -72,7 +72,7 @@ class LocationSharingScreenViewModel: LocationSharingScreenViewModelType, Locati
                 state.bindings.showsUserLocationMode = .showAndFollow
             case .some(false):
                 let action: () -> Void = { [weak self] in self?.actionsSubject.send(.openSystemSettings) }
-                state.bindings.alertInfo = .init(locationSharingViewError: .missingAuthorization,
+                state.bindings.alertInfo = .init(alertID: .missingAuthorization,
                                                  primaryButton: .init(title: L10n.actionNotNow, role: .cancel, action: nil),
                                                  secondaryButton: .init(title: L10n.commonSettings, action: action))
             }
@@ -112,13 +112,23 @@ class LocationSharingScreenViewModel: LocationSharingScreenViewModelType, Locati
         }
     }
     
+    private static let durationFormatter: DateComponentsFormatter = {
+        let formatter = DateComponentsFormatter()
+        formatter.unitsStyle = .full
+        formatter.allowedUnits = [.hour, .minute]
+        return formatter
+    }()
+    
     private func startLiveLocationSharing() {
+        requestAlwaysLocationPermission()
+    }
+    
+    private func requestAlwaysLocationPermission() {
         authorizationStatusSubscription = nil
         let authorizationStatus = liveLocationManager.authorizationStatus.value
         switch authorizationStatus {
         case .authorizedAlways:
-            // TODO: Start sending live location updates to the room
-            break
+            showLiveLocationDisclaimer()
         case .notDetermined:
             // This is to solve a race condition with map libre which always tries first
             // to request the when in use permission, we wait for it and then try again
@@ -127,7 +137,7 @@ class LocationSharingScreenViewModel: LocationSharingScreenViewModelType, Locati
                 .first() // this publisher only fires when there is an actual change, and if the user is done with permissions
                 .sink { [weak self] newValue in
                     guard newValue == .authorizedWhenInUse else { return }
-                    self?.startLiveLocationSharing()
+                    self?.requestAlwaysLocationPermission()
                 }
         case .authorizedWhenInUse:
             guard liveLocationManager.requestAlwaysAuthorizationIfPossible() else {
@@ -139,17 +149,59 @@ class LocationSharingScreenViewModel: LocationSharingScreenViewModelType, Locati
             authorizationStatusSubscription = liveLocationManager.authorizationStatus
                 .filter { $0 != authorizationStatus } // skip current status
                 .first() // this publisher only fires when there is an actual change, and if the user is done with permissions
-                .sink { newValue in
+                .sink { [weak self] newValue in
                     guard newValue == .authorizedAlways else { return }
-                    // TODO: Start sending live location updates to the room
+                    self?.showLiveLocationDisclaimer()
                 }
         default:
             showMissingAlwaysAuthorizedAlert()
         }
     }
     
+    private func showLiveLocationDisclaimer() {
+        state.bindings.alertInfo = .init(alertID: .liveLocationDisclaimer,
+                                         primaryButton: .init(title: L10n.actionDecline, role: .cancel, action: nil),
+                                         secondaryButton: .init(title: L10n.actionAccept) { [weak self] in
+                                             // Delay so SwiftUI finishes dismissing the current alert
+                                             // before presenting the next one.
+                                             DispatchQueue.main.async {
+                                                 self?.showLiveLocationDurationPicker()
+                                             }
+                                         })
+    }
+    
+    private func showLiveLocationDurationPicker() {
+        let durations: [TimeInterval] = [15 * 60, // 15 minutes
+                                         60 * 60, // 1 hour
+                                         8 * 60 * 60] // 8 hours
+        
+        let durationButtons: [AlertInfo<LocationSharingViewAlert>.AlertButton] = durations.compactMap { duration in
+            guard let title = Self.durationFormatter.string(from: duration) else { return nil }
+            return .init(title: title) { [weak self] in
+                Task { [weak self] in await self?.startLiveLocationSharingInRoom(durationMillis: UInt64(duration * 1000)) }
+            }
+        }
+        
+        state.bindings.alertInfo = .init(alertID: .liveLocationDurationSelection,
+                                         primaryButton: .init(title: L10n.actionCancel, role: .cancel, action: nil),
+                                         verticalButtons: durationButtons)
+    }
+    
+    private func startLiveLocationSharingInRoom(durationMillis: UInt64) async {
+        let result = await liveLocationManager.startLiveLocation(roomID: roomProxy.id,
+                                                                 durationMillis: durationMillis)
+        
+        switch result {
+        case .success:
+            actionsSubject.send(.close)
+        case .failure(let error):
+            MXLog.error("Failed to start live location sharing: \(error)")
+            showErrorIndicator()
+        }
+    }
+    
     private func showMissingAlwaysAuthorizedAlert() {
-        state.bindings.alertInfo = .init(locationSharingViewError: .missingAlwaysAuthorization,
+        state.bindings.alertInfo = .init(alertID: .missingAlwaysAuthorization,
                                          primaryButton: .init(title: L10n.actionNotNow, role: .cancel, action: nil),
                                          secondaryButton: .init(title: L10n.commonSettings) { [weak self] in self?.actionsSubject.send(.openSystemSettings) })
     }

--- a/ElementX/Sources/Screens/Timeline/TimelineModels.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineModels.swift
@@ -70,6 +70,8 @@ enum TimelineViewAction {
     case handlePollAction(TimelineViewPollAction)
     case handleAudioPlayerAction(TimelineAudioPlayerAction)
     
+    case stopLiveLocationSharing
+    
     /// Focus the timeline onto the specified event ID (switching to a detached timeline if needed).
     case focusOnEventID(String)
     /// Switch back to a live timeline (from a detached one).

--- a/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
@@ -199,6 +199,8 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
             handlePollAction(pollAction)
         case .handleAudioPlayerAction(let audioPlayerAction):
             handleAudioPlayerAction(audioPlayerAction)
+        case .stopLiveLocationSharing:
+            Task { await userSession.liveLocationManager.stopLiveLocation(roomID: state.roomID) }
         case .focusOnEventID(let eventID):
             Task { await focusOnEvent(eventID: eventID) }
         case .focusLive:

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/LiveLocationRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/LiveLocationRoomTimelineView.swift
@@ -173,7 +173,9 @@ struct LiveLocationRoomTimelineView: View {
             Spacer()
             
             if isLive, timelineItem.isOutgoing {
-                Button { } label: {
+                Button {
+                    context?.send(viewAction: .stopLiveLocationSharing)
+                } label: {
                     CompoundIcon(\.stop, size: .small, relativeTo: .compound.bodySMSemibold)
                         .foregroundStyle(.compound.iconOnSolidPrimary)
                         .padding(5)

--- a/ElementX/Sources/Services/Location/LiveLocationManager.swift
+++ b/ElementX/Sources/Services/Location/LiveLocationManager.swift
@@ -15,6 +15,14 @@ class LiveLocationManager: NSObject, LiveLocationManagerProtocol, CLLocationMana
     
     private let authorizationStatusSubject: CurrentValueSubject<CLAuthorizationStatus, Never>
     
+    /// Cached joined room proxies keyed by room ID, kept in sync with the active sessions dictionary.
+    private var activeRoomProxies = [String: JoinedRoomProxyProtocol]()
+    
+    /// The running task that iterates over live location updates.
+    private var locationUpdatesTask: Task<Void, Never>?
+    
+    private var cancellables = Set<AnyCancellable>()
+    
     var authorizationStatus: CurrentValuePublisher<CLAuthorizationStatus, Never> {
         authorizationStatusSubject.asCurrentValuePublisher()
     }
@@ -33,6 +41,11 @@ class LiveLocationManager: NSObject, LiveLocationManagerProtocol, CLLocationMana
         super.init()
         
         locationManager.delegate = self
+        locationManager.allowsBackgroundLocationUpdates = true
+        locationManager.desiredAccuracy = kCLLocationAccuracyNearestTenMeters
+        locationManager.pausesLocationUpdatesAutomatically = false
+        
+        setupSubscriptions()
     }
     
     // MARK: - LiveLocationManagerProtocol
@@ -45,6 +58,39 @@ class LiveLocationManager: NSObject, LiveLocationManagerProtocol, CLLocationMana
         return true
     }
     
+    func startLiveLocation(roomID: String, durationMillis: UInt64) async -> Result<Void, LiveLocationManagerError> {
+        guard case .joined(let roomProxy) = await clientProxy.roomForIdentifier(roomID) else {
+            MXLog.error("Failed to resolve joined room for identifier: \(roomID)")
+            return .failure(.roomNotJoined)
+        }
+        
+        let result = await roomProxy.startLiveLocationShare(durationMillis: durationMillis)
+        
+        guard case .success = result else {
+            MXLog.error("Failed to start live location share in room: \(roomID)")
+            return .failure(.startFailed)
+        }
+        
+        let timeoutDate = Date().addingTimeInterval(TimeInterval(durationMillis) / 1000.0)
+        appSettings.liveLocationSharingTimeoutDatesByRoomID[roomID] = timeoutDate
+        
+        return .success(())
+    }
+    
+    func stopLiveLocation(roomID: String) async {
+        // Best effort: send the stop event to the room regardless of tracking state.
+        if let roomProxy = await resolveRoomProxy(for: roomID) {
+            let result = await roomProxy.stopLiveLocationShare()
+            if case .failure(let error) = result {
+                MXLog.error("Failed to stop live location share in room \(roomID): \(error)")
+            }
+        }
+        
+        // Always clean up locally.
+        appSettings.liveLocationSharingTimeoutDatesByRoomID.removeValue(forKey: roomID)
+        activeRoomProxies.removeValue(forKey: roomID)
+    }
+    
     // MARK: - CLLocationManagerDelegate
     
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
@@ -53,6 +99,109 @@ class LiveLocationManager: NSObject, LiveLocationManagerProtocol, CLLocationMana
         if manager.authorizationStatus == .notDetermined {
             appSettings.hasRequestedLocationAlwaysLocationAuthorization = false
         }
+        
+        // If authorization was revoked, stop all active sessions.
+        if manager.authorizationStatus != .authorizedAlways {
+            stopAllSessions()
+        }
+        
         authorizationStatusSubject.send(manager.authorizationStatus)
+    }
+    
+    // MARK: - Private
+    
+    private func setupSubscriptions() {
+        appSettings.$liveLocationSharingTimeoutDatesByRoomID
+            .removeDuplicates()
+            .sink { [weak self] sessions in
+                guard let self else { return }
+                syncActiveRoomProxies(with: sessions)
+                
+                if sessions.isEmpty {
+                    stopLocationUpdates()
+                } else {
+                    startLocationUpdatesIfNeeded()
+                }
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func syncActiveRoomProxies(with sessions: [String: Date]) {
+        // Remove proxies for rooms no longer in the dictionary.
+        let activeRoomIDs = Set(sessions.keys)
+        for roomID in activeRoomProxies.keys where !activeRoomIDs.contains(roomID) {
+            activeRoomProxies.removeValue(forKey: roomID)
+        }
+    }
+    
+    private func startLocationUpdatesIfNeeded() {
+        guard locationUpdatesTask == nil else { return }
+        
+        locationUpdatesTask = Task { [weak self] in
+            do {
+                for try await update in CLLocationUpdate.liveUpdates() {
+                    guard let self, !Task.isCancelled else { break }
+                    
+                    await self.sendLocationToActiveRooms(update)
+                }
+            } catch {
+                MXLog.error("Live location updates failed with error: \(error)")
+                self?.stopAllSessions()
+            }
+        }
+    }
+    
+    private func stopLocationUpdates() {
+        locationUpdatesTask?.cancel()
+        locationUpdatesTask = nil
+    }
+    
+    private func sendLocationToActiveRooms(_ update: CLLocationUpdate) async {
+        let sessions = appSettings.liveLocationSharingTimeoutDatesByRoomID
+        let geoURI = update.location.map { GeoURI(coordinate: $0.coordinate, uncertainty: $0.horizontalAccuracy) }
+        
+        for (roomID, timeoutDate) in sessions {
+            if Date() >= timeoutDate {
+                MXLog.info("Live location session expired for room: \(roomID)")
+                await stopLiveLocation(roomID: roomID)
+                continue
+            }
+            
+            guard let geoURI else { continue }
+            
+            let roomProxy = await resolveRoomProxy(for: roomID)
+            guard let roomProxy else {
+                MXLog.error("Failed to resolve room proxy for live location update in room: \(roomID)")
+                continue
+            }
+            
+            let result = await roomProxy.sendLiveLocation(geoURI: geoURI)
+            if case .failure(let error) = result {
+                MXLog.error("Failed to send live location update to room \(roomID): \(error)")
+            }
+        }
+    }
+    
+    private func resolveRoomProxy(for roomID: String) async -> JoinedRoomProxyProtocol? {
+        if let cached = activeRoomProxies[roomID] {
+            return cached
+        }
+        
+        guard case .joined(let roomProxy) = await clientProxy.roomForIdentifier(roomID) else {
+            return nil
+        }
+        
+        activeRoomProxies[roomID] = roomProxy
+        return roomProxy
+    }
+    
+    private func stopAllSessions() {
+        let roomIDs = Array(appSettings.liveLocationSharingTimeoutDatesByRoomID.keys)
+        Task { [weak self] in
+            guard let self else { return }
+            for roomID in roomIDs {
+                await stopLiveLocation(roomID: roomID)
+            }
+        }
     }
 }

--- a/ElementX/Sources/Services/Location/LiveLocationManagerProtocol.swift
+++ b/ElementX/Sources/Services/Location/LiveLocationManagerProtocol.swift
@@ -9,6 +9,11 @@ import Combine
 import CoreLocation
 import Foundation
 
+enum LiveLocationManagerError: Error {
+    case roomNotJoined
+    case startFailed
+}
+
 // sourcery: AutoMockable
 protocol LiveLocationManagerProtocol: AnyObject {
     /// Publishes the current location authorization status.
@@ -20,4 +25,18 @@ protocol LiveLocationManagerProtocol: AnyObject {
     ///            `false` if the request was already made before and iOS would silently ignore it.
     @discardableResult
     func requestAlwaysAuthorizationIfPossible() -> Bool
+    
+    /// Starts sharing live location in a room.
+    ///
+    /// - Parameters:
+    ///   - roomID: The identifier of the room to share live location in.
+    ///   - durationMillis: The duration in milliseconds for how long the live location should be shared.
+    func startLiveLocation(roomID: String, durationMillis: UInt64) async -> Result<Void, LiveLocationManagerError>
+    
+    /// Stops sharing live location in a room.
+    ///
+    /// Sends a stop event to the room (best effort) and removes it from the tracked sessions.
+    /// Can also be used to stop a live location share started by another device.
+    /// - Parameter roomID: The identifier of the room to stop sharing live location in.
+    func stopLiveLocation(roomID: String) async
 }

--- a/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
@@ -751,6 +751,38 @@ class JoinedRoomProxy: JoinedRoomProxyProtocol {
             return .failure(.sdkError(error))
         }
     }
+    
+    // MARK: - Live Location
+    
+    func startLiveLocationShare(durationMillis: UInt64) async -> Result<Void, RoomProxyError> {
+        do {
+            try await room.startLiveLocationShare(durationMillis: durationMillis)
+            return .success(())
+        } catch {
+            MXLog.error("Failed starting live location share with error: \(error)")
+            return .failure(.sdkError(error))
+        }
+    }
+    
+    func sendLiveLocation(geoURI: GeoURI) async -> Result<Void, RoomProxyError> {
+        do {
+            try await room.sendLiveLocation(geoUri: geoURI.string)
+            return .success(())
+        } catch {
+            MXLog.error("Failed sending live location with error: \(error)")
+            return .failure(.sdkError(error))
+        }
+    }
+    
+    func stopLiveLocationShare() async -> Result<Void, RoomProxyError> {
+        do {
+            try await room.stopLiveLocationShare()
+            return .success(())
+        } catch {
+            MXLog.error("Failed stopping live location share with error: \(error)")
+            return .failure(.sdkError(error))
+        }
+    }
 
     // MARK: - Private
     

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -194,6 +194,12 @@ protocol JoinedRoomProxyProtocol: RoomProxyProtocol {
     func saveDraft(_ draft: ComposerDraft, threadRootEventID: String?) async -> Result<Void, RoomProxyError>
     func loadDraft(threadRootEventID: String?) async -> Result<ComposerDraft?, RoomProxyError>
     func clearDraft(threadRootEventID: String?) async -> Result<Void, RoomProxyError>
+    
+    // MARK: - Live Location
+    
+    func startLiveLocationShare(durationMillis: UInt64) async -> Result<Void, RoomProxyError>
+    func sendLiveLocation(geoURI: GeoURI) async -> Result<Void, RoomProxyError>
+    func stopLiveLocationShare() async -> Result<Void, RoomProxyError>
 }
 
 extension JoinedRoomProxyProtocol {

--- a/ElementX/SupportingFiles/Info.plist
+++ b/ElementX/SupportingFiles/Info.plist
@@ -93,6 +93,7 @@
 		<string>fetch</string>
 		<string>processing</string>
 		<string>voip</string>
+		<string>location</string>
 	</array>
 	<key>UILaunchScreen</key>
 	<dict>

--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -98,7 +98,8 @@ targets:
           audio,
           fetch,
           processing,
-          voip
+          voip,
+          location
         ]
         BGTaskSchedulerPermittedIdentifiers: [
           io.element.elementx.background.refresh

--- a/UnitTests/Sources/LocationSharingScreenViewModelTests.swift
+++ b/UnitTests/Sources/LocationSharingScreenViewModelTests.swift
@@ -71,11 +71,11 @@ final class LocationSharingScreenViewModelTests {
     @Test
     func errorMapping() {
         setupViewModel()
-        let mapError = AlertInfo(locationSharingViewError: .mapError(.failedLoadingMap))
+        let mapError = AlertInfo(alertID: .mapError(.failedLoadingMap))
         #expect(mapError.title == L10n.errorFailedLoadingMap(InfoPlistReader.main.bundleDisplayName))
-        let locationError = AlertInfo(locationSharingViewError: .mapError(.failedLocatingUser))
+        let locationError = AlertInfo(alertID: .mapError(.failedLocatingUser))
         #expect(locationError.title == L10n.errorFailedLocatingUser(InfoPlistReader.main.bundleDisplayName))
-        let AuthorizationError = AlertInfo(locationSharingViewError: .missingAuthorization)
+        let AuthorizationError = AlertInfo(alertID: .missingAuthorization)
         #expect(AuthorizationError.message == L10n.dialogPermissionLocationDescriptionIos(InfoPlistReader.main.bundleDisplayName))
     }
 
@@ -141,13 +141,6 @@ final class LocationSharingScreenViewModelTests {
     }
     
     @Test
-    func startLiveLocationWithAlwaysAuthorization() {
-        setupViewModel(liveLocationManagerConfiguration: .init(authorizationStatus: .authorizedAlways))
-        context.send(viewAction: .startLiveLocation)
-        #expect(context.alertInfo == nil)
-    }
-    
-    @Test
     func startLiveLocationWithWhenInUseAuthorizationAlreadyRequested() {
         setupViewModel(liveLocationManagerConfiguration: .init(authorizationStatus: .authorizedWhenInUse,
                                                                requestAlwaysAuthorizationIfPossibleReturnValue: false))
@@ -191,8 +184,79 @@ final class LocationSharingScreenViewModelTests {
         #expect(context.alertInfo == nil)
     }
     
+    // MARK: - Live Location Start Flow Tests
+
+    @Test
+    func startLiveLocationShowsDisclaimer() {
+        setupViewModel(liveLocationManagerConfiguration: .init(authorizationStatus: .authorizedAlways))
+        context.send(viewAction: .startLiveLocation)
+        #expect(context.alertInfo?.id == .liveLocationDisclaimer)
+    }
+
+    @Test
+    func startLiveLocationDisclaimerDeclineSkipsStart() {
+        let liveLocationManagerMock = LiveLocationManagerMock(.init(authorizationStatus: .authorizedAlways))
+        setupViewModel(liveLocationManagerMock: liveLocationManagerMock)
+        context.send(viewAction: .startLiveLocation)
+        context.alertInfo?.primaryButton.action?()
+        #expect(!liveLocationManagerMock.startLiveLocationRoomIDDurationMillisCalled)
+    }
+
+    @Test
+    func startLiveLocationDisclaimerAcceptShowsDurationPicker() async throws {
+        setupViewModel(liveLocationManagerConfiguration: .init(authorizationStatus: .authorizedAlways))
+        context.send(viewAction: .startLiveLocation)
+        #expect(context.alertInfo?.id == .liveLocationDisclaimer)
+        let deferred = deferFulfillment(context.observe(\.alertInfo)) { $0?.id == .liveLocationDurationSelection }
+        context.alertInfo?.secondaryButton?.action?()
+        try await deferred.fulfill()
+    }
+
+    @Test
+    func startLiveLocationDurationPickerCancelSkipsStart() async throws {
+        let liveLocationManagerMock = LiveLocationManagerMock(.init(authorizationStatus: .authorizedAlways))
+        setupViewModel(liveLocationManagerMock: liveLocationManagerMock)
+        context.send(viewAction: .startLiveLocation)
+        let deferred = deferFulfillment(context.observe(\.alertInfo)) { $0?.id == .liveLocationDurationSelection }
+        context.alertInfo?.secondaryButton?.action?()
+        try await deferred.fulfill()
+        context.alertInfo?.primaryButton.action?()
+        #expect(!liveLocationManagerMock.startLiveLocationRoomIDDurationMillisCalled)
+    }
+
+    @Test
+    func startLiveLocationSuccess() async throws {
+        let liveLocationManagerMock = LiveLocationManagerMock(.init(authorizationStatus: .authorizedAlways))
+        setupViewModel(liveLocationManagerMock: liveLocationManagerMock)
+        context.send(viewAction: .startLiveLocation)
+        let durationPicker = deferFulfillment(context.observe(\.alertInfo)) { $0?.id == .liveLocationDurationSelection }
+        context.alertInfo?.secondaryButton?.action?()
+        try await durationPicker.fulfill()
+
+        let deferred = deferFulfillment(viewModel.actions) { $0 == .close }
+        context.alertInfo?.verticalButtons?.first?.action?()
+        try await deferred.fulfill()
+
+        #expect(liveLocationManagerMock.startLiveLocationRoomIDDurationMillisCalled)
+    }
+
+    @Test
+    func startLiveLocationFailureDoesNotClose() async throws {
+        let liveLocationManagerMock = LiveLocationManagerMock(.init(authorizationStatus: .authorizedAlways))
+        liveLocationManagerMock.startLiveLocationRoomIDDurationMillisReturnValue = .failure(.startFailed)
+        setupViewModel(liveLocationManagerMock: liveLocationManagerMock)
+        context.send(viewAction: .startLiveLocation)
+        let durationPicker = deferFulfillment(context.observe(\.alertInfo)) { $0?.id == .liveLocationDurationSelection }
+        context.alertInfo?.secondaryButton?.action?()
+        try await durationPicker.fulfill()
+
+        let deferredFailure = deferFailure(viewModel.actions, timeout: .seconds(1)) { $0 == .close }
+        context.alertInfo?.verticalButtons?.first?.action?()
+        try await deferredFailure.fulfill()
+    }
+
     // MARK: - Private
-    
+
     private func setupViewModel(liveLocationManagerConfiguration: LiveLocationManagerMock.Configuration = .init()) {
         timelineProxy = TimelineProxyMock(.init())
         viewModel = LocationSharingScreenViewModel(interactionMode: .picker,


### PR DESCRIPTION
This PR implements inside the LiveLocationManager the following functions
- Start live location sharing
- Send LLS updates (all done in background the user doesn't need to worry about anything)
- Stop LLS

It also implements a store that keeps track of what are the rooms this device is sending LLS to, in this way in case of a crash, kill or reopen we can restore the LLS updates.

We also try to stop events once they have expired in conformance with the MSC.
It's important to note that this is a best effort thing, if it's not possible we don't try again (usually clients implement an internal check to consider an LLS expired, so that's generally fine).

To review commit by commit.

Also the send functions will not work properly on the current SDK release, since we need a fix for the sync over the `beaconInfo` event, which is being worked on here: https://github.com/matrix-org/matrix-rust-sdk/pull/6385