### PR TITLE
Add a new workflow that runs the preview tests and re-records the snapshots

### DIFF
--- a/.github/workflows/record_snapshots.yml
+++ b/.github/workflows/record_snapshots.yml
@@ -1,0 +1,63 @@
+name: Record Snapshots
+
+on:
+  # Triggered when a maintainer adds the "record-snapshots" label to a PR.
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
+    types: [labeled]
+
+permissions: {}
+
+jobs:
+  record-snapshots:
+    name: Record Preview Snapshots
+    runs-on: macos-26
+    timeout-minutes: 45
+
+    if: >
+      contains(github.event.issue.labels.*.name, 'record-snapshots') &&
+      github.event.pull_request.head.repo.full_name == github.repository 
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    concurrency:
+      group: record-snapshots-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Remove label
+        run: gh pr edit "${{ github.event.pull_request.number }}" --remove-label 'record-snapshots'
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Checkout PR
+        uses: nschloe/action-cached-lfs-checkout@385a8ecc719e50b8c71af6ab01a624b486b7c3bc # v1.2.5
+        with:
+          # Check out the PR head commit (not the base branch).
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: true
+
+      - name: Setup environment
+        run: source ci_scripts/ci_common.sh && setup_github_actions_environment
+
+      - name: Run preview tests in recording mode
+        run: swift run -q tools ci preview-tests --record
+
+      - name: Commit and push updated snapshots
+        run: |
+          git config user.name "ElementRobot"
+          git config user.email "releases@riot.im"
+
+          # Stage only snapshot changes.
+          git add PreviewTests/Sources/__Snapshots__/
+
+          if git diff --cached --quiet; then
+            echo "✅ No snapshot changes detected."
+          else
+            git commit -m "Record preview snapshots"
+            git push origin HEAD:refs/heads/${GITHUB_EVENT_PULL_REQUEST_HEAD_REF}
+            echo "✅ Snapshots recorded and pushed."
+          fi
+        env:
+          GITHUB_EVENT_PULL_REQUEST_HEAD_REF: ${{ github.event.pull_request.head.ref }}

