### PR TITLE
add dev option to re-register for push notifications

### DIFF
--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
@@ -48,6 +48,7 @@ struct DeveloperOptionsScreenViewStateBindings {
 
 enum DeveloperOptionsScreenViewAction {
     case clearCache
+    case reregisterPushNotifications
 }
 
 protocol DeveloperOptionsProtocol: AnyObject {

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenViewModel.swift
@@ -55,6 +55,8 @@ class DeveloperOptionsScreenViewModel: DeveloperOptionsScreenViewModelType, Deve
         switch viewAction {
         case .clearCache:
             actionsSubject.send(.clearCache)
+        case .reregisterPushNotifications:
+            UIApplication.shared.registerForRemoteNotifications()
         }
     }
 }

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
@@ -132,6 +132,10 @@ struct DeveloperOptionsScreen: View {
                 Toggle(isOn: $context.focusEventOnNotificationTap) {
                     Text("Focus event on notification tap")
                 }
+
+                Button("Re-register Push Notifications", action: {
+                    context.send(viewAction: .reregisterPushNotifications)
+                })
             }
             
             Section {


### PR DESCRIPTION
In testing my other PR, I'm running into notification issues. This is a dev feature to help with that troubleshooting that should also be useful in the long run.

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.