### PR TITLE
Add editorconfig to enforce style guides naturally in the editor

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.swift]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = false


### PR DESCRIPTION
Adds an `.editorconfig` file to enforce the project's existing code style preferences in editors that support it. No Xcode preference changes are required -- the file simply overrides settings per-project.

For all files:
- Line endings: LF
- Insert final newline

For Swift files:
- Space indentation, 4 spaces
- Trailing whitespace trimming disabled (preserves indentation on whitespace-only lines, per project convention)


### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
