### PR TITLE
Avoid logouts when resetting the caches

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -965,12 +965,9 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
         
         stopSync(isBackgroundTask: false)
         userSessionFlowCoordinator?.stop()
-        
-        tearDownUserSession()
     
         // Allow for everything to deallocate properly
         Task {
-            try? await Task.sleep(for: .seconds(2))
             await userSession.clientProxy.clearCaches()
             stateMachine.processEvent(.startWithExistingSession)
             hideLoadingIndicator()


### PR DESCRIPTION
The SDK is reporting a `Failed to run migrations: locking protocol` but in practice we tear down the session before using said session to access the `clearCaches` method on its client, which is obviously wrong.

This patch removes that step and the delay as everything seems to work properly without them.