### PR TITLE
Add xcresult-analysis Copilot skill

### DIFF
--- a/.github/skills/xcresult-analysis/.gitignore
+++ b/.github/skills/xcresult-analysis/.gitignore
@@ -1,0 +1,2 @@
+work/
+scripts/analyze-xcresult

--- a/.github/skills/xcresult-analysis/SKILL.md
+++ b/.github/skills/xcresult-analysis/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: xcresult-analysis
+description: 'Analyse Xcode xcresult bundles to diagnose failing tests. Accepts a local .xcresult path or a GitHub Actions run URL. Use when: investigating test failures from CI or local runs (unit, snapshot/preview, accessibility, integration, UI); needing the XCUITest activity log before a failure; debugging flakiness; or triaging CI artifacts.'
+argument-hint: '<path-to.xcresult>'
+---
+
+# xcresult Analysis
+
+Extracts failing test names, failure messages, file/line locations, and the XCUITest activity log from an `.xcresult` bundle via `xcresulttool`. Works for all test targets: `UnitTests`, `PreviewTests`, `AccessibilityTests`, `IntegrationTests`, `UITests`.
+
+## Procedure
+
+### 1. Compile the script (first time only)
+
+```
+swiftc .github/skills/xcresult-analysis/scripts/analyze-xcresult.swift \
+       -o .github/skills/xcresult-analysis/scripts/analyze-xcresult
+```
+
+The compiled binary is gitignored. It only needs to be recompiled when the `.swift` source changes.
+
+### 2. Run the analysis
+
+**Option A: Local xcresult path**
+
+```
+.github/skills/xcresult-analysis/scripts/analyze-xcresult <path-to.xcresult>
+```
+
+Common local locations:
+- `test_output/UnitTests.xcresult`
+- `test_output/PreviewTests.xcresult`
+- `test_output/AccessibilityTests.xcresult`
+- `test_output/IntegrationTests.xcresult`
+- `test_output/UITests.xcresult`
+
+**Option B: GitHub Actions run URL**
+
+Use a run URL (e.g. `https://github.com/element-hq/element-x-ios/actions/runs/24243377085`) and download artifacts with the GitHub CLI.
+
+```
+RUN_URL="https://github.com/element-hq/element-x-ios/actions/runs/24243377085"
+RUN_ID=$(echo "$RUN_URL" | grep -oE '[0-9]+$')
+WORK_ROOT=".github/skills/xcresult-analysis/work"
+RUN_DIR="$WORK_ROOT/$RUN_ID"
+mkdir -p "$RUN_DIR"
+
+# Most failing workflows upload an artifact named "Results".
+gh run download "$RUN_ID" --repo element-hq/element-x-ios --name Results --dir "$RUN_DIR"
+
+# If "Results" does not exist (for example, some UI test jobs), list artifact names and retry.
+gh run view "$RUN_ID" --repo element-hq/element-x-ios --json artifacts
+# gh run download "$RUN_ID" --repo element-hq/element-x-ios --name <ARTIFACT_NAME> --dir "$RUN_DIR"
+
+find "$RUN_DIR" -name "*.zip" -exec unzip -q {} -d "$RUN_DIR" \;
+XCRESULT_PATH=$(find "$RUN_DIR" -name "*.xcresult" -type d | head -1)
+
+.github/skills/xcresult-analysis/scripts/analyze-xcresult "$XCRESULT_PATH"
+```
+
+Authentication note: run `gh auth login` first (or set `GH_TOKEN`).
+The `work/` folder is gitignored and can keep per-run folders (`work/<RUN_ID>`) for later inspection.
+
+Optional flag: `--last N` — number of activity log steps to show per failure (default: 40).
+
+### 3. Read the output
+
+The script prints two sections:
+
+**Overview** — one line per test with ✅/❌ and duration.
+
+**Failure detail** — for each failure:
+- **Test name** and identifier
+- **Location: file:line** of the failing assertion — only printed when available. XCTest failures always include it; **Swift Testing failures (`#expect`, `deferFulfillment`) do not** — the `sourceCodeContext` is absent from `failureSummaries` in the xcresult for those.
+- **Failure message**
+- **Activity log** — the last N steps the test took (integration/UI tests only; empty for unit/snapshot tests)
+
+### 4. Diagnose by test type
+
+#### Unit tests (`UnitTests.xcresult`)
+
+The activity log is empty — the failure message is all you need. `Location:` is printed for XCTest-style failures but **absent for Swift Testing** (`#expect`, `deferFulfillment`) — search the source by test name to locate the assertion. Common messages:
+
+- `XCTAssertEqual failed: ("x") is not equal to ("y")` — logic bug, check the relevant method.
+- `XCTAssertTrue failed` at a specific line — check the condition on that line in context.
+- Async assertion failures — check `deferFulfillment` / publisher observation patterns.
+
+#### Snapshot & Preview tests (`PreviewTests.xcresult`)
+
+- `Snapshot does not match reference` — a UI change caused a visual diff. Re-record snapshots on the correct device/OS: `swift run tools ci unit-tests` or open the test in Xcode and enable record mode.
+- The script shows file:line pointing to the generated snapshot test. The actual diff images are stored as xcresult attachments — open the `.xcresult` in Xcode to view the reference, failure, and diff images side by side.
+
+#### Accessibility tests (`AccessibilityTests.xcresult`)
+
+- Failure messages describe the specific audit issue (e.g. contrast ratio, missing label). The file:line points to the generated test — find the originating preview via the test name, then fix the accessibility issue in the view.
+
+#### Integration & UI tests (`IntegrationTests.xcresult`)
+
+The activity log is the primary diagnostic. The last entry before `• Tear Down` reveals what the test was doing when it failed:
+
+- **`Waiting Xs for … to exist`** — the element never appeared. The app likely didn't navigate to the expected screen, or the identifier is wrong.
+- **`Timed out while evaluating UI query`** on a tap — the element existed when `waitForExistence` checked but was gone by the time `tap` ran (common with dismissing sheets/pickers whose elements linger briefly during animation). Gate the tap on `isHittable == true` instead of `exists`.
+- **`Asynchronous wait failed: Exceeded timeout`** on `exists == 0` — an element that should have disappeared matched something in the next screen. Use a more specific query scoped to the outgoing screen.
+- **`Checking existence` repeated many times then abrupt stop** — `waitForExistence(timeout:)` ran out. The timeout is too short for CI, or the app is stuck.
+
+### 5. Fix the test
+
+Apply the fix to the relevant source file based on the diagnosis:
+
+- Unit test logic: `UnitTests/Sources/`
+- Snapshot re-record: run tests with record mode, then commit the new `__Snapshots__` images
+- Accessibility issue: fix in the SwiftUI view
+- Integration test: `IntegrationTests/Sources/UserFlowTests.swift` or `Common.swift`
+
+## Notes
+
+- Uses `--legacy` flag required by `xcresulttool` on Xcode 16+.
+- Activity log entries are nested subactivities flattened to depth 2 — deeper polling noise is suppressed.
+- The `summaryRef` on each failing test node is fetched in a separate `xcresulttool` call. Stderr is drained concurrently to prevent pipe-buffer deadlocks on large (100MB+) bundles.

--- a/.github/skills/xcresult-analysis/scripts/analyze-xcresult.swift
+++ b/.github/skills/xcresult-analysis/scripts/analyze-xcresult.swift
@@ -1,0 +1,238 @@
+#!/usr/bin/env swift
+//
+// analyze-xcresult.swift
+// Usage: swift analyze-xcresult.swift <path-to.xcresult> [--last N]
+//
+// Extracts failing tests, failure messages, file/line locations, and the
+// XCUITest activity log from an xcresult bundle via xcresulttool.
+//
+
+import Foundation
+
+// MARK: - xcresulttool wrapper
+
+func runXcresulttool(xcresultPath: String, objectID: String? = nil) -> [String: Any]? {
+    var arguments = ["xcrun", "xcresulttool", "get", "object", "--legacy",
+                     "--path", xcresultPath, "--format", "json"]
+    if let objectID {
+        arguments += ["--id", objectID]
+    }
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    process.arguments = arguments
+
+    let outputPipe = Pipe()
+    let errorPipe = Pipe()
+    process.standardOutput = outputPipe
+    process.standardError = errorPipe
+
+    try? process.run()
+
+    // Read stderr concurrently to prevent the process deadlocking when its error
+    // buffer fills up (which blocks stdout writes, causing readDataToEndOfFile to hang).
+    let stderrQueue = DispatchQueue(label: "xcresulttool.stderr")
+    stderrQueue.async { _ = errorPipe.fileHandleForReading.readDataToEndOfFile() }
+
+    let data = outputPipe.fileHandleForReading.readDataToEndOfFile()
+    process.waitUntilExit()
+
+    guard process.terminationStatus == 0 else { return nil }
+    return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+}
+
+// MARK: - xcresult JSON navigation
+//
+// Every value in xcresult JSON is boxed: { "_type": {...}, "_value": "…" }
+// Arrays use:                           { "_type": {...}, "_values": […] }
+
+func xcString(_ node: [String: Any], _ key: String) -> String? {
+    (node[key] as? [String: Any])?["_value"] as? String
+}
+
+func xcChildren(_ node: [String: Any], _ key: String) -> [[String: Any]] {
+    (node[key] as? [String: Any])?["_values"] as? [[String: Any]] ?? []
+}
+
+func xcChild(_ node: [String: Any], _ key: String) -> [String: Any]? {
+    node[key] as? [String: Any]
+}
+
+// MARK: - Activity log
+
+struct ActivityStep {
+    let title: String
+    let depth: Int
+}
+
+// maxDepth=2 captures the high-level step (depth 0) and its immediate sub-steps (depth 1),
+// which is where failures manifest. Depth 2+ is mostly repeated "Checking existence" polling
+// noise that bloats the output without adding diagnostic value.
+func flattenActivities(_ nodes: [[String: Any]], depth: Int = 0, maxDepth: Int = 2) -> [ActivityStep] {
+    nodes.flatMap { node -> [ActivityStep] in
+        let title = xcString(node, "title") ?? ""
+        let step = ActivityStep(title: title, depth: depth)
+        guard depth < maxDepth else { return [step] }
+        let subs = xcChildren(node, "subactivities")
+        return [step] + flattenActivities(subs, depth: depth + 1, maxDepth: maxDepth)
+    }
+}
+
+// MARK: - Test failure
+
+struct TestFailure {
+    let testName: String
+    let message: String
+    let fileURL: String
+    let lineNumber: String
+    let activityLog: [ActivityStep]
+}
+
+func scanForFailures(node: [String: Any], xcresultPath: String) -> [TestFailure] {
+    var failures: [TestFailure] = []
+    let status = xcString(node, "testStatus") ?? ""
+
+    if status == "Failure" || status == "Error",
+       let summaryRefID = xcChild(node, "summaryRef").flatMap({ xcString($0, "id") }),
+       let summary = runXcresulttool(xcresultPath: xcresultPath, objectID: summaryRefID) {
+
+        let activityLog = flattenActivities(xcChildren(summary, "activitySummaries"))
+        let name = xcString(node, "identifier") ?? xcString(node, "name") ?? "Unknown"
+
+        for fs in xcChildren(summary, "failureSummaries") {
+            let message = xcString(fs, "message") ?? "(no message)"
+            let location = xcChild(fs, "sourceCodeContext").flatMap { xcChild($0, "location") }
+            let fileURL = location.flatMap { xcString($0, "url") } ?? ""
+            let lineNumber = location.flatMap { xcString($0, "lineNumber") } ?? ""
+
+            failures.append(TestFailure(
+                testName: name,
+                message: message,
+                fileURL: fileURL,
+                lineNumber: lineNumber,
+                activityLog: activityLog
+            ))
+        }
+    }
+
+    for child in xcChildren(node, "subtests") {
+        failures += scanForFailures(node: child, xcresultPath: xcresultPath)
+    }
+
+    return failures
+}
+
+// MARK: - Summary printer (pass/fail overview)
+
+func printSummary(_ node: [String: Any], depth: Int = 0) {
+    let status = xcString(node, "testStatus") ?? ""
+    guard !status.isEmpty else {
+        for child in xcChildren(node, "subtests") {
+            printSummary(child, depth: depth)
+        }
+        return
+    }
+
+    let indent = String(repeating: "  ", count: depth)
+    let icon: String
+    switch status {
+    case "Success": icon = "✅"
+    case "Failure", "Error": icon = "❌"
+    default: icon = "·"
+    }
+    let name = xcString(node, "identifier") ?? xcString(node, "name") ?? ""
+    let duration = xcString(node, "duration").flatMap { Double($0) }.map { String(format: " (%.1fs)", $0) } ?? ""
+    print("\(indent)\(icon) \(name)\(duration)")
+
+    for child in xcChildren(node, "subtests") {
+        printSummary(child, depth: depth + 1)
+    }
+}
+
+// MARK: - Main
+
+let args = CommandLine.arguments
+guard args.count > 1 else {
+    fputs("Usage: swift analyze-xcresult.swift <path-to.xcresult> [--last N]\n", stderr)
+    fputs("\n  --last N    Number of activity log steps to show per failure (default: 40)\n", stderr)
+    exit(1)
+}
+
+let xcresultPath = args[1]
+
+var lastN = 40
+if let idx = args.firstIndex(of: "--last"), idx + 1 < args.count, let n = Int(args[idx + 1]) {
+    lastN = n
+}
+
+guard let root = runXcresulttool(xcresultPath: xcresultPath) else {
+    fputs("❌ Could not read xcresult at: \(xcresultPath)\n", stderr)
+    exit(1)
+}
+
+guard let firstAction = xcChildren(root, "actions").first,
+      let testsRefID = xcChild(firstAction, "actionResult")
+          .flatMap({ xcChild($0, "testsRef") })
+          .flatMap({ xcString($0, "id") }) else {
+    fputs("❌ No test results reference found in xcresult.\n", stderr)
+    exit(1)
+}
+
+guard let testsRoot = runXcresulttool(xcresultPath: xcresultPath, objectID: testsRefID) else {
+    fputs("❌ Could not fetch test results object.\n", stderr)
+    exit(1)
+}
+
+// Print pass/fail overview
+print("📦 \(xcresultPath)\n")
+for summary in xcChildren(testsRoot, "summaries") {
+    for testableSummary in xcChildren(summary, "testableSummaries") {
+        for test in xcChildren(testableSummary, "tests") {
+            printSummary(test)
+        }
+    }
+}
+
+// Collect all failures
+var allFailures: [TestFailure] = []
+for summary in xcChildren(testsRoot, "summaries") {
+    for testableSummary in xcChildren(summary, "testableSummaries") {
+        for test in xcChildren(testableSummary, "tests") {
+            allFailures += scanForFailures(node: test, xcresultPath: xcresultPath)
+        }
+    }
+}
+
+guard !allFailures.isEmpty else {
+    print("\n✅ All tests passed.")
+    exit(0)
+}
+
+print("\n❌ \(allFailures.count) failure(s):\n")
+
+let thin = String(repeating: "─", count: 60)
+let thick = String(repeating: "═", count: 60)
+
+for (index, failure) in allFailures.enumerated() {
+    print(thick)
+    print("Failure \(index + 1): \(failure.testName)")
+
+    if !failure.fileURL.isEmpty {
+        let path = failure.fileURL.replacingOccurrences(of: "file://", with: "")
+        print("Location: \(path):\(failure.lineNumber)")
+    }
+
+    print("Message:  \(failure.message)")
+
+    if !failure.activityLog.isEmpty {
+        let tail = failure.activityLog.suffix(lastN)
+        print("\nActivity log — last \(tail.count) of \(failure.activityLog.count) steps:")
+        print(thin)
+        for step in tail {
+            let indent = String(repeating: "  ", count: min(step.depth, 3))
+            print("\(indent)• \(step.title)")
+        }
+    }
+
+    print()
+}


### PR DESCRIPTION
Adds a new `xcresult-analysis` Copilot CLI skill for analysing Xcode xcresult bundles to diagnose failing tests.
The skill accepts a local `.xcresult` path or a GitHub Actions run URL, and surfaces failing test details, activity logs, and diffs.

I used to improve integration tests in https://github.com/element-hq/element-x-ios/pull/5352. I successful tested it locally on unit tests by breaking them first. It was able to fix them.

⚠️ This skill has to be used with copilot. Apparently, it burns tokens too quickly with an Anthropic plan.

