### PR TITLE
Use isDM from the SDK

### DIFF
--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -13318,6 +13318,11 @@ class NotificationItemProxyMock: NotificationItemProxyProtocol, @unchecked Senda
         set(value) { underlyingIsRoomPrivate = value }
     }
     var underlyingIsRoomPrivate: Bool!
+    var isDM: Bool {
+        get { return underlyingIsDM }
+        set(value) { underlyingIsDM = value }
+    }
+    var underlyingIsDM: Bool!
     var isNoisy: Bool {
         get { return underlyingIsNoisy }
         set(value) { underlyingIsNoisy = value }
@@ -15284,6 +15289,11 @@ class RoomInfoProxyMock: RoomInfoProxyProtocol, @unchecked Sendable {
         set(value) { underlyingIsDirect = value }
     }
     var underlyingIsDirect: Bool!
+    var isDM: Bool {
+        get { return underlyingIsDM }
+        set(value) { underlyingIsDM = value }
+    }
+    var underlyingIsDM: Bool!
     var isSpace: Bool {
         get { return underlyingIsSpace }
         set(value) { underlyingIsSpace = value }
@@ -15404,6 +15414,11 @@ class RoomMemberProxyMock: RoomMemberProxyProtocol, @unchecked Sendable {
         set(value) { underlyingPowerLevel = value }
     }
     var underlyingPowerLevel: RoomPowerLevel!
+    var isServiceMember: Bool {
+        get { return underlyingIsServiceMember }
+        set(value) { underlyingIsServiceMember = value }
+    }
+    var underlyingIsServiceMember: Bool!
 
 }
 class RoomMembershipDetailsProxyMock: RoomMembershipDetailsProxyProtocol, @unchecked Sendable {

--- a/ElementX/Sources/Mocks/InvitedRoomProxyMock.swift
+++ b/ElementX/Sources/Mocks/InvitedRoomProxyMock.swift
@@ -85,6 +85,6 @@ private extension RoomMember {
                   isIgnored: proxy.isIgnored,
                   suggestedRoleForPowerLevel: proxy.role.rustRole,
                   membershipChangeReason: proxy.membershipChangeReason,
-                  isServiceMember: false)
+                  isServiceMember: proxy.isServiceMember)
     }
 }

--- a/ElementX/Sources/Mocks/JoinedRoomProxyMock.swift
+++ b/ElementX/Sources/Mocks/JoinedRoomProxyMock.swift
@@ -182,6 +182,7 @@ extension RoomInfoProxyMock {
         activeMembersCount = configuration.members.filter { $0.membership == .join || $0.membership == .invite }.count
         invitedMembersCount = configuration.members.filter { $0.membership == .invite }.count
         joinedMembersCount = configuration.members.filter { $0.membership == .join }.count
+        isDM = isDirect && activeMembersCount <= 2
         highlightCount = 0
         notificationCount = 0
         cachedUserDefinedNotificationMode = .allMessages

--- a/ElementX/Sources/Mocks/NotificationItemProxyMock.swift
+++ b/ElementX/Sources/Mocks/NotificationItemProxyMock.swift
@@ -52,5 +52,6 @@ extension NotificationItemProxyMock {
         underlyingIsNoisy = configuration.isNoisy
         underlyingHasMention = configuration.hasMention
         threadRootEventID = configuration.threadRootEventID
+        underlyingIsDM = configuration.isRoomDirect && configuration.roomJoinedMembers <= 2
     }
 }

--- a/ElementX/Sources/Mocks/SDK/LeaveSpaceHandleSDKMock.swift
+++ b/ElementX/Sources/Mocks/SDK/LeaveSpaceHandleSDKMock.swift
@@ -151,7 +151,8 @@ private extension SpaceRoom {
          childrenCount: UInt64 = 0,
          membership: Membership? = .joined,
          heroes: [RoomHero]? = [],
-         via: [String] = []) {
+         via: [String] = [],
+         isDM: Bool? = false) {
         self.init(roomId: id,
                   canonicalAlias: canonicalAlias,
                   displayName: name,
@@ -168,6 +169,6 @@ private extension SpaceRoom {
                   state: membership,
                   heroes: heroes,
                   via: via,
-                  isDm: false)
+                  isDm: isDM)
     }
 }

