### PR TITLE
Client pausing and resuming

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -211,10 +211,6 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
         stateMachine.processEvent(.startWithExistingSession)
     }
 
-    func stop() {
-        hideLoadingIndicator()
-    }
-    
     func toPresentable() -> AnyView {
         AnyView(navigationRootCoordinator.toPresentable()
             .environment(\.analyticsService, analyticsService)

--- a/ElementX/Sources/Application/Settings/AppSettings.swift
+++ b/ElementX/Sources/Application/Settings/AppSettings.swift
@@ -81,6 +81,7 @@ final class AppSettings {
         case focusEventOnNotificationTap
         case linkNewDeviceEnabled
         case automaticBackPaginationEnabled
+        case clientPausingAndResumingEnabled
         
         // Doug's tweaks 🔧
         case roomListActivityVisibility
@@ -447,6 +448,9 @@ final class AppSettings {
     
     @UserPreference(key: UserDefaultsKeys.automaticBackPaginationEnabled, defaultValue: false, storageType: .userDefaults(store))
     var automaticBackPaginationEnabled
+    
+    @UserPreference(key: UserDefaultsKeys.clientPausingAndResumingEnabled, defaultValue: appBuildType != .release, storageType: .volatile)
+    var clientPausingAndResumingEnabled
     
     @UserPreference(key: UserDefaultsKeys.developerOptionsEnabled, defaultValue: appBuildType != .release, storageType: .userDefaults(store))
     var developerOptionsEnabled

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -403,6 +403,14 @@ class ClientProxy: ClientProxyProtocol {
         MXLog.info("Starting sync")
         
         Task {
+            if appSettings.clientPausingAndResumingEnabled {
+                do {
+                    try await client.resume()
+                } catch {
+                    MXLog.error("Failed resuming client with error: \(error)")
+                }
+            }
+            
             await syncService.start()
             
             // If we are using OAuth we want to cache the account management URL in volatile memory on the SDK side.
@@ -454,6 +462,15 @@ class ClientProxy: ClientProxyProtocol {
             }
             
             await syncService.stop()
+            
+            if appSettings.clientPausingAndResumingEnabled {
+                do {
+                    try await client.pause()
+                } catch {
+                    MXLog.error("Failed pausing client with error: \(error)")
+                }
+            }
+            
             MXLog.info("Sync stopped")
         }
     }


### PR DESCRIPTION
This will hopefully close all file descriptors and prevent the system from killing the app in the background.

Reported in https://github.com/matrix-org/matrix-rust-sdk/issues/6366 and implemented in https://github.com/matrix-org/matrix-rust-sdk/pull/6495