### PR TITLE
call: Only group voice/video call if threads developer option is on

### DIFF
--- a/ElementX/Sources/Other/AccessibilityIdentifiers.swift
+++ b/ElementX/Sources/Other/AccessibilityIdentifiers.swift
@@ -159,6 +159,9 @@ enum A11yIdentifiers {
         let joinCall = "room-join_call"
         let scrollToBottom = "room-scroll_to_bottom"
         
+        let startVoiceCall = "room-start_voice_call"
+        let startVideoCall = "room-start_video_call"
+        
         let messageComposer = "room-message_composer"
         let sendButton = "room-send_button"
 

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomCallControlsToolbar.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomCallControlsToolbar.swift
@@ -23,24 +23,45 @@ struct RoomCallControlsToolbar: ToolbarContent {
             }
         } else {
             if viewState.isDirectOneToOneRoom {
-                ToolbarItem(placement: .primaryAction) {
-                    Menu {
-                        Button {
-                            onCallTap(true)
+                if viewState.roomThreadListEnabled {
+                    // If the developer mode room thread list option is enabled there
+                    // is not enough place for 2 calls buttons
+                    ToolbarItem(placement: .primaryAction) {
+                        Menu {
+                            Button {
+                                onCallTap(true)
+                            } label: {
+                                Label(L10n.a11yStartVoiceCall, icon: \.voiceCallSolid)
+                            }
+                                
+                            Button {
+                                onCallTap(false)
+                            } label: {
+                                Label(L10n.a11yStartVideoCall, icon: \.videoCallSolid)
+                            }
                         } label: {
-                            Label(L10n.a11yStartVoiceCall, icon: \.voiceCallSolid)
+                            CompoundIcon(\.voiceCallSolid)
                         }
-                        
-                        Button {
-                            onCallTap(false)
-                        } label: {
-                            Label(L10n.a11yStartVideoCall, icon: \.videoCallSolid)
-                        }
-                    } label: {
-                        CompoundIcon(\.voiceCallSolid)
+                        .accessibilityLabel(L10n.a11yStartCall)
+                        .disabled(!viewState.canJoinCall)
                     }
-                    .accessibilityLabel(L10n.a11yStartCall)
-                    .disabled(!viewState.canJoinCall)
+                } else {
+                    ToolbarItem(placement: .primaryAction) {
+                        Button { onCallTap(true) } label: {
+                            CompoundIcon(\.voiceCallSolid)
+                        }
+                        .accessibilityLabel(L10n.a11yStartVoiceCall)
+                        .accessibilityIdentifier(A11yIdentifiers.roomScreen.startVoiceCall)
+                        .disabled(!viewState.canJoinCall)
+                    }
+                    ToolbarItem(placement: .primaryAction) {
+                        Button { onCallTap(false) } label: {
+                            CompoundIcon(\.videoCallSolid)
+                        }
+                        .accessibilityLabel(L10n.a11yStartVideoCall)
+                        .accessibilityIdentifier(A11yIdentifiers.roomScreen.startVideoCall)
+                        .disabled(!viewState.canJoinCall)
+                    }
                 }
             } else {
                 ToolbarItem(placement: .primaryAction) {
@@ -66,6 +87,10 @@ struct RoomCallControlsToolbar_Previews: PreviewProvider {
             ElementNavigationStack {
                 Color.clear.toolbar { RoomCallControlsToolbar(viewState: .mock(hasOngoingCall: false, isDirectOneToOneRoom: true)) { _ in } }
             }
+            
+            ElementNavigationStack {
+                Color.clear.toolbar { RoomCallControlsToolbar(viewState: .mock(hasOngoingCall: false, isDirectOneToOneRoom: true, roomThreadListEnabled: true)) { _ in } }
+            }
             ElementNavigationStack {
                 Color.clear.toolbar { RoomCallControlsToolbar(viewState: .mock(hasOngoingCall: false)) { _ in } }
             }
@@ -81,12 +106,13 @@ struct RoomCallControlsToolbar_Previews: PreviewProvider {
 }
 
 private extension RoomScreenViewState {
-    static func mock(hasOngoingCall: Bool, isDirectOneToOneRoom: Bool = false, canJoinCall: Bool = true, activeRoomCallIntent: CallIntent? = nil) -> RoomScreenViewState {
+    static func mock(hasOngoingCall: Bool, isDirectOneToOneRoom: Bool = false, canJoinCall: Bool = true, activeRoomCallIntent: CallIntent? = nil, roomThreadListEnabled: Bool = false) -> RoomScreenViewState {
         RoomScreenViewState(roomAvatar: .room(id: "mock", name: "Mock Room", avatarURL: nil),
                             canJoinCall: canJoinCall,
                             hasOngoingCall: hasOngoingCall,
                             activeRoomCallIntent: activeRoomCallIntent,
                             isDirectOneToOneRoom: isDirectOneToOneRoom,
+                            roomThreadListEnabled: roomThreadListEnabled,
                             hasSuccessor: false)
     }
 }


### PR DESCRIPTION
### Pull Request Checklist

Amend https://github.com/element-hq/element-x-ios/pull/5473 that has removed the voice shortcut to make place for another header button that is only present in a rare case of lab + developer option.

Now if the developer option is not available we keep two buttons.

**Default**
<img width="454" height="134" alt="image" src="https://github.com/user-attachments/assets/18ce8ec5-b3b2-46e8-8ef6-b8b17b3da7d6" />

**With dev option** 

<img width="400" height="119" alt="image" src="https://github.com/user-attachments/assets/60e7e1bb-1489-4fa7-9ba2-b071e36159f8" />
<img width="423" height="151" alt="image" src="https://github.com/user-attachments/assets/4b844d0f-8ec7-410b-bcfb-bb2c8d93ae95" />


(dev option)
<img width="419" height="222" alt="image" src="https://github.com/user-attachments/assets/82707a54-683c-4d23-a3e3-6cc03e316191" />


@amshakal I believe this adress your comment here https://github.com/element-hq/element-x-ios/pull/5473#issuecomment-4303729177

- [ ] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
