### PR TITLE
Move verification request acceptance confirmation to method call response instead of delegate callback

### DIFF
--- a/ElementX/Sources/Screens/Onboarding/SessionVerificationScreen/SessionVerificationScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Onboarding/SessionVerificationScreen/SessionVerificationScreenViewModel.swift
@@ -166,7 +166,8 @@ class SessionVerificationScreenViewModel: SessionVerificationViewModelType, Sess
             
             switch await sessionVerificationControllerProxy.acceptVerificationRequest() {
             case .success:
-                stateMachine.processEvent(.didAcceptVerificationRequest)
+                // Need to wait for the callback from the remote
+                break
             case .failure:
                 stateMachine.processEvent(.didFail)
             }

--- a/ElementX/Sources/Services/SessionVerification/SessionVerificationControllerProxy.swift
+++ b/ElementX/Sources/Services/SessionVerification/SessionVerificationControllerProxy.swift
@@ -85,6 +85,10 @@ class SessionVerificationControllerProxy: SessionVerificationControllerProxyProt
         
         do {
             try await sessionVerificationController.acceptVerificationRequest()
+            
+            MXLog.info("Accepted verification request")
+            actions.send(.acceptedVerificationRequest)
+            
             return .success(())
         } catch {
             MXLog.error("Failed requesting session verification with error: \(error)")
@@ -179,9 +183,10 @@ class SessionVerificationControllerProxy: SessionVerificationControllerProxyProt
     }
     
     fileprivate func didAcceptVerificationRequest() {
-        MXLog.info("Accepted verification request")
-        
-        actions.send(.acceptedVerificationRequest)
+        // Noop because the rust side state machine changes states before sending
+        // the actual request, leading to race conditions with the SAS verification
+        // startup. The `acceptedVerificationRequest` is now called from the `startSasVerification`
+        // method above.
     }
     
     fileprivate func didStartSasVerification() {


### PR DESCRIPTION
This because the Rust side verification state machine doesn't wait for the request to be sent and acknowledged before changing its inner state and with the automatic starting of SAS in https://github.com/element-hq/element-x-ios/pull/5116 that creates race conditions between `m.key.verification.ready` and `m.key.verification.start`.
