### PR TITLE
Add a Developer Options button to the AuthenticationStartScreen on Nightly builds.

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -662,6 +662,7 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
                                                         navigationRootCoordinator: navigationRootCoordinator,
                                                         appMediator: appMediator,
                                                         appSettings: appSettings,
+                                                        appHooks: appHooks,
                                                         analytics: ServiceLocator.shared.analytics,
                                                         userIndicatorController: ServiceLocator.shared.userIndicatorController)
         coordinator.delegate = self

--- a/ElementX/Sources/Application/Settings/AppSettings.swift
+++ b/ElementX/Sources/Application/Settings/AppSettings.swift
@@ -453,7 +453,7 @@ final class AppSettings {
     @UserPreference(key: UserDefaultsKeys.automaticBackPaginationEnabled, defaultValue: false, storageType: .userDefaults(store))
     var automaticBackPaginationEnabled
     
-    @UserPreference(key: UserDefaultsKeys.developerOptionsEnabled, defaultValue: appBuildType == .debug, storageType: .userDefaults(store))
+    @UserPreference(key: UserDefaultsKeys.developerOptionsEnabled, defaultValue: appBuildType != .release, storageType: .userDefaults(store))
     var developerOptionsEnabled
 }
 

--- a/ElementX/Sources/FlowCoordinators/AuthenticationFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/AuthenticationFlowCoordinator.swift
@@ -22,6 +22,7 @@ class AuthenticationFlowCoordinator: FlowCoordinatorProtocol {
     private let navigationStackCoordinator: NavigationStackCoordinator
     private let appMediator: AppMediatorProtocol
     private let appSettings: AppSettings
+    private let appHooks: AppHooks
     private let analytics: AnalyticsService
     private let userIndicatorController: UserIndicatorControllerProtocol
     
@@ -46,6 +47,8 @@ class AuthenticationFlowCoordinator: FlowCoordinatorProtocol {
         
         /// The screen to report an error.
         case bugReportFlow
+        /// The screen to toggle feature flags.
+        case developerOptions
         
         /// The flow is complete.
         case complete
@@ -62,8 +65,6 @@ class AuthenticationFlowCoordinator: FlowCoordinatorProtocol {
         case loginWithQR
         /// Show the server confirmation screen.
         case confirmServer(AuthenticationFlow)
-        /// The user encountered a problem.
-        case reportProblem
         
         /// The QR login flow was aborted.
         case cancelledLoginWithQR
@@ -84,8 +85,15 @@ class AuthenticationFlowCoordinator: FlowCoordinatorProtocol {
         /// The password login was aborted.
         case cancelledPasswordLogin(previousState: State)
         
+        /// The user encountered a problem.
+        case reportProblem
         /// The user has finished reporting a problem (or viewing the logs).
         case bugReportFlowComplete
+        
+        /// The user wants to toggle a feature flag.
+        case developerOptions
+        /// The user finished toggling feature flags.
+        case dismissedDeveloperOptions
         
         /// The user has successfully signed in. The new session can be found in the `userInfo`.
         case signedIn
@@ -106,6 +114,7 @@ class AuthenticationFlowCoordinator: FlowCoordinatorProtocol {
          navigationRootCoordinator: NavigationRootCoordinator,
          appMediator: AppMediatorProtocol,
          appSettings: AppSettings,
+         appHooks: AppHooks,
          analytics: AnalyticsService,
          userIndicatorController: UserIndicatorControllerProtocol) {
         self.authenticationService = authenticationService
@@ -113,6 +122,7 @@ class AuthenticationFlowCoordinator: FlowCoordinatorProtocol {
         self.navigationRootCoordinator = navigationRootCoordinator
         self.appMediator = appMediator
         self.appSettings = appSettings
+        self.appHooks = appHooks
         self.analytics = analytics
         self.userIndicatorController = userIndicatorController
         
@@ -162,6 +172,8 @@ class AuthenticationFlowCoordinator: FlowCoordinatorProtocol {
         case .loginScreen:
             navigationStackCoordinator.popToRoot(animated: animated)
         case .bugReportFlow:
+            navigationStackCoordinator.setSheetCoordinator(nil)
+        case .developerOptions:
             navigationStackCoordinator.setSheetCoordinator(nil)
         case .complete:
             fatalError()
@@ -231,6 +243,13 @@ class AuthenticationFlowCoordinator: FlowCoordinatorProtocol {
         }
         stateMachine.addRoutes(event: .bugReportFlowComplete, transitions: [.bugReportFlow => .startScreen])
         
+        // Developer Options
+        
+        stateMachine.addRoutes(event: .developerOptions, transitions: [.startScreen => .developerOptions]) { [weak self] _ in
+            self?.showDeveloperOptionsScreen()
+        }
+        stateMachine.addRoutes(event: .dismissedDeveloperOptions, transitions: [.developerOptions => .startScreen])
+        
         // Completion
         
         stateMachine.addRoutes(event: .signedIn, transitions: [.qrCodeLoginScreen => .complete,
@@ -285,13 +304,16 @@ class AuthenticationFlowCoordinator: FlowCoordinatorProtocol {
                     stateMachine.tryEvent(.confirmServer(.login))
                 case .register:
                     stateMachine.tryEvent(.confirmServer(.register))
-                case .reportProblem:
-                    stateMachine.tryEvent(.reportProblem)
                     
                 case .loginDirectlyWithOIDC(let oidcData, let window):
                     stateMachine.tryEvent(.continueWithOIDC, userInfo: (oidcData, window))
                 case .loginDirectlyWithPassword(let loginHint):
                     stateMachine.tryEvent(.continueWithPassword, userInfo: loginHint)
+                
+                case .reportProblem:
+                    stateMachine.tryEvent(.reportProblem)
+                case .developerOptions:
+                    stateMachine.tryEvent(.developerOptions)
                 }
             }
             .store(in: &cancellables)
@@ -463,6 +485,28 @@ class AuthenticationFlowCoordinator: FlowCoordinatorProtocol {
         
         bugReportFlowCoordinator = coordinator
         coordinator.start()
+    }
+    
+    // MARK: - Developer Options
+    
+    private func showDeveloperOptionsScreen() {
+        let stackCoordinator = NavigationStackCoordinator()
+        let coordinator = DeveloperOptionsScreenCoordinator(appSettings: appSettings,
+                                                            appHooks: appHooks,
+                                                            clientProxy: nil)
+        coordinator.actions
+            .sink { action in
+                switch action {
+                case .clearCache:
+                    break // Not sent when clientProxy == nil
+                }
+            }
+            .store(in: &cancellables)
+        
+        stackCoordinator.setRootCoordinator(coordinator)
+        navigationStackCoordinator.setSheetCoordinator(stackCoordinator) { [weak self] in
+            self?.stateMachine.tryEvent(.dismissedDeveloperOptions)
+        }
     }
     
     // MARK: - Completion

--- a/ElementX/Sources/Screens/Authentication/StartScreen/AuthenticationStartScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Authentication/StartScreen/AuthenticationStartScreenCoordinator.swift
@@ -23,10 +23,12 @@ enum AuthenticationStartScreenCoordinatorAction {
     case loginWithQR
     case login
     case register
-    case reportProblem
     
     case loginDirectlyWithOIDC(data: OIDCAuthorizationDataProxy, window: UIWindow)
     case loginDirectlyWithPassword(loginHint: String?)
+    
+    case reportProblem
+    case developerOptions
 }
 
 final class AuthenticationStartScreenCoordinator: CoordinatorProtocol {
@@ -62,13 +64,16 @@ final class AuthenticationStartScreenCoordinator: CoordinatorProtocol {
                     actionsSubject.send(.login)
                 case .register:
                     actionsSubject.send(.register)
-                case .reportProblem:
-                    actionsSubject.send(.reportProblem)
                 
                 case .loginDirectlyWithOIDC(let data, let window):
                     actionsSubject.send(.loginDirectlyWithOIDC(data: data, window: window))
                 case .loginDirectlyWithPassword(let loginHint):
                     actionsSubject.send(.loginDirectlyWithPassword(loginHint: loginHint))
+                
+                case .reportProblem:
+                    actionsSubject.send(.reportProblem)
+                case .developerOptions:
+                    actionsSubject.send(.developerOptions)
                 }
             }
             .store(in: &cancellables)

--- a/ElementX/Sources/Screens/Authentication/StartScreen/AuthenticationStartScreenModels.swift
+++ b/ElementX/Sources/Screens/Authentication/StartScreen/AuthenticationStartScreenModels.swift
@@ -12,10 +12,12 @@ enum AuthenticationStartScreenViewModelAction: Equatable {
     case loginWithQR
     case login
     case register
-    case reportProblem
     
     case loginDirectlyWithOIDC(data: OIDCAuthorizationDataProxy, window: UIWindow)
     case loginDirectlyWithPassword(loginHint: String?)
+    
+    case reportProblem
+    case developerOptions
 }
 
 struct AuthenticationStartScreenViewState: BindableState {
@@ -56,11 +58,12 @@ enum AuthenticationStartScreenAlertType {
 enum AuthenticationStartScreenViewAction {
     /// Updates the window used as the OIDC presentation anchor.
     case updateWindow(UIWindow)
+    case developerOptions
+    case reportProblem
     
     case loginWithQR
     case login
     case register
-    case reportProblem
     
     case continueWithClassic(ClassicAppAccount)
     case otherOptions(ClassicAppAccount)

--- a/ElementX/Sources/Screens/Authentication/StartScreen/AuthenticationStartScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Authentication/StartScreen/AuthenticationStartScreenViewModel.swift
@@ -83,16 +83,20 @@ class AuthenticationStartScreenViewModel: AuthenticationStartScreenViewModelType
         case .updateWindow(let window):
             guard state.window != window else { return }
             state.window = window
+        case .reportProblem:
+            if canReportProblem {
+                actionsSubject.send(.reportProblem)
+            }
+        case .developerOptions:
+            actionsSubject.send(.developerOptions)
+        
         case .loginWithQR:
             actionsSubject.send(.loginWithQR)
         case .login:
             Task { await login() }
         case .register:
             actionsSubject.send(.register)
-        case .reportProblem:
-            if canReportProblem {
-                actionsSubject.send(.reportProblem)
-            }
+        
         case .continueWithClassic(let account):
             Task { await login(classicAppAccount: account) }
         case .otherOptions(let account):

--- a/ElementX/Sources/Screens/Authentication/StartScreen/View/AuthenticationStartScreen.swift
+++ b/ElementX/Sources/Screens/Authentication/StartScreen/View/AuthenticationStartScreen.swift
@@ -123,12 +123,15 @@ struct AuthenticationStartScreen: View {
             versionText
                 .font(.compound.bodySM)
                 .foregroundColor(.compound.textSecondary)
-                .frame(maxWidth: .infinity)
-                .padding(.top, 16)
                 .onTapGesture(count: 7) {
                     context.send(viewAction: .reportProblem)
                 }
                 .accessibilityIdentifier(A11yIdentifiers.authenticationStartScreen.appVersion)
+                .overlay(alignment: .trailing) {
+                    developerOptionsButton
+                        .scaledOffset(x: 32, y: -0.5, relativeTo: .compound.bodySM)
+                }
+                .padding(.top, 16)
         }
         .padding(.horizontal, verticalSizeClass == .compact ? 128 : 24)
         .readableFrame()
@@ -138,6 +141,17 @@ struct AuthenticationStartScreen: View {
         // Let's not deal with snapshotting a changing version string.
         let shortVersionString = ProcessInfo.isRunningTests ? "0.0.0" : InfoPlistReader.main.bundleShortVersionString
         return Text(L10n.screenOnboardingAppVersion(shortVersionString))
+    }
+    
+    @ViewBuilder
+    var developerOptionsButton: some View {
+        if AppSettings.appBuildType != .release, !ProcessInfo.isRunningTests {
+            Button { context.send(viewAction: .developerOptions) } label: {
+                CompoundIcon(\.code)
+                    .foregroundStyle(.compound.iconSecondary)
+            }
+            .accessibilityLabel(L10n.commonDeveloperOptions)
+        }
     }
     
     @ToolbarContentBuilder

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenCoordinator.swift
@@ -23,7 +23,7 @@ final class DeveloperOptionsScreenCoordinator: CoordinatorProtocol {
         actionsSubject.eraseToAnyPublisher()
     }
     
-    init(appSettings: AppSettings, appHooks: AppHooks, clientProxy: ClientProxyProtocol) {
+    init(appSettings: AppSettings, appHooks: AppHooks, clientProxy: ClientProxyProtocol?) {
         viewModel = DeveloperOptionsScreenViewModel(developerOptions: appSettings,
                                                     elementCallBaseURL: appSettings.elementCallBaseURL,
                                                     appHooks: appHooks,

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
@@ -16,6 +16,9 @@ struct DeveloperOptionsScreenViewState: BindableState {
     let elementCallBaseURL: URL
     let appHooks: AppHooks
     var storeSizes: [StoreSize]?
+    let shouldShowClearCache: Bool
+    let isPresentedModally: Bool
+    
     var bindings: DeveloperOptionsScreenViewStateBindings
     
     struct StoreSize: Identifiable {

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenViewModel.swift
@@ -18,13 +18,15 @@ class DeveloperOptionsScreenViewModel: DeveloperOptionsScreenViewModelType, Deve
         actionsSubject.eraseToAnyPublisher()
     }
     
-    init(developerOptions: DeveloperOptionsProtocol, elementCallBaseURL: URL, appHooks: AppHooks, clientProxy: ClientProxyProtocol) {
+    init(developerOptions: DeveloperOptionsProtocol, elementCallBaseURL: URL, appHooks: AppHooks, clientProxy: ClientProxyProtocol?) {
         super.init(initialViewState: .init(elementCallBaseURL: elementCallBaseURL,
                                            appHooks: appHooks,
+                                           shouldShowClearCache: clientProxy != nil,
+                                           isPresentedModally: clientProxy == nil,
                                            bindings: .init(developerOptions: developerOptions)))
         
         Task {
-            if case let .success(sizes) = await clientProxy.storeSizes() {
+            if case let .success(sizes) = await clientProxy?.storeSizes() {
                 let formatter = ByteCountFormatStyle(style: .file)
                 
                 var components = [DeveloperOptionsScreenViewState.StoreSize]()

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
@@ -9,6 +9,8 @@
 import SwiftUI
 
 struct DeveloperOptionsScreen: View {
+    @Environment(\.dismiss) private var dismiss
+    
     @Bindable var context: DeveloperOptionsScreenViewModel.Context
     
     @State private var showConfetti = false
@@ -121,7 +123,7 @@ struct DeveloperOptionsScreen: View {
                 Text("WARNING: this feature is EXPERIMENTAL and not all security precautions are implemented. Do not enable on production accounts.")
             }
 
-            Section {
+            Section("Element Call remote URL override") {
                 TextField("Leave empty to use EC locally", text: $elementCallURLOverrideString)
                     .autocorrectionDisabled(true)
                     .autocapitalization(.none)
@@ -134,8 +136,6 @@ struct DeveloperOptionsScreen: View {
                             context.elementCallBaseURLOverride = url
                         }
                     }
-            } header: {
-                Text("Element Call remote URL override")
             }
             
             Section("Notifications") {
@@ -158,19 +158,22 @@ struct DeveloperOptionsScreen: View {
                         .alignmentGuide(.listRowSeparatorLeading) { _ in 0 } // Fix separator alignment
                 }
             }
-
-            Section {
-                Button(role: .destructive) {
-                    context.send(viewAction: .clearCache)
-                } label: {
-                    Text("Clear cache")
-                        .frame(maxWidth: .infinity)
+            
+            if context.viewState.shouldShowClearCache {
+                Section {
+                    Button(role: .destructive) {
+                        context.send(viewAction: .clearCache)
+                    } label: {
+                        Text("Clear cache")
+                            .frame(maxWidth: .infinity)
+                    }
                 }
             }
         }
         .overlay(effectsView)
         .navigationTitle(L10n.commonDeveloperOptions)
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar { toolbar }
     }
 
     @ViewBuilder
@@ -186,6 +189,19 @@ struct DeveloperOptionsScreen: View {
     private func removeConfettiAfterDelay() async {
         try? await Task.sleep(for: .seconds(4))
         showConfetti = false
+    }
+    
+    @ToolbarContentBuilder
+    private var toolbar: some ToolbarContent {
+        if context.viewState.isPresentedModally {
+            ToolbarItem(placement: .primaryAction) {
+                if #available(iOS 26.0, *) {
+                    Button(role: .close, action: dismiss.callAsFunction)
+                } else {
+                    Button(L10n.actionDone, action: dismiss.callAsFunction)
+                }
+            }
+        }
     }
 }
 

--- a/ElementX/Sources/UITests/UITestsAppCoordinator.swift
+++ b/ElementX/Sources/UITests/UITestsAppCoordinator.swift
@@ -157,6 +157,7 @@ class MockScreen: Identifiable {
                                                                 navigationRootCoordinator: navigationRootCoordinator,
                                                                 appMediator: AppMediatorMock.default,
                                                                 appSettings: appSettings,
+                                                                appHooks: AppHooks(),
                                                                 analytics: ServiceLocator.shared.analytics,
                                                                 userIndicatorController: ServiceLocator.shared.userIndicatorController)
             flowCoordinator.start()


### PR DESCRIPTION
iOS equivalent to https://github.com/element-hq/element-x-android/pull/6587

I've deviated slightly by using the same icon as we use in the SettingScreen and have put it at the bottom rather than the top. The store sizes section won't be shown as there isn't a ClientProxy at this stage.

https://github.com/user-attachments/assets/41189503-9c06-4313-81ab-e79a22c9dbea

