### PR TITLE
Fix a potential crash caused by using old Sentry transactions.

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -1027,7 +1027,8 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
 
         // This callback is only executed once during the entire run of the program to avoid
         // multiple callbacks if there are multiple crash events to send (see method documentation)
-        options.onCrashedLastRun = { event in
+        options.onLastRunStatusDetermined = { status, event in
+            guard case .didCrash = status, let event else { return }
             MXLog.error("Sentry detected a crash in the previous run: \(event.eventId.sentryIdString)")
             bugReportService.lastCrashEventID = event.eventId.sentryIdString
         }

--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -1033,6 +1033,10 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
             bugReportService.lastCrashEventID = event.eventId.sentryIdString
         }
         
+        // Any ongoing transactions will no longer be valid after calling SentrySDK.start so lets
+        // remove them and start over, otherwise the app will crash if finishTransaction is used.
+        ServiceLocator.shared.analytics.signpost.resetTransactions()
+        
         SentrySDK.start(options: options) // Swift
         enableSentryLogging(enabled: options.enabled) // Rust
         

--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -1039,11 +1039,6 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
         MXLog.info("Sentry configured (enabled: \(options.enabled))")
     }
     
-    private func teardownSentry() {
-        SentrySDK.close()
-        MXLog.info("SentrySDK stopped")
-    }
-    
     private func processInlineReply(roomID: String, replyText: String) async {
         guard let userSession else {
             fatalError("User session not setup")

--- a/ElementX/Sources/Services/Analytics/Signposter.swift
+++ b/ElementX/Sources/Services/Analytics/Signposter.swift
@@ -75,6 +75,10 @@ class Signposter {
         transactions[transactionName] = nil
     }
     
+    func resetTransactions() {
+        transactions.removeAll()
+    }
+    
     // MARK: - Spans
     
     func addSpan(_ spanName: SpanName, toTransaction transactionName: TransactionName) -> Span? {


### PR DESCRIPTION
The trigger looked like this:

- You login and we start syncing and create the transaction to track the sync length.
- You see the Analytics prompt which triggers [setupSentry](https://github.com/element-hq/element-x-ios/blob/4e1c855467c2d4ad80f14b9b24dd0bcddb128399/ElementX/Sources/Application/AppCoordinator.swift#L979) which calls `SentrySDK.start`. Presumably this clears any in-flight transactions on their side.
- Eventually syncing is done and we finish the transaction.
- 💥

At least for now we can fix this by resetting the transactions any time the user opts in/out of analytics.

Also fixes a deprecation since upgrading the Sentry dependency, along with removing an unused method.