### PR TITLE
Use CurrentValuePublisher for `[LiveLocationShare]` updates

### DIFF
--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -15362,11 +15362,11 @@ class RoomInfoProxyMock: RoomInfoProxyProtocol, @unchecked Sendable {
 
 }
 class RoomLiveLocationServiceMock: RoomLiveLocationServiceProtocol, @unchecked Sendable {
-    var liveLocationsPublisher: AnyPublisher<[LiveLocationShare], Never> {
+    var liveLocationsPublisher: CurrentValuePublisher<[LiveLocationShare], Never> {
         get { return underlyingLiveLocationsPublisher }
         set(value) { underlyingLiveLocationsPublisher = value }
     }
-    var underlyingLiveLocationsPublisher: AnyPublisher<[LiveLocationShare], Never>!
+    var underlyingLiveLocationsPublisher: CurrentValuePublisher<[LiveLocationShare], Never>!
 
 }
 class RoomMemberProxyMock: RoomMemberProxyProtocol, @unchecked Sendable {

--- a/ElementX/Sources/Mocks/RoomLiveLocationServiceMock.swift
+++ b/ElementX/Sources/Mocks/RoomLiveLocationServiceMock.swift
@@ -15,6 +15,6 @@ struct RoomLiveLocationServiceMockConfiguration {
 extension RoomLiveLocationServiceMock {
     convenience init(_ configuration: RoomLiveLocationServiceMockConfiguration = .init()) {
         self.init()
-        liveLocationsPublisher = CurrentValueSubject(configuration.shares).eraseToAnyPublisher()
+        liveLocationsPublisher = CurrentValueSubject(configuration.shares).asCurrentValuePublisher()
     }
 }

--- a/ElementX/Sources/Services/Location/RoomLiveLocationService.swift
+++ b/ElementX/Sources/Services/Location/RoomLiveLocationService.swift
@@ -15,13 +15,11 @@ final class RoomLiveLocationService: RoomLiveLocationServiceProtocol {
     // periphery:ignore - required for instance retention in the rust codebase
     private var observationToken: TaskHandle?
     
-    private let liveLocationsSubject = PassthroughSubject<[LiveLocationShare], Never>()
-    var liveLocationsPublisher: AnyPublisher<[LiveLocationShare], Never> {
-        liveLocationsSubject.eraseToAnyPublisher()
+    private let liveLocationsSubject = CurrentValueSubject<[LiveLocationShare], Never>([])
+    var liveLocationsPublisher: CurrentValuePublisher<[LiveLocationShare], Never> {
+        liveLocationsSubject.asCurrentValuePublisher()
     }
-    
-    private var previousLiveLocationShares: [LiveLocationShare] = []
-    
+        
     init(liveLocationShares: LiveLocationShares) {
         self.liveLocationShares = liveLocationShares
         observationToken = liveLocationShares
@@ -37,7 +35,7 @@ final class RoomLiveLocationService: RoomLiveLocationServiceProtocol {
     // MARK: - Private
     
     private func handleLiveLocationShareUpdates(_ updates: [LiveLocationShareUpdate]) -> [LiveLocationShare] {
-        var shares = previousLiveLocationShares
+        var shares = liveLocationsSubject.value
         
         for update in updates {
             switch update {
@@ -66,7 +64,6 @@ final class RoomLiveLocationService: RoomLiveLocationServiceProtocol {
             }
         }
         
-        previousLiveLocationShares = shares
         return shares
     }
 }

--- a/ElementX/Sources/Services/Location/RoomLiveLocationServiceProtocol.swift
+++ b/ElementX/Sources/Services/Location/RoomLiveLocationServiceProtocol.swift
@@ -10,5 +10,5 @@ import Foundation
 
 // sourcery: AutoMockable
 protocol RoomLiveLocationServiceProtocol {
-    var liveLocationsPublisher: AnyPublisher<[LiveLocationShare], Never> { get }
+    var liveLocationsPublisher: CurrentValuePublisher<[LiveLocationShare], Never> { get }
 }

--- a/UnitTests/Sources/LocationSharingScreenViewModelTests.swift
+++ b/UnitTests/Sources/LocationSharingScreenViewModelTests.swift
@@ -358,7 +358,7 @@ final class LocationSharingScreenViewModelTests {
                                            liveLocationsSubject: CurrentValueSubject<[LiveLocationShare], Never>,
                                            members: [RoomMemberProxyMock] = .allMembers) {
         let liveLocationServiceMock = RoomLiveLocationServiceMock()
-        liveLocationServiceMock.liveLocationsPublisher = liveLocationsSubject.eraseToAnyPublisher()
+        liveLocationServiceMock.liveLocationsPublisher = liveLocationsSubject.asCurrentValuePublisher()
 
         let roomProxyMock = JoinedRoomProxyMock(.init(members: members))
         roomProxyMock.makeLiveLocationServiceReturnValue = liveLocationServiceMock


### PR DESCRIPTION
The reason is that the Passthrough was sending so fast, that it may have made the subscribers miss the first update.