### PR TITLE
Implement live location sharing start and stop actions in the UI

### DIFF
--- a/ElementX/Resources/Localizations/en-US.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en-US.lproj/Localizable.strings
@@ -680,6 +680,13 @@
 "screen_media_upload_preview_item_count" = "Item %1$d of %2$d";
 "screen_media_upload_preview_optimize_image_quality_title" = "Optimize image quality";
 "screen_media_upload_preview_processing" = "Processing...";
+"screen_missing_key_backup_open_element_classic" = "Open Element Classic";
+"screen_missing_key_backup_step_1" = "Open Element Classic on your device";
+"screen_missing_key_backup_step_2" = "Go to \"Settings\" > \"Security &Privacy\"";
+"screen_missing_key_backup_step_3" = "In the section \"Cryptography Keys Management\", click on \"Encrypted Messages Recovery\"";
+"screen_missing_key_backup_step_4" = "Follow instructions";
+"screen_missing_key_backup_step_5" = "Done!";
+"screen_missing_key_backup_title" = "We need you to enable your key storage before processing to %1$@";
 "screen_onboarding_welcome_back" = "Welcome back";
 "screen_pinned_timeline_empty_state_description" = "Press on a message and choose “%1$@” to include here.";
 "screen_pinned_timeline_empty_state_headline" = "Pin important messages so that they can be easily discovered";
@@ -758,6 +765,7 @@
 "screen_security_and_privacy_room_visibility_section_footer" = "Addresses are a way to find and access rooms and spaces. This also ensures you can easily share them with others.";
 "screen_security_and_privacy_room_visibility_section_header" = "Visibility";
 "screen_security_and_privacy_title" = "Security & privacy";
+"screen_share_location_live_location_disclaimer_title" = "Your live location history will be stored in the room and visible to members after the session ends.";
 "screen_share_location_live_location_duration_picker_title" = "Choose how long to share your live location.";
 "screen_sharing_location_option_sheet_title" = "Sharing options";
 "screen_space_add_room_action" = "Room";

--- a/ElementX/Resources/Localizations/en.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Localizable.strings
@@ -680,6 +680,13 @@
 "screen_media_upload_preview_item_count" = "Item %1$d of %2$d";
 "screen_media_upload_preview_optimize_image_quality_title" = "Optimise image quality";
 "screen_media_upload_preview_processing" = "Processing...";
+"screen_missing_key_backup_open_element_classic" = "Open Element Classic";
+"screen_missing_key_backup_step_1" = "Open Element Classic on your device";
+"screen_missing_key_backup_step_2" = "Go to \"Settings\" > \"Security &Privacy\"";
+"screen_missing_key_backup_step_3" = "In the section \"Cryptography Keys Management\", click on \"Encrypted Messages Recovery\"";
+"screen_missing_key_backup_step_4" = "Follow instructions";
+"screen_missing_key_backup_step_5" = "Done!";
+"screen_missing_key_backup_title" = "We need you to enable your key storage before processing to %1$@";
 "screen_onboarding_welcome_back" = "Welcome back";
 "screen_pinned_timeline_empty_state_description" = "Press on a message and choose “%1$@” to include here.";
 "screen_pinned_timeline_empty_state_headline" = "Pin important messages so that they can be easily discovered";
@@ -758,6 +765,7 @@
 "screen_security_and_privacy_room_visibility_section_footer" = "Addresses are a way to find and access rooms and spaces. This also ensures you can easily share them with others.";
 "screen_security_and_privacy_room_visibility_section_header" = "Visibility";
 "screen_security_and_privacy_title" = "Security & privacy";
+"screen_share_location_live_location_disclaimer_title" = "Your live location history will be stored in the room and visible to members after the session ends.";
 "screen_share_location_live_location_duration_picker_title" = "Choose how long to share your live location.";
 "screen_sharing_location_option_sheet_title" = "Sharing options";
 "screen_space_add_room_action" = "Room";

--- a/ElementX/Sources/Generated/Strings.swift
+++ b/ElementX/Sources/Generated/Strings.swift
@@ -2200,6 +2200,22 @@ internal enum L10n {
   internal static var screenMigrationMessage: String { return L10n.tr("Localizable", "screen_migration_message") }
   /// Setting up your account.
   internal static var screenMigrationTitle: String { return L10n.tr("Localizable", "screen_migration_title") }
+  /// Open Element Classic
+  internal static var screenMissingKeyBackupOpenElementClassic: String { return L10n.tr("Localizable", "screen_missing_key_backup_open_element_classic") }
+  /// Open Element Classic on your device
+  internal static var screenMissingKeyBackupStep1: String { return L10n.tr("Localizable", "screen_missing_key_backup_step_1") }
+  /// Go to "Settings" > "Security &Privacy"
+  internal static var screenMissingKeyBackupStep2: String { return L10n.tr("Localizable", "screen_missing_key_backup_step_2") }
+  /// In the section "Cryptography Keys Management", click on "Encrypted Messages Recovery"
+  internal static var screenMissingKeyBackupStep3: String { return L10n.tr("Localizable", "screen_missing_key_backup_step_3") }
+  /// Follow instructions
+  internal static var screenMissingKeyBackupStep4: String { return L10n.tr("Localizable", "screen_missing_key_backup_step_4") }
+  /// Done!
+  internal static var screenMissingKeyBackupStep5: String { return L10n.tr("Localizable", "screen_missing_key_backup_step_5") }
+  /// We need you to enable your key storage before processing to %1$@
+  internal static func screenMissingKeyBackupTitle(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "screen_missing_key_backup_title", String(describing: p1))
+  }
   /// You can change your settings later.
   internal static var screenNotificationOptinSubtitle: String { return L10n.tr("Localizable", "screen_notification_optin_subtitle") }
   /// Allow notifications and never miss a message
@@ -3183,6 +3199,8 @@ internal enum L10n {
   internal static var screenSessionVerificationWaitingToAcceptSubtitle: String { return L10n.tr("Localizable", "screen_session_verification_waiting_to_accept_subtitle") }
   /// Waiting to accept request
   internal static var screenSessionVerificationWaitingToAcceptTitle: String { return L10n.tr("Localizable", "screen_session_verification_waiting_to_accept_title") }
+  /// Your live location history will be stored in the room and visible to members after the session ends.
+  internal static var screenShareLocationLiveLocationDisclaimerTitle: String { return L10n.tr("Localizable", "screen_share_location_live_location_disclaimer_title") }
   /// Choose how long to share your live location.
   internal static var screenShareLocationLiveLocationDurationPickerTitle: String { return L10n.tr("Localizable", "screen_share_location_live_location_duration_picker_title") }
   /// Share location

--- a/ElementX/Sources/Mocks/LiveLocationManagerMock.swift
+++ b/ElementX/Sources/Mocks/LiveLocationManagerMock.swift
@@ -21,5 +21,6 @@ extension LiveLocationManagerMock {
         underlyingAuthorizationStatus = .init(authorizationStatusSubject)
         
         requestAlwaysAuthorizationIfPossibleReturnValue = configuration.requestAlwaysAuthorizationIfPossibleReturnValue
+        startLiveLocationRoomIDDurationReturnValue = .success(())
     }
 }

--- a/ElementX/Sources/Screens/LocationSharing/LocationSharingScreenModels.swift
+++ b/ElementX/Sources/Screens/LocationSharing/LocationSharingScreenModels.swift
@@ -10,9 +10,11 @@ import CoreLocation
 import Foundation
 import MatrixRustSDK
 
-enum LocationSharingViewError: Error, Hashable {
+enum LocationSharingViewAlert: Hashable {
     case missingAuthorization
     case missingAlwaysAuthorization
+    case liveLocationDisclaimer
+    case liveLocationDurationSelection
     case mapError(MapLibreError)
 }
 
@@ -130,12 +132,12 @@ struct LocationSharingScreenBindings {
             return nil
         }
         set {
-            alertInfo = newValue.map { AlertInfo(locationSharingViewError: .mapError($0)) }
+            alertInfo = newValue.map { AlertInfo(alertID: .mapError($0)) }
         }
     }
     
     /// Information describing the currently displayed alert.