--- a/Tools/Sources/Commands/CI/CI.swift
+++ b/Tools/Sources/Commands/CI/CI.swift
@@ -6,6 +6,7 @@ import Yams
 struct CI: ParsableCommand {
     static let configuration = CommandConfiguration(abstract: "CI workflow commands that can be run both locally and in CI environments.",
                                                     subcommands: [
+                                                        PreviewTests.self,
                                                         AccessibilityTests.self,
                                                         UnitTests.self,
                                                         UITests.self,

--- a/Tools/Sources/Commands/CI/PreviewTests.swift
+++ b/Tools/Sources/Commands/CI/PreviewTests.swift
@@ -1,0 +1,42 @@
+import ArgumentParser
+import Foundation
+
+struct PreviewTests: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "preview-tests",
+                                                    abstract: "Runs the preview test CI workflow.")
+
+    @Option(help: "iOS version for the simulator.")
+    var osVersion = "26.4"
+
+    private static let scheme = "PreviewTests"
+    private static let device = "iPhone SE (3rd generation)"
+    private static let simulatorType = "com.apple.CoreSimulator.SimDeviceType.iPhone-SE-3rd-generation"
+    private static let testPlanPath = "PreviewTests/SupportingFiles/PreviewTests.xctestplan"
+
+    func run() async throws {
+        var testsFailed = false
+        do {
+            logger.info("\n🧪 Running preview tests…\n")
+            try await RunTests.parse([
+                "--scheme", Self.scheme,
+                "--device", Self.device,
+                "--os-version", osVersion,
+                "--create-simulator-name", Self.device,
+                "--create-simulator-type", Self.simulatorType
+            ]).run()
+        } catch {
+            logger.error("\n❌ Preview tests failed.\n")
+            testsFailed = true
+        }
+
+        // Collect coverage and test results regardless of test outcome (best-effort).
+        await CI.collectCoverage(resultBundle: "\(Self.scheme).xcresult", outputName: "preview-cobertura.xml")
+        await CI.collectTestResults(resultBundle: "\(Self.scheme).xcresult", outputName: "preview-junit.xml")
+
+        if testsFailed {
+            throw ExitCode.failure
+        }
+
+        logger.info("\n✅ Preview tests passed.\n")
+    }
+}

--- a/Tools/Sources/Commands/CI/PreviewTests.swift
+++ b/Tools/Sources/Commands/CI/PreviewTests.swift
@@ -3,10 +3,13 @@ import Foundation
 
 struct PreviewTests: AsyncParsableCommand {
     static let configuration = CommandConfiguration(commandName: "preview-tests",
-                                                    abstract: "Runs the preview test CI workflow.")
+                                                    abstract: "Runs the preview test CI workflow, with optional snapshot recording.")
 
     @Option(help: "iOS version for the simulator.")
     var osVersion = "26.4"
+
+    @Flag(help: "Re-record snapshots for tests that fail or are missing a reference image.")
+    var record = false
 
     private static let scheme = "PreviewTests"
     private static let device = "iPhone SE (3rd generation)"
@@ -14,6 +17,10 @@ struct PreviewTests: AsyncParsableCommand {
     private static let testPlanPath = "PreviewTests/SupportingFiles/PreviewTests.xctestplan"
 
     func run() async throws {
+        if record {
+            try setRecordFailures(enabled: true)
+        }
+
         var testsFailed = false
         do {
             logger.info("\n🧪 Running preview tests…\n")
@@ -25,8 +32,22 @@ struct PreviewTests: AsyncParsableCommand {
                 "--create-simulator-type", Self.simulatorType
             ]).run()
         } catch {
-            logger.error("\n❌ Preview tests failed.\n")
-            testsFailed = true
+            if record {
+                // In recording mode, test failures are expected — swift-snapshot-testing marks
+                // recording runs as failed. Check whether the xcresult bundle was created to
+                // distinguish genuine failures (compilation error, simulator issue) from the
+                // expected snapshot-recording "failures".
+                let resultBundleURL = URL.projectDirectory
+                    .appending(path: "\(CI.testOutputDirectory)/\(Self.scheme).xcresult")
+                guard FileManager.default.fileExists(atPath: resultBundleURL.path) else {
+                    logger.error("\n❌ Preview tests could not run. Check for compilation or configuration errors.\n")
+                    throw error
+                }
+                logger.info("\n📸 Snapshots recorded.\n")
+            } else {
+                logger.error("\n❌ Preview tests failed.\n")
+                testsFailed = true
+            }
         }
 
         // Collect coverage and test results regardless of test outcome (best-effort).
@@ -37,6 +58,33 @@ struct PreviewTests: AsyncParsableCommand {
             throw ExitCode.failure
         }
 
-        logger.info("\n✅ Preview tests passed.\n")
+        if !record {
+            logger.info("\n✅ Preview tests passed.\n")
+        }
+    }
+
+    // MARK: - Test Plan
+
+    /// Enables or disables the `RECORD_FAILURES` environment variable entry in the test plan.
+    private func setRecordFailures(enabled: Bool) throws {
+        let url = URL.projectDirectory.appendingPathComponent(Self.testPlanPath)
+        let data = try Data(contentsOf: url)
+
+        guard var plan = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              var defaultOptions = plan["defaultOptions"] as? [String: Any],
+              var envVars = defaultOptions["environmentVariableEntries"] as? [[String: Any]] else {
+            throw ValidationError("Could not parse test plan at \(Self.testPlanPath).")
+        }
+
+        for index in envVars.indices where envVars[index]["key"] as? String == "RECORD_FAILURES" {
+            envVars[index]["enabled"] = enabled
+            break
+        }
+
+        defaultOptions["environmentVariableEntries"] = envVars
+        plan["defaultOptions"] = defaultOptions
+
+        let jsonData = try JSONSerialization.data(withJSONObject: plan, options: [.prettyPrinted, .sortedKeys])
+        try jsonData.write(to: url)
     }
 }

--- a/Tools/Sources/Commands/CI/UnitTests.swift
+++ b/Tools/Sources/Commands/CI/UnitTests.swift
@@ -34,19 +34,10 @@ struct UnitTests: AsyncParsableCommand {
         }
         
         if !skipPreviews {
-            // Run preview tests on a smaller device
             do {
-                logger.info("\n🧪 Running preview tests…\n")
-                try await RunTests.parse([
-                    "--scheme", "PreviewTests",
-                    "--device", "iPhone SE (3rd generation)",
-                    "--os-version", osVersion,
-                    "--create-simulator-name", "iPhone SE (3rd generation)",
-                    "--create-simulator-type", "com.apple.CoreSimulator.SimDeviceType.iPhone-SE-3rd-generation"
-                ]).run()
+                try await PreviewTests.parse(["--os-version", osVersion]).run()
             } catch {
                 failures.append("Preview tests failed: \(error)")
-                logger.error("\n❌ Preview tests failed.\n")
             }
         }
         
@@ -54,13 +45,9 @@ struct UnitTests: AsyncParsableCommand {
         await CI.zipResults(bundles: ["UnitTests.xcresult", "PreviewTests.xcresult"],
                             outputName: "UnitTests.zip")
         
-        // Collect coverage reports
+        // Collect coverage and JUnit results for unit tests
         await CI.collectCoverage(resultBundle: "UnitTests.xcresult", outputName: "unit-cobertura.xml")
-        await CI.collectCoverage(resultBundle: "PreviewTests.xcresult", outputName: "preview-cobertura.xml")
-        
-        // Collect JUnit test results
         await CI.collectTestResults(resultBundle: "UnitTests.xcresult", outputName: "unit-junit.xml")
-        await CI.collectTestResults(resultBundle: "PreviewTests.xcresult", outputName: "preview-junit.xml")
         
         if !failures.isEmpty {
             logger.error("\n❌ \(failures.count) test suite(s) failed.\n")


### PR DESCRIPTION
..  for PRs that are labeled with `record-snapshots`