### PR TITLE
Remove the `shouldDisambiguateDisplayNames` parameter from the `RoomEvent` and `RoomStateEvent` string builders

### DIFF
--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -1340,9 +1340,8 @@ private struct ClientProxyServices {
                                                                                                                            mentionBuilder: PlainMentionBuilder()),
                                                                           style: .senderPrefixed)
         
-        eventStringBuilder = try RoomEventStringBuilder(stateEventStringBuilder: RoomStateEventStringBuilder(userID: client.userId(), shouldDisambiguateDisplayNames: false),
+        eventStringBuilder = try RoomEventStringBuilder(stateEventStringBuilder: RoomStateEventStringBuilder(userID: client.userId()),
                                                         messageEventStringBuilder: roomMessageEventStringBuilder,
-                                                        shouldDisambiguateDisplayNames: false,
                                                         shouldPrefixSenderName: true)
         
         roomSummaryProvider = RoomSummaryProvider(roomListService: roomListService,

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomEventStringBuilder.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomEventStringBuilder.swift
@@ -12,7 +12,6 @@ import MatrixRustSDK
 struct RoomEventStringBuilder {
     let stateEventStringBuilder: RoomStateEventStringBuilder
     let messageEventStringBuilder: RoomMessageEventStringBuilder
-    let shouldDisambiguateDisplayNames: Bool
     let shouldPrefixSenderName: Bool
     
     func buildAttributedString(for eventItemProxy: EventTimelineItemProxy) -> AttributedString? {
@@ -22,11 +21,7 @@ struct RoomEventStringBuilder {
     }
     
     func buildAttributedString(for content: TimelineItemContent, sender: TimelineItemSender, isOutgoing: Bool) -> AttributedString? {
-        let displayName = if shouldDisambiguateDisplayNames {
-            sender.disambiguatedDisplayName ?? sender.id
-        } else {
-            sender.displayName ?? sender.id
-        }
+        let displayName = sender.disambiguatedDisplayName ?? sender.id
         
         switch content {
         case .msgLike(let messageLikeContent):
@@ -105,20 +100,16 @@ struct RoomEventStringBuilder {
     }
     
     static func pinnedEventStringBuilder(userID: String) -> Self {
-        RoomEventStringBuilder(stateEventStringBuilder: .init(userID: userID,
-                                                              shouldDisambiguateDisplayNames: true),
+        RoomEventStringBuilder(stateEventStringBuilder: .init(userID: userID),
                                messageEventStringBuilder: .init(attributedStringBuilder: AttributedStringBuilder(cacheKey: "pinnedEvents", mentionBuilder: PlainMentionBuilder()),
                                                                 style: .typeBolded),
-                               shouldDisambiguateDisplayNames: true,
                                shouldPrefixSenderName: false)
     }
     
     static func threadListEventStringBuilder(userID: String) -> Self {
-        RoomEventStringBuilder(stateEventStringBuilder: .init(userID: userID,
-                                                              shouldDisambiguateDisplayNames: true),
+        RoomEventStringBuilder(stateEventStringBuilder: .init(userID: userID),
                                messageEventStringBuilder: .init(attributedStringBuilder: AttributedStringBuilder(cacheKey: "threadList", mentionBuilder: PlainMentionBuilder()),
                                                                 style: .plain),
-                               shouldDisambiguateDisplayNames: true,
                                shouldPrefixSenderName: false)
     }
 }

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomStateEventStringBuilder.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomStateEventStringBuilder.swift
@@ -11,7 +11,6 @@ import UIKit
 
 struct RoomStateEventStringBuilder {
     let userID: String
-    var shouldDisambiguateDisplayNames = true
     
     func buildString(for change: MembershipChange?,
                      reason: String?,
@@ -27,11 +26,7 @@ struct RoomStateEventStringBuilder {
         let senderIsYou = isOutgoing
         let memberIsYou = memberUserID == userID
         let member = memberDisplayName ?? memberUserID
-        let senderDisplayName = if shouldDisambiguateDisplayNames {
-            sender.disambiguatedDisplayName ?? sender.id
-        } else {
-            sender.displayName ?? sender.id
-        }
+        let senderDisplayName = sender.disambiguatedDisplayName ?? sender.id
         
         switch change {
         case .joined:
@@ -138,11 +133,7 @@ struct RoomStateEventStringBuilder {
     }
     
     func buildString(for state: OtherState, sender: TimelineItemSender, isOutgoing: Bool) -> String? {
-        let displayName = if shouldDisambiguateDisplayNames {
-            sender.disambiguatedDisplayName ?? sender.id
-        } else {
-            sender.displayName ?? sender.id
-        }
+        let displayName = sender.disambiguatedDisplayName ?? sender.id
         
         switch state {
         case .roomAvatar(let url):

--- a/UnitTests/Sources/RoomEventStringBuilderTests.swift
+++ b/UnitTests/Sources/RoomEventStringBuilderTests.swift
@@ -22,7 +22,6 @@ struct RoomEventStringBuilderTests {
         stringBuilder = RoomEventStringBuilder(stateEventStringBuilder: stateEventStringBuilder,
                                                messageEventStringBuilder: RoomMessageEventStringBuilder(attributedStringBuilder: attributedStringBuilder,
                                                                                                         style: .senderPrefixed),
-                                               shouldDisambiguateDisplayNames: true,
                                                shouldPrefixSenderName: true)
     }
     

--- a/UnitTests/Sources/RoomSummaryProviderTests.swift
+++ b/UnitTests/Sources/RoomSummaryProviderTests.swift
@@ -103,7 +103,6 @@ final class RoomSummaryProviderTests {
         let eventStringBuilder = RoomEventStringBuilder(stateEventStringBuilder: stateEventStringBuilder,
                                                         messageEventStringBuilder: RoomMessageEventStringBuilder(attributedStringBuilder: attributedStringBuilder,
                                                                                                                  style: .senderPrefixed),
-                                                        shouldDisambiguateDisplayNames: true,
                                                         shouldPrefixSenderName: true)
 
         roomSummaryProvider = RoomSummaryProvider(roomListService: RoomListServiceSDKMock(),


### PR DESCRIPTION
Doug and I had a think about it and we can't come up with a reason why names should ever not be disambiguated