--- a/ElementX/Sources/Other/Extensions/ClientBuilder.swift
+++ b/ElementX/Sources/Other/Extensions/ClientBuilder.swift
@@ -29,6 +29,7 @@ extension ClientBuilder {
                                          timeout: requestTimeout,
                                          maxConcurrentRequests: nil,
                                          maxRetryTime: maxRequestRetryTime))
+            .dmRoomDefinition(dmRoomDefinition: .twoMembers)
         
         builder = switch slidingSync {
         case .restored: builder

--- a/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewViewModel.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewViewModel.swift
@@ -156,7 +156,7 @@ class TimelineMediaPreviewViewModel: TimelineMediaPreviewViewModelType {
                                            canCurrentUserRedactOthers: timelineContext.viewState.canCurrentUserRedactOthers,
                                            canCurrentUserPin: timelineContext.viewState.canCurrentUserPin,
                                            pinnedEventIDs: timelineContext.viewState.pinnedEventIDs,
-                                           isDM: timelineContext.viewState.isDirectOneToOneRoom,
+                                           isDM: timelineContext.viewState.isDM,
                                            isViewSourceEnabled: timelineContext.viewState.isViewSourceEnabled,
                                            areThreadsEnabled: timelineContext.viewState.areThreadsEnabled,
                                            timelineKind: timelineContext.viewState.timelineKind,

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -404,12 +404,12 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
             
             guard roomProxy.infoPublisher.value.joinedMembersCount > 1 else {
                 state.bindings.leaveRoomAlertItem = LeaveRoomAlertItem(roomID: roomID,
-                                                                       isDM: roomProxy.isDirectOneToOneRoom,
+                                                                       isDM: roomProxy.infoPublisher.value.isDM,
                                                                        state: roomProxy.infoPublisher.value.isPrivate ?? true ? .empty : .public)
                 return
             }
             
-            if !roomProxy.isDirectOneToOneRoom {
+            if !roomProxy.infoPublisher.value.isDM {
                 if case let .success(ownMember) = await roomProxy.getMember(userID: roomProxy.ownUserID),
                    ownMember.role.isOwner {
                     await roomProxy.updateMembers()
@@ -434,7 +434,7 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
                 }
             }
             
-            state.bindings.leaveRoomAlertItem = LeaveRoomAlertItem(roomID: roomID, isDM: roomProxy.isDirectOneToOneRoom, state: roomProxy.infoPublisher.value.isPrivate ?? true ? .private : .public)
+            state.bindings.leaveRoomAlertItem = LeaveRoomAlertItem(roomID: roomID, isDM: roomProxy.infoPublisher.value.isDM, state: roomProxy.infoPublisher.value.isPrivate ?? true ? .private : .public)
         }
     }
     

--- a/ElementX/Sources/Screens/JoinRoomScreen/JoinRoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/JoinRoomScreen/JoinRoomScreenViewModel.swift
@@ -228,7 +228,7 @@ class JoinRoomScreenViewModel: JoinRoomScreenViewModelType, JoinRoomScreenViewMo
         if case .space(let spaceServiceRoom) = source {
             switch spaceServiceRoom.state {
             case .invited:
-                state.mode = .invited(isDM: spaceServiceRoom.isDirect == true && spaceServiceRoom.joinedMembersCount == 1)
+                state.mode = .invited(isDM: spaceServiceRoom.isDM == true)
             case .knocked:
                 state.mode = .knocked
             case .banned:

--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
@@ -172,12 +172,12 @@ class RoomDetailsScreenViewModel: RoomDetailsScreenViewModelType, RoomDetailsScr
         
         guard state.joinedMembersCount > 1 else {
             state.bindings.leaveRoomAlertItem = LeaveRoomAlertItem(roomID: roomProxy.id,
-                                                                   isDM: roomProxy.isDirectOneToOneRoom,
+                                                                   isDM: roomProxy.infoPublisher.value.isDM,
                                                                    state: roomProxy.infoPublisher.value.isPrivate ?? true ? .empty : .public)
             return
         }
         
-        if !roomProxy.isDirectOneToOneRoom, state.accountOwner?.role.isOwner == true {
+        if !roomProxy.infoPublisher.value.isDM, state.accountOwner?.role.isOwner == true {
             var isLastOwner = true
             for member in roomProxy.membersPublisher.value where member.userID != roomProxy.ownUserID && member.membership == .join {
                 if member.role.isOwner {
@@ -199,7 +199,7 @@ class RoomDetailsScreenViewModel: RoomDetailsScreenViewModelType, RoomDetailsScr
         }
         
         state.bindings.leaveRoomAlertItem = LeaveRoomAlertItem(roomID: roomProxy.id,
-                                                               isDM: roomProxy.isDirectOneToOneRoom,
+                                                               isDM: roomProxy.infoPublisher.value.isDM,
                                                                state: roomProxy.infoPublisher.value.isPrivate ?? true ? .private : .public)
     }
     
@@ -307,7 +307,7 @@ class RoomDetailsScreenViewModel: RoomDetailsScreenViewModelType, RoomDetailsScr
                     self.state.accountOwner = .init(withProxy: accountOwner)
                 }
                 
-                guard roomProxy.isDirectOneToOneRoom else {
+                guard roomProxy.infoPublisher.value.isDM else {
                     return
                 }
                 
@@ -328,7 +328,7 @@ class RoomDetailsScreenViewModel: RoomDetailsScreenViewModelType, RoomDetailsScr
             return
         }
         
-        if roomProxy.isDirectOneToOneRoom {
+        if roomProxy.infoPublisher.value.isDM {
             if var dmRecipientInfo = state.dmRecipientInfo {
                 if case let .success(userIdentity) = await userSession.clientProxy.userIdentity(for: dmRecipientInfo.member.id, fallBackToServer: true) {
                     dmRecipientInfo.verificationState = userIdentity?.verificationState

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/CompletionSuggestionService.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/CompletionSuggestionService.swift
@@ -91,7 +91,7 @@ final class CompletionSuggestionService: CompletionSuggestionServiceProtocol {
             }
         
         if canMentionAllUsers,
-           !roomProxy.isDirectOneToOneRoom,
+           !roomProxy.infoPublisher.value.isDM,
            Self.shouldIncludeMember(userID: PillUtilities.atRoom, displayName: PillUtilities.everyone, searchText: suggestionTrigger.text) {
             membersSuggestion
                 .insert(SuggestionItem(suggestionType: .allUsers(roomProxy.details.avatar), range: suggestionTrigger.range, rawSuggestionText: suggestionTrigger.text), at: 0)

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
@@ -70,7 +70,7 @@ struct RoomScreenViewState: BindableState {
     }
     
     /// Whether the current room is a DM
-    var isDirectOneToOneRoom: Bool
+    var isDM: Bool
     
     var roomThreadListEnabled = false
     var isKnockableRoom = false

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -70,7 +70,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
         let viewState = RoomScreenViewState(roomTitle: roomProxy.infoPublisher.value.displayName ?? roomProxy.id,
                                             roomAvatar: roomProxy.infoPublisher.value.avatar,
                                             hasOngoingCall: roomProxy.infoPublisher.value.hasRoomCall,
-                                            isDirectOneToOneRoom: roomProxy.isDirectOneToOneRoom,
+                                            isDM: roomProxy.infoPublisher.value.isDM,
                                             hasSuccessor: roomProxy.infoPublisher.value.successor != nil,
                                             roomHistorySharingState: roomProxy.infoPublisher.value.historySharingState)
         super.init(initialViewState: appHooks.roomScreenHook.update(viewState),
@@ -271,7 +271,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
     }
     
     private func updateVerificationBadge() async {
-        guard roomProxy.isDirectOneToOneRoom,
+        guard roomProxy.infoPublisher.value.isDM,
               let dmRecipient = roomProxy.membersPublisher.value.first(where: { $0.userID != roomProxy.ownUserID }),
               case let .success(userIdentity) = await clientProxy.userIdentity(for: dmRecipient.userID, fallBackToServer: true) else {
             state.dmRecipientVerificationState = .notVerified
@@ -338,6 +338,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
         state.hasOngoingCall = roomInfo.hasRoomCall
         state.activeRoomCallIntent = roomInfo.activeRoomCallIntent
         state.hasSuccessor = roomInfo.successor != nil
+        state.isDM = roomInfo.isDM
         
         let pinnedEventIDs = roomInfo.pinnedEventIDs
         // Only update the loading state of the banner
@@ -345,7 +346,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
             state.pinnedEventsBannerState = .loading(numbersOfEvents: pinnedEventIDs.count)
         }
         
-        switch (roomProxy.isDirectOneToOneRoom, roomInfo.joinRule) {
+        switch (roomInfo.isDM, roomInfo.joinRule) {
         case (false, .knock), (false, .knockRestricted):
             state.isKnockableRoom = true
         default:

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomCallControlsToolbar.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomCallControlsToolbar.swift
@@ -22,7 +22,7 @@ struct RoomCallControlsToolbar: ToolbarContent {
                 .disabled(!viewState.canJoinCall)
             }
         } else {
-            if viewState.isDirectOneToOneRoom {
+            if viewState.isDM {
                 if viewState.roomThreadListEnabled {
                     // If the developer mode room thread list option is enabled there
                     // is not enough place for 2 calls buttons
@@ -85,11 +85,11 @@ struct RoomCallControlsToolbar_Previews: PreviewProvider {
                 Color.clear.toolbar { RoomCallControlsToolbar(viewState: .mock(hasOngoingCall: true)) { _ in } }
             }
             ElementNavigationStack {
-                Color.clear.toolbar { RoomCallControlsToolbar(viewState: .mock(hasOngoingCall: false, isDirectOneToOneRoom: true)) { _ in } }
+                Color.clear.toolbar { RoomCallControlsToolbar(viewState: .mock(hasOngoingCall: false, isDM: true)) { _ in } }
             }
             
             ElementNavigationStack {
-                Color.clear.toolbar { RoomCallControlsToolbar(viewState: .mock(hasOngoingCall: false, isDirectOneToOneRoom: true, roomThreadListEnabled: true)) { _ in } }
+                Color.clear.toolbar { RoomCallControlsToolbar(viewState: .mock(hasOngoingCall: false, isDM: true, roomThreadListEnabled: true)) { _ in } }
             }
             ElementNavigationStack {
                 Color.clear.toolbar { RoomCallControlsToolbar(viewState: .mock(hasOngoingCall: false)) { _ in } }
@@ -106,12 +106,12 @@ struct RoomCallControlsToolbar_Previews: PreviewProvider {
 }
 
 private extension RoomScreenViewState {
-    static func mock(hasOngoingCall: Bool, isDirectOneToOneRoom: Bool = false, canJoinCall: Bool = true, activeRoomCallIntent: CallIntent? = nil, roomThreadListEnabled: Bool = false) -> RoomScreenViewState {
+    static func mock(hasOngoingCall: Bool, isDM: Bool = false, canJoinCall: Bool = true, activeRoomCallIntent: CallIntent? = nil, roomThreadListEnabled: Bool = false) -> RoomScreenViewState {
         RoomScreenViewState(roomAvatar: .room(id: "mock", name: "Mock Room", avatarURL: nil),
                             canJoinCall: canJoinCall,
                             hasOngoingCall: hasOngoingCall,
                             activeRoomCallIntent: activeRoomCallIntent,
-                            isDirectOneToOneRoom: isDirectOneToOneRoom,
+                            isDM: isDM,
                             roomThreadListEnabled: roomThreadListEnabled,
                             hasSuccessor: false)
     }

--- a/ElementX/Sources/Screens/ThreadTimelineScreen/ThreadTimelineScreenViewModel.swift
+++ b/ElementX/Sources/Screens/ThreadTimelineScreen/ThreadTimelineScreenViewModel.swift
@@ -84,7 +84,7 @@ class ThreadTimelineScreenViewModel: ThreadTimelineScreenViewModelType, ThreadTi
     // MARK: - Private
     
     private func updateVerificationBadge() async {
-        guard roomProxy.isDirectOneToOneRoom,
+        guard roomProxy.infoPublisher.value.isDM,
               let dmRecipient = roomProxy.membersPublisher.value.first(where: { $0.userID != roomProxy.ownUserID }),
               case let .success(userIdentity) = await userSession.clientProxy.userIdentity(for: dmRecipient.userID, fallBackToServer: true) else {
             state.dmRecipientVerificationState = .notVerified

--- a/ElementX/Sources/Screens/Timeline/TimelineModels.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineModels.swift
@@ -103,7 +103,7 @@ struct TimelineViewState: BindableState {
     var typingMembers: [String] = []
     var showLoading = false
     var showReadReceipts = false
-    var isDirectOneToOneRoom = false
+    var isDM = false
     var timelineState: TimelineState // check the doc before changing this
 
     var ownUserID: String

--- a/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
@@ -95,7 +95,7 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
         }
         super.init(initialViewState: TimelineViewState(timelineKind: timelineController.timelineKind,
                                                        roomID: roomProxy.id,
-                                                       isDirectOneToOneRoom: roomProxy.isDirectOneToOneRoom,
+                                                       isDM: roomProxy.infoPublisher.value.isDM,
                                                        timelineState: TimelineState(focussedEvent: focussedEventID.map { .init(eventID: $0, appearance: .immediate) }),
                                                        ownUserID: roomProxy.ownUserID,
                                                        hideTimelineMedia: hideTimelineMedia,
@@ -420,6 +420,7 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
     
     private func updateRoomInfo(_ roomInfo: RoomInfoProxyProtocol) {
         state.pinnedEventIDs = roomInfo.pinnedEventIDs
+        state.isDM = roomInfo.isDM
         
         if let powerLevels = roomInfo.powerLevels {
             state.canCurrentUserSendMessage = powerLevels.canOwnUser(sendMessage: .roomMessage)

--- a/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemBubbledStylerView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemBubbledStylerView.swift
@@ -18,8 +18,8 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
     let adjustedDeliveryStatus: TimelineItemDeliveryStatus?
     @ViewBuilder let content: () -> Content
 
-    private var isDirectOneToOneRoom: Bool {
-        context.viewState.isDirectOneToOneRoom
+    private var isDM: Bool {
+        context.viewState.isDM
     }
 
     private var isFocussed: Bool {
@@ -40,14 +40,14 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
     private let bubbleHorizontalPadding: CGFloat = 8
     /// Additional padding applied to outgoing bubbles when the avatar is shown
     private var bubbleAvatarPadding: CGFloat {
-        guard !timelineItem.isOutgoing, !isDirectOneToOneRoom else { return 0 }
+        guard !timelineItem.isOutgoing, !isDM else { return 0 }
         return 8
     }
     
     var body: some View {
         ZStack(alignment: .trailingFirstTextBaseline) {
             VStack(alignment: alignment, spacing: -12) {
-                if !timelineItem.isOutgoing, !isDirectOneToOneRoom {
+                if !timelineItem.isOutgoing, !isDM {
                     header
                         .zIndex(1)
                 }
@@ -164,7 +164,7 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
                                                               canCurrentUserRedactOthers: context.viewState.canCurrentUserRedactOthers,
                                                               canCurrentUserPin: context.viewState.canCurrentUserPin,
                                                               pinnedEventIDs: context.viewState.pinnedEventIDs,
-                                                              isDM: context.viewState.isDirectOneToOneRoom,
+                                                              isDM: context.viewState.isDM,
                                                               isViewSourceEnabled: context.viewState.isViewSourceEnabled,
                                                               areThreadsEnabled: context.viewState.areThreadsEnabled,
                                                               timelineKind: context.viewState.timelineKind,
@@ -218,7 +218,7 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
     }
     
     private var messageBubbleTopPadding: CGFloat {
-        guard timelineItem.isOutgoing || isDirectOneToOneRoom else { return 0 }
+        guard timelineItem.isOutgoing || isDM else { return 0 }
         return timelineGroupStyle == .single || timelineGroupStyle == .first ? 8 : 0
     }
     

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/TimelineStartRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/TimelineStartRoomTimelineView.swift
@@ -19,7 +19,7 @@ struct TimelineStartRoomTimelineView: View {
                 upgradeDialogue
             }
             // We don't display the title for tombstoned DMs
-            if context?.viewState.isDirectOneToOneRoom != true {
+            if context?.viewState.isDM != true {
                 Text(title)
                     .font(.compound.bodySM)
                     .foregroundColor(.compound.textSecondary)

--- a/ElementX/Sources/Screens/Timeline/View/TimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineView.swift
@@ -34,7 +34,7 @@ struct TimelineView: View {
                                                              canCurrentUserRedactOthers: timelineContext.viewState.canCurrentUserRedactOthers,
                                                              canCurrentUserPin: timelineContext.viewState.canCurrentUserPin,
                                                              pinnedEventIDs: timelineContext.viewState.pinnedEventIDs,
-                                                             isDM: timelineContext.viewState.isDirectOneToOneRoom,
+                                                             isDM: timelineContext.viewState.isDM,
                                                              isViewSourceEnabled: timelineContext.viewState.isViewSourceEnabled,
                                                              areThreadsEnabled: timelineContext.viewState.areThreadsEnabled,
                                                              timelineKind: timelineContext.viewState.timelineKind,

--- a/ElementX/Sources/Services/Room/RoomInfoProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomInfoProxy.swift
@@ -49,6 +49,10 @@ struct RoomInfoProxy: RoomInfoProxyProtocol {
     var isDirect: Bool {
         roomInfo.isDirect
     }
+    
+    var isDM: Bool {
+        roomInfo.isDm
+    }
 
     var isSpace: Bool {
         roomInfo.isSpace

--- a/ElementX/Sources/Services/Room/RoomInfoProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomInfoProxyProtocol.swift
@@ -36,6 +36,7 @@ protocol RoomInfoProxyProtocol: BaseRoomInfoProxyProtocol {
 
     var isEncrypted: Bool { get }
     var isDirect: Bool { get }
+    var isDM: Bool { get }
     var isSpace: Bool { get }
     var isFavourite: Bool { get }
     

--- a/ElementX/Sources/Services/Room/RoomMember/RoomMemberProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomMember/RoomMemberProxy.swift
@@ -51,4 +51,8 @@ final class RoomMemberProxy: RoomMemberProxyProtocol {
     var powerLevel: RoomPowerLevel {
         .init(rustPowerLevel: member.powerLevel)
     }
+    
+    var isServiceMember: Bool {
+        member.isServiceMember
+    }
 }

--- a/ElementX/Sources/Services/Room/RoomMember/RoomMemberProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomMember/RoomMemberProxyProtocol.swift
@@ -25,6 +25,8 @@ protocol RoomMemberProxyProtocol: AnyObject {
     var isIgnored: Bool { get }
     
     var powerLevel: RoomPowerLevel { get }
+    
+    var isServiceMember: Bool { get }
 }
 
 extension RoomMemberProxyProtocol {

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -222,10 +222,6 @@ extension JoinedRoomProxyProtocol {
                            isDirect: infoPublisher.value.isDirect,
                            historySharingState: historySharingState)
     }
-    
-    var isDirectOneToOneRoom: Bool {
-        infoPublisher.value.isDirect && infoPublisher.value.activeMembersCount <= 2
-    }
 
     func members() async -> [RoomMemberProxyProtocol]? {
         await updateMembers()

--- a/ElementX/Sources/Services/Spaces/SpaceServiceRoom.swift
+++ b/ElementX/Sources/Services/Spaces/SpaceServiceRoom.swift
@@ -24,6 +24,7 @@ struct SpaceServiceRoom {
     
     var isSpace: Bool
     var isDirect: Bool?
+    var isDM: Bool?
     var childrenCount: Int
     
     var joinedMembersCount: Int
@@ -70,6 +71,7 @@ extension SpaceServiceRoom {
         
         isSpace = spaceRoom.roomType == .space
         isDirect = spaceRoom.isDirect
+        isDM = spaceRoom.isDm
         childrenCount = Int(spaceRoom.childrenCount)
         
         joinedMembersCount = Int(spaceRoom.numJoinedMembers)
@@ -92,6 +94,7 @@ extension SpaceServiceRoom {
                      avatarURL: URL? = nil,
                      isSpace: Bool,
                      isDirect: Bool? = nil,
+                     isDM: Bool? = nil,
                      childrenCount: Int = 0,
                      joinedMembersCount: Int = 0,
                      heroes: [UserProfileProxy] = [],
@@ -108,6 +111,7 @@ extension SpaceServiceRoom {
                          avatarURL: avatarURL,
                          isSpace: isSpace,
                          isDirect: isDirect,
+                         isDM: isDM,
                          childrenCount: childrenCount,
                          joinedMembersCount: joinedMembersCount,
                          heroes: heroes,

--- a/ElementX/Sources/Services/Timeline/TimelineController/TimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/TimelineController.swift
@@ -419,7 +419,7 @@ class TimelineController: TimelineControllerProtocol {
         let isNewTimeline = isSwitchingTimelines
         isSwitchingTimelines = false
         
-        let isDM = roomProxy.isDirectOneToOneRoom
+        let isDM = roomProxy.infoPublisher.value.isDM
         let displayName = roomProxy.infoPublisher.value.displayName
         let hasPredecessor = roomProxy.predecessorRoom != nil
         

--- a/NSE/Sources/NotificationItemProxy/NotificationItemProxy.swift
+++ b/NSE/Sources/NotificationItemProxy/NotificationItemProxy.swift
@@ -45,6 +45,10 @@ struct NotificationItemProxy: NotificationItemProxyProtocol {
         notificationItem.roomInfo.isDirect
     }
     
+    var isDM: Bool {
+        notificationItem.roomInfo.isDm
+    }
+    
     var isRoomPrivate: Bool {
         switch notificationItem.roomInfo.joinRule {
         case .invite, .knock, .restricted, .knockRestricted:
@@ -119,6 +123,10 @@ struct EmptyNotificationItemProxy: NotificationItemProxyProtocol {
     }
     
     var isRoomDirect: Bool {
+        false
+    }
+    
+    var isDM: Bool {
         false
     }
     

--- a/NSE/Sources/NotificationItemProxy/NotificationItemProxyProtocol.swift
+++ b/NSE/Sources/NotificationItemProxy/NotificationItemProxyProtocol.swift
@@ -35,16 +35,12 @@ protocol NotificationItemProxyProtocol {
     var isRoomDirect: Bool { get }
     
     var isRoomPrivate: Bool { get }
+    
+    var isDM: Bool { get }
 
     var isNoisy: Bool { get }
 
     var hasMention: Bool { get }
     
     var threadRootEventID: String? { get }
-}
-
-extension NotificationItemProxyProtocol {
-    var isDM: Bool {
-        isRoomDirect && roomJoinedMembers <= 2
-    }
 }


### PR DESCRIPTION
This changes the way the JoinedRoom, the SpaceService room and the NotificationItem determine if a room is a DM, by using the isDM check directly from the SDK instead of determine it client side.

This also includes using the dm specification in the client builder (otherwise it defaults to the matrix spec which considers a dm any simple direct room instead for also checking the number of active non service members).

I also added an isServiceMember var to the RoomMemberProxy but as of right now it's not used anywhere, but might be useful in the future.

fixes #5538 
fixes #5551 