### PR TITLE
Require video for callkit even if voice call only to workaround a bug answering calls on the lock screen

### DIFF
--- a/ElementX/Sources/Services/ElementCall/ElementCallService.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallService.swift
@@ -202,7 +202,11 @@ class ElementCallService: NSObject, ElementCallServiceProtocol, PKPushRegistryDe
         let roomDisplayName = payload.dictionaryPayload[ElementCallServiceNotificationKey.roomDisplayName.rawValue] as? String
         
         let update = CXCallUpdate()
-        update.hasVideo = !isVoiceCall
+        // Work Around: Always set video to true! https://github.com/element-hq/element-x-ios/issues/5335
+        // If not for audio call the app will not be put to foreground and the webview won't be able to handle the call...
+        // Consequence: The call will be presented to the user as a video call in CallKit UI,
+        // but once Element Call is launched it will correctly route to a voice-only call.
+        update.hasVideo = true
         update.localizedCallerName = roomDisplayName
         // https://stackoverflow.com/a/41230020/730924
         update.remoteHandle = .init(type: .generic, value: roomID)

--- a/UnitTests/Sources/ElementCallServiceTests.swift
+++ b/UnitTests/Sources/ElementCallServiceTests.swift
@@ -73,7 +73,9 @@ final class ElementCallServiceTests {
         #expect(callProvider.reportNewIncomingCallWithUpdateCompletionCalled)
         // Verify the provider was called with a CXCallUpdate that has video enabled
         if let args = callProvider.reportNewIncomingCallWithUpdateCompletionReceivedArguments {
-            #expect(args.update.hasVideo == false)
+            // Due to a limitation on Callkit and Webviews, we currently have to report voice calls as having video,
+            // even if they are voice calls :/ If not the webview is not started and the call is not shown to the user.
+            #expect(args.update.hasVideo == true)
         } else {
             Issue.record("Expected reportNewIncomingCallWithUpdateCompletionReceivedArguments to be captured")
         }


### PR DESCRIPTION
### Pull Request Checklist

Work-around for https://github.com/element-hq/element-x-ios/issues/5335

Apparently we are facing a limitation of compatibility between callkit and webviews :/
If we want great call support, we would need to implement native Element Call.

The only work-around I see for now is to still tell CallKit that we want video, like that it will properly start the app.
Then video will be disabled on EC.

Downsides:
- The call will be presented to the user as a video call in CallKit UI.
- Requires a FaceID to answer

It partially reverts the changes from https://github.com/element-hq/element-x-ios/pull/5298 (regarding callkit UI)


- [ ] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
