### PR TITLE
LocationSharingScreen: fix indefinite loading on the center to location button in non picker mode

### DIFF
--- a/ElementX/Sources/Screens/LocationSharing/LocationSharingScreenModels.swift
+++ b/ElementX/Sources/Screens/LocationSharing/LocationSharingScreenModels.swift
@@ -117,10 +117,18 @@ struct LocationSharingScreenViewState: BindableState {
         }
     }
     
-    /// Returns true if the user's location has not yet been determined, while location permissions are given or not yet set
+    /// Displays a loader if the user's location has not yet been determined
     /// Does not work as intended on simulator.
     var isLocationLoading: Bool {
-        !bindings.hasLoadedUserLocation && bindings.isLocationAuthorized != false
+        if case .picker = interactionMode {
+            // In picker mode permissions are requested immediately so returns true
+            // if the user's location has not yet been determined while location permissions are given or not yet set
+            !bindings.hasLoadedUserLocation && bindings.isLocationAuthorized != false
+        } else {
+            // In other modes permissions are requested only if the center to user button is tapped
+            // So we only display the loader if the user's location has not yet been determined while location permissions are given.
+            !bindings.hasLoadedUserLocation && bindings.isLocationAuthorized == true
+        }
     }
 
     var zoomLevel: Double {

--- a/ElementX/Sources/Screens/LocationSharing/View/LocationSharingScreen.swift
+++ b/ElementX/Sources/Screens/LocationSharing/View/LocationSharingScreen.swift
@@ -133,6 +133,8 @@ struct LocationSharingScreen_Previews: PreviewProvider, TestablePreview {
     
     static let pickerViewModel = LocationSharingScreenViewModel.mock(type: .picker)
     
+    static let liveLocationViewModel = LocationSharingScreenViewModel.mock(type: .viewLive)
+    
     static var previews: some View {
         ElementNavigationStack {
             LocationSharingScreen(context: pickerViewModel.context)
@@ -153,5 +155,10 @@ struct LocationSharingScreen_Previews: PreviewProvider, TestablePreview {
             LocationSharingScreen(context: pinViewModel.context)
         }
         .previewDisplayName("Pin Static Location")
+        
+        ElementNavigationStack {
+            LocationSharingScreen(context: liveLocationViewModel.context)
+        }
+        .previewDisplayName("Live Location")
     }
 }

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/locationSharingScreen.Live-Location-iPad-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/locationSharingScreen.Live-Location-iPad-en-GB.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ebe9ad381e752245ac59cd33c9cdbdc813dad50e923c0bfd262bb920c93aad74
+size 91241

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/locationSharingScreen.Live-Location-iPad-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/locationSharingScreen.Live-Location-iPad-pseudo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ebe9ad381e752245ac59cd33c9cdbdc813dad50e923c0bfd262bb920c93aad74
+size 91241

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/locationSharingScreen.Live-Location-iPhone-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/locationSharingScreen.Live-Location-iPhone-en-GB.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e79d367b72ad8c487aed8d31dc57c496e7b6ba68ee9474cffbb4ad08f18b26b
+size 49018

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/locationSharingScreen.Live-Location-iPhone-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/locationSharingScreen.Live-Location-iPhone-pseudo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e79d367b72ad8c487aed8d31dc57c496e7b6ba68ee9474cffbb4ad08f18b26b
+size 49018

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/locationSharingScreen.Pin-Static-Location-iPad-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/locationSharingScreen.Pin-Static-Location-iPad-en-GB.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:64737509400fe27cdb017b8f66cffe8c0807f958827cff84a9ce5484db0ca3fc
-size 80109
+oid sha256:7248f6ea27240d462603a5428c92f2f7baf0b74a70955a627f7ef07aa72918c3
+size 80410

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/locationSharingScreen.Pin-Static-Location-iPad-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/locationSharingScreen.Pin-Static-Location-iPad-pseudo.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:64737509400fe27cdb017b8f66cffe8c0807f958827cff84a9ce5484db0ca3fc
-size 80109
+oid sha256:7248f6ea27240d462603a5428c92f2f7baf0b74a70955a627f7ef07aa72918c3
+size 80410

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/locationSharingScreen.Pin-Static-Location-iPhone-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/locationSharingScreen.Pin-Static-Location-iPhone-en-GB.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a068c98796f52c050c1adbffcd58a73f848c2ffccc814545c3e825fe70cff608
-size 38354
+oid sha256:4e53a62e486d779323565226b129815e99f9df6ce8917975a69455e73449b30c
+size 38581

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/locationSharingScreen.Pin-Static-Location-iPhone-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/locationSharingScreen.Pin-Static-Location-iPhone-pseudo.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a068c98796f52c050c1adbffcd58a73f848c2ffccc814545c3e825fe70cff608
-size 38354
+oid sha256:4e53a62e486d779323565226b129815e99f9df6ce8917975a69455e73449b30c
+size 38581

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/locationSharingScreen.User-Static-Location-iPad-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/locationSharingScreen.User-Static-Location-iPad-en-GB.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:40b1b5e02ed04dce7e1c384004f295f2ac535e7a5a21e807122239bd6979688c
-size 92341
+oid sha256:6267e1c1ee76225db644b0d36bbb3c94b8562a445c3b011e5a24df10ff54dc65
+size 92658

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/locationSharingScreen.User-Static-Location-iPad-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/locationSharingScreen.User-Static-Location-iPad-pseudo.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:40b1b5e02ed04dce7e1c384004f295f2ac535e7a5a21e807122239bd6979688c
-size 92341
+oid sha256:6267e1c1ee76225db644b0d36bbb3c94b8562a445c3b011e5a24df10ff54dc65
+size 92658

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/locationSharingScreen.User-Static-Location-iPhone-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/locationSharingScreen.User-Static-Location-iPhone-en-GB.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8cc0b6d024146792039a958fcc043be64b7e002bf4b796de3e2d7a3497f80995
-size 50211
+oid sha256:622e337753d18e986f06c3b8b031131be0c1ff47f441dfa0a4e1abb669e45e7f
+size 50412

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/locationSharingScreen.User-Static-Location-iPhone-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/locationSharingScreen.User-Static-Location-iPhone-pseudo.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8cc0b6d024146792039a958fcc043be64b7e002bf4b796de3e2d7a3497f80995
-size 50211
+oid sha256:622e337753d18e986f06c3b8b031131be0c1ff47f441dfa0a4e1abb669e45e7f
+size 50412

--- a/UnitTests/Sources/LocationSharingScreenViewModelTests.swift
+++ b/UnitTests/Sources/LocationSharingScreenViewModelTests.swift
@@ -169,6 +169,7 @@ final class LocationSharingScreenViewModelTests {
         #expect(!context.viewState.isLocationLoading)
     }
     
+    @Test
     func isLocationLoadingInNonPickerModeWithAuthorizationGiven() {
         let aliceShare = makeLiveLocationShare(userID: "@alice:matrix.org")
         let sender = TimelineItemSender(id: "@alice:matrix.org", displayName: "Alice")

--- a/UnitTests/Sources/LocationSharingScreenViewModelTests.swift
+++ b/UnitTests/Sources/LocationSharingScreenViewModelTests.swift
@@ -124,6 +124,61 @@ final class LocationSharingScreenViewModelTests {
         }
     }
     
+    // MARK: - isLocationLoading Tests
+
+    @Test
+    func isLocationLoadingInPickerModeWithAuthorizationNotDetermined() {
+        setupViewModel()
+        context.isLocationAuthorized = nil
+        context.hasLoadedUserLocation = false
+        #expect(context.viewState.isLocationLoading)
+    }
+
+    @Test
+    func isLocationLoadingInPickerModeWithAuthorizationGranted() {
+        setupViewModel()
+        context.isLocationAuthorized = true
+        context.hasLoadedUserLocation = false
+        #expect(context.viewState.isLocationLoading)
+    }
+
+    @Test
+    func isLocationNotLoadingInPickerModeWhenLocationLoaded() {
+        setupViewModel()
+        context.isLocationAuthorized = true
+        context.hasLoadedUserLocation = true
+        #expect(!context.viewState.isLocationLoading)
+    }
+
+    @Test
+    func isLocationNotLoadingInPickerModeWhenAuthorizationDenied() {
+        setupViewModel()
+        context.isLocationAuthorized = false
+        context.hasLoadedUserLocation = false
+        #expect(!context.viewState.isLocationLoading)
+    }
+
+    @Test
+    func isLocationNotLoadingInNonPickerModeWithAuthorizationNotDetermined() {
+        let aliceShare = makeLiveLocationShare(userID: "@alice:matrix.org")
+        let sender = TimelineItemSender(id: "@alice:matrix.org", displayName: "Alice")
+        let liveLocationsSubject = CurrentValueSubject<[LiveLocationShare], Never>([aliceShare])
+        setupViewModelForViewLive(sender: sender, initialShare: aliceShare, liveLocationsSubject: liveLocationsSubject)
+        context.isLocationAuthorized = nil
+        context.hasLoadedUserLocation = false
+        #expect(!context.viewState.isLocationLoading)
+    }
+    
+    func isLocationLoadingInNonPickerModeWithAuthorizationGiven() {
+        let aliceShare = makeLiveLocationShare(userID: "@alice:matrix.org")
+        let sender = TimelineItemSender(id: "@alice:matrix.org", displayName: "Alice")
+        let liveLocationsSubject = CurrentValueSubject<[LiveLocationShare], Never>([aliceShare])
+        setupViewModelForViewLive(sender: sender, initialShare: aliceShare, liveLocationsSubject: liveLocationsSubject)
+        context.isLocationAuthorized = true
+        context.hasLoadedUserLocation = false
+        #expect(context.viewState.isLocationLoading)
+    }
+
     // MARK: - Live Location Authorization Tests
     
     @Test


### PR DESCRIPTION
In picker mode since `showAndFollow` is the default state and the permissions are asked immediately to the user we display a spinner in the center to location button while the user grants permission or if they are granted, while the system gives the first user position.

In other modes however, permissions are not asked immediately, and would only be asked if the user wants the map to center on his own location, so we don't need to be so strict with the loading check, so we only show a loader if permissions ARE granted AND the location has not been loaded yet.

fixes #5462 