### PR TITLE
Fix an accessibility test failure.

### DIFF
--- a/ElementX/Sources/Screens/Authentication/StartScreen/View/AuthenticationClassicAppAccountView.swift
+++ b/ElementX/Sources/Screens/Authentication/StartScreen/View/AuthenticationClassicAppAccountView.swift
@@ -60,6 +60,7 @@ struct AuthenticationClassicAppAccountView: View {
                                 contentID: classicAppAccount.userID,
                                 avatarSize: .user(on: .classicAppAccount),
                                 mediaProvider: context.mediaProvider)
+                .accessibilityHidden(true)
             
             VStack(spacing: 0) {
                 Text(L10n.screenOnboardingWelcomeBack)


### PR DESCRIPTION
The test was failing due to the avatar not having a label. I've hidden it as it isn't interactive anyway.