### PR TITLE
Avoid force-unwrap of scene.keyWindow in WindowManager.configure.

### DIFF
--- a/ElementX/Sources/Application/Windowing/WindowManager.swift
+++ b/ElementX/Sources/Application/Windowing/WindowManager.swift
@@ -70,7 +70,9 @@ class WindowManager: SecureWindowManagerProtocol {
             scene.resizeWindowOnMac(to: previousSize)
         }
         
-        mainWindow = scene.keyWindow
+        // `keyWindow` can be nil on iOS 26 until the scene becomes active, but the
+        // SwiftUI WindowGroup's window is already attached to the scene by then.
+        mainWindow = scene.keyWindow ?? scene.windows.first
         mainWindow.tintColor = .compound.textActionPrimary
         
         overlayWindow = PassthroughWindow(windowScene: scene)


### PR DESCRIPTION
### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog) — please apply `pr-bugfix` (external contributors can't add labels).

### What

`WindowManager.configure(withScene:session:)` force-unwraps `mainWindow` immediately after assigning it from `scene.keyWindow`. `UIWindowScene.keyWindow` is typed `UIWindow?` (nullable since iOS 15), so the API contract allows it to be nil. The implicit force-unwrap depends on a non-API guarantee that it will be non-nil at this point in the scene lifecycle. When that doesn't hold, the next line crashes with `EXC_BREAKPOINT`.

### Fix

Fall back to `scene.windows.first` when `keyWindow` is nil. The SwiftUI `WindowGroup`'s window is already attached to the scene at this point, so it's a safe substitute.

```swift
mainWindow = scene.keyWindow ?? scene.windows.first
```

### Confirming the crash in Sentry

Element's Sentry (`sentry.tools.element.io`) is internal so I can't link the issue directly, but the signature is very recognisable:

- **Type:** `EXC_BREAKPOINT (SIGTRAP)` — Swift trap from force-unwrapping `nil`
- **Crashing frame:** `WindowManager.configure(withScene:session:)`, on the line `mainWindow.tintColor = .compound.textActionPrimary` (immediately after `mainWindow = scene.keyWindow`)
- **iOS:** 26.0+
- **App state:** cold launch / first scene connection — `scene(_:willConnectTo:)`

Searching Sentry for `WindowManager.configure` filtered to iOS 26+ should surface any reports. The change is strictly defensive: the type signature allows nil and the existing implicit force-unwrap depends on a non-API guarantee.

### Why the fallback is safe

- `keyWindow` is the only place in the upstream codebase that reads it for assignment; the only other `keyWindow` access (line 63 of the same method) already uses optional chaining.
- At the moment of assignment, `WindowManager` has not yet created `overlayWindow` / `globalSearchWindow` / `alternateWindow`, so `scene.windows` contains exactly the SwiftUI `WindowGroup`'s auto-created window — the same window that `keyWindow` would point to once the scene becomes active.
- Pre-iOS-26 behaviour is byte-for-byte unchanged because `keyWindow` is non-nil there and `??` short-circuits.

**UI changes have been tested with:**
(No UI changes — windowing setup only.)
