### PR TITLE
Limit knock FF only room creation and access type changes

### DIFF
--- a/ElementX/Sources/Screens/JoinRoomScreen/JoinRoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/JoinRoomScreen/JoinRoomScreenViewModel.swift
@@ -238,7 +238,7 @@ class JoinRoomScreenViewModel: JoinRoomScreenViewModelType, JoinRoomScreenViewMo
                 case .invite:
                     state.mode = .inviteRequired
                 case .knock, .knockRestricted:
-                    state.mode = appSettings.knockingEnabled ? .knockable : .joinable
+                    state.mode = .knockable
                 case .restricted(let rules):
                     state.mode = clientProxy.canJoinRoom(with: rules) ? .joinable : .restricted
                 default:
@@ -261,7 +261,7 @@ class JoinRoomScreenViewModel: JoinRoomScreenViewModelType, JoinRoomScreenViewMo
                 case .invite:
                     state.mode = .inviteRequired
                 case .knock, .knockRestricted:
-                    state.mode = appSettings.knockingEnabled ? .knockable : .joinable
+                    state.mode = .knockable
                 case .restricted(let rules):
                     state.mode = clientProxy.canJoinRoom(with: rules) ? .joinable : .restricted
                 default:

--- a/ElementX/Sources/Screens/JoinRoomScreen/View/JoinRoomScreen.swift
+++ b/ElementX/Sources/Screens/JoinRoomScreen/View/JoinRoomScreen.swift
@@ -404,8 +404,7 @@ struct JoinRoomScreenPreviewWrapper: Identifiable {
         self.customPreviewName = customPreviewName
         
         let appSettings = AppSettings()
-        appSettings.knockingEnabled = true
-        
+
         let clientProxy = ClientProxyMock(.init(hideInviteAvatars: hideInviteAvatars))
         clientProxy.canJoinRoomWithReturnValue = canJoinRoom
         

--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenModels.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenModels.swift
@@ -64,14 +64,13 @@ struct RoomDetailsScreenViewState: BindableState {
     var canJoinCall = false
     var pinnedEventsActionState = RoomDetailsScreenPinnedEventsActionState.loading
     
-    var knockingEnabled = false
     var isKnockableRoom = false
     var knockRequestsCount = 0
-    
+
     var reportRoomEnabled = false
-    
+
     var canSeeKnockingRequests: Bool {
-        knockingEnabled && dmRecipientInfo == nil && isKnockableRoom && (canInviteUsers || canKickUsers || canBanUsers)
+        dmRecipientInfo == nil && isKnockableRoom && (canInviteUsers || canKickUsers || canBanUsers)
     }
     
     var canSeeSecurityAndPrivacy: Bool {

--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
@@ -71,10 +71,6 @@ class RoomDetailsScreenViewModel: RoomDetailsScreenViewModelType, RoomDetailsScr
                                            bindings: .init()),
                    mediaProvider: userSession.mediaProvider)
         
-        appSettings.$knockingEnabled
-            .weakAssign(to: \.state.knockingEnabled, on: self)
-            .store(in: &cancellables)
-        
         Task {
             state.reportRoomEnabled = await userSession.clientProxy.isReportRoomSupported
         }

--- a/ElementX/Sources/Screens/RoomDetailsScreen/View/RoomDetailsScreen.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/View/RoomDetailsScreen.swift
@@ -374,7 +374,6 @@ struct RoomDetailsScreen_Previews: PreviewProvider, TestablePreview {
     }
     
     private static func makeGenericRoomViewModel(historyVisibility: RoomHistoryVisibility) -> RoomDetailsScreenViewModel {
-        ServiceLocator.shared.settings.knockingEnabled = true
         let knockRequests: [KnockRequestProxyMock] = [.init()]
         
         let members: [RoomMemberProxyMock] = [
@@ -417,7 +416,6 @@ struct RoomDetailsScreen_Previews: PreviewProvider, TestablePreview {
     }
     
     private static func makeSimpleRoomViewModel() -> RoomDetailsScreenViewModel {
-        ServiceLocator.shared.settings.knockingEnabled = true
         let knockRequests: [KnockRequestProxyMock] = [.init()]
         
         let members: [RoomMemberProxyMock] = [

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
@@ -73,7 +73,6 @@ struct RoomScreenViewState: BindableState {
     var isDirectOneToOneRoom: Bool
     
     var roomThreadListEnabled = false
-    var isKnockingEnabled = false
     var isKnockableRoom = false
     var canAcceptKnocks = false
     var canDeclineKnocks = false
@@ -88,8 +87,7 @@ struct RoomScreenViewState: BindableState {
     }
     
     var shouldSeeKnockRequests: Bool {
-        isKnockingEnabled &&
-            isKnockableRoom &&
+        isKnockableRoom &&
             !displayedKnockRequests.isEmpty &&
             (canAcceptKnocks || canDeclineKnocks || canBan)
     }

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -167,10 +167,6 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
             .weakAssign(to: \.state.roomThreadListEnabled, on: self)
             .store(in: &cancellables)
         
-        appSettings.$knockingEnabled
-            .weakAssign(to: \.state.isKnockingEnabled, on: self)
-            .store(in: &cancellables)
-        
         appSettings.$liveLocationSharingSessionsByRoomID
             .receive(on: DispatchQueue.main)
             .sink { [weak self] sessionsByRoomID in

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -808,7 +808,7 @@ class ClientProxy: ClientProxyProtocol {
     }
     
     func roomDirectorySearchProxy() -> RoomDirectorySearchProxyProtocol {
-        RoomDirectorySearchProxy(roomDirectorySearch: client.roomDirectorySearch(), appSettings: appSettings)
+        RoomDirectorySearchProxy(roomDirectorySearch: client.roomDirectorySearch())
     }
     
     func resolveRoomAlias(_ alias: String) async -> Result<ResolvedRoomAlias, ClientProxyError> {
@@ -1206,10 +1206,6 @@ class ClientProxy: ClientProxyProtocol {
             case .invited:
                 return try await .invited(InvitedRoomProxy(room: room))
             case .knocked:
-                guard appSettings.knockingEnabled else {
-                    return nil
-                }
-                
                 return try await .knocked(KnockedRoomProxy(room: room))
             case .joined:
                 let roomProxy = try await JoinedRoomProxy(roomListService: roomListService,

--- a/ElementX/Sources/Services/RoomDirectorySearch/RoomDirectorySearchProxy.swift
+++ b/ElementX/Sources/Services/RoomDirectorySearch/RoomDirectorySearchProxy.swift
@@ -12,7 +12,6 @@ import MatrixRustSDK
 
 final class RoomDirectorySearchProxy: RoomDirectorySearchProxyProtocol {
     private let roomDirectorySearch: RoomDirectorySearchProtocol
-    private let appSettings: AppSettings
     private let serialDispatchQueue = DispatchQueue(label: "io.element.elementx.room_directory_search_proxy", qos: .default)
     
     private let resultsSubject = CurrentValueSubject<[RoomDirectorySearchResult], Never>([])
@@ -32,10 +31,8 @@ final class RoomDirectorySearchProxy: RoomDirectorySearchProxyProtocol {
     
     private var cancellables = Set<AnyCancellable>()
     
-    init(roomDirectorySearch: RoomDirectorySearchProtocol,
-         appSettings: AppSettings) {
+    init(roomDirectorySearch: RoomDirectorySearchProtocol) {
         self.roomDirectorySearch = roomDirectorySearch
-        self.appSettings = appSettings
         diffsPublisher
             .receive(on: serialDispatchQueue)
             .sink { [weak self] in self?.updateResultsWithDiffs($0) }
@@ -149,6 +146,6 @@ final class RoomDirectorySearchProxy: RoomDirectorySearchProxyProtocol {
                                   name: value.name,
                                   topic: value.topic,
                                   avatar: .room(id: value.roomId, name: value.name, avatarURL: value.avatarUrl.flatMap(URL.init(string:))),
-                                  canBeJoined: value.joinRule == .public || (appSettings.knockingEnabled && value.joinRule == .knock))
+                                  canBeJoined: value.joinRule == .public || value.joinRule == .knock)
     }
 }

--- a/UnitTests/Sources/JoinRoomScreenViewModelTests.swift
+++ b/UnitTests/Sources/JoinRoomScreenViewModelTests.swift
@@ -169,8 +169,6 @@ final class JoinRoomScreenViewModelTests {
     // MARK: - Helpers
     
     private func setupViewModel(throwing: Bool = false, mode: TestMode = .joined) {
-        ServiceLocator.shared.settings.knockingEnabled = true
-        
         clientProxy = ClientProxyMock(.init())
         
         clientProxy.joinRoomViaReturnValue = throwing ? .failure(.sdkError(ClientProxyMockError.generic)) : .success(())

--- a/UnitTests/Sources/RoomDetailsScreenViewModelTests.swift
+++ b/UnitTests/Sources/RoomDetailsScreenViewModelTests.swift
@@ -697,7 +697,6 @@ struct RoomDetailsScreenViewModelTests {
     
     @Test
     mutating func knockRequestsCounter() async throws {
-        ServiceLocator.shared.settings.knockingEnabled = true
         let mockedRequests: [KnockRequestProxyMock] = [.init(), .init()]
         roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", isDirect: false, knockRequestsState: .loaded(mockedRequests), joinRule: .knock))
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
@@ -720,7 +719,6 @@ struct RoomDetailsScreenViewModelTests {
     
     @Test
     mutating func knockRequestsCounterIsLoading() async throws {
-        ServiceLocator.shared.settings.knockingEnabled = true
         roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", isDirect: false, knockRequestsState: .loading, joinRule: .knock))
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                userSession: UserSessionMock(.init()),
@@ -739,7 +737,6 @@ struct RoomDetailsScreenViewModelTests {
     
     @Test
     mutating func knockRequestsCounterIsNotShownIfNoPermissions() async throws {
-        ServiceLocator.shared.settings.knockingEnabled = true
         let mockedRequests: [KnockRequestProxyMock] = [.init(), .init()]
         roomProxyMock = JoinedRoomProxyMock(.init(name: "Test",
                                                   isDirect: false,
@@ -766,7 +763,6 @@ struct RoomDetailsScreenViewModelTests {
     
     @Test
     mutating func knockRequestsCounterIsNotShownIfDM() async throws {
-        ServiceLocator.shared.settings.knockingEnabled = true
         let mockedRequests: [KnockRequestProxyMock] = [.init(), .init()]
         let mockedMembers: [RoomMemberProxyMock] = [.mockMe, .mockAlice]
         roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", isDirect: true, members: mockedMembers, knockRequestsState: .loaded(mockedRequests), joinRule: .knock))

--- a/UnitTests/Sources/RoomScreenViewModelTests.swift
+++ b/UnitTests/Sources/RoomScreenViewModelTests.swift
@@ -341,7 +341,6 @@ final class RoomScreenViewModelTests {
     
     @Test
     func knockRequestBanner() async throws {
-        ServiceLocator.shared.settings.knockingEnabled = true
         let roomProxyMock = JoinedRoomProxyMock(.init(knockRequestsState: .loaded([KnockRequestProxyMock(.init(eventID: "1", userID: "@alice:matrix.org", displayName: "Alice", reason: "Hello World!")),
                                                                                    // This one should be filtered
                                                                                    KnockRequestProxyMock(.init(eventID: "2", userID: "@bob:matrix.org", isSeen: true))]),
@@ -376,7 +375,6 @@ final class RoomScreenViewModelTests {
     
     @Test
     func knockRequestBannerMarkAsSeen() async throws {
-        ServiceLocator.shared.settings.knockingEnabled = true
         let roomProxyMock = JoinedRoomProxyMock(.init(knockRequestsState: .loaded([KnockRequestProxyMock(.init(eventID: "1", userID: "@alice:matrix.org", displayName: "Alice", reason: "Hello World!")),
                                                                                    // This one should be filtered
                                                                                    KnockRequestProxyMock(.init(eventID: "2", userID: "@bob:matrix.org"))]),
@@ -408,7 +406,6 @@ final class RoomScreenViewModelTests {
     
     @Test
     func loadingKnockRequests() async throws {
-        ServiceLocator.shared.settings.knockingEnabled = true
         let roomProxyMock = JoinedRoomProxyMock(.init(knockRequestsState: .loading,
                                                       joinRule: .knock))
         let viewModel = RoomScreenViewModel(userSession: UserSessionMock(.init()),
@@ -428,7 +425,6 @@ final class RoomScreenViewModelTests {
     
     @Test
     func knockRequestsBannerDoesNotAppearIfUserHasNoPermission() async throws {
-        ServiceLocator.shared.settings.knockingEnabled = true
         let roomProxyMock = JoinedRoomProxyMock(.init(knockRequestsState: .loaded([KnockRequestProxyMock(.init(eventID: "1", userID: "@alice:matrix.org", displayName: "Alice", reason: "Hello World!"))]),
                                                       joinRule: .knock,
                                                       powerLevelsConfiguration: .init(canUserInvite: false)))


### PR DESCRIPTION
fixes #5523

We are essentially allowing to manage knock requests and send knock requests we are just preventing creation of knockable rooms or setting an existing room as a knockable one.