### PR TITLE
Add a build flag for Verify with Classic to disable it for the next RC.

### DIFF
--- a/ElementX/Sources/Application/Settings/AppSettings.swift
+++ b/ElementX/Sources/Application/Settings/AppSettings.swift
@@ -445,6 +445,8 @@ final class AppSettings {
     @UserPreference(key: UserDefaultsKeys.liveLocationSharingEnabled, defaultValue: false, storageType: .userDefaults(store))
     var liveLocationSharingEnabled
     
+    let verifyWithClassicEnabled = appBuildType != .release
+    
     @UserPreference(key: UserDefaultsKeys.developerOptionsEnabled, defaultValue: appBuildType == .debug, storageType: .userDefaults(store))
     var developerOptionsEnabled
 }

--- a/ElementX/Sources/Services/Authentication/AuthenticationService.swift
+++ b/ElementX/Sources/Services/Authentication/AuthenticationService.swift
@@ -46,7 +46,7 @@ class AuthenticationService: AuthenticationServiceProtocol {
         self.appHooks = appHooks
         
         do {
-            if let classicAppManager {
+            if let classicAppManager, appSettings.verifyWithClassicEnabled {
                 classicAppAccount = try classicAppManager.loadAccounts().first
             } else {
                 MXLog.info("Classic App not configured, skipping loadAccounts.")


### PR DESCRIPTION
As this RC is an off-schedule bug-fix and we haven't tested the feature yet.

I've left it enabled on Nightly and Debug builds and just disabled it for release builds (didn't see the point in making this an actual editable flag).

Note: I've also changed the label on #5374 to `pr-wip` so the changelog is correct.