### PR TITLE
Live Location Sharing update filtering based on time and distance

### DIFF
--- a/ElementX/Resources/Localizations/en.lproj/Localizable.stringsdict
+++ b/ElementX/Resources/Localizations/en.lproj/Localizable.stringsdict
@@ -283,9 +283,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%1$d meter</string>
+			<string>Every %1$d meter</string>
 			<key>other</key>
-			<string>%1$d meters</string>
+			<string>Every %1$d meters</string>
 		</dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>%#@COUNT@</string>

--- a/ElementX/Sources/Application/Settings/AppSettings.swift
+++ b/ElementX/Sources/Application/Settings/AppSettings.swift
@@ -66,6 +66,7 @@ final class AppSettings {
         
         case voiceMessagePlaybackSpeed
         case liveLocationSharingTimeoutDatesByRoomID
+        case liveLocationMinimumDistanceUpdate
         
         // Feature flags
         case publicSearchEnabled
@@ -348,6 +349,9 @@ final class AppSettings {
     
     @UserPreference(key: UserDefaultsKeys.liveLocationSharingTimeoutDatesByRoomID, defaultValue: [String: Date](), storageType: .userDefaults(store))
     var liveLocationSharingTimeoutDatesByRoomID
+    
+    @UserPreference(key: UserDefaultsKeys.liveLocationMinimumDistanceUpdate, defaultValue: 10, storageType: .userDefaults(store))
+    var liveLocationMinimumDistanceUpdate
     
     @UserPreference(key: UserDefaultsKeys.frequentlyUsedSystemEmojis, defaultValue: [FrequentlyUsedEmoji](), storageType: .userDefaults(store))
     var frequentlyUsedSystemEmojis

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -2199,6 +2199,11 @@ class CLLocationManagerMock: CLLocationManagerProtocol, @unchecked Sendable {
         set(value) { underlyingDesiredAccuracy = value }
     }
     var underlyingDesiredAccuracy: CLLocationAccuracy!
+    var distanceFilter: CLLocationDistance {
+        get { return underlyingDistanceFilter }
+        set(value) { underlyingDistanceFilter = value }
+    }
+    var underlyingDistanceFilter: CLLocationDistance!
     var pausesLocationUpdatesAutomatically: Bool {
         get { return underlyingPausesLocationUpdatesAutomatically }
         set(value) { underlyingPausesLocationUpdatesAutomatically = value }

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -2194,6 +2194,11 @@ class CLLocationManagerMock: CLLocationManagerProtocol, @unchecked Sendable {
         set(value) { underlyingAllowsBackgroundLocationUpdates = value }
     }
     var underlyingAllowsBackgroundLocationUpdates: Bool!
+    var showsBackgroundLocationIndicator: Bool {
+        get { return underlyingShowsBackgroundLocationIndicator }
+        set(value) { underlyingShowsBackgroundLocationIndicator = value }
+    }
+    var underlyingShowsBackgroundLocationIndicator: Bool!
     var desiredAccuracy: CLLocationAccuracy {
         get { return underlyingDesiredAccuracy }
         set(value) { underlyingDesiredAccuracy = value }
@@ -2204,11 +2209,6 @@ class CLLocationManagerMock: CLLocationManagerProtocol, @unchecked Sendable {
         set(value) { underlyingDistanceFilter = value }
     }
     var underlyingDistanceFilter: CLLocationDistance!
-    var pausesLocationUpdatesAutomatically: Bool {
-        get { return underlyingPausesLocationUpdatesAutomatically }
-        set(value) { underlyingPausesLocationUpdatesAutomatically = value }
-    }
-    var underlyingPausesLocationUpdatesAutomatically: Bool!
     var authorizationStatus: CLAuthorizationStatus {
         get { return underlyingAuthorizationStatus }
         set(value) { underlyingAuthorizationStatus = value }
@@ -2249,6 +2249,76 @@ class CLLocationManagerMock: CLLocationManagerProtocol, @unchecked Sendable {
     func requestAlwaysAuthorization() {
         requestAlwaysAuthorizationCallsCount += 1
         requestAlwaysAuthorizationClosure?()
+    }
+    //MARK: - startUpdatingLocation
+
+    var startUpdatingLocationUnderlyingCallsCount = 0
+    var startUpdatingLocationCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return startUpdatingLocationUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = startUpdatingLocationUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                startUpdatingLocationUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    startUpdatingLocationUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var startUpdatingLocationCalled: Bool {
+        return startUpdatingLocationCallsCount > 0
+    }
+    var startUpdatingLocationClosure: (() -> Void)?
+
+    func startUpdatingLocation() {
+        startUpdatingLocationCallsCount += 1
+        startUpdatingLocationClosure?()
+    }
+    //MARK: - stopUpdatingLocation
+
+    var stopUpdatingLocationUnderlyingCallsCount = 0
+    var stopUpdatingLocationCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return stopUpdatingLocationUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = stopUpdatingLocationUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                stopUpdatingLocationUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    stopUpdatingLocationUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var stopUpdatingLocationCalled: Bool {
+        return stopUpdatingLocationCallsCount > 0
+    }
+    var stopUpdatingLocationClosure: (() -> Void)?
+
+    func stopUpdatingLocation() {
+        stopUpdatingLocationCallsCount += 1
+        stopUpdatingLocationClosure?()
     }
 }
 class CXProviderMock: CXProviderProtocol, @unchecked Sendable {

--- a/ElementX/Sources/Screens/Settings/AdvancedSettingsScreen/AdvancedSettingsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/AdvancedSettingsScreen/AdvancedSettingsScreenModels.swift
@@ -61,6 +61,7 @@ protocol AdvancedSettingsProtocol: AnyObject {
     var sharePresence: Bool { get set }
     var optimizeMediaUploads: Bool { get set }
     var liveLocationMinimumDistanceUpdate: Int { get set }
+    var liveLocationSharingEnabled: Bool { get set }
 }
 
 extension AppSettings: AdvancedSettingsProtocol { }

--- a/ElementX/Sources/Screens/Settings/AdvancedSettingsScreen/AdvancedSettingsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/AdvancedSettingsScreen/AdvancedSettingsScreenModels.swift
@@ -7,12 +7,30 @@
 //
 
 import Foundation
+import UIKit
 
 struct AdvancedSettingsScreenViewState: BindableState {
+    init(timelineMediaVisibility: TimelineMediaVisibility, hideInviteAvatars: Bool, isWaitingTimelineMediaVisibility: Bool = false, isWaitingHideInviteAvatars: Bool = false, bindings: AdvancedSettingsScreenViewStateBindings) {
+        self.timelineMediaVisibility = timelineMediaVisibility
+        self.hideInviteAvatars = hideInviteAvatars
+        self.isWaitingTimelineMediaVisibility = isWaitingTimelineMediaVisibility
+        self.isWaitingHideInviteAvatars = isWaitingHideInviteAvatars
+        self.bindings = bindings
+        
+        let linkPlaceholder = "{link}"
+        var footerString = AttributedString(L10n.screenAdvancedSettingsLiveLocationSectionFooter(linkPlaceholder))
+        var linkString = AttributedString(L10n.screenAdvancedSettingsLiveLocationSectionFooterLink)
+        linkString.link = URL(string: UIApplication.openSettingsURLString)
+        linkString.bold()
+        footerString.replace(linkPlaceholder, with: linkString)
+        liveLocationUpdateFooterAttributedString = footerString
+    }
+    
+    let liveLocationUpdateFooterAttributedString: AttributedString
     var timelineMediaVisibility: TimelineMediaVisibility
     var hideInviteAvatars: Bool
-    var isWaitingTimelineMediaVisibility = false
-    var isWaitingHideInviteAvatars = false
+    var isWaitingTimelineMediaVisibility: Bool
+    var isWaitingHideInviteAvatars: Bool
     var bindings: AdvancedSettingsScreenViewStateBindings
 }
 
@@ -42,6 +60,7 @@ protocol AdvancedSettingsProtocol: AnyObject {
     var appAppearance: AppAppearance { get set }
     var sharePresence: Bool { get set }
     var optimizeMediaUploads: Bool { get set }
+    var liveLocationMinimumDistanceUpdate: Int { get set }
 }
 
 extension AppSettings: AdvancedSettingsProtocol { }

--- a/ElementX/Sources/Screens/Settings/AdvancedSettingsScreen/View/AdvancedSettingsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/AdvancedSettingsScreen/View/AdvancedSettingsScreen.swift
@@ -37,6 +37,7 @@ struct AdvancedSettingsScreen: View {
             
             moderationAndSafetySection
             timelineMediaSection
+            liveLocationSection
         }
         .compoundList()
         .navigationTitle(L10n.commonAdvancedSettings)
@@ -81,6 +82,30 @@ struct AdvancedSettingsScreen: View {
                 .compoundListSectionHeader()
         } footer: {
             Text(L10n.screenAdvancedSettingsShowMediaTimelineSubtitle)
+                .compoundListSectionFooter()
+        }
+    }
+    
+    private var liveLocationSection: some View {
+        Section {
+            ListRow(kind: .custom {
+                Stepper(L10n.screenAdvancedSettingsLiveLocationUpdateDistance(context.liveLocationMinimumDistanceUpdate),
+                        value: $context.liveLocationMinimumDistanceUpdate, in: 1...100)
+                    .font(.compound.bodyLG)
+                    .foregroundStyle(.compound.textPrimary)
+                    .padding(.horizontal, ListRowPadding.horizontal)
+                    .padding(.vertical, ListRowPadding.vertical)
+            })
+        } header: {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(L10n.screenAdvancedSettingsLiveLocationSectionTitle)
+                    .compoundListSectionHeader()
+                Text(L10n.screenAdvancedSettingsLiveLocationSectionDescription)
+                    .font(.compound.bodyMD)
+                    .foregroundStyle(.compound.textSecondary)
+            }
+        } footer: {
+            Text(context.viewState.liveLocationUpdateFooterAttributedString)
                 .compoundListSectionFooter()
         }
     }

--- a/ElementX/Sources/Screens/Settings/AdvancedSettingsScreen/View/AdvancedSettingsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/AdvancedSettingsScreen/View/AdvancedSettingsScreen.swift
@@ -10,6 +10,13 @@ import Compound
 import SwiftUI
 
 struct AdvancedSettingsScreen: View {
+    static let measurementFormatter = {
+        let formatter = MeasurementFormatter()
+        formatter.unitOptions = .providedUnit
+        formatter.unitStyle = .short
+        return formatter
+    }()
+    
     @Bindable var context: AdvancedSettingsScreenViewModel.Context
     
     var body: some View {
@@ -37,7 +44,9 @@ struct AdvancedSettingsScreen: View {
             
             moderationAndSafetySection
             timelineMediaSection
-            liveLocationSection
+            if context.liveLocationSharingEnabled {
+                liveLocationSection
+            }
         }
         .compoundList()
         .navigationTitle(L10n.commonAdvancedSettings)
@@ -86,15 +95,41 @@ struct AdvancedSettingsScreen: View {
         }
     }
     
+    @ViewBuilder
     private var liveLocationSection: some View {
+        let binding = Binding(get: {
+            Double(context.liveLocationMinimumDistanceUpdate)
+        }, set: { newValue in
+            context.liveLocationMinimumDistanceUpdate = Int(newValue)
+        })
+        
         Section {
             ListRow(kind: .custom {
-                Stepper(L10n.screenAdvancedSettingsLiveLocationUpdateDistance(context.liveLocationMinimumDistanceUpdate),
-                        value: $context.liveLocationMinimumDistanceUpdate, in: 1...100)
-                    .font(.compound.bodyLG)
-                    .foregroundStyle(.compound.textPrimary)
-                    .padding(.horizontal, ListRowPadding.horizontal)
-                    .padding(.vertical, ListRowPadding.vertical)
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(L10n.screenAdvancedSettingsLiveLocationUpdateDistance(context.liveLocationMinimumDistanceUpdate))
+                        .font(.compound.bodyLG)
+                        .foregroundStyle(.compound.textPrimary)
+                        // The internal hidden label of the slider will read voice over
+                        .accessibilityHidden(true)
+                    Slider(value: binding, in: 1...100) {
+                        Text(L10n.screenAdvancedSettingsLiveLocationUpdateDistance(context.liveLocationMinimumDistanceUpdate))
+                    } minimumValueLabel: {
+                        Text(Self.measurementFormatter.string(from: .init(value: 1,
+                                                                          unit: UnitLength.meters)))
+                            .font(.compound.bodyLG)
+                            .foregroundStyle(.compound.textSecondary)
+                            .padding(.trailing, 15)
+                    } maximumValueLabel: {
+                        Text(Self.measurementFormatter.string(from: .init(value: 100,
+                                                                          unit: UnitLength.meters)))
+                            .font(.compound.bodyLG)
+                            .foregroundStyle(.compound.textSecondary)
+                            .padding(.leading, 15)
+                    }
+                    .tint(.compound.iconAccentPrimary)
+                }
+                .padding(.horizontal, ListRowPadding.horizontal)
+                .padding(.vertical, ListRowPadding.vertical)
             })
         } header: {
             VStack(alignment: .leading, spacing: 4) {
@@ -127,10 +162,16 @@ private extension AppAppearance {
 // MARK: - Previews
 
 struct AdvancedSettingsScreen_Previews: PreviewProvider, TestablePreview {
-    static let viewModel = AdvancedSettingsScreenViewModel(advancedSettings: ServiceLocator.shared.settings,
-                                                           analytics: ServiceLocator.shared.analytics,
-                                                           clientProxy: ClientProxyMock(.init()),
-                                                           userIndicatorController: UserIndicatorControllerMock())
+    static let viewModel = {
+        AppSettings.resetAllSettings()
+        let appSettings = AppSettings()
+        appSettings.liveLocationSharingEnabled = true
+        return AdvancedSettingsScreenViewModel(advancedSettings: appSettings,
+                                               analytics: ServiceLocator.shared.analytics,
+                                               clientProxy: ClientProxyMock(.init()),
+                                               userIndicatorController: UserIndicatorControllerMock())
+    }()
+    
     static var previews: some View {
         ElementNavigationStack {
             AdvancedSettingsScreen(context: viewModel.context)

--- a/ElementX/Sources/Services/Location/CLLocationManagerProtocol.swift
+++ b/ElementX/Sources/Services/Location/CLLocationManagerProtocol.swift
@@ -12,6 +12,7 @@ protocol CLLocationManagerProtocol: AnyObject {
     var delegate: CLLocationManagerDelegate? { get set }
     var allowsBackgroundLocationUpdates: Bool { get set }
     var desiredAccuracy: CLLocationAccuracy { get set }
+    var distanceFilter: CLLocationDistance { get set }
     var pausesLocationUpdatesAutomatically: Bool { get set }
     var authorizationStatus: CLAuthorizationStatus { get }
     

--- a/ElementX/Sources/Services/Location/CLLocationManagerProtocol.swift
+++ b/ElementX/Sources/Services/Location/CLLocationManagerProtocol.swift
@@ -7,16 +7,19 @@
 
 import CoreLocation
 
+/// Protocol for CLLocationManager used for authorization handling and location updates.
 // sourcery: AutoMockable
 protocol CLLocationManagerProtocol: AnyObject {
     var delegate: CLLocationManagerDelegate? { get set }
     var allowsBackgroundLocationUpdates: Bool { get set }
+    var showsBackgroundLocationIndicator: Bool { get set }
     var desiredAccuracy: CLLocationAccuracy { get set }
     var distanceFilter: CLLocationDistance { get set }
-    var pausesLocationUpdatesAutomatically: Bool { get set }
     var authorizationStatus: CLAuthorizationStatus { get }
     
     func requestAlwaysAuthorization()
+    func startUpdatingLocation()
+    func stopUpdatingLocation()
 }
 
 extension CLLocationManager: CLLocationManagerProtocol { }

--- a/ElementX/Sources/Services/Location/LiveLocationManager.swift
+++ b/ElementX/Sources/Services/Location/LiveLocationManager.swift
@@ -22,6 +22,9 @@ class LiveLocationManager: NSObject, LiveLocationManagerProtocol, CLLocationMana
     @CancellableTask
     private var locationUpdatesTask: Task<Void, Never>?
     
+    /// Subject used to pipe location updates through Combine's throttle operator.
+    private let locationUpdateSubject = PassthroughSubject<CLLocationUpdate, Never>()
+    
     private var cancellables = Set<AnyCancellable>()
     
     var authorizationStatus: CurrentValuePublisher<CLAuthorizationStatus, Never> {
@@ -49,7 +52,7 @@ class LiveLocationManager: NSObject, LiveLocationManagerProtocol, CLLocationMana
         
         setupSubscriptions()
     }
-    
+
     // MARK: - LiveLocationManagerProtocol
     
     @discardableResult
@@ -125,6 +128,17 @@ class LiveLocationManager: NSObject, LiveLocationManagerProtocol, CLLocationMana
     // MARK: - Private
     
     private func setupSubscriptions() {
+        locationUpdateSubject
+            .throttle(for: .seconds(3), scheduler: DispatchQueue.main, latest: true)
+            .sink { [weak self] update in
+                guard let self else { return }
+                guard !appSettings.liveLocationSharingTimeoutDatesByRoomID.isEmpty else { return }
+                Task { [weak self] in
+                    await self?.sendLocationToActiveRooms(update)
+                }
+            }
+            .store(in: &cancellables)
+        
         appSettings.$liveLocationSharingTimeoutDatesByRoomID
             .removeDuplicates()
             .sink { [weak self] sessions in
@@ -166,7 +180,7 @@ class LiveLocationManager: NSObject, LiveLocationManagerProtocol, CLLocationMana
                 for try await update in CLLocationUpdate.liveUpdates() {
                     guard let self, !Task.isCancelled else { break }
                     
-                    await self.sendLocationToActiveRooms(update)
+                    self.locationUpdateSubject.send(update)
                 }
             } catch {
                 MXLog.error("Live location updates failed with error: \(error)")

--- a/ElementX/Sources/Services/Location/LiveLocationManager.swift
+++ b/ElementX/Sources/Services/Location/LiveLocationManager.swift
@@ -47,9 +47,8 @@ class LiveLocationManager: NSObject, LiveLocationManagerProtocol, CLLocationMana
         
         self.locationManager.delegate = self
         self.locationManager.allowsBackgroundLocationUpdates = true
-        self.locationManager.desiredAccuracy = kCLLocationAccuracyNearestTenMeters
         self.locationManager.pausesLocationUpdatesAutomatically = false
-        
+        setupMinumDistance(appSettings.liveLocationMinimumDistanceUpdate)
         setupSubscriptions()
     }
 
@@ -162,6 +161,27 @@ class LiveLocationManager: NSObject, LiveLocationManagerProtocol, CLLocationMana
                 locationUpdatesTask = nil
             }
             .store(in: &cancellables)
+        
+        appSettings.$liveLocationMinimumDistanceUpdate
+            .removeDuplicates()
+            .debounce(for: .seconds(3), scheduler: DispatchQueue.main)
+            .sink { [weak self] minimumDistance in
+                self?.setupMinumDistance(minimumDistance)
+            }
+            .store(in: &cancellables)
+    }
+    
+    /// Sets up the distance filter and the most optimal accuracy given the minimum distance to save battery,
+    private func setupMinumDistance(_ minimumDistance: Int) {
+        switch minimumDistance {
+        case 0..<10:
+            locationManager.desiredAccuracy = kCLLocationAccuracyBest
+        case 10..<100:
+            locationManager.desiredAccuracy = kCLLocationAccuracyNearestTenMeters
+        default:
+            locationManager.desiredAccuracy = kCLLocationAccuracyHundredMeters
+        }
+        locationManager.distanceFilter = CLLocationDistance(minimumDistance)
     }
     
     private func syncActiveRoomProxies(with sessions: [String: Date]) {

--- a/ElementX/Sources/Services/Location/LiveLocationManager.swift
+++ b/ElementX/Sources/Services/Location/LiveLocationManager.swift
@@ -173,7 +173,7 @@ class LiveLocationManager: NSObject, LiveLocationManagerProtocol, CLLocationMana
         
         appSettings.$liveLocationMinimumDistanceUpdate
             .removeDuplicates()
-            .debounce(for: .seconds(3), scheduler: DispatchQueue.main)
+            .debounce(for: .seconds(1), scheduler: DispatchQueue.main)
             .sink { [weak self] minimumDistance in
                 self?.setupMinimumDistance(minimumDistance)
             }

--- a/ElementX/Sources/Services/Location/LiveLocationManager.swift
+++ b/ElementX/Sources/Services/Location/LiveLocationManager.swift
@@ -18,12 +18,8 @@ class LiveLocationManager: NSObject, LiveLocationManagerProtocol, CLLocationMana
     /// Cached joined room proxies keyed by room ID, kept in sync with the active sessions dictionary.
     private var activeRoomProxies = [String: JoinedRoomProxyProtocol]()
     
-    /// The running task that iterates over live location updates.
-    @CancellableTask
-    private var locationUpdatesTask: Task<Void, Never>?
-    
     /// Subject used to pipe location updates through Combine's throttle operator.
-    private let locationUpdateSubject = PassthroughSubject<CLLocationUpdate, Never>()
+    private let locationUpdateSubject = PassthroughSubject<CLLocationCoordinate2D, Never>()
     
     private var cancellables = Set<AnyCancellable>()
     
@@ -45,10 +41,11 @@ class LiveLocationManager: NSObject, LiveLocationManagerProtocol, CLLocationMana
         
         super.init()
         
+        // Configure CLLocationManager for continuous background tracking.
         self.locationManager.delegate = self
         self.locationManager.allowsBackgroundLocationUpdates = true
-        self.locationManager.pausesLocationUpdatesAutomatically = false
-        setupMinumDistance(appSettings.liveLocationMinimumDistanceUpdate)
+        self.locationManager.showsBackgroundLocationIndicator = true
+        setupMinimumDistance(appSettings.liveLocationMinimumDistanceUpdate)
         setupSubscriptions()
     }
 
@@ -124,6 +121,18 @@ class LiveLocationManager: NSObject, LiveLocationManagerProtocol, CLLocationMana
         authorizationStatusSubject.send(manager.authorizationStatus)
     }
     
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let location = locations.last else { return }
+        
+        MXLog.verbose("Received location update via delegate, sending to rooms")
+        locationUpdateSubject.send(location.coordinate)
+    }
+    
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        MXLog.error("Location manager failed with error: \(error)")
+        stopAllSessions()
+    }
+    
     // MARK: - Private
     
     private func setupSubscriptions() {
@@ -145,9 +154,9 @@ class LiveLocationManager: NSObject, LiveLocationManagerProtocol, CLLocationMana
                 syncActiveRoomProxies(with: sessions)
                 
                 if sessions.isEmpty {
-                    locationUpdatesTask = nil
+                    self.stopUpdatingLocation()
                 } else {
-                    startLocationUpdatesIfNeeded()
+                    self.startUpdatingLocation()
                 }
             }
             .store(in: &cancellables)
@@ -158,7 +167,7 @@ class LiveLocationManager: NSObject, LiveLocationManagerProtocol, CLLocationMana
                 guard let self else { return }
                 appSettings.liveLocationSharingTimeoutDatesByRoomID.removeAll()
                 activeRoomProxies.removeAll()
-                locationUpdatesTask = nil
+                self.stopUpdatingLocation()
             }
             .store(in: &cancellables)
         
@@ -166,13 +175,21 @@ class LiveLocationManager: NSObject, LiveLocationManagerProtocol, CLLocationMana
             .removeDuplicates()
             .debounce(for: .seconds(3), scheduler: DispatchQueue.main)
             .sink { [weak self] minimumDistance in
-                self?.setupMinumDistance(minimumDistance)
+                self?.setupMinimumDistance(minimumDistance)
             }
             .store(in: &cancellables)
     }
     
-    /// Sets up the distance filter and the most optimal accuracy given the minimum distance to save battery,
-    private func setupMinumDistance(_ minimumDistance: Int) {
+    private func syncActiveRoomProxies(with sessions: [String: Date]) {
+        // Remove proxies for rooms no longer in the dictionary.
+        let activeRoomIDs = Set(sessions.keys)
+        for roomID in activeRoomProxies.keys where !activeRoomIDs.contains(roomID) {
+            activeRoomProxies.removeValue(forKey: roomID)
+        }
+    }
+    
+    /// Sets up the distance filter and the most optimal accuracy given the minimum distance to save battery.
+    private func setupMinimumDistance(_ minimumDistance: Int) {
         switch minimumDistance {
         case 0..<10:
             locationManager.desiredAccuracy = kCLLocationAccuracyBest
@@ -184,34 +201,27 @@ class LiveLocationManager: NSObject, LiveLocationManagerProtocol, CLLocationMana
         locationManager.distanceFilter = CLLocationDistance(minimumDistance)
     }
     
-    private func syncActiveRoomProxies(with sessions: [String: Date]) {
-        // Remove proxies for rooms no longer in the dictionary.
-        let activeRoomIDs = Set(sessions.keys)
-        for roomID in activeRoomProxies.keys where !activeRoomIDs.contains(roomID) {
-            activeRoomProxies.removeValue(forKey: roomID)
-        }
-    }
+    private var isUpdating = false
     
-    private func startLocationUpdatesIfNeeded() {
-        guard locationUpdatesTask == nil else { return }
+    private func startUpdatingLocation() {
+        guard !isUpdating else { return }
+        isUpdating = true
         
-        locationUpdatesTask = Task { [weak self] in
-            do {
-                for try await update in CLLocationUpdate.liveUpdates() {
-                    guard let self, !Task.isCancelled else { break }
-                    
-                    self.locationUpdateSubject.send(update)
-                }
-            } catch {
-                MXLog.error("Live location updates failed with error: \(error)")
-                self?.stopAllSessions()
-            }
-        }
+        MXLog.info("Starting live location updates via delegate")
+        locationManager.startUpdatingLocation()
     }
     
-    private func sendLocationToActiveRooms(_ update: CLLocationUpdate) async {
+    private func stopUpdatingLocation() {
+        guard isUpdating else { return }
+        isUpdating = false
+        
+        MXLog.info("Stopping live location updates")
+        locationManager.stopUpdatingLocation()
+    }
+    
+    private func sendLocationToActiveRooms(_ coordinate: CLLocationCoordinate2D) async {
         let sessions = appSettings.liveLocationSharingTimeoutDatesByRoomID
-        let geoURI = update.location.map { GeoURI(coordinate: $0.coordinate, uncertainty: $0.horizontalAccuracy) }
+        let geoURI = GeoURI(coordinate: coordinate, uncertainty: nil)
         
         for (roomID, timeoutDate) in sessions {
             if Date() >= timeoutDate {
@@ -220,16 +230,16 @@ class LiveLocationManager: NSObject, LiveLocationManagerProtocol, CLLocationMana
                 continue
             }
             
-            guard let geoURI else { continue }
-            
             let roomProxy = await resolveRoomProxy(for: roomID)
             guard let roomProxy else {
                 MXLog.error("Failed to resolve room proxy for live location update in room: \(roomID)")
                 continue
             }
             
-            let result = await roomProxy.sendLiveLocation(geoURI: geoURI)
-            if case .failure(let error) = result {
+            switch await roomProxy.sendLiveLocation(geoURI: geoURI) {
+            case .success:
+                MXLog.debug("Sent live location to room: \(roomID)")
+            case .failure(let error):
                 MXLog.error("Failed to send live location update to room \(roomID): \(error)")
             }
         }

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/advancedSettingsScreen.iPad-en-GB-0.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/advancedSettingsScreen.iPad-en-GB-0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c30282bd1093590cb60fda722552305473fd3cacad999bed81044c2eccc9d57c
-size 171794
+oid sha256:7cf54519ba66ea01ee0fbb2cac517ad99bdb0018409d6a70e66c5d6f383ecf8f
+size 192815

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/advancedSettingsScreen.iPad-pseudo-0.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/advancedSettingsScreen.iPad-pseudo-0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3d02782eb9595efd43c2fff296316cae7b350ef8bb9d14aefabefcbef29f0da7
-size 211907
+oid sha256:5f9ebe7f8b2081eaa353a8c6cc491d9667e9d58785d792d05dceb1c6b499285c
+size 241765

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/advancedSettingsScreen.iPhone-en-GB-0.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/advancedSettingsScreen.iPhone-en-GB-0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:497c7f492ee43082bb72ec58ff20353e72d33be936b66ff9478eda5b653332a0
-size 125423
+oid sha256:0727ef553dcdd695436b11d8f167d035636678dddeaf55326b23ed88060b0ec3
+size 136037


### PR DESCRIPTION
- Updates will always be throttled by 3 seconds
- Updates are also filtered by distanced specified by the users, which also dynamically adapt accuracy to save battery
- Use the full CLLocationManager delegate based approach instead of CLLocation.liveUpdates() for live updates since:
  - liveUpdates() was unreliable in background mode
  - liveUpdates() doesn't support accuracy and distance filter since it used a different CLLocationManager instance under the hood, that doesn't allow for the fine tuned implementation we want, which makes it good for simple apps that just need to track the location for brief periods of time, but not for our use case.

fixes #5198 
<img width="585" height="1266" alt="Screenshot 2026-04-21 at 12 02 06" src="https://github.com/user-attachments/assets/e0dd3760-8efb-4fdf-a079-4b63e8a99fc2" />