-    var alertInfo: AlertInfo<LocationSharingViewError>?
+    var alertInfo: AlertInfo<LocationSharingViewAlert>?
 
     var showShareSheet = false
 }
@@ -148,30 +150,42 @@ enum LocationSharingScreenViewAction {
     case userDidPan
 }
 
-extension AlertInfo where T == LocationSharingViewError {
-    init(locationSharingViewError error: LocationSharingViewError,
+extension AlertInfo where T == LocationSharingViewAlert {
+    init(alertID: LocationSharingViewAlert,
          primaryButton: AlertButton = AlertButton(title: L10n.actionOk, action: nil),
-         secondaryButton: AlertButton? = nil) {
-        switch error {
+         secondaryButton: AlertButton? = nil,
+         verticalButtons: [AlertButton]? = nil) {
+        switch alertID {
         case .missingAuthorization:
-            self.init(id: error,
+            self.init(id: alertID,
                       title: L10n.dialogAllowAccess,
                       message: L10n.dialogPermissionLocationDescriptionIos(InfoPlistReader.main.bundleDisplayName),
                       primaryButton: primaryButton,
                       secondaryButton: secondaryButton)
         case .missingAlwaysAuthorization:
-            self.init(id: error,
+            self.init(id: alertID,
                       title: L10n.dialogAllowAccess,
                       message: L10n.dialogPermissionLiveLocationDescriptionIos(InfoPlistReader.main.bundleDisplayName),
                       primaryButton: primaryButton,
                       secondaryButton: secondaryButton)
+        case .liveLocationDisclaimer:
+            self.init(id: alertID,
+                      title: L10n.screenShareLocationLiveLocationDisclaimerTitle,
+                      primaryButton: primaryButton,
+                      secondaryButton: secondaryButton)
+        case .liveLocationDurationSelection:
+            self.init(id: alertID,
+                      title: L10n.screenShareLocationLiveLocationDurationPickerTitle,
+                      primaryButton: primaryButton,
+                      secondaryButton: nil,
+                      verticalButtons: verticalButtons)
         case .mapError(.failedLoadingMap):
-            self.init(id: error,
+            self.init(id: alertID,
                       title: L10n.errorFailedLoadingMap(InfoPlistReader.main.bundleDisplayName),
                       primaryButton: primaryButton,
                       secondaryButton: secondaryButton)
         case .mapError(.failedLocatingUser):
-            self.init(id: error,
+            self.init(id: alertID,
                       title: L10n.errorFailedLocatingUser(InfoPlistReader.main.bundleDisplayName),
                       primaryButton: primaryButton,
                       secondaryButton: secondaryButton)

--- a/ElementX/Sources/Screens/LocationSharing/LocationSharingScreenViewModel.swift
+++ b/ElementX/Sources/Screens/LocationSharing/LocationSharingScreenViewModel.swift
@@ -72,7 +72,7 @@ class LocationSharingScreenViewModel: LocationSharingScreenViewModelType, Locati
                 state.bindings.showsUserLocationMode = .showAndFollow
             case .some(false):
                 let action: () -> Void = { [weak self] in self?.actionsSubject.send(.openSystemSettings) }
-                state.bindings.alertInfo = .init(locationSharingViewError: .missingAuthorization,
+                state.bindings.alertInfo = .init(alertID: .missingAuthorization,
                                                  primaryButton: .init(title: L10n.actionNotNow, role: .cancel, action: nil),
                                                  secondaryButton: .init(title: L10n.commonSettings, action: action))
             }
@@ -112,13 +112,23 @@ class LocationSharingScreenViewModel: LocationSharingScreenViewModelType, Locati
         }
     }
     
+    private static let durationFormatter: DateComponentsFormatter = {
+        let formatter = DateComponentsFormatter()
+        formatter.unitsStyle = .full
+        formatter.allowedUnits = [.hour, .minute]
+        return formatter
+    }()
+    
     private func startLiveLocationSharing() {
+        requestAlwaysLocationPermission()
+    }
+    
+    private func requestAlwaysLocationPermission() {
         authorizationStatusSubscription = nil
         let authorizationStatus = liveLocationManager.authorizationStatus.value
         switch authorizationStatus {
         case .authorizedAlways:
-            // TODO: Start sending live location updates to the room
-            break
+            showLiveLocationDisclaimer()
         case .notDetermined:
             // This is to solve a race condition with map libre which always tries first
             // to request the when in use permission, we wait for it and then try again
@@ -127,7 +137,7 @@ class LocationSharingScreenViewModel: LocationSharingScreenViewModelType, Locati
                 .first() // this publisher only fires when there is an actual change, and if the user is done with permissions
                 .sink { [weak self] newValue in
                     guard newValue == .authorizedWhenInUse else { return }
-                    self?.startLiveLocationSharing()
+                    self?.requestAlwaysLocationPermission()
                 }
         case .authorizedWhenInUse:
             guard liveLocationManager.requestAlwaysAuthorizationIfPossible() else {
@@ -139,17 +149,59 @@ class LocationSharingScreenViewModel: LocationSharingScreenViewModelType, Locati
             authorizationStatusSubscription = liveLocationManager.authorizationStatus
                 .filter { $0 != authorizationStatus } // skip current status
                 .first() // this publisher only fires when there is an actual change, and if the user is done with permissions
-                .sink { newValue in
+                .sink { [weak self] newValue in
                     guard newValue == .authorizedAlways else { return }
-                    // TODO: Start sending live location updates to the room
+                    self?.showLiveLocationDisclaimer()
                 }
         default:
             showMissingAlwaysAuthorizedAlert()
         }
     }
     
+    private func showLiveLocationDisclaimer() {
+        state.bindings.alertInfo = .init(alertID: .liveLocationDisclaimer,
+                                         primaryButton: .init(title: L10n.actionDecline, role: .cancel, action: nil),
+                                         secondaryButton: .init(title: L10n.actionAccept) { [weak self] in
+                                             // Delay so SwiftUI finishes dismissing the current alert
+                                             // before presenting the next one.
+                                             DispatchQueue.main.async {
+                                                 self?.showLiveLocationDurationPicker()
+                                             }
+                                         })
+    }
+    
+    private func showLiveLocationDurationPicker() {
+        let durations: [TimeInterval] = [15 * 60, // 15 minutes
+                                         60 * 60, // 1 hour
+                                         8 * 60 * 60] // 8 hours
+        
+        let durationButtons: [AlertInfo<LocationSharingViewAlert>.AlertButton] = durations.compactMap { duration in
+            guard let title = Self.durationFormatter.string(from: duration) else { return nil }
+            return .init(title: title) { [weak self] in
+                Task { [weak self] in await self?.startLiveLocationSharingInRoom(durationMillis: UInt64(duration * 1000)) }
+            }
+        }
+        
+        state.bindings.alertInfo = .init(alertID: .liveLocationDurationSelection,
+                                         primaryButton: .init(title: L10n.actionCancel, role: .cancel, action: nil),
+                                         verticalButtons: durationButtons)
+    }
+    
+    private func startLiveLocationSharingInRoom(durationMillis: UInt64) async {
+        let result = await liveLocationManager.startLiveLocation(roomID: roomProxy.id,
+                                                                 durationMillis: durationMillis)
+        
+        switch result {
+        case .success:
+            actionsSubject.send(.close)
+        case .failure(let error):
+            MXLog.error("Failed to start live location sharing: \(error)")
+            showErrorIndicator()
+        }
+    }
+    
     private func showMissingAlwaysAuthorizedAlert() {
-        state.bindings.alertInfo = .init(locationSharingViewError: .missingAlwaysAuthorization,
+        state.bindings.alertInfo = .init(alertID: .missingAlwaysAuthorization,
                                          primaryButton: .init(title: L10n.actionNotNow, role: .cancel, action: nil),
                                          secondaryButton: .init(title: L10n.commonSettings) { [weak self] in self?.actionsSubject.send(.openSystemSettings) })
     }

--- a/ElementX/Sources/Screens/LocationSharing/LocationSharingScreenViewModel.swift
+++ b/ElementX/Sources/Screens/LocationSharing/LocationSharingScreenViewModel.swift
@@ -59,7 +59,7 @@ class LocationSharingScreenViewModel: LocationSharingScreenViewModelType, Locati
         case .close:
             actionsSubject.send(.close)
         case .startLiveLocation:
-            startLiveLocationSharing()
+            checkAlwaysShareLocationPermission()
         case .selectLocation:
             guard let coordinate = state.bindings.mapCenterLocation else { return }
             let uncertainty = state.isSharingUserLocation ? context.geolocationUncertainty : nil
@@ -118,12 +118,8 @@ class LocationSharingScreenViewModel: LocationSharingScreenViewModelType, Locati
         formatter.allowedUnits = [.hour, .minute]
         return formatter
     }()
-    
-    private func startLiveLocationSharing() {
-        requestAlwaysLocationPermission()
-    }
-    
-    private func requestAlwaysLocationPermission() {
+        
+    private func checkAlwaysShareLocationPermission() {
         authorizationStatusSubscription = nil
         let authorizationStatus = liveLocationManager.authorizationStatus.value
         switch authorizationStatus {
@@ -137,7 +133,7 @@ class LocationSharingScreenViewModel: LocationSharingScreenViewModelType, Locati
                 .first() // this publisher only fires when there is an actual change, and if the user is done with permissions
                 .sink { [weak self] newValue in
                     guard newValue == .authorizedWhenInUse else { return }
-                    self?.requestAlwaysLocationPermission()
+                    self?.checkAlwaysShareLocationPermission()
                 }
         case .authorizedWhenInUse:
             guard liveLocationManager.requestAlwaysAuthorizationIfPossible() else {
@@ -171,14 +167,14 @@ class LocationSharingScreenViewModel: LocationSharingScreenViewModelType, Locati
     }
     
     private func showLiveLocationDurationPicker() {
-        let durations: [TimeInterval] = [15 * 60, // 15 minutes
-                                         60 * 60, // 1 hour
-                                         8 * 60 * 60] // 8 hours
+        let durations: [Duration] = [.seconds(15 * 60), // 15 minutes
+                                     .seconds(60 * 60), // 1 hour
+                                     .seconds(60 * 60 * 8)] // 8 hours
         
         let durationButtons: [AlertInfo<LocationSharingViewAlert>.AlertButton] = durations.compactMap { duration in
-            guard let title = Self.durationFormatter.string(from: duration) else { return nil }
+            guard let title = Self.durationFormatter.string(from: duration.seconds) else { return nil }
             return .init(title: title) { [weak self] in
-                Task { [weak self] in await self?.startLiveLocationSharingInRoom(durationMillis: UInt64(duration * 1000)) }
+                Task { [weak self] in await self?.startLiveLocationSharingInRoom(duration: duration) }
             }
         }
         
@@ -187,9 +183,9 @@ class LocationSharingScreenViewModel: LocationSharingScreenViewModelType, Locati
                                          verticalButtons: durationButtons)
     }
     
-    private func startLiveLocationSharingInRoom(durationMillis: UInt64) async {
+    private func startLiveLocationSharingInRoom(duration: Duration) async {
         let result = await liveLocationManager.startLiveLocation(roomID: roomProxy.id,
-                                                                 durationMillis: durationMillis)
+                                                                 duration: duration)
         
         switch result {
         case .success:

--- a/ElementX/Sources/Screens/Timeline/TimelineModels.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineModels.swift
@@ -70,6 +70,8 @@ enum TimelineViewAction {
     case handlePollAction(TimelineViewPollAction)
     case handleAudioPlayerAction(TimelineAudioPlayerAction)
     
+    case stopLiveLocationSharing
+    
     /// Focus the timeline onto the specified event ID (switching to a detached timeline if needed).
     case focusOnEventID(String)
     /// Switch back to a live timeline (from a detached one).

--- a/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
@@ -199,6 +199,8 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
             handlePollAction(pollAction)
         case .handleAudioPlayerAction(let audioPlayerAction):
             handleAudioPlayerAction(audioPlayerAction)
+        case .stopLiveLocationSharing:
+            Task { await userSession.liveLocationManager.stopLiveLocation(roomID: state.roomID) }
         case .focusOnEventID(let eventID):
             Task { await focusOnEvent(eventID: eventID) }
         case .focusLive:

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/LiveLocationRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/LiveLocationRoomTimelineView.swift
@@ -173,7 +173,9 @@ struct LiveLocationRoomTimelineView: View {
             Spacer()
             
             if isLive, timelineItem.isOutgoing {
-                Button { } label: {
+                Button {
+                    context?.send(viewAction: .stopLiveLocationSharing)
+                } label: {
                     CompoundIcon(\.stop, size: .small, relativeTo: .compound.bodySMSemibold)
                         .foregroundStyle(.compound.iconOnSolidPrimary)
                         .padding(5)

--- a/UnitTests/Sources/LocationSharingScreenViewModelTests.swift
+++ b/UnitTests/Sources/LocationSharingScreenViewModelTests.swift
@@ -71,11 +71,11 @@ final class LocationSharingScreenViewModelTests {
     @Test
     func errorMapping() {
         setupViewModel()
-        let mapError = AlertInfo(locationSharingViewError: .mapError(.failedLoadingMap))
+        let mapError = AlertInfo(alertID: .mapError(.failedLoadingMap))
         #expect(mapError.title == L10n.errorFailedLoadingMap(InfoPlistReader.main.bundleDisplayName))
-        let locationError = AlertInfo(locationSharingViewError: .mapError(.failedLocatingUser))
+        let locationError = AlertInfo(alertID: .mapError(.failedLocatingUser))
         #expect(locationError.title == L10n.errorFailedLocatingUser(InfoPlistReader.main.bundleDisplayName))
-        let AuthorizationError = AlertInfo(locationSharingViewError: .missingAuthorization)
+        let AuthorizationError = AlertInfo(alertID: .missingAuthorization)
         #expect(AuthorizationError.message == L10n.dialogPermissionLocationDescriptionIos(InfoPlistReader.main.bundleDisplayName))
     }
 
@@ -141,13 +141,6 @@ final class LocationSharingScreenViewModelTests {
     }
     
     @Test
-    func startLiveLocationWithAlwaysAuthorization() {
-        setupViewModel(liveLocationManagerConfiguration: .init(authorizationStatus: .authorizedAlways))
-        context.send(viewAction: .startLiveLocation)
-        #expect(context.alertInfo == nil)
-    }
-    
-    @Test
     func startLiveLocationWithWhenInUseAuthorizationAlreadyRequested() {
         setupViewModel(liveLocationManagerConfiguration: .init(authorizationStatus: .authorizedWhenInUse,
                                                                requestAlwaysAuthorizationIfPossibleReturnValue: false))
@@ -191,8 +184,81 @@ final class LocationSharingScreenViewModelTests {
         #expect(context.alertInfo == nil)
     }
     
+    // MARK: - Live Location Start Flow Tests
+
+    @Test
+    func startLiveLocationShowsDisclaimer() {
+        setupViewModel(liveLocationManagerConfiguration: .init(authorizationStatus: .authorizedAlways))
+        context.send(viewAction: .startLiveLocation)
+        #expect(context.alertInfo?.id == .liveLocationDisclaimer)
+    }
+
+    @Test
+    func startLiveLocationDisclaimerDeclineSkipsStart() {
+        let liveLocationManagerMock = LiveLocationManagerMock(.init(authorizationStatus: .authorizedAlways))
+        setupViewModel(liveLocationManagerMock: liveLocationManagerMock)
+        context.send(viewAction: .startLiveLocation)
+        context.alertInfo?.primaryButton.action?()
+        #expect(!liveLocationManagerMock.startLiveLocationRoomIDDurationCalled)
+    }
+
+    @Test
+    func startLiveLocationDisclaimerAcceptShowsDurationPicker() async throws {
+        setupViewModel(liveLocationManagerConfiguration: .init(authorizationStatus: .authorizedAlways))
+        context.send(viewAction: .startLiveLocation)
+        #expect(context.alertInfo?.id == .liveLocationDisclaimer)
+        let deferred = deferFulfillment(context.observe(\.alertInfo)) { $0?.id == .liveLocationDurationSelection }
+        context.alertInfo?.secondaryButton?.action?()
+        try await deferred.fulfill()
+    }
+
+    @Test
+    func startLiveLocationDurationPickerCancelSkipsStart() async throws {
+        let liveLocationManagerMock = LiveLocationManagerMock(.init(authorizationStatus: .authorizedAlways))
+        setupViewModel(liveLocationManagerMock: liveLocationManagerMock)
+        context.send(viewAction: .startLiveLocation)
+        let deferred = deferFulfillment(context.observe(\.alertInfo)) { $0?.id == .liveLocationDurationSelection }
+        context.alertInfo?.secondaryButton?.action?()
+        try await deferred.fulfill()
+        context.alertInfo?.primaryButton.action?()
+        #expect(!liveLocationManagerMock.startLiveLocationRoomIDDurationCalled)
+    }
+
+    @Test
+    func startLiveLocationSuccess() async throws {
+        let liveLocationManagerMock = LiveLocationManagerMock(.init(authorizationStatus: .authorizedAlways))
+        setupViewModel(liveLocationManagerMock: liveLocationManagerMock)
+        context.send(viewAction: .startLiveLocation)
+        let durationPicker = deferFulfillment(context.observe(\.alertInfo)) { $0?.id == .liveLocationDurationSelection }
+        context.alertInfo?.secondaryButton?.action?()
+        try await durationPicker.fulfill()
+
+        let deferred = deferFulfillment(viewModel.actions) { $0 == .close }
+        context.alertInfo?.verticalButtons?.first?.action?()
+        try await deferred.fulfill()
+
+        #expect(liveLocationManagerMock.startLiveLocationRoomIDDurationCalled)
+        let arguments = try #require(liveLocationManagerMock.startLiveLocationRoomIDDurationReceivedArguments)
+        #expect(arguments.duration == .seconds(60 * 15))
+    }
+
+    @Test
+    func startLiveLocationFailureDoesNotClose() async throws {
+        let liveLocationManagerMock = LiveLocationManagerMock(.init(authorizationStatus: .authorizedAlways))
+        liveLocationManagerMock.startLiveLocationRoomIDDurationReturnValue = .failure(.startFailed)
+        setupViewModel(liveLocationManagerMock: liveLocationManagerMock)
+        context.send(viewAction: .startLiveLocation)
+        let durationPicker = deferFulfillment(context.observe(\.alertInfo)) { $0?.id == .liveLocationDurationSelection }
+        context.alertInfo?.secondaryButton?.action?()
+        try await durationPicker.fulfill()
+
+        let deferredFailure = deferFailure(viewModel.actions, timeout: .seconds(1)) { $0 == .close }
+        context.alertInfo?.verticalButtons?.first?.action?()
+        try await deferredFailure.fulfill()
+    }
+
     // MARK: - Private
-    
+
     private func setupViewModel(liveLocationManagerConfiguration: LiveLocationManagerMock.Configuration = .init()) {
         timelineProxy = TimelineProxyMock(.init())
         viewModel = LocationSharingScreenViewModel(interactionMode: .picker,


### PR DESCRIPTION
Okay so this PR finally connects the CTAs that were already in the app about LLS with its manager.

- It adds a bunch of alerts after the permissions are determined when selecting the live location sharing option from the location screen (a disclaimer about your privacy + a duration selector) and then calls the start function for the room
- it connects the stop function to the live location timeline item view stop button
- Adds a bunch of tests to the `LocationSharingScreenViewModel`