### PR TITLE
Re-enable the AppLock UI tests on iPhone only.

### DIFF
--- a/UITests/Sources/AppLockSetupTests.swift
+++ b/UITests/Sources/AppLockSetupTests.swift
@@ -31,7 +31,10 @@ class AppLockSetupUITests: XCTestCase {
         }
     }
     
-    func disabled_testCreateFlow() async throws {
+    func testCreateFlow() async throws {
+        // There's an issue with the number pad keyboard style on iPad.
+        guard UIDevice.current.userInterfaceIdiom == .phone else { return }
+        
         app = Application.launch(.appLockSetupFlow)
         
         // Wait for the keyboard to push the sheet up before snapshotting
@@ -101,7 +104,10 @@ class AppLockSetupUITests: XCTestCase {
         try await app.assertScreenshot(step: Step.setupBiometrics)
     }
     
-    func disabled_testUnlockFlow() async throws {
+    func testUnlockFlow() async throws {
+        // There's an issue with the number pad keyboard style on iPad.
+        guard UIDevice.current.userInterfaceIdiom == .phone else { return }
+        
         app = Application.launch(.appLockSetupFlowUnlock)
         
         // Create PIN screen.
@@ -119,7 +125,10 @@ class AppLockSetupUITests: XCTestCase {
         try await app.assertScreenshot(step: Step.clearedStack)
     }
     
-    func disabled_testCancel() async throws {
+    func testCancel() async throws {
+        // There's an issue with the number pad keyboard style on iPad.
+        guard UIDevice.current.userInterfaceIdiom == .phone else { return }
+        
         app = Application.launch(.appLockSetupFlowUnlock)
         
         app.showKeyboardIfNeeded() // The secure text field is focussed automatically


### PR DESCRIPTION
These were disabled in #5502 but as I understand it, it was only iPad that had an issue, so let's keep running them on iPhone.

Test run here: https://github.com/element-hq/element-x-ios/actions/runs/25217436220