### PR TITLE
Use macOS 26 for all workflows.

### DIFF
--- a/.github/workflows/automatic-calendar-version.yml
+++ b/.github/workflows/automatic-calendar-version.yml
@@ -13,7 +13,7 @@ permissions: {}
 # Patch bumps are handled by the release script.
 jobs:
   automatic-calendar-version:
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 15
     
     # Skip in forks

--- a/.github/workflows/translations-pr.yml
+++ b/.github/workflows/translations-pr.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   open-translations-pr:
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 15
     
     # Skip in forks

--- a/compound-ios/Package.resolved
+++ b/compound-ios/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4ef76dbc3bfba3928a5fcd58ed30e2b87b63c2faff12983fd1b717bec0ff5ddc",
+  "originHash" : "ae93e5e028f3ecd93929879130e93705035af00e0a6d1e4131fc7b7bee7fd255",
   "pins" : [
     {
       "identity" : "compound-design-tokens",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "a8b7c5e0ed33d8ab8887d1654d9b59f2cbad529b",
-        "version" : "1.18.7"
+        "revision" : "ad5e3190cc63dc288f28546f9c6827efc1e9d495",
+        "version" : "1.19.2"
       }
     },
     {


### PR DESCRIPTION
The translations workflow failed this morning: https://github.com/element-hq/element-x-ios/actions/runs/24648003941/job/72064570491

And check in an out-dated Package.resolved file.