### PR TITLE
Start send and stop functions of the LiveLocationManager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ build
 
 ## Editors
 .nova
+.vscode
 
 ## Project specific
 test_output

--- a/ElementX/Sources/Application/Settings/AppSettings.swift
+++ b/ElementX/Sources/Application/Settings/AppSettings.swift
@@ -80,6 +80,7 @@ final class AppSettings {
         case focusEventOnNotificationTap
         case linkNewDeviceEnabled
         case liveLocationSharingEnabled
+        case liveLocationSharingTimeoutDatesByRoomID
         case floatingTimelineDateEnabled
         
         // Doug's tweaks 🔧
@@ -348,6 +349,9 @@ final class AppSettings {
     
     @UserPreference(key: UserDefaultsKeys.hasRequestedLocationAlwaysLocationAuthorization, defaultValue: false, storageType: .userDefaults(store))
     var hasRequestedLocationAlwaysLocationAuthorization
+    
+    @UserPreference(key: UserDefaultsKeys.liveLocationSharingTimeoutDatesByRoomID, defaultValue: [String: Date](), storageType: .userDefaults(store))
+    var liveLocationSharingTimeoutDatesByRoomID
     
     @UserPreference(key: UserDefaultsKeys.frequentlyUsedSystemEmojis, defaultValue: [FrequentlyUsedEmoji](), storageType: .userDefaults(store))
     var frequentlyUsedSystemEmojis

--- a/ElementX/Sources/Application/Settings/AppSettings.swift
+++ b/ElementX/Sources/Application/Settings/AppSettings.swift
@@ -66,6 +66,7 @@ final class AppSettings {
         case elementCallBaseURLOverride
         
         case voiceMessagePlaybackSpeed
+        case liveLocationSharingTimeoutDatesByRoomID
         
         // Feature flags
         case publicSearchEnabled
@@ -80,7 +81,6 @@ final class AppSettings {
         case focusEventOnNotificationTap
         case linkNewDeviceEnabled
         case liveLocationSharingEnabled
-        case liveLocationSharingTimeoutDatesByRoomID
         case floatingTimelineDateEnabled
         
         // Doug's tweaks 🔧

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -10062,6 +10062,210 @@ class JoinedRoomProxyMock: JoinedRoomProxyProtocol, @unchecked Sendable {
             return clearDraftThreadRootEventIDReturnValue
         }
     }
+    //MARK: - startLiveLocationShare
+
+    var startLiveLocationShareDurationMillisUnderlyingCallsCount = 0
+    var startLiveLocationShareDurationMillisCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return startLiveLocationShareDurationMillisUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = startLiveLocationShareDurationMillisUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                startLiveLocationShareDurationMillisUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    startLiveLocationShareDurationMillisUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var startLiveLocationShareDurationMillisCalled: Bool {
+        return startLiveLocationShareDurationMillisCallsCount > 0
+    }
+    var startLiveLocationShareDurationMillisReceivedDurationMillis: UInt64?
+    var startLiveLocationShareDurationMillisReceivedInvocations: [UInt64] = []
+
+    var startLiveLocationShareDurationMillisUnderlyingReturnValue: Result<Void, RoomProxyError>!
+    var startLiveLocationShareDurationMillisReturnValue: Result<Void, RoomProxyError>! {
+        get {
+            if Thread.isMainThread {
+                return startLiveLocationShareDurationMillisUnderlyingReturnValue
+            } else {
+                var returnValue: Result<Void, RoomProxyError>? = nil
+                DispatchQueue.main.sync {
+                    returnValue = startLiveLocationShareDurationMillisUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                startLiveLocationShareDurationMillisUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    startLiveLocationShareDurationMillisUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    var startLiveLocationShareDurationMillisClosure: ((UInt64) async -> Result<Void, RoomProxyError>)?
+
+    func startLiveLocationShare(durationMillis: UInt64) async -> Result<Void, RoomProxyError> {
+        startLiveLocationShareDurationMillisCallsCount += 1
+        startLiveLocationShareDurationMillisReceivedDurationMillis = durationMillis
+        DispatchQueue.main.async {
+            self.startLiveLocationShareDurationMillisReceivedInvocations.append(durationMillis)
+        }
+        if let startLiveLocationShareDurationMillisClosure = startLiveLocationShareDurationMillisClosure {
+            return await startLiveLocationShareDurationMillisClosure(durationMillis)
+        } else {
+            return startLiveLocationShareDurationMillisReturnValue
+        }
+    }
+    //MARK: - sendLiveLocation
+
+    var sendLiveLocationGeoURIUnderlyingCallsCount = 0
+    var sendLiveLocationGeoURICallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return sendLiveLocationGeoURIUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = sendLiveLocationGeoURIUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                sendLiveLocationGeoURIUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    sendLiveLocationGeoURIUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var sendLiveLocationGeoURICalled: Bool {
+        return sendLiveLocationGeoURICallsCount > 0
+    }
+    var sendLiveLocationGeoURIReceivedGeoURI: GeoURI?
+    var sendLiveLocationGeoURIReceivedInvocations: [GeoURI] = []
+
+    var sendLiveLocationGeoURIUnderlyingReturnValue: Result<Void, RoomProxyError>!
+    var sendLiveLocationGeoURIReturnValue: Result<Void, RoomProxyError>! {
+        get {
+            if Thread.isMainThread {
+                return sendLiveLocationGeoURIUnderlyingReturnValue
+            } else {
+                var returnValue: Result<Void, RoomProxyError>? = nil
+                DispatchQueue.main.sync {
+                    returnValue = sendLiveLocationGeoURIUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                sendLiveLocationGeoURIUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    sendLiveLocationGeoURIUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    var sendLiveLocationGeoURIClosure: ((GeoURI) async -> Result<Void, RoomProxyError>)?
+
+    func sendLiveLocation(geoURI: GeoURI) async -> Result<Void, RoomProxyError> {
+        sendLiveLocationGeoURICallsCount += 1
+        sendLiveLocationGeoURIReceivedGeoURI = geoURI
+        DispatchQueue.main.async {
+            self.sendLiveLocationGeoURIReceivedInvocations.append(geoURI)
+        }
+        if let sendLiveLocationGeoURIClosure = sendLiveLocationGeoURIClosure {
+            return await sendLiveLocationGeoURIClosure(geoURI)
+        } else {
+            return sendLiveLocationGeoURIReturnValue
+        }
+    }
+    //MARK: - stopLiveLocationShare
+
+    var stopLiveLocationShareUnderlyingCallsCount = 0
+    var stopLiveLocationShareCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return stopLiveLocationShareUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = stopLiveLocationShareUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                stopLiveLocationShareUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    stopLiveLocationShareUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var stopLiveLocationShareCalled: Bool {
+        return stopLiveLocationShareCallsCount > 0
+    }
+
+    var stopLiveLocationShareUnderlyingReturnValue: Result<Void, RoomProxyError>!
+    var stopLiveLocationShareReturnValue: Result<Void, RoomProxyError>! {
+        get {
+            if Thread.isMainThread {
+                return stopLiveLocationShareUnderlyingReturnValue
+            } else {
+                var returnValue: Result<Void, RoomProxyError>? = nil
+                DispatchQueue.main.sync {
+                    returnValue = stopLiveLocationShareUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                stopLiveLocationShareUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    stopLiveLocationShareUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    var stopLiveLocationShareClosure: (() async -> Result<Void, RoomProxyError>)?
+
+    func stopLiveLocationShare() async -> Result<Void, RoomProxyError> {
+        stopLiveLocationShareCallsCount += 1
+        if let stopLiveLocationShareClosure = stopLiveLocationShareClosure {
+            return await stopLiveLocationShareClosure()
+        } else {
+            return stopLiveLocationShareReturnValue
+        }
+    }
 }
 class KeychainControllerMock: KeychainControllerProtocol, @unchecked Sendable {
 
@@ -11235,6 +11439,117 @@ class LiveLocationManagerMock: LiveLocationManagerProtocol, @unchecked Sendable 
         } else {
             return requestAlwaysAuthorizationIfPossibleReturnValue
         }
+    }
+    //MARK: - startLiveLocation
+
+    var startLiveLocationRoomIDDurationMillisUnderlyingCallsCount = 0
+    var startLiveLocationRoomIDDurationMillisCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return startLiveLocationRoomIDDurationMillisUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = startLiveLocationRoomIDDurationMillisUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                startLiveLocationRoomIDDurationMillisUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    startLiveLocationRoomIDDurationMillisUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var startLiveLocationRoomIDDurationMillisCalled: Bool {
+        return startLiveLocationRoomIDDurationMillisCallsCount > 0
+    }
+    var startLiveLocationRoomIDDurationMillisReceivedArguments: (roomID: String, durationMillis: UInt64)?
+    var startLiveLocationRoomIDDurationMillisReceivedInvocations: [(roomID: String, durationMillis: UInt64)] = []
+
+    var startLiveLocationRoomIDDurationMillisUnderlyingReturnValue: Result<Void, LiveLocationManagerError>!
+    var startLiveLocationRoomIDDurationMillisReturnValue: Result<Void, LiveLocationManagerError>! {
+        get {
+            if Thread.isMainThread {
+                return startLiveLocationRoomIDDurationMillisUnderlyingReturnValue
+            } else {
+                var returnValue: Result<Void, LiveLocationManagerError>? = nil
+                DispatchQueue.main.sync {
+                    returnValue = startLiveLocationRoomIDDurationMillisUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                startLiveLocationRoomIDDurationMillisUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    startLiveLocationRoomIDDurationMillisUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    var startLiveLocationRoomIDDurationMillisClosure: ((String, UInt64) async -> Result<Void, LiveLocationManagerError>)?
+
+    func startLiveLocation(roomID: String, durationMillis: UInt64) async -> Result<Void, LiveLocationManagerError> {
+        startLiveLocationRoomIDDurationMillisCallsCount += 1
+        startLiveLocationRoomIDDurationMillisReceivedArguments = (roomID: roomID, durationMillis: durationMillis)
+        DispatchQueue.main.async {
+            self.startLiveLocationRoomIDDurationMillisReceivedInvocations.append((roomID: roomID, durationMillis: durationMillis))
+        }
+        if let startLiveLocationRoomIDDurationMillisClosure = startLiveLocationRoomIDDurationMillisClosure {
+            return await startLiveLocationRoomIDDurationMillisClosure(roomID, durationMillis)
+        } else {
+            return startLiveLocationRoomIDDurationMillisReturnValue
+        }
+    }
+    //MARK: - stopLiveLocation
+
+    var stopLiveLocationRoomIDUnderlyingCallsCount = 0
+    var stopLiveLocationRoomIDCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return stopLiveLocationRoomIDUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = stopLiveLocationRoomIDUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                stopLiveLocationRoomIDUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    stopLiveLocationRoomIDUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var stopLiveLocationRoomIDCalled: Bool {
+        return stopLiveLocationRoomIDCallsCount > 0
+    }
+    var stopLiveLocationRoomIDReceivedRoomID: String?
+    var stopLiveLocationRoomIDReceivedInvocations: [String] = []
+    var stopLiveLocationRoomIDClosure: ((String) async -> Void)?
+
+    func stopLiveLocation(roomID: String) async {
+        stopLiveLocationRoomIDCallsCount += 1
+        stopLiveLocationRoomIDReceivedRoomID = roomID
+        DispatchQueue.main.async {
+            self.stopLiveLocationRoomIDReceivedInvocations.append(roomID)
+        }
+        await stopLiveLocationRoomIDClosure?(roomID)
     }
 }
 class MediaLoaderMock: MediaLoaderProtocol, @unchecked Sendable {

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -10064,15 +10064,15 @@ class JoinedRoomProxyMock: JoinedRoomProxyProtocol, @unchecked Sendable {
     }
     //MARK: - startLiveLocationShare
 
-    var startLiveLocationShareDurationMillisUnderlyingCallsCount = 0
-    var startLiveLocationShareDurationMillisCallsCount: Int {
+    var startLiveLocationShareDurationUnderlyingCallsCount = 0
+    var startLiveLocationShareDurationCallsCount: Int {
         get {
             if Thread.isMainThread {
-                return startLiveLocationShareDurationMillisUnderlyingCallsCount
+                return startLiveLocationShareDurationUnderlyingCallsCount
             } else {
                 var returnValue: Int? = nil
                 DispatchQueue.main.sync {
-                    returnValue = startLiveLocationShareDurationMillisUnderlyingCallsCount
+                    returnValue = startLiveLocationShareDurationUnderlyingCallsCount
                 }
 
                 return returnValue!
@@ -10080,29 +10080,29 @@ class JoinedRoomProxyMock: JoinedRoomProxyProtocol, @unchecked Sendable {
         }
         set {
             if Thread.isMainThread {
-                startLiveLocationShareDurationMillisUnderlyingCallsCount = newValue
+                startLiveLocationShareDurationUnderlyingCallsCount = newValue
             } else {
                 DispatchQueue.main.sync {
-                    startLiveLocationShareDurationMillisUnderlyingCallsCount = newValue
+                    startLiveLocationShareDurationUnderlyingCallsCount = newValue
                 }
             }
         }
     }
-    var startLiveLocationShareDurationMillisCalled: Bool {
-        return startLiveLocationShareDurationMillisCallsCount > 0
+    var startLiveLocationShareDurationCalled: Bool {
+        return startLiveLocationShareDurationCallsCount > 0
     }
-    var startLiveLocationShareDurationMillisReceivedDurationMillis: UInt64?
-    var startLiveLocationShareDurationMillisReceivedInvocations: [UInt64] = []
+    var startLiveLocationShareDurationReceivedDuration: Duration?
+    var startLiveLocationShareDurationReceivedInvocations: [Duration] = []
 
-    var startLiveLocationShareDurationMillisUnderlyingReturnValue: Result<Void, RoomProxyError>!
-    var startLiveLocationShareDurationMillisReturnValue: Result<Void, RoomProxyError>! {
+    var startLiveLocationShareDurationUnderlyingReturnValue: Result<Void, RoomProxyError>!
+    var startLiveLocationShareDurationReturnValue: Result<Void, RoomProxyError>! {
         get {
             if Thread.isMainThread {
-                return startLiveLocationShareDurationMillisUnderlyingReturnValue
+                return startLiveLocationShareDurationUnderlyingReturnValue
             } else {
                 var returnValue: Result<Void, RoomProxyError>? = nil
                 DispatchQueue.main.sync {
-                    returnValue = startLiveLocationShareDurationMillisUnderlyingReturnValue
+                    returnValue = startLiveLocationShareDurationUnderlyingReturnValue
                 }
 
                 return returnValue!
@@ -10110,26 +10110,26 @@ class JoinedRoomProxyMock: JoinedRoomProxyProtocol, @unchecked Sendable {
         }
         set {
             if Thread.isMainThread {
-                startLiveLocationShareDurationMillisUnderlyingReturnValue = newValue
+                startLiveLocationShareDurationUnderlyingReturnValue = newValue
             } else {
                 DispatchQueue.main.sync {
-                    startLiveLocationShareDurationMillisUnderlyingReturnValue = newValue
+                    startLiveLocationShareDurationUnderlyingReturnValue = newValue
                 }
             }
         }
     }
-    var startLiveLocationShareDurationMillisClosure: ((UInt64) async -> Result<Void, RoomProxyError>)?
+    var startLiveLocationShareDurationClosure: ((Duration) async -> Result<Void, RoomProxyError>)?
 
-    func startLiveLocationShare(durationMillis: UInt64) async -> Result<Void, RoomProxyError> {
-        startLiveLocationShareDurationMillisCallsCount += 1
-        startLiveLocationShareDurationMillisReceivedDurationMillis = durationMillis
+    func startLiveLocationShare(duration: Duration) async -> Result<Void, RoomProxyError> {
+        startLiveLocationShareDurationCallsCount += 1
+        startLiveLocationShareDurationReceivedDuration = duration
         DispatchQueue.main.async {
-            self.startLiveLocationShareDurationMillisReceivedInvocations.append(durationMillis)
+            self.startLiveLocationShareDurationReceivedInvocations.append(duration)
         }
-        if let startLiveLocationShareDurationMillisClosure = startLiveLocationShareDurationMillisClosure {
-            return await startLiveLocationShareDurationMillisClosure(durationMillis)
+        if let startLiveLocationShareDurationClosure = startLiveLocationShareDurationClosure {
+            return await startLiveLocationShareDurationClosure(duration)
         } else {
-            return startLiveLocationShareDurationMillisReturnValue
+            return startLiveLocationShareDurationReturnValue
         }
     }
     //MARK: - sendLiveLocation
@@ -11442,15 +11442,15 @@ class LiveLocationManagerMock: LiveLocationManagerProtocol, @unchecked Sendable 
     }
     //MARK: - startLiveLocation
 
-    var startLiveLocationRoomIDDurationMillisUnderlyingCallsCount = 0
-    var startLiveLocationRoomIDDurationMillisCallsCount: Int {
+    var startLiveLocationRoomIDDurationUnderlyingCallsCount = 0
+    var startLiveLocationRoomIDDurationCallsCount: Int {
         get {
             if Thread.isMainThread {
-                return startLiveLocationRoomIDDurationMillisUnderlyingCallsCount
+                return startLiveLocationRoomIDDurationUnderlyingCallsCount
             } else {
                 var returnValue: Int? = nil
                 DispatchQueue.main.sync {
-                    returnValue = startLiveLocationRoomIDDurationMillisUnderlyingCallsCount
+                    returnValue = startLiveLocationRoomIDDurationUnderlyingCallsCount
                 }
 
                 return returnValue!
@@ -11458,29 +11458,29 @@ class LiveLocationManagerMock: LiveLocationManagerProtocol, @unchecked Sendable 
         }
         set {
             if Thread.isMainThread {
-                startLiveLocationRoomIDDurationMillisUnderlyingCallsCount = newValue
+                startLiveLocationRoomIDDurationUnderlyingCallsCount = newValue
             } else {
                 DispatchQueue.main.sync {
-                    startLiveLocationRoomIDDurationMillisUnderlyingCallsCount = newValue
+                    startLiveLocationRoomIDDurationUnderlyingCallsCount = newValue
                 }
             }
         }
     }
-    var startLiveLocationRoomIDDurationMillisCalled: Bool {
-        return startLiveLocationRoomIDDurationMillisCallsCount > 0
+    var startLiveLocationRoomIDDurationCalled: Bool {
+        return startLiveLocationRoomIDDurationCallsCount > 0
     }
-    var startLiveLocationRoomIDDurationMillisReceivedArguments: (roomID: String, durationMillis: UInt64)?
-    var startLiveLocationRoomIDDurationMillisReceivedInvocations: [(roomID: String, durationMillis: UInt64)] = []
+    var startLiveLocationRoomIDDurationReceivedArguments: (roomID: String, duration: Duration)?
+    var startLiveLocationRoomIDDurationReceivedInvocations: [(roomID: String, duration: Duration)] = []
 
-    var startLiveLocationRoomIDDurationMillisUnderlyingReturnValue: Result<Void, LiveLocationManagerError>!
-    var startLiveLocationRoomIDDurationMillisReturnValue: Result<Void, LiveLocationManagerError>! {
+    var startLiveLocationRoomIDDurationUnderlyingReturnValue: Result<Void, LiveLocationManagerError>!
+    var startLiveLocationRoomIDDurationReturnValue: Result<Void, LiveLocationManagerError>! {
         get {
             if Thread.isMainThread {
-                return startLiveLocationRoomIDDurationMillisUnderlyingReturnValue
+                return startLiveLocationRoomIDDurationUnderlyingReturnValue
             } else {
                 var returnValue: Result<Void, LiveLocationManagerError>? = nil
                 DispatchQueue.main.sync {
-                    returnValue = startLiveLocationRoomIDDurationMillisUnderlyingReturnValue
+                    returnValue = startLiveLocationRoomIDDurationUnderlyingReturnValue
                 }
 
                 return returnValue!
@@ -11488,26 +11488,26 @@ class LiveLocationManagerMock: LiveLocationManagerProtocol, @unchecked Sendable 
         }
         set {
             if Thread.isMainThread {
-                startLiveLocationRoomIDDurationMillisUnderlyingReturnValue = newValue
+                startLiveLocationRoomIDDurationUnderlyingReturnValue = newValue
             } else {
                 DispatchQueue.main.sync {
-                    startLiveLocationRoomIDDurationMillisUnderlyingReturnValue = newValue
+                    startLiveLocationRoomIDDurationUnderlyingReturnValue = newValue
                 }
             }
         }
     }
-    var startLiveLocationRoomIDDurationMillisClosure: ((String, UInt64) async -> Result<Void, LiveLocationManagerError>)?
+    var startLiveLocationRoomIDDurationClosure: ((String, Duration) async -> Result<Void, LiveLocationManagerError>)?
 
-    func startLiveLocation(roomID: String, durationMillis: UInt64) async -> Result<Void, LiveLocationManagerError> {
-        startLiveLocationRoomIDDurationMillisCallsCount += 1
-        startLiveLocationRoomIDDurationMillisReceivedArguments = (roomID: roomID, durationMillis: durationMillis)
+    func startLiveLocation(roomID: String, duration: Duration) async -> Result<Void, LiveLocationManagerError> {
+        startLiveLocationRoomIDDurationCallsCount += 1
+        startLiveLocationRoomIDDurationReceivedArguments = (roomID: roomID, duration: duration)
         DispatchQueue.main.async {
-            self.startLiveLocationRoomIDDurationMillisReceivedInvocations.append((roomID: roomID, durationMillis: durationMillis))
+            self.startLiveLocationRoomIDDurationReceivedInvocations.append((roomID: roomID, duration: duration))
         }
-        if let startLiveLocationRoomIDDurationMillisClosure = startLiveLocationRoomIDDurationMillisClosure {
-            return await startLiveLocationRoomIDDurationMillisClosure(roomID, durationMillis)
+        if let startLiveLocationRoomIDDurationClosure = startLiveLocationRoomIDDurationClosure {
+            return await startLiveLocationRoomIDDurationClosure(roomID, duration)
         } else {
-            return startLiveLocationRoomIDDurationMillisReturnValue
+            return startLiveLocationRoomIDDurationReturnValue
         }
     }
     //MARK: - stopLiveLocation

--- a/ElementX/Sources/Services/Location/LiveLocationManager.swift
+++ b/ElementX/Sources/Services/Location/LiveLocationManager.swift
@@ -59,20 +59,20 @@ class LiveLocationManager: NSObject, LiveLocationManagerProtocol, CLLocationMana
         return true
     }
     
-    func startLiveLocation(roomID: String, durationMillis: UInt64) async -> Result<Void, LiveLocationManagerError> {
+    func startLiveLocation(roomID: String, duration: Duration) async -> Result<Void, LiveLocationManagerError> {
         guard case .joined(let roomProxy) = await clientProxy.roomForIdentifier(roomID) else {
             MXLog.error("Failed to resolve joined room for identifier: \(roomID)")
             return .failure(.roomNotJoined)
         }
         
-        let result = await roomProxy.startLiveLocationShare(durationMillis: durationMillis)
+        let result = await roomProxy.startLiveLocationShare(duration: duration)
         
         guard case .success = result else {
             MXLog.error("Failed to start live location share in room: \(roomID)")
             return .failure(.startFailed)
         }
         
-        let timeoutDate = Date().addingTimeInterval(TimeInterval(durationMillis) / 1000.0)
+        let timeoutDate = Date().addingTimeInterval(TimeInterval(duration.seconds))
         appSettings.liveLocationSharingTimeoutDatesByRoomID[roomID] = timeoutDate
         
         return .success(())

--- a/ElementX/Sources/Services/Location/LiveLocationManager.swift
+++ b/ElementX/Sources/Services/Location/LiveLocationManager.swift
@@ -15,6 +15,15 @@ class LiveLocationManager: NSObject, LiveLocationManagerProtocol, CLLocationMana
     
     private let authorizationStatusSubject: CurrentValueSubject<CLAuthorizationStatus, Never>
     
+    /// Cached joined room proxies keyed by room ID, kept in sync with the active sessions dictionary.
+    private var activeRoomProxies = [String: JoinedRoomProxyProtocol]()
+    
+    /// The running task that iterates over live location updates.
+    @CancellableTask
+    private var locationUpdatesTask: Task<Void, Never>?
+    
+    private var cancellables = Set<AnyCancellable>()
+    
     var authorizationStatus: CurrentValuePublisher<CLAuthorizationStatus, Never> {
         authorizationStatusSubject.asCurrentValuePublisher()
     }
@@ -33,6 +42,11 @@ class LiveLocationManager: NSObject, LiveLocationManagerProtocol, CLLocationMana
         super.init()
         
         locationManager.delegate = self
+        locationManager.allowsBackgroundLocationUpdates = true
+        locationManager.desiredAccuracy = kCLLocationAccuracyNearestTenMeters
+        locationManager.pausesLocationUpdatesAutomatically = false
+        
+        setupSubscriptions()
     }
     
     // MARK: - LiveLocationManagerProtocol
@@ -45,6 +59,39 @@ class LiveLocationManager: NSObject, LiveLocationManagerProtocol, CLLocationMana
         return true
     }
     
+    func startLiveLocation(roomID: String, durationMillis: UInt64) async -> Result<Void, LiveLocationManagerError> {
+        guard case .joined(let roomProxy) = await clientProxy.roomForIdentifier(roomID) else {
+            MXLog.error("Failed to resolve joined room for identifier: \(roomID)")
+            return .failure(.roomNotJoined)
+        }
+        
+        let result = await roomProxy.startLiveLocationShare(durationMillis: durationMillis)
+        
+        guard case .success = result else {
+            MXLog.error("Failed to start live location share in room: \(roomID)")
+            return .failure(.startFailed)
+        }
+        
+        let timeoutDate = Date().addingTimeInterval(TimeInterval(durationMillis) / 1000.0)
+        appSettings.liveLocationSharingTimeoutDatesByRoomID[roomID] = timeoutDate
+        
+        return .success(())
+    }
+    
+    func stopLiveLocation(roomID: String) async {
+        // Best effort: send the stop event to the room regardless of tracking state.
+        if let roomProxy = await resolveRoomProxy(for: roomID) {
+            let result = await roomProxy.stopLiveLocationShare()
+            if case .failure(let error) = result {
+                MXLog.error("Failed to stop live location share in room \(roomID): \(error)")
+            }
+        }
+        
+        // Always clean up locally.
+        appSettings.liveLocationSharingTimeoutDatesByRoomID.removeValue(forKey: roomID)
+        activeRoomProxies.removeValue(forKey: roomID)
+    }
+    
     // MARK: - CLLocationManagerDelegate
     
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
@@ -53,6 +100,114 @@ class LiveLocationManager: NSObject, LiveLocationManagerProtocol, CLLocationMana
         if manager.authorizationStatus == .notDetermined {
             appSettings.hasRequestedLocationAlwaysLocationAuthorization = false
         }
+        
+        // If authorization was revoked, stop all active sessions.
+        if manager.authorizationStatus != .authorizedAlways {
+            stopAllSessions()
+        }
+        
         authorizationStatusSubject.send(manager.authorizationStatus)
+    }
+    
+    // MARK: - Private
+    
+    private func setupSubscriptions() {
+        appSettings.$liveLocationSharingTimeoutDatesByRoomID
+            .removeDuplicates()
+            .sink { [weak self] sessions in
+                guard let self else { return }
+                syncActiveRoomProxies(with: sessions)
+                
+                if sessions.isEmpty {
+                    locationUpdatesTask = nil
+                } else {
+                    startLocationUpdatesIfNeeded()
+                }
+            }
+            .store(in: &cancellables)
+        
+        appSettings.$liveLocationSharingEnabled
+            .filter { !$0 }
+            .sink { [weak self] _ in
+                guard let self else { return }
+                appSettings.liveLocationSharingTimeoutDatesByRoomID.removeAll()
+                activeRoomProxies.removeAll()
+                locationUpdatesTask = nil
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func syncActiveRoomProxies(with sessions: [String: Date]) {
+        // Remove proxies for rooms no longer in the dictionary.
+        let activeRoomIDs = Set(sessions.keys)
+        for roomID in activeRoomProxies.keys where !activeRoomIDs.contains(roomID) {
+            activeRoomProxies.removeValue(forKey: roomID)
+        }
+    }
+    
+    private func startLocationUpdatesIfNeeded() {
+        guard locationUpdatesTask == nil else { return }
+        
+        locationUpdatesTask = Task { [weak self] in
+            do {
+                for try await update in CLLocationUpdate.liveUpdates() {
+                    guard let self, !Task.isCancelled else { break }
+                    
+                    await self.sendLocationToActiveRooms(update)
+                }
+            } catch {
+                MXLog.error("Live location updates failed with error: \(error)")
+                self?.stopAllSessions()
+            }
+        }
+    }
+    
+    private func sendLocationToActiveRooms(_ update: CLLocationUpdate) async {
+        let sessions = appSettings.liveLocationSharingTimeoutDatesByRoomID
+        let geoURI = update.location.map { GeoURI(coordinate: $0.coordinate, uncertainty: $0.horizontalAccuracy) }
+        
+        for (roomID, timeoutDate) in sessions {
+            if Date() >= timeoutDate {
+                MXLog.info("Live location session expired for room: \(roomID)")
+                await stopLiveLocation(roomID: roomID)
+                continue
+            }
+            
+            guard let geoURI else { continue }
+            
+            let roomProxy = await resolveRoomProxy(for: roomID)
+            guard let roomProxy else {
+                MXLog.error("Failed to resolve room proxy for live location update in room: \(roomID)")
+                continue
+            }
+            
+            let result = await roomProxy.sendLiveLocation(geoURI: geoURI)
+            if case .failure(let error) = result {
+                MXLog.error("Failed to send live location update to room \(roomID): \(error)")
+            }
+        }
+    }
+    
+    private func resolveRoomProxy(for roomID: String) async -> JoinedRoomProxyProtocol? {
+        if let cached = activeRoomProxies[roomID] {
+            return cached
+        }
+        
+        guard case .joined(let roomProxy) = await clientProxy.roomForIdentifier(roomID) else {
+            return nil
+        }
+        
+        activeRoomProxies[roomID] = roomProxy
+        return roomProxy
+    }
+    
+    private func stopAllSessions() {
+        let roomIDs = Array(appSettings.liveLocationSharingTimeoutDatesByRoomID.keys)
+        Task { [weak self] in
+            guard let self else { return }
+            for roomID in roomIDs {
+                await stopLiveLocation(roomID: roomID)
+            }
+        }
     }
 }

--- a/ElementX/Sources/Services/Location/LiveLocationManagerProtocol.swift
+++ b/ElementX/Sources/Services/Location/LiveLocationManagerProtocol.swift
@@ -30,8 +30,8 @@ protocol LiveLocationManagerProtocol: AnyObject {
     ///
     /// - Parameters:
     ///   - roomID: The identifier of the room to share live location in.
-    ///   - durationMillis: The duration in milliseconds for how long the live location should be shared.
-    func startLiveLocation(roomID: String, durationMillis: UInt64) async -> Result<Void, LiveLocationManagerError>
+    ///   - duration: How long the live location should be shared.
+    func startLiveLocation(roomID: String, duration: Duration) async -> Result<Void, LiveLocationManagerError>
     
     /// Stops sharing live location in a room.
     ///

--- a/ElementX/Sources/Services/Location/LiveLocationManagerProtocol.swift
+++ b/ElementX/Sources/Services/Location/LiveLocationManagerProtocol.swift
@@ -9,6 +9,11 @@ import Combine
 import CoreLocation
 import Foundation
 
+enum LiveLocationManagerError: Error {
+    case roomNotJoined
+    case startFailed
+}
+
 // sourcery: AutoMockable
 protocol LiveLocationManagerProtocol: AnyObject {
     /// Publishes the current location authorization status.
@@ -20,4 +25,18 @@ protocol LiveLocationManagerProtocol: AnyObject {
     ///            `false` if the request was already made before and iOS would silently ignore it.
     @discardableResult
     func requestAlwaysAuthorizationIfPossible() -> Bool
+    
+    /// Starts sharing live location in a room.
+    ///
+    /// - Parameters:
+    ///   - roomID: The identifier of the room to share live location in.
+    ///   - durationMillis: The duration in milliseconds for how long the live location should be shared.
+    func startLiveLocation(roomID: String, durationMillis: UInt64) async -> Result<Void, LiveLocationManagerError>
+    
+    /// Stops sharing live location in a room.
+    ///
+    /// Sends a stop event to the room (best effort) and removes it from the tracked sessions.
+    /// Can also be used to stop a live location share started by another device.
+    /// - Parameter roomID: The identifier of the room to stop sharing live location in.
+    func stopLiveLocation(roomID: String) async
 }

--- a/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
@@ -754,9 +754,9 @@ class JoinedRoomProxy: JoinedRoomProxyProtocol {
     
     // MARK: - Live Location
     
-    func startLiveLocationShare(durationMillis: UInt64) async -> Result<Void, RoomProxyError> {
+    func startLiveLocationShare(duration: Duration) async -> Result<Void, RoomProxyError> {
         do {
-            try await room.startLiveLocationShare(durationMillis: durationMillis)
+            try await room.startLiveLocationShare(durationMillis: UInt64(duration.seconds * 1000))
             return .success(())
         } catch {
             MXLog.error("Failed starting live location share with error: \(error)")

--- a/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
@@ -751,6 +751,38 @@ class JoinedRoomProxy: JoinedRoomProxyProtocol {
             return .failure(.sdkError(error))
         }
     }
+    
+    // MARK: - Live Location
+    
+    func startLiveLocationShare(durationMillis: UInt64) async -> Result<Void, RoomProxyError> {
+        do {
+            try await room.startLiveLocationShare(durationMillis: durationMillis)
+            return .success(())
+        } catch {
+            MXLog.error("Failed starting live location share with error: \(error)")
+            return .failure(.sdkError(error))
+        }
+    }
+    
+    func sendLiveLocation(geoURI: GeoURI) async -> Result<Void, RoomProxyError> {
+        do {
+            try await room.sendLiveLocation(geoUri: geoURI.string)
+            return .success(())
+        } catch {
+            MXLog.error("Failed sending live location with error: \(error)")
+            return .failure(.sdkError(error))
+        }
+    }
+    
+    func stopLiveLocationShare() async -> Result<Void, RoomProxyError> {
+        do {
+            try await room.stopLiveLocationShare()
+            return .success(())
+        } catch {
+            MXLog.error("Failed stopping live location share with error: \(error)")
+            return .failure(.sdkError(error))
+        }
+    }
 
     // MARK: - Private
     

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -197,7 +197,7 @@ protocol JoinedRoomProxyProtocol: RoomProxyProtocol {
     
     // MARK: - Live Location
     
-    func startLiveLocationShare(durationMillis: UInt64) async -> Result<Void, RoomProxyError>
+    func startLiveLocationShare(duration: Duration) async -> Result<Void, RoomProxyError>
     func sendLiveLocation(geoURI: GeoURI) async -> Result<Void, RoomProxyError>
     func stopLiveLocationShare() async -> Result<Void, RoomProxyError>
 }

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -194,6 +194,12 @@ protocol JoinedRoomProxyProtocol: RoomProxyProtocol {
     func saveDraft(_ draft: ComposerDraft, threadRootEventID: String?) async -> Result<Void, RoomProxyError>
     func loadDraft(threadRootEventID: String?) async -> Result<ComposerDraft?, RoomProxyError>
     func clearDraft(threadRootEventID: String?) async -> Result<Void, RoomProxyError>
+    
+    // MARK: - Live Location
+    
+    func startLiveLocationShare(durationMillis: UInt64) async -> Result<Void, RoomProxyError>
+    func sendLiveLocation(geoURI: GeoURI) async -> Result<Void, RoomProxyError>
+    func stopLiveLocationShare() async -> Result<Void, RoomProxyError>
 }
 
 extension JoinedRoomProxyProtocol {

--- a/ElementX/SupportingFiles/Info.plist
+++ b/ElementX/SupportingFiles/Info.plist
@@ -93,6 +93,7 @@
 		<string>fetch</string>
 		<string>processing</string>
 		<string>voip</string>
+		<string>location</string>
 	</array>
 	<key>UILaunchScreen</key>
 	<dict>

--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -98,7 +98,8 @@ targets:
           audio,
           fetch,
           processing,
-          voip
+          voip,
+          location
         ]
         BGTaskSchedulerPermittedIdentifiers: [
           io.element.elementx.background.refresh


### PR DESCRIPTION
This PR implements inside the LiveLocationManager the following functions
- Start live location sharing
- Send LLS updates (all done in background the user doesn't need to worry about anything)
- Stop LLS

It also implements a store that keeps track of what are the rooms this device is sending LLS to, in this way in case of a crash, kill or reopen we can restore the LLS updates.
Also when there are no more rooms to send LLS events to, we just stop the CLLocationUpdates entirely.

We also try to stop events once they have expired in conformance with the MSC.
It's important to note that this is a best effort thing, if it's not possible we don't try again (usually clients implement an internal check to consider an LLS expired, so that's generally fine).

To review commit by commit.

Also the send functions will not work properly on the current SDK release, since we need a fix for the sync over the `beaconInfo` event, which is being worked on here: https://github.com/matrix-org/matrix-rust-sdk/pull/6385

The following PR is the inclusion of these functions inside the UI + tests: https://github.com/element-hq/element-x-ios/pull/5349

fixes #5197