### PR TITLE
Move the Acknowledgements generation to the post-renovate workflow.

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,10 +9,4 @@ then
   exit 1
 fi
 
-swift-package-list ElementX.xcodeproj --requires-license --ignore-package compound-ios --ignore-package compound-design-tokens --ignore-package matrix-rich-text-editor-swift --ignore-package element-call-swift --output-type settings-bundle --output-path ElementX/SupportingFiles
-if ! git diff --quiet -- ./ElementX/SupportingFiles/Settings.bundle || [ -n "$(git ls-files --others --exclude-standard -- ./ElementX/SupportingFiles/Settings.bundle)" ]; then
-  echo "pre-commit: Commit aborted due to unstaged changes to the package Acknowledgements."
-  exit 1
-fi
-
 ./Tools/Scripts/validate_lfs.sh

--- a/.github/workflows/renovate-xcodegen.yml
+++ b/.github/workflows/renovate-xcodegen.yml
@@ -32,11 +32,11 @@ jobs:
           # We need to push any changes to the project.
           persist-credentials: true
 
-      - name: Install XcodeGen
+      - name: Install dependencies
         run: |
           unset HOMEBREW_NO_INSTALL_FROM_API
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
-          brew install xcodegen
+          brew install xcodegen FelixHerrmann/tap/swift-package-list
 
       - name: Run XcodeGen
         run: xcodegen
@@ -44,11 +44,15 @@ jobs:
       - name: Resolve package dependencies
         run: xcodebuild -resolvePackageDependencies -project ElementX.xcodeproj
 
+      - name: Update Acknowledgements
+        run: swift-package-list ElementX.xcodeproj --requires-license --ignore-package compound-ios --ignore-package compound-design-tokens --ignore-package matrix-rich-text-editor-swift --ignore-package element-call-swift --output-type settings-bundle --output-path ElementX/SupportingFiles
+
       - name: Commit and push changes
         run: |
           git config user.name "ElementRobot"
           git config user.email "releases@riot.im"
           git add ElementX.xcodeproj/project.pbxproj
           git add ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
-          git diff --staged --quiet || git commit -m "Run XcodeGen and update Package.resolved"
+          git add ElementX/SupportingFiles/Settings.bundle
+          git diff --staged --quiet || git commit -m "Run XcodeGen, update Package.resolved and Settings.bundle"
           git push

--- a/.github/workflows/renovate-xcodegen.yml
+++ b/.github/workflows/renovate-xcodegen.yml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   update-project:
     name: Update Xcode project
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 20
     permissions:
       contents: write

--- a/Tools/Sources/Commands/SetupProject.swift
+++ b/Tools/Sources/Commands/SetupProject.swift
@@ -17,7 +17,7 @@ struct SetupProject: ParsableCommand {
     }
 
     func brewInstall() throws {
-        try Zsh.run(command: "brew install xcodegen swiftgen swiftformat git-lfs sourcery mint pkl kiliankoe/formulae/swift-outdated localazy/tools/localazy peripheryapp/periphery/periphery FelixHerrmann/tap/swift-package-list")
+        try Zsh.run(command: "brew install xcodegen swiftgen swiftformat git-lfs sourcery mint pkl kiliankoe/formulae/swift-outdated localazy/tools/localazy peripheryapp/periphery/periphery")
     }
 
     func mintPackagesInstall() throws {


### PR DESCRIPTION
Following the automated dependency updates `develop` is now missing some changes that is failing commits. Given we have a workflow, let's just let CI handle the generation instead.
