### PR TITLE
Update the Deactivate Account strings (and icon) to call it Delete Account.

### DIFF
--- a/ElementX/Resources/Localizations/en-US.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en-US.lproj/Localizable.strings
@@ -76,10 +76,12 @@
 "action_create" = "Create";
 "action_create_room" = "Create room";
 "action_create_space" = "Create space";
-"action_deactivate" = "Delete";
-"action_deactivate_account" = "Delete account";
+"action_deactivate" = "Deactivate";
+"action_deactivate_account" = "Deactivate account";
 "action_decline" = "Decline";
 "action_decline_and_block" = "Decline and block";
+"action_delete" = "Delete";
+"action_delete_account" = "Delete account";
 "action_delete_poll" = "Delete Poll";
 "action_deselect_all" = "Deselect all";
 "action_disable" = "Disable";

--- a/ElementX/Resources/Localizations/en.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Localizable.strings
@@ -76,10 +76,12 @@
 "action_create" = "Create";
 "action_create_room" = "Create room";
 "action_create_space" = "Create space";
-"action_deactivate" = "Delete";
-"action_deactivate_account" = "Delete account";
+"action_deactivate" = "Deactivate";
+"action_deactivate_account" = "Deactivate account";
 "action_decline" = "Decline";
 "action_decline_and_block" = "Decline and block";
+"action_delete" = "Delete";
+"action_delete_account" = "Delete account";
 "action_delete_poll" = "Delete Poll";
 "action_deselect_all" = "Deselect all";
 "action_disable" = "Disable";

--- a/ElementX/Sources/Generated/Strings.swift
+++ b/ElementX/Sources/Generated/Strings.swift
@@ -186,14 +186,18 @@ internal enum L10n {
   internal static var actionCreateRoom: String { return L10n.tr("Localizable", "action_create_room") }
   /// Create space
   internal static var actionCreateSpace: String { return L10n.tr("Localizable", "action_create_space") }
-  /// Delete
+  /// Deactivate
   internal static var actionDeactivate: String { return L10n.tr("Localizable", "action_deactivate") }
-  /// Delete account
+  /// Deactivate account
   internal static var actionDeactivateAccount: String { return L10n.tr("Localizable", "action_deactivate_account") }
   /// Decline
   internal static var actionDecline: String { return L10n.tr("Localizable", "action_decline") }
   /// Decline and block
   internal static var actionDeclineAndBlock: String { return L10n.tr("Localizable", "action_decline_and_block") }
+  /// Delete
+  internal static var actionDelete: String { return L10n.tr("Localizable", "action_delete") }
+  /// Delete account
+  internal static var actionDeleteAccount: String { return L10n.tr("Localizable", "action_delete_account") }
   /// Delete Poll
   internal static var actionDeletePoll: String { return L10n.tr("Localizable", "action_delete_poll") }
   /// Deselect all

--- a/ElementX/Sources/Screens/Settings/DeactivateAccountScreen/DeactivateAccountScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Settings/DeactivateAccountScreen/DeactivateAccountScreenViewModel.swift
@@ -44,7 +44,7 @@ class DeactivateAccountScreenViewModel: DeactivateAccountScreenViewModelType, De
         state.bindings.alertInfo = .init(id: .confirmation,
                                          title: L10n.screenDeactivateAccountTitle,
                                          message: L10n.screenDeactivateAccountConfirmationDialogContent,
-                                         primaryButton: .init(title: L10n.actionDeactivate) {
+                                         primaryButton: .init(title: L10n.actionDelete) {
                                              Task { await self.deactivateAccount() }
                                          },
                                          secondaryButton: .init(title: L10n.actionCancel, role: .cancel, action: nil))

--- a/ElementX/Sources/Screens/Settings/DeactivateAccountScreen/View/DeactivateAccountScreen.swift
+++ b/ElementX/Sources/Screens/Settings/DeactivateAccountScreen/View/DeactivateAccountScreen.swift
@@ -20,7 +20,7 @@ struct DeactivateAccountScreen: View {
         }
         .compoundList()
         .safeAreaInset(edge: .bottom) {
-            Button(L10n.actionDeactivateAccount, role: .destructive) {
+            Button(L10n.actionDeleteAccount, role: .destructive) {
                 context.send(viewAction: .deactivate)
             }
             .buttonStyle(.compound(.primary))

--- a/ElementX/Sources/Screens/Settings/SettingsScreen/View/SettingsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/SettingsScreen/View/SettingsScreen.swift
@@ -190,8 +190,8 @@ struct SettingsScreen: View {
                     .accessibilityIdentifier(A11yIdentifiers.settingsScreen.logout)
             
             if context.viewState.showAccountDeactivation {
-                ListRow(label: .action(title: L10n.actionDeactivateAccount,
-                                       icon: \.warning,
+                ListRow(label: .action(title: L10n.actionDeleteAccount,
+                                       icon: \.delete,
                                        role: .destructive),
                         kind: .navigationLink {
                             context.send(viewAction: .deactivateAccount)


### PR DESCRIPTION
The strings were pulled in by #5452 and so the snapshots have already been updated. But there was an icon to update  to do (not in any snapshots) and we the `action.` strings have been renamed to follow the naming guidelines.

Closes #5432