### PR TITLE
Fix session verification SAS flow not automatically starting

### DIFF
--- a/ElementX/Sources/Screens/Onboarding/SessionVerificationScreen/SessionVerificationScreenModels.swift
+++ b/ElementX/Sources/Screens/Onboarding/SessionVerificationScreen/SessionVerificationScreenModels.swift
@@ -17,7 +17,6 @@ enum SessionVerificationScreenViewAction {
     case acceptVerificationRequest
     case ignoreVerificationRequest
     case requestVerification
-    case startSasVerification
     case restart
     case accept
     case decline

--- a/ElementX/Sources/Screens/Onboarding/SessionVerificationScreen/SessionVerificationScreenStateMachine.swift
+++ b/ElementX/Sources/Screens/Onboarding/SessionVerificationScreen/SessionVerificationScreenStateMachine.swift
@@ -46,8 +46,6 @@ class SessionVerificationScreenStateMachine {
         case requestVerification
         /// The current verification request has been accepted
         case didAcceptVerificationRequest
-        /// Start a SaS verification flow
-        case startSasVerification
         /// Started a SaS verification flow
         case didStartSasVerification
         /// Has received emojis
@@ -85,8 +83,6 @@ class SessionVerificationScreenStateMachine {
         
         stateMachine.addRoutes(event: .didAcceptVerificationRequest, transitions: [.acceptingVerificationRequest => .verificationRequestAccepted,
                                                                                    .requestingVerification => .verificationRequestAccepted])
-        
-        stateMachine.addRoutes(event: .startSasVerification, transitions: [.verificationRequestAccepted => .startingSasVerification])
         
         stateMachine.addRoutes(event: .didFail, transitions: [.requestingVerification => .initial,
                                                               .acceptingVerificationRequest => .initial])

--- a/ElementX/Sources/Screens/Onboarding/SessionVerificationScreen/SessionVerificationScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Onboarding/SessionVerificationScreen/SessionVerificationScreenViewModel.swift
@@ -87,8 +87,6 @@ class SessionVerificationScreenViewModel: SessionVerificationViewModelType, Sess
             actionsSubject.send(.finished)
         case .requestVerification:
             stateMachine.processEvent(.requestVerification)
-        case .startSasVerification:
-            stateMachine.processEvent(.startSasVerification)
         case .restart:
             stateMachine.processEvent(.restart)
         case .accept:
@@ -133,7 +131,7 @@ class SessionVerificationScreenViewModel: SessionVerificationViewModelType, Sess
                         self.stateMachine.processEvent(.didFail)
                     }
                 }
-            case (.verificationRequestAccepted, .startSasVerification, .startingSasVerification):
+            case (.acceptingVerificationRequest, .didAcceptVerificationRequest, .verificationRequestAccepted):
                 startSasVerification()
             case (.showingChallenge, .acceptChallenge, .acceptingChallenge):
                 acceptChallenge()

--- a/UnitTests/Sources/SessionVerificationViewModelTests.swift
+++ b/UnitTests/Sources/SessionVerificationViewModelTests.swift
@@ -109,9 +109,9 @@ struct SessionVerificationViewModelTests {
     private mutating func setupChallengeReceived() async throws {
         let actionsPublisher = sessionVerificationController.actions.delay(for: .seconds(0.1), scheduler: DispatchQueue.main)
         let cancellable = actionsPublisher
-            .sink { [context] action in
+            .sink { [sessionVerificationController] action in
                 if case .acceptedVerificationRequest = action {
-                    context?.send(viewAction: .startSasVerification)
+                    Task { await sessionVerificationController?.startSasVerification() }
                 }
             }
         


### PR DESCRIPTION
With #5116 removing the `verificationRequestAccepted` view state and its `.startSasVerification` button action we now need another way of starting the SAS flows whenever the verification requests gets accepted. 
As such a state machine transition from `acceptingVerificationRequest` to `verificationRequestAccepted` will now automatically call `startSasVerification` on the SessionVerificationProxy.