### PR TITLE
Fix the space filters button on iPad.

### DIFF
--- a/ElementX/Sources/Application/Navigation/NavigationCoordinators.swift
+++ b/ElementX/Sources/Application/Navigation/NavigationCoordinators.swift
@@ -326,6 +326,11 @@ import SwiftUI
     }
 }
 
+extension EnvironmentValues {
+    /// Whether or not the current view is part of the sidebar module of a `NavigationSplitCoordinator`.
+    @Entry var isInSidebar = false
+}
+
 private struct NavigationSplitCoordinatorView: View {
     @State private var columnVisibility = NavigationSplitViewVisibility.all
     
@@ -381,9 +386,11 @@ private struct NavigationSplitCoordinatorView: View {
         NavigationSplitView(columnVisibility: $columnVisibility) {
             if let sidebarModule = navigationSplitCoordinator.sidebarModule {
                 sidebarModule.coordinator?.toPresentable()
+                    .environment(\.isInSidebar, true)
                     .id(sidebarModule.id)
             } else {
                 navigationSplitCoordinator.placeholderModule.coordinator?.toPresentable()
+                    .environment(\.isInSidebar, true)
                     .id(navigationSplitCoordinator.placeholderModule.id)
             }
         } detail: {

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
@@ -127,22 +127,46 @@ struct HomeScreen: View {
     }
     
     private struct SpaceFiltersButton: View {
+        @Environment(\.isInSidebar) private var isInSidebar
+        
         var selected = false
         var action: () -> Void
         
+        /// Design prefers the custom style over the system's styling of a Toggle within a toolbar,
+        /// however Glass isn't supported for toolbar buttons in the sidebar on iPadOS 26 (likely due
+        /// to glass on glass being discouraged by Apple), so we need to handle our styling accordingly.
+        var shouldUseGlassButtonStyle: Bool {
+            !isInSidebar
+        }
+        
         var body: some View {
-            // Use a Toggle to let the system handle the selection style for both the Liquid Glass
-            // button on iPhone, along with the plain button used in the sidebar on iPad/Mac.
-            Toggle(isOn: .constant(selected)) {
-                CompoundIcon(\.filter)
-                    .foregroundStyle(selected ? .compound.iconOnSolidPrimary : .compound.iconPrimary)
+            if #available(iOS 26, *), shouldUseGlassButtonStyle {
+                if selected {
+                    content
+                        .backportButtonStyleGlassProminent()
+                        .tint(.compound.bgActionPrimaryRest)
+                } else {
+                    content
+                }
+            } else {
+                if selected {
+                    content
+                        .buttonStyle(.compound(.primary, size: .toolbarIcon))
+                } else {
+                    content
+                        .buttonStyle(.compound(.tertiary, size: .toolbarIcon))
+                }
             }
-            .overlay {
-                // The tap gesture is ignored when applied to the toggle so apply it to an overlay instead.
-                Color.black.opacity(0.001)
-                    .onTapGesture(perform: action)
+        }
+        
+        private var content: some View {
+            Button {
+                action()
+            } label: {
+                CompoundIcon(\.filter)
             }
             .accessibilityLabel(L10n.screenRoomlistYourSpaces)
+            .accessibilityAddTraits(selected ? .isSelected : [])
             .accessibilityIdentifier(A11yIdentifiers.homeScreen.spaceFilters)
         }
     }

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
@@ -131,33 +131,18 @@ struct HomeScreen: View {
         var action: () -> Void
         
         var body: some View {
-            if #available(iOS 26, *) {
-                if selected {
-                    content
-                        .backportButtonStyleGlassProminent()
-                        .tint(.compound.bgActionPrimaryRest)
-                } else {
-                    content
-                }
-            } else {
-                if selected {
-                    content
-                        .buttonStyle(.compound(.primary, size: .toolbarIcon))
-                } else {
-                    content
-                        .buttonStyle(.compound(.tertiary, size: .toolbarIcon))
-                }
-            }
-        }
-        
-        private var content: some View {
-            Button {
-                action()
-            } label: {
+            // Use a Toggle to let the system handle the selection style for both the Liquid Glass
+            // button on iPhone, along with the plain button used in the sidebar on iPad/Mac.
+            Toggle(isOn: .constant(selected)) {
                 CompoundIcon(\.filter)
+                    .foregroundStyle(selected ? .compound.iconOnSolidPrimary : .compound.iconPrimary)
+            }
+            .overlay {
+                // The tap gesture is ignored when applied to the toggle so apply it to an overlay instead.
+                Color.black.opacity(0.001)
+                    .onTapGesture(perform: action)
             }
             .accessibilityLabel(L10n.screenRoomlistYourSpaces)
-            .accessibilityAddTraits(selected ? .isSelected : [])
             .accessibilityIdentifier(A11yIdentifiers.homeScreen.spaceFilters)
         }
     }


### PR DESCRIPTION
There's currently a bug on iPad when a space filter is selected where the background isn't visible (and the icon is white so it can't be seen). This PR switches the `SpaceFiltersButton` to use the default `Toggle` instead of the custom `Button` and let iOS do the styling automatically:

| Selected Before | Select After |
| - | - |
| <img width="2420" height="1668" alt="Simulator Screenshot - iPad Pro 11-inch (M5) - 2026-04-15 at 20 14 59" src="https://github.com/user-attachments/assets/0fb37d61-f235-4e85-b2b6-c6358e4879e9" /> | <img width="2420" height="1668" alt="Simulator Screenshot - iPad Pro 11-inch (M5) - 2026-04-15 at 20 08 06" src="https://github.com/user-attachments/assets/26560d82-a974-4115-96d1-d869ae01a76c" /> |

Note that a side-effect of this is that we have a slightly different style when selected on iPhone:

| Before | After |
| - | - |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-04-15 at 20 13 51" src="https://github.com/user-attachments/assets/0b25b521-8449-4921-967f-6e04861d7f41" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-04-15 at 20 11 29" src="https://github.com/user-attachments/assets/b387c3f6-4011-4ab1-ad39-666c34b259b2" /> |

However this means that the style now matches e.g. Messages and Mail:

<img width="563" height="176" alt="Screenshot 2026-04-15 at 8 32 22 pm" src="https://github.com/user-attachments/assets/f79e09b9-4dee-404b-90d5-c915e1b9e033" />

@americanrefugee Are you happy with this change of style when the button is using Liquid Glass on iPhone?

