### PR TITLE
Fix avatar not updating on existing timeline messages

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -448,6 +448,7 @@
 		4BBF6C8E3EFC944B55231B19 /* AppMediatorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05AF58372CA884A789EB9C5A /* AppMediatorProtocol.swift */; };
 		4BD5AB54A6982CF19F5CC7C4 /* ChatsTabFlowCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0328F54E0C3AAEDDF3E05D9D /* ChatsTabFlowCoordinatorTests.swift */; };
 		4C356F5CCB4CDC99BFA45185 /* AppLockSetupPINScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7884BD256C091EB511B2EDF /* AppLockSetupPINScreenViewModelProtocol.swift */; };
+		4C56BC82B0272C4BA97F28DF /* TimelineItemProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B7B9E70029438A765275F7F /* TimelineItemProviderTests.swift */; };
 		4C5A638DAA8AF64565BA4866 /* EncryptedRoomTimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5351EBD7A0B9610548E4B7B2 /* EncryptedRoomTimelineItem.swift */; };
 		4C8C0C9FC10BA73AB7780534 /* RoomListFiltersStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE0C9653870803E4F91F474 /* RoomListFiltersStateTests.swift */; };
 		4CB30D9BD72CA3FEEFAA0793 /* NSEUserSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C9651CD1066F239C7739240 /* NSEUserSession.swift */; };
@@ -2488,6 +2489,7 @@
 		9B6572E6EF5D5F4B0C338A40 /* PinnedEventsTimelineScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedEventsTimelineScreenModels.swift; sourceTree = "<group>"; };
 		9B663BE498BB39EADC24025D /* SettingsScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScreenModels.swift; sourceTree = "<group>"; };
 		9B67DF223EEB8DCAF178A1D4 /* AnalyticsPromptScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsPromptScreenCoordinator.swift; sourceTree = "<group>"; };
+		9B7B9E70029438A765275F7F /* TimelineItemProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineItemProviderTests.swift; sourceTree = "<group>"; };
 		9B7D8D3638864B7482E148CC /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		9C5E81214D27A6B898FC397D /* ElementX.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ElementX.entitlements; sourceTree = "<group>"; };
 		9C6624240FFD32B7F0834229 /* IdentityConfirmedScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityConfirmedScreenViewModel.swift; sourceTree = "<group>"; };
@@ -4990,6 +4992,7 @@
 				6DF438EAFC732D2D95D34BF6 /* StartChatViewModelTests.swift */,
 				2CEBCB9676FCD1D0F13188DD /* StringTests.swift */,
 				9AA3AF94A06D319BB37E52DA /* TimelineItemFactoryTests.swift */,
+				9B7B9E70029438A765275F7F /* TimelineItemProviderTests.swift */,
 				ED0AD0C652385F69FA90FAF5 /* TimelineMediaPreviewDataSourceTests.swift */,
 				5C1F000589F2CEE6B03ECFAB /* TimelineMediaPreviewViewModelTests.swift */,
 				6509708F54FC883604DFDC95 /* TimelineViewModelTests.swift */,
@@ -7958,6 +7961,7 @@
 				1FEC0A4EC6E6DF693C16B32A /* StringTests.swift in Sources */,
 				E75CE800B3E64D0F7F8E228D /* TemplateScreenViewModelTests.swift in Sources */,
 				0D4EB2ABAA5FE8CB10FDBCB8 /* TimelineItemFactoryTests.swift in Sources */,
+				4C56BC82B0272C4BA97F28DF /* TimelineItemProviderTests.swift in Sources */,
 				C02DE5F62C81FB9E173C3D2F /* TimelineMediaPreviewDataSourceTests.swift in Sources */,
 				F6BF52CB027393EE03CEC523 /* TimelineMediaPreviewViewModelTests.swift in Sources */,
 				2F6207CB5C4715FE313B1E95 /* TimelineViewModelTests.swift in Sources */,

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -18990,11 +18990,11 @@ class TimelineItemProviderMock: TimelineItemProviderProtocol, @unchecked Sendabl
         set(value) { underlyingKind = value }
     }
     var underlyingKind: TimelineKind!
-    var membershipChangePublisher: AnyPublisher<Void, Never> {
-        get { return underlyingMembershipChangePublisher }
-        set(value) { underlyingMembershipChangePublisher = value }
+    var roomMemberEventPublisher: AnyPublisher<Void, Never> {
+        get { return underlyingRoomMemberEventPublisher }
+        set(value) { underlyingRoomMemberEventPublisher = value }
     }
-    var underlyingMembershipChangePublisher: AnyPublisher<Void, Never>!
+    var underlyingRoomMemberEventPublisher: AnyPublisher<Void, Never>!
 
 }
 class TimelineProxyMock: TimelineProxyProtocol, @unchecked Sendable {

--- a/ElementX/Sources/Mocks/TimelineProxyMock.swift
+++ b/ElementX/Sources/Mocks/TimelineProxyMock.swift
@@ -31,7 +31,7 @@ extension TimelineProxyMock {
         } else {
             let timelineItemProvider = TimelineItemProviderMock()
             timelineItemProvider.paginationState = .init(backward: configuration.timelineStartReached ? .endReached : .idle, forward: .endReached)
-            timelineItemProvider.underlyingMembershipChangePublisher = PassthroughSubject().eraseToAnyPublisher()
+            timelineItemProvider.underlyingRoomMemberEventPublisher = PassthroughSubject().eraseToAnyPublisher()
             underlyingTimelineItemProvider = timelineItemProvider
         }
     }

--- a/ElementX/Sources/Screens/RoomChangeRolesScreen/RoomChangeRolesScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomChangeRolesScreen/RoomChangeRolesScreenViewModel.swift
@@ -43,7 +43,7 @@ class RoomChangeRolesScreenViewModel: RoomChangeRolesScreenViewModelType, RoomCh
             }
             .store(in: &cancellables)
         
-        roomProxy.timeline.timelineItemProvider.membershipChangePublisher.sink { [roomProxy] in
+        roomProxy.timeline.timelineItemProvider.roomMemberEventPublisher.sink { [roomProxy] in
             Task { await roomProxy.updateMembers() }
         }
         .store(in: &cancellables)

--- a/ElementX/Sources/Screens/RoomMemberListScreen/RoomMembersListScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomMemberListScreen/RoomMembersListScreenViewModel.swift
@@ -77,7 +77,7 @@ class RoomMembersListScreenViewModel: RoomMembersListScreenViewModelType, RoomMe
             }
             .store(in: &cancellables)
         
-        roomProxy.timeline.timelineItemProvider.membershipChangePublisher.sink { [roomProxy] _ in
+        roomProxy.timeline.timelineItemProvider.roomMemberEventPublisher.sink { [roomProxy] _ in
             Task { await roomProxy.updateMembers() }
         }
         .store(in: &cancellables)

--- a/ElementX/Sources/Screens/Timeline/View/TimelineSenderAvatarView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineSenderAvatarView.swift
@@ -10,16 +10,16 @@ import Foundation
 import SwiftUI
 
 struct TimelineSenderAvatarView: View {
-    @Environment(\.timelineContext) private var context
-
+    @EnvironmentObject private var context: TimelineViewModel.Context
+    
     let timelineItem: EventBasedTimelineItemProtocol
-        
+    
     var body: some View {
-        LoadableAvatarImage(url: timelineItem.sender.avatarURL,
+        LoadableAvatarImage(url: context.viewState.members[timelineItem.sender.id]?.avatarURL ?? timelineItem.sender.avatarURL,
                             name: timelineItem.sender.displayName,
                             contentID: timelineItem.sender.id,
                             avatarSize: .user(on: .timeline),
-                            mediaProvider: context?.mediaProvider)
+                            mediaProvider: context.mediaProvider)
             .overlay {
                 Circle().stroke(Color.compound.bgCanvasDefault, lineWidth: 3)
             }

--- a/ElementX/Sources/Services/Timeline/TimelineController/TimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/TimelineController.swift
@@ -62,6 +62,7 @@ class TimelineController: TimelineControllerProtocol {
         activeTimelineItemProvider = liveTimelineItemProvider
         
         liveTimelineItemProvider.roomMemberEventPublisher.sink {
+            MXLog.info("Received room member event, updating members")
             Task { await roomProxy.updateMembers() }
         }
         .store(in: &cancellables)

--- a/ElementX/Sources/Services/Timeline/TimelineController/TimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/TimelineController.swift
@@ -61,7 +61,7 @@ class TimelineController: TimelineControllerProtocol {
         activeTimeline = timelineProxy
         activeTimelineItemProvider = liveTimelineItemProvider
         
-        liveTimelineItemProvider.membershipChangePublisher.sink {
+        liveTimelineItemProvider.roomMemberEventPublisher.sink {
             Task { await roomProxy.updateMembers() }
         }
         .store(in: &cancellables)

--- a/ElementX/Sources/Services/Timeline/TimelineController/TimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/TimelineController.swift
@@ -19,6 +19,8 @@ class TimelineController: TimelineControllerProtocol {
     private let mediaProvider: MediaProviderProtocol
     private let appSettings: AppSettings
     
+    private var cancellables: Set<AnyCancellable> = []
+    
     let callbacks = PassthroughSubject<TimelineControllerCallback, Never>()
     
     private var activeTimeline: TimelineProxyProtocol
@@ -58,6 +60,11 @@ class TimelineController: TimelineControllerProtocol {
         
         activeTimeline = timelineProxy
         activeTimelineItemProvider = liveTimelineItemProvider
+        
+        liveTimelineItemProvider.membershipChangePublisher.sink {
+            Task { await roomProxy.updateMembers() }
+        }
+        .store(in: &cancellables)
         
         guard let initialFocussedEventID else {
             configureActiveTimelineItemProvider()

--- a/ElementX/Sources/Services/Timeline/TimelineItemProvider.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItemProvider.swift
@@ -36,9 +36,9 @@ class TimelineItemProvider: TimelineItemProviderProtocol {
     
     let kind: TimelineKind
     
-    private let membershipChangeSubject = PassthroughSubject<Void, Never>()
-    var membershipChangePublisher: AnyPublisher<Void, Never> {
-        membershipChangeSubject
+    private let roomMemberEventSubject = PassthroughSubject<Void, Never>()
+    var roomMemberEventPublisher: AnyPublisher<Void, Never> {
+        roomMemberEventSubject
             .eraseToAnyPublisher()
     }
     
@@ -100,8 +100,8 @@ class TimelineItemProvider: TimelineItemProviderProtocol {
             for (index, item) in items.enumerated() {
                 let itemProxy = TimelineItemProxy(item: item)
                 
-                if itemProxy.isMembershipChange {
-                    membershipChangeSubject.send(())
+                if itemProxy.isRoomMemberEvent {
+                    roomMemberEventSubject.send(())
                 }
                 
                 changes.append(.insert(offset: Int(itemProxies.count) + index, element: itemProxy, associatedWith: nil))
@@ -124,8 +124,8 @@ class TimelineItemProvider: TimelineItemProviderProtocol {
         case .pushBack(let item):
             let itemProxy = TimelineItemProxy(item: item)
             
-            if itemProxy.isMembershipChange {
-                membershipChangeSubject.send(())
+            if itemProxy.isRoomMemberEvent {
+                roomMemberEventSubject.send(())
             }
             
             changes.append(.insert(offset: Int(itemProxies.count), element: itemProxy, associatedWith: nil))
@@ -158,7 +158,7 @@ class TimelineItemProvider: TimelineItemProviderProtocol {
 }
 
 private extension TimelineItemProxy {
-    var isMembershipChange: Bool {
+    var isRoomMemberEvent: Bool {
         switch self {
         case .event(let eventTimelineItemProxy):
             switch eventTimelineItemProxy.content {

--- a/ElementX/Sources/Services/Timeline/TimelineItemProvider.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItemProvider.swift
@@ -162,7 +162,7 @@ private extension TimelineItemProxy {
         switch self {
         case .event(let eventTimelineItemProxy):
             switch eventTimelineItemProxy.content {
-            case .roomMembership:
+            case .roomMembership, .profileChange:
                 true
             default:
                 false

--- a/ElementX/Sources/Services/Timeline/TimelineItemProviderProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItemProviderProtocol.swift
@@ -31,10 +31,10 @@ protocol TimelineItemProviderProtocol {
     var paginationState: TimelinePaginationState { get }
     /// The kind of the timeline
     var kind: TimelineKind { get }
-    /// A publisher that signals when changes to the room's membership have occurred through `/sync`.
+    /// A publisher that signals when member changes have occurred in the room through `/sync`.
     ///
     /// This is temporary and will be replace by a subscription on the room itself.
-    var membershipChangePublisher: AnyPublisher<Void, Never> { get }
+    var roomMemberEventPublisher: AnyPublisher<Void, Never> { get }
 }
 
 // sourcery: AutoMockable

--- a/UnitTests/Sources/TimelineItemProviderTests.swift
+++ b/UnitTests/Sources/TimelineItemProviderTests.swift
@@ -1,0 +1,102 @@
+//
+// Copyright 2025 Element Creations Ltd.
+// Copyright 2025 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Combine
+@testable import ElementX
+import Foundation
+import MatrixRustSDK
+import MatrixRustSDKMocks
+import Testing
+
+@MainActor
+struct TimelineItemProviderTests {
+    // MARK: - roomMemberEventPublisher
+
+    @Test
+    func roomMemberEventPublisherFiresOnMembershipChange() async throws {
+        // Given a TimelineItemProvider with a controllable timeline listener.
+        let (provider, listener) = try await makeProviderAndListener()
+
+        // When a membership change event arrives via sync.
+        let deferred = deferFulfillment(provider.roomMemberEventPublisher) { _ in true }
+        let item = makeTimelineItem(content: .roomMembership(userId: "@bob:matrix.org",
+                                                             userDisplayName: "Bob",
+                                                             change: .joined,
+                                                             reason: nil))
+        listener.onUpdate(diff: [.pushBack(value: item)])
+        try await deferred.fulfill()
+    }
+
+    @Test
+    func roomMemberEventPublisherFiresOnProfileChange() async throws {
+        // Given a TimelineItemProvider with a controllable timeline listener.
+        let (provider, listener) = try await makeProviderAndListener()
+
+        // When a profile change event (e.g. avatar update) arrives via sync.
+        let deferred = deferFulfillment(provider.roomMemberEventPublisher) { _ in true }
+        let item = makeTimelineItem(content: .profileChange(displayName: "Bob",
+                                                            prevDisplayName: "Bob",
+                                                            avatarUrl: "mxc://matrix.org/newavatar",
+                                                            prevAvatarUrl: "mxc://matrix.org/oldavatar"))
+        listener.onUpdate(diff: [.pushBack(value: item)])
+        try await deferred.fulfill()
+    }
+
+    @Test
+    func roomMemberEventPublisherDoesNotFireOnRegularMessage() async throws {
+        // Given a TimelineItemProvider with a controllable timeline listener.
+        let (provider, listener) = try await makeProviderAndListener()
+
+        // When a regular message event arrives via sync.
+        var fired = false
+        let cancellable = provider.roomMemberEventPublisher.sink { fired = true }
+        defer { cancellable.cancel() }
+        
+        let messageContent = TimelineItemContent.msgLike(content: .init(kind: .redacted,
+                                                                        reactions: [],
+                                                                        inReplyTo: nil,
+                                                                        threadRoot: nil,
+                                                                        threadSummary: nil))
+        let item = makeTimelineItem(content: messageContent)
+        listener.onUpdate(diff: [.pushBack(value: item)])
+
+        // Then the publisher does not fire.
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(!fired)
+    }
+
+    // MARK: - Helpers
+
+    private func makeProviderAndListener() async throws -> (TimelineItemProvider, TimelineListener) {
+        var capturedListener: TimelineListener?
+        let timelineMock = TimelineSDKMock()
+        timelineMock.addListenerListenerClosure = { listener in
+            capturedListener = listener
+            return TaskHandleSDKMock()
+        }
+
+        let provider = TimelineItemProvider(timeline: timelineMock,
+                                            kind: .live,
+                                            paginationStatePublisher: Empty().eraseToAnyPublisher())
+
+        // addListener is called in a Task inside init, yield until it's captured.
+        while capturedListener == nil {
+            await Task.yield()
+        }
+
+        return try (provider, #require(capturedListener))
+    }
+
+    private func makeTimelineItem(content: TimelineItemContent) -> TimelineItem {
+        let sdkItem = TimelineItemSDKMock()
+        let eventItem = EventTimelineItem(configuration: .init(content: content))
+        sdkItem.asEventReturnValue = eventItem
+        sdkItem.uniqueIdReturnValue = .init(id: UUID().uuidString)
+        return sdkItem
+    }
+}


### PR DESCRIPTION
Fixes the same issue tracked on Android in element-hq/element-x-android#5176.

### Problem

When a room member changes their avatar, existing messages they sent do not update to show the new avatar. A "profile changed" event appears at the bottom of the timeline, but scrolling up reveals all previous messages still showing the old avatar. Backing out and re-entering the room shows the correct avatar.

The root cause is in the Rust SDK: when a profile change event arrives via sync, the SDK correctly appends a new timeline item for the change, but does not re-emit existing timeline items with updated sender profile data. Ideally the SDK would emit timeline items with only a sender ID and the app would resolve the current profile at render time from a single source of truth -- avoiding this class of staleness entirely.

### Fix

Two changes work together to address this:

**1. `TimelineItemProvider` now publishes on `roomMemberEventPublisher` for profile changes**

Previously `isRoomMemberEvent` (formerly `isMembershipChange`) only evaluated true for join/leave/ban events. Profile changes (`profileChange` content) are also `m.room.member` events per the Matrix spec and now correctly evaluate true, triggering the publisher.

**2. `TimelineSenderAvatarView` reads from the live member cache**

The avatar URL is now resolved from `context.viewState.members` (the live member cache already maintained by `TimelineViewModel`) rather than the stale snapshot baked into the timeline item at creation time, with the snapshot kept as a fallback. This effectively treats the timeline item sender as no more than an identifier, as suggested earlier.

`TimelineController` subscribes to `roomMemberEventPublisher` and calls `roomProxy.updateMembers()` when it fires, refreshing the cache and triggering a view update.

### Note

`@EnvironmentObject` is used in `TimelineSenderAvatarView` instead of `@Environment(\.timelineContext)` to ensure SwiftUI's observation tracking picks up changes to `viewState.members`. The `environmentObject` is always injected alongside the environment key at the call site in `TimelineTableViewController`.

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
