### PR TITLE
Fix testUserFlow integration tests, at least locally

### DIFF
--- a/IntegrationTests/Sources/Common.swift
+++ b/IntegrationTests/Sources/Common.swift
@@ -125,13 +125,13 @@ extension XCUIApplication {
         // Make the logout button visible
         swipeUp()
         
-        // Logout
+        // Remove this device (was "Sign out" before)
         let logoutButton = buttons[A11yIdentifiers.settingsScreen.logout]
         XCTAssertTrue(logoutButton.waitForExistence(timeout: 10.0))
         logoutButton.tap(.center)
         
-        // Confirm logout
-        let alertLogoutButton = alerts.firstMatch.buttons["Sign out"].firstMatch
+        // Confirm Remove this Device
+        let alertLogoutButton = alerts.firstMatch.buttons[A11yIdentifiers.alertInfo.primaryButton].firstMatch
         XCTAssertTrue(alertLogoutButton.waitForExistence(timeout: 10.0))
         alertLogoutButton.tap(.center)
         

--- a/IntegrationTests/Sources/Common.swift
+++ b/IntegrationTests/Sources/Common.swift
@@ -133,12 +133,12 @@ extension XCUIApplication {
         // Make the logout button visible
         swipeUp()
         
-        // Remove this device (was "Sign out" before)
+        // Logout
         let logoutButton = buttons[A11yIdentifiers.settingsScreen.logout]
         XCTAssertTrue(logoutButton.waitForExistence(timeout: 10.0))
         logoutButton.tap(.center)
         
-        // Confirm Remove this Device
+        // Confirm logout (Remove this device)
         let alertLogoutButton = alerts.firstMatch.buttons[A11yIdentifiers.alertInfo.primaryButton].firstMatch
         XCTAssertTrue(alertLogoutButton.waitForExistence(timeout: 10.0))
         alertLogoutButton.tap(.center)

--- a/IntegrationTests/Sources/Common.swift
+++ b/IntegrationTests/Sources/Common.swift
@@ -74,6 +74,14 @@ extension XCUIApplication {
         let webAuthenticationView = XCUIApplication(bundleIdentifier: "com.apple.SafariViewService")
         XCTAssertTrue(webAuthenticationView.waitForExistence(timeout: 10.0))
         webAuthenticationView.tap(.top) // Tap the web view to properly focus the app again.
+
+        // The user may already be authenticated on MAS. Sign them out.
+        // The button label varies by MAS version: "Sign out" or "Use another account".
+        let masLogoutPredicate = NSPredicate(format: "label == 'Sign out' OR label == 'Use another account'")
+        let masLogoutButton = webAuthenticationView.buttons.matching(masLogoutPredicate).firstMatch
+        if masLogoutButton.waitForExistence(timeout: 2.0) {
+            masLogoutButton.tap(.center)
+        }
         
         let webUsernameTextField = textFields["Username or Email"]
         XCTAssertTrue(webUsernameTextField.waitForExistence(timeout: 10.0))

--- a/IntegrationTests/Sources/Common.swift
+++ b/IntegrationTests/Sources/Common.swift
@@ -77,10 +77,10 @@ extension XCUIApplication {
 
         // The user may already be authenticated on MAS. Sign them out.
         // The button label varies by MAS version: "Sign out" or "Use another account".
-        let masLogoutPredicate = NSPredicate(format: "label == 'Sign out' OR label == 'Use another account'")
-        let masLogoutButton = webAuthenticationView.buttons.matching(masLogoutPredicate).firstMatch
-        if masLogoutButton.waitForExistence(timeout: 2.0) {
-            masLogoutButton.tap(.center)
+        let webLogoutPredicate = NSPredicate(format: "label == 'Sign out' OR label == 'Use another account'")
+        let webLogoutButton = webAuthenticationView.buttons.matching(webLogoutPredicate).firstMatch
+        if webLogoutButton.waitForExistence(timeout: 2.0) {
+            webLogoutButton.tap(.center)
         }
         
         let webUsernameTextField = textFields["Username or Email"]

--- a/IntegrationTests/Sources/UserFlowTests.swift
+++ b/IntegrationTests/Sources/UserFlowTests.swift
@@ -190,10 +190,17 @@ class UserFlowTests: XCTestCase {
         XCTAssertTrue(roomHeader.waitForExistence(timeout: 10.0))
         roomHeader.tap(.center)
         
-        // Make the People item visible
-        app.swipeUp()
-        
-        // Open the room member details
+        // Swipe until the People button is hittable
+        let peopleButton = app.buttons[A11yIdentifiers.roomDetailsScreen.people]
+        if !peopleButton.isHittable {
+            var attempts = 0
+            while !peopleButton.isHittable, attempts < 5 {
+                app.swipeUp()
+                attempts += 1
+            }
+        }
+
+        // Open the room members list.
         tapOnButton(A11yIdentifiers.roomDetailsScreen.people)
         
         // Open the first member's details. Loading members for big rooms can take a while.

--- a/IntegrationTests/Sources/UserFlowTests.swift
+++ b/IntegrationTests/Sources/UserFlowTests.swift
@@ -145,7 +145,7 @@ class UserFlowTests: XCTestCase {
         
         allowLocationPermissionOnce()
         
-        tapOnButton("Cancel", waitForDisappearance: true)
+        tapOnButton("Close", waitForDisappearance: true)
     }
     
     private func allowLocationPermissionOnce() {
@@ -189,6 +189,9 @@ class UserFlowTests: XCTestCase {
         let roomHeader = app.buttons[A11yIdentifiers.roomScreen.name]
         XCTAssertTrue(roomHeader.waitForExistence(timeout: 10.0))
         roomHeader.tap(.center)
+        
+        // Make the People item visible
+        app.swipeUp()
         
         // Open the room member details
         tapOnButton(A11yIdentifiers.roomDetailsScreen.people)


### PR DESCRIPTION
Fixes three issues causing `testUserFlow` integration tests to fail:

- Use `Close` instead of `Cancel` button label when dismissing the location picker (button label changed)
- Scroll up before tapping the People button in room details to ensure it's visible on screen
- Use `Remove this device` instead of log out

I splitted the tests into 4 with so that they are better clustered. The login test is mandatory for others.
I also made a change to log out any existing previous MAS session to avoid tests to fail if you relaunch them.

Tests locally pass:
<img width="286" height="251" alt="image" src="https://github.com/user-attachments/assets/931e84c7-cf10-41b5-89ed-5ac6d7b4410c" />

Then, I tried to make them less flakey on the CI by:
- Removing the `sleep()` calls and use `waitForExistence()` instead 
- Adding retry mechanism

I also tried to reduce the flakiness on the CI but with no success. The most important here is that they pass locally.

You can check review commits one by one but be aware I made a back and forth on `tap(.center)`. I expect a squash and merge at the end.


