### PR TITLE
Back off sync restarts after repeated sync failures

### DIFF
--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -147,6 +147,9 @@ class ClientProxy: ClientProxyProtocol {
     /// before the client is released which ends up running in a loop. This is a workaround until the sync service
     /// can tell us *what* error occurred so we can handle restarts more gracefully.
     private var hasEncounteredAuthError = false
+
+    /// Tracks consecutive sync failures so we can slow down retries if the same persisted sync state keeps failing.
+    private var consecutiveSyncFailureCount = 0
     
     deinit {
         stopSync { [delegateHandle] in
@@ -451,12 +454,16 @@ class ClientProxy: ClientProxyProtocol {
     
     func restartSync() {
         guard restartTask == nil else { return }
+
+        let failureCount = min(consecutiveSyncFailureCount + 1, 5)
+        let restartDelay = Self.syncRestartDelay(forFailureCount: failureCount)
+        consecutiveSyncFailureCount = failureCount
+
+        MXLog.warning("Scheduling sync restart in \(restartDelay) after sync failure #\(failureCount).")
         
         restartTask = Task { [weak self] in
             do {
-                // Until the SDK can tell us the failure, we add a small
-                // delay to avoid generating multi-gigabyte log files.
-                try await Task.sleep(for: .milliseconds(250))
+                try await Task.sleep(for: restartDelay)
                 self?.startSync()
             } catch {
                 MXLog.error("Restart cancelled.")
@@ -471,6 +478,8 @@ class ClientProxy: ClientProxyProtocol {
     
     func stopSync(completion: (() -> Void)?) {
         MXLog.info("Stopping sync")
+
+        consecutiveSyncFailureCount = 0
         
         if restartTask != nil {
             MXLog.warning("Removing the sync service restart task.")
@@ -1089,7 +1098,11 @@ class ClientProxy: ClientProxyProtocol {
             MXLog.info("Received sync service update: \(state)")
             
             switch state {
-            case .running, .terminated, .idle:
+            case .running:
+                consecutiveSyncFailureCount = 0
+                restartTask = nil
+                homeserverReachabilitySubject.send(.reachable)
+            case .terminated, .idle:
                 homeserverReachabilitySubject.send(.reachable)
             case .offline:
                 homeserverReachabilitySubject.send(.unreachable)
@@ -1097,6 +1110,21 @@ class ClientProxy: ClientProxyProtocol {
                 restartSync()
             }
         })
+    }
+
+    private static func syncRestartDelay(forFailureCount failureCount: Int) -> Duration {
+        switch failureCount {
+        case 1:
+            .milliseconds(250)
+        case 2:
+            .seconds(1)
+        case 3:
+            .seconds(3)
+        case 4:
+            .seconds(10)
+        default:
+            .seconds(30)
+        }
     }
     
     private func createMediaPreviewConfigObserver() async -> TaskHandle? {


### PR DESCRIPTION
### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.

## Summary

Client side mitigation for this: https://github.com/element-hq/synapse/pull/19651

Android version: https://github.com/element-hq/element-x-android/pull/6532

This adds bounded backoff to the sync restart path in `ClientProxy` so the app stops hammering the same failing sync state over and over.

This is a client-side mitigation, not the root-cause fix. The underlying server-side failure is addressed in.

## Motivation and context

The reported issue was that after leaving a room in a bad server state, Element X could get stuck syncing forever until local state was reset.

The useful diagnosis came from synapse logs, not the iOS app log:

- incremental Sliding Sync was returning HTTP 500
- Synapse was asserting in `synapse/handlers/sliding_sync/room_lists.py` while reconstructing newly-left rooms

On the iOS side, `ClientProxy` restarts sync on every `.error` state. If the same persisted sync position keeps reproducing the same server failure, the app just re-enters the loop immediately.

This change adds bounded backoff of `250ms`, `1s`, `3s`, `10s`, and `30s`, and resets that backoff once sync genuinely reaches `.running` again.

## Testing

- Reviewed the `ClientProxy` sync error and restart flow after the change.
- Verified the retry path now backs off based on consecutive failures and resets after `.running`.
- Don't have or want access to Apple devices to test.