### PR TITLE
Use onScrollGeometryChange to hide the scrollable media caption fade.

### DIFF
--- a/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewController.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewController.swift
@@ -333,21 +333,21 @@ private struct CaptionScrollView: View {
     @State private var shouldShowFade = false
     
     var body: some View {
-        ZStack(alignment: .bottom) {
-            ScrollView(.vertical) {
-                captionContent
-                    .background {
-                        GeometryReader { geometry in
-                            DispatchQueue.main.async {
-                                shouldShowFade = geometry.size.height > maxHeight
-                            }
-                            return Color.clear
-                        }
-                    }
+        ScrollView(.vertical) {
+            captionContent
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(16)
+        }
+        .onScrollGeometryChange(for: Bool.self) { geometry in
+            geometry.contentOffset.y >= geometry.contentSize.height - geometry.containerSize.height - geometry.contentInsets.bottom
+        } action: { _, isBottomVisible in
+            if shouldShowFade == isBottomVisible {
+                withAnimation(.elementDefault) { shouldShowFade = !isBottomVisible }
             }
-            .frame(maxHeight: maxHeight)
-            .padding(16)
-            
+        }
+        .scrollBounceBehavior(.basedOnSize)
+        .frame(maxHeight: maxHeight)
+        .overlay(alignment: .bottom) {
             if shouldShowFade {
                 LinearGradient(stops: [.init(color: .clear, location: 0.0),
                                        .init(color: .black.opacity(0.5), location: 1.0)],
@@ -356,7 +356,6 @@ private struct CaptionScrollView: View {
                     .frame(height: 40)
             }
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
         .background {
             BlurEffectView(style: .systemChromeMaterial)
                 .ignoresSafeArea()


### PR DESCRIPTION
Small follow-up to #5384 that fixes a hang on macOS (presumably caused by the `GeometryReader`) when opening an image with a caption. This also aligns more closely with the Android implementation so that the fade is hidden when the bottom of the scroll view is visible.

I also tweaked the layout a bit so that the scrollbar is shown on the edge of the screen instead of being inset by the padding.

https://github.com/user-attachments/assets/dbbe0abf-a3d1-4ab9-b05d-d4edfd6063f8

