### PR TITLE
Invite the DM recipient to a new room

### DIFF
--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -537,11 +537,8 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
                 
                 presentMediaUploadPreviewScreen(for: mediaURLs, timelineController: timelineController, animated: animated)
                 
-            case (_, .presentInviteUsersScreen, .inviteUsersScreen):
-                presentInviteUsersScreen()
-
-            case (_, .presentInviteToNewRoomScreen(let invitee), .inviteToNewRoomScreen):
-                presentInviteToNewRoomScreen(invitee: invitee)
+            case (_, .presentInviteUsersScreen(let mode), .inviteUsersScreen):
+                presentInviteUsersScreen(mode: mode)
 
             case (_, .presentTransferOwnershipScreen, .transferOwnershipScreen):
                 presentTransferOwnershipScreen()
@@ -958,9 +955,9 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
             case .presentNotificationSettingsScreen:
                 stateMachine.tryEvent(.presentNotificationSettingsScreen)
             case .presentInviteUsersScreen:
-                stateMachine.tryEvent(.presentInviteUsersScreen)
+                stateMachine.tryEvent(.presentInviteUsersScreen(mode: .existingRoom))
             case .presentInviteToNewRoom(let invitee):
-                stateMachine.tryEvent(.presentInviteToNewRoomScreen(invitee: invitee))
+                stateMachine.tryEvent(.presentInviteUsersScreen(mode: .newRoom(invitee: invitee)))
             case .presentPollsHistory:
                 stateMachine.tryEvent(.presentPollsHistory)
             case .presentRolesAndPermissionsScreen:
@@ -1331,10 +1328,30 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
         }
     }
     
-    private func presentInviteUsersScreen() {
+    enum InviteUsersFlowMode: Hashable {
+        /// Invite people into the current room.
+        case existingRoom
+        /// Start a new room with the given invitee pre-selected and locked.
+        case newRoom(invitee: UserProfileProxy)
+    }
+
+    private func presentInviteUsersScreen(mode: InviteUsersFlowMode = .existingRoom) {
         let stackCoordinator = NavigationStackCoordinator()
+
+        let roomType: InviteUsersScreenRoomType
+        let lockedInvitees: [UserProfileProxy]
+        switch mode {
+        case .existingRoom:
+            roomType = .room(roomProxy: roomProxy)
+            lockedInvitees = []
+        case .newRoom(let invitee):
+            roomType = .draft
+            lockedInvitees = [invitee]
+        }
+
         let inviteParameters = InviteUsersScreenCoordinatorParameters(userSession: userSession,
-                                                                      roomType: .room(roomProxy: roomProxy),
+                                                                      roomType: roomType,
+                                                                      lockedInvitees: lockedInvitees,
                                                                       isSkippable: false,
                                                                       userDiscoveryService: UserDiscoveryService(clientProxy: userSession.clientProxy),
                                                                       userIndicatorController: flowParameters.userIndicatorController,
@@ -1349,8 +1366,10 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
             switch action {
             case .dismiss:
                 navigationStackCoordinator.setSheetCoordinator(nil)
-            case .invite:
-                break
+            case .openRoom(let roomID):
+                guard case .newRoom = mode else { return }
+                navigationStackCoordinator.setSheetCoordinator(nil)
+                stateMachine.tryEvent(.startChildFlow(roomID: roomID, via: [], entryPoint: .room))
             }
         }
         .store(in: &cancellables)
@@ -1665,35 +1684,6 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
         
         flowCoordinator.start(animated: animated)
         membersFlowCoordinator = flowCoordinator
-    }
-
-    private func presentInviteToNewRoomScreen(invitee: UserProfileProxy) {
-        let stackCoordinator = NavigationStackCoordinator()
-        let inviteParameters = InviteUsersScreenCoordinatorParameters(userSession: userSession,
-                                                                      roomType: .draft,
-                                                                      lockedInvitees: [invitee],
-                                                                      isSkippable: false,
-                                                                      userDiscoveryService: UserDiscoveryService(clientProxy: userSession.clientProxy),
-                                                                      userIndicatorController: flowParameters.userIndicatorController,
-                                                                      appSettings: flowParameters.appSettings)
-        let coordinator = InviteUsersScreenCoordinator(parameters: inviteParameters)
-        stackCoordinator.setRootCoordinator(coordinator)
-
-        coordinator.actions.sink { [weak self] action in
-            guard let self else { return }
-            switch action {
-            case .dismiss:
-                navigationStackCoordinator.setSheetCoordinator(nil)
-            case .invite:
-                // Phase 3: create the room with these userIDs.
-                navigationStackCoordinator.setSheetCoordinator(nil)
-            }
-        }
-        .store(in: &cancellables)
-
-        navigationStackCoordinator.setSheetCoordinator(stackCoordinator) { [weak self] in
-            self?.stateMachine.tryEvent(.dismissInviteToNewRoomScreen)
-        }
     }
 
     private static let loadingIndicatorID = "\(RoomFlowCoordinator.self)-Loading"

--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -89,7 +89,7 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
     private var spaceFlowCoordinator: SpaceFlowCoordinator?
     // periphery:ignore - retaining purpose
     private var membersFlowCoordinator: RoomMembersFlowCoordinator?
-    
+
     private let stateMachine: StateMachine<State, Event> = .init(state: .initial)
     
     private var cancellables = Set<AnyCancellable>()
@@ -539,7 +539,10 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
                 
             case (_, .presentInviteUsersScreen, .inviteUsersScreen):
                 presentInviteUsersScreen()
-                
+
+            case (_, .presentInviteToNewRoomScreen(let invitee), .inviteToNewRoomScreen):
+                presentInviteToNewRoomScreen(invitee: invitee)
+
             case (_, .presentTransferOwnershipScreen, .transferOwnershipScreen):
                 presentTransferOwnershipScreen()
                     
@@ -956,6 +959,8 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
                 stateMachine.tryEvent(.presentNotificationSettingsScreen)
             case .presentInviteUsersScreen:
                 stateMachine.tryEvent(.presentInviteUsersScreen)
+            case .presentInviteToNewRoom(let invitee):
+                stateMachine.tryEvent(.presentInviteToNewRoomScreen(invitee: invitee))
             case .presentPollsHistory:
                 stateMachine.tryEvent(.presentPollsHistory)
             case .presentRolesAndPermissionsScreen:
@@ -1329,25 +1334,27 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
     private func presentInviteUsersScreen() {
         let stackCoordinator = NavigationStackCoordinator()
         let inviteParameters = InviteUsersScreenCoordinatorParameters(userSession: userSession,
-                                                                      roomProxy: roomProxy,
+                                                                      roomType: .room(roomProxy: roomProxy),
                                                                       isSkippable: false,
                                                                       userDiscoveryService: UserDiscoveryService(clientProxy: userSession.clientProxy),
                                                                       userIndicatorController: flowParameters.userIndicatorController,
                                                                       appSettings: flowParameters.appSettings)
-        
+
         let coordinator = InviteUsersScreenCoordinator(parameters: inviteParameters)
         stackCoordinator.setRootCoordinator(coordinator)
-        
+
         coordinator.actions.sink { [weak self] action in
             guard let self else { return }
-            
+
             switch action {
             case .dismiss:
                 navigationStackCoordinator.setSheetCoordinator(nil)
+            case .invite:
+                break
             }
         }
         .store(in: &cancellables)
-        
+
         navigationStackCoordinator.setSheetCoordinator(stackCoordinator) { [weak self] in
             self?.stateMachine.tryEvent(.dismissInviteUsersScreen)
         }
@@ -1659,7 +1666,36 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
         flowCoordinator.start(animated: animated)
         membersFlowCoordinator = flowCoordinator
     }
-    
+
+    private func presentInviteToNewRoomScreen(invitee: UserProfileProxy) {
+        let stackCoordinator = NavigationStackCoordinator()
+        let inviteParameters = InviteUsersScreenCoordinatorParameters(userSession: userSession,
+                                                                      roomType: .draft,
+                                                                      lockedInvitees: [invitee],
+                                                                      isSkippable: false,
+                                                                      userDiscoveryService: UserDiscoveryService(clientProxy: userSession.clientProxy),
+                                                                      userIndicatorController: flowParameters.userIndicatorController,
+                                                                      appSettings: flowParameters.appSettings)
+        let coordinator = InviteUsersScreenCoordinator(parameters: inviteParameters)
+        stackCoordinator.setRootCoordinator(coordinator)
+
+        coordinator.actions.sink { [weak self] action in
+            guard let self else { return }
+            switch action {
+            case .dismiss:
+                navigationStackCoordinator.setSheetCoordinator(nil)
+            case .invite:
+                // Phase 3: create the room with these userIDs.
+                navigationStackCoordinator.setSheetCoordinator(nil)
+            }
+        }
+        .store(in: &cancellables)
+
+        navigationStackCoordinator.setSheetCoordinator(stackCoordinator) { [weak self] in
+            self?.stateMachine.tryEvent(.dismissInviteToNewRoomScreen)
+        }
+    }
+
     private static let loadingIndicatorID = "\(RoomFlowCoordinator.self)-Loading"
     
     private func showLoadingIndicator(delay: Duration? = nil,

--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -60,6 +60,13 @@ struct FocusEvent: Hashable {
     let shouldSetPin: Bool
 }
 
+enum InviteUsersFlow: Hashable {
+    /// Invite people into the current room.
+    case existingRoom
+    /// Start a new room with the given invitee pre-selected and mandatory.
+    case newRoom(mandatoryInvitee: UserProfileProxy)
+}
+
 // swiftlint:disable:next type_body_length
 class RoomFlowCoordinator: FlowCoordinatorProtocol {
     private let roomID: String
@@ -89,7 +96,7 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
     private var spaceFlowCoordinator: SpaceFlowCoordinator?
     // periphery:ignore - retaining purpose
     private var membersFlowCoordinator: RoomMembersFlowCoordinator?
-
+    
     private let stateMachine: StateMachine<State, Event> = .init(state: .initial)
     
     private var cancellables = Set<AnyCancellable>()
@@ -537,9 +544,9 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
                 
                 presentMediaUploadPreviewScreen(for: mediaURLs, timelineController: timelineController, animated: animated)
                 
-            case (_, .presentInviteUsersScreen(let mode), .inviteUsersScreen):
-                presentInviteUsersScreen(mode: mode)
-
+            case (_, .presentInviteUsersScreen(let flow), .inviteUsersScreen):
+                presentInviteUsersScreen(flow: flow)
+                
             case (_, .presentTransferOwnershipScreen, .transferOwnershipScreen):
                 presentTransferOwnershipScreen()
                     
@@ -955,9 +962,9 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
             case .presentNotificationSettingsScreen:
                 stateMachine.tryEvent(.presentNotificationSettingsScreen)
             case .presentInviteUsersScreen:
-                stateMachine.tryEvent(.presentInviteUsersScreen(mode: .existingRoom))
-            case .presentInviteToNewRoom(let invitee):
-                stateMachine.tryEvent(.presentInviteUsersScreen(mode: .newRoom(invitee: invitee)))
+                stateMachine.tryEvent(.presentInviteUsersScreen(flow: .existingRoom))
+            case .presentInviteToNewRoom(let mandatoryInvitee):
+                stateMachine.tryEvent(.presentInviteUsersScreen(flow: .newRoom(mandatoryInvitee: mandatoryInvitee)))
             case .presentPollsHistory:
                 stateMachine.tryEvent(.presentPollsHistory)
             case .presentRolesAndPermissionsScreen:
@@ -1328,52 +1335,38 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
         }
     }
     
-    enum InviteUsersFlowMode: Hashable {
-        /// Invite people into the current room.
-        case existingRoom
-        /// Start a new room with the given invitee pre-selected and locked.
-        case newRoom(invitee: UserProfileProxy)
-    }
-
-    private func presentInviteUsersScreen(mode: InviteUsersFlowMode = .existingRoom) {
+    private func presentInviteUsersScreen(flow: InviteUsersFlow = .existingRoom) {
         let stackCoordinator = NavigationStackCoordinator()
 
-        let roomType: InviteUsersScreenRoomType
-        let lockedInvitees: [UserProfileProxy]
-        switch mode {
-        case .existingRoom:
-            roomType = .room(roomProxy: roomProxy)
-            lockedInvitees = []
-        case .newRoom(let invitee):
-            roomType = .draft
-            lockedInvitees = [invitee]
+        let roomType: InviteUsersScreenRoomType = switch flow {
+        case .existingRoom: .existingRoom(roomProxy: roomProxy)
+        case .newRoom(let mandatoryInvitee): .draft(mandatoryInvitees: [mandatoryInvitee])
         }
 
         let inviteParameters = InviteUsersScreenCoordinatorParameters(userSession: userSession,
                                                                       roomType: roomType,
-                                                                      lockedInvitees: lockedInvitees,
                                                                       isSkippable: false,
                                                                       userDiscoveryService: UserDiscoveryService(clientProxy: userSession.clientProxy),
                                                                       userIndicatorController: flowParameters.userIndicatorController,
                                                                       appSettings: flowParameters.appSettings)
-
+        
         let coordinator = InviteUsersScreenCoordinator(parameters: inviteParameters)
         stackCoordinator.setRootCoordinator(coordinator)
-
+        
         coordinator.actions.sink { [weak self] action in
             guard let self else { return }
-
+            
             switch action {
             case .dismiss:
                 navigationStackCoordinator.setSheetCoordinator(nil)
             case .openRoom(let roomID):
-                guard case .newRoom = mode else { return }
+                guard case .newRoom = flow else { return }
                 navigationStackCoordinator.setSheetCoordinator(nil)
                 stateMachine.tryEvent(.startChildFlow(roomID: roomID, via: [], entryPoint: .room))
             }
         }
         .store(in: &cancellables)
-
+        
         navigationStackCoordinator.setSheetCoordinator(stackCoordinator) { [weak self] in
             self?.stateMachine.tryEvent(.dismissInviteUsersScreen)
         }
@@ -1685,7 +1678,7 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
         flowCoordinator.start(animated: animated)
         membersFlowCoordinator = flowCoordinator
     }
-
+    
     private static let loadingIndicatorID = "\(RoomFlowCoordinator.self)-Loading"
     
     private func showLoadingIndicator(delay: Duration? = nil,

--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinatorStateMachine.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinatorStateMachine.swift
@@ -65,7 +65,7 @@ extension RoomFlowCoordinator {
         case roomDetailsEditScreen
         case notificationSettings
         case globalNotificationSettings
-        case inviteUsersScreen(mode: InviteUsersFlowMode, previousState: State)
+        case inviteUsersScreen(flow: InviteUsersFlow, previousState: State)
         case mediaUploadPicker(mode: MediaPickerScreenMode, previousState: State)
         case mediaUploadPreview(mediaURLs: [URL], previousState: State)
         case emojiPicker(itemID: TimelineItemIdentifier, selectedEmojis: Set<String>, previousState: State)
@@ -136,7 +136,7 @@ extension RoomFlowCoordinator {
         case presentGlobalNotificationSettingsScreen
         case dismissGlobalNotificationSettingsScreen
         
-        case presentInviteUsersScreen(mode: InviteUsersFlowMode)
+        case presentInviteUsersScreen(flow: InviteUsersFlow)
         case dismissInviteUsersScreen
                 
         case presentMediaUploadPicker(mode: MediaPickerScreenMode)
@@ -404,11 +404,11 @@ extension RoomFlowCoordinator {
             case (.mediaUploadPicker(_, let previousMediaUploadPickerState), .presentMediaUploadPreview(let mediaURLs)):
                 return .mediaUploadPreview(mediaURLs: mediaURLs, previousState: previousMediaUploadPickerState)
                 
-            case (_, .presentInviteUsersScreen(let mode)):
-                return .inviteUsersScreen(mode: mode, previousState: fromState)
+            case (_, .presentInviteUsersScreen(let flow)):
+                return .inviteUsersScreen(flow: flow, previousState: fromState)
             case (.inviteUsersScreen(_, let previousState), .dismissInviteUsersScreen):
                 return previousState
-
+                
             case (_, .presentTransferOwnershipScreen):
                 return .transferOwnershipScreen(previousState: fromState)
             case (.transferOwnershipScreen(let previousState), .dismissedTransferOwnershipScreen):

--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinatorStateMachine.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinatorStateMachine.swift
@@ -65,7 +65,7 @@ extension RoomFlowCoordinator {
         case roomDetailsEditScreen
         case notificationSettings
         case globalNotificationSettings
-        case inviteUsersScreen(previousState: State)
+        case inviteUsersScreen(mode: InviteUsersFlowMode, previousState: State)
         case mediaUploadPicker(mode: MediaPickerScreenMode, previousState: State)
         case mediaUploadPreview(mediaURLs: [URL], previousState: State)
         case emojiPicker(itemID: TimelineItemIdentifier, selectedEmojis: Set<String>, previousState: State)
@@ -95,8 +95,6 @@ extension RoomFlowCoordinator {
         case spaceFlow(previousState: State)
         /// A members flow is in progress
         case membersFlow(previousState: State)
-        /// Inviting people to a not-yet-created room (e.g. starting a new room from a DM).
-        case inviteToNewRoomScreen(previousState: State)
     }
     
     struct EventUserInfo {
@@ -138,7 +136,7 @@ extension RoomFlowCoordinator {
         case presentGlobalNotificationSettingsScreen
         case dismissGlobalNotificationSettingsScreen
         
-        case presentInviteUsersScreen
+        case presentInviteUsersScreen(mode: InviteUsersFlowMode)
         case dismissInviteUsersScreen
                 
         case presentMediaUploadPicker(mode: MediaPickerScreenMode)
@@ -197,9 +195,6 @@ extension RoomFlowCoordinator {
         
         case startMembersFlow(entryPoint: RoomMembersFlowCoordinatorEntryPoint)
         case stopMembersFlow
-
-        case presentInviteToNewRoomScreen(invitee: UserProfileProxy)
-        case dismissInviteToNewRoomScreen
     }
     
     // swiftlint:disable:next function_body_length
@@ -409,14 +404,9 @@ extension RoomFlowCoordinator {
             case (.mediaUploadPicker(_, let previousMediaUploadPickerState), .presentMediaUploadPreview(let mediaURLs)):
                 return .mediaUploadPreview(mediaURLs: mediaURLs, previousState: previousMediaUploadPickerState)
                 
-            case (_, .presentInviteUsersScreen):
-                return .inviteUsersScreen(previousState: fromState)
-            case (.inviteUsersScreen(let previousState), .dismissInviteUsersScreen):
-                return previousState
-
-            case (_, .presentInviteToNewRoomScreen):
-                return .inviteToNewRoomScreen(previousState: fromState)
-            case (.inviteToNewRoomScreen(let previousState), .dismissInviteToNewRoomScreen):
+            case (_, .presentInviteUsersScreen(let mode)):
+                return .inviteUsersScreen(mode: mode, previousState: fromState)
+            case (.inviteUsersScreen(_, let previousState), .dismissInviteUsersScreen):
                 return previousState
 
             case (_, .presentTransferOwnershipScreen):

--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinatorStateMachine.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinatorStateMachine.swift
@@ -95,6 +95,8 @@ extension RoomFlowCoordinator {
         case spaceFlow(previousState: State)
         /// A members flow is in progress
         case membersFlow(previousState: State)
+        /// Inviting people to a not-yet-created room (e.g. starting a new room from a DM).
+        case inviteToNewRoomScreen(previousState: State)
     }
     
     struct EventUserInfo {
@@ -195,6 +197,9 @@ extension RoomFlowCoordinator {
         
         case startMembersFlow(entryPoint: RoomMembersFlowCoordinatorEntryPoint)
         case stopMembersFlow
+
+        case presentInviteToNewRoomScreen(invitee: UserProfileProxy)
+        case dismissInviteToNewRoomScreen
     }
     
     // swiftlint:disable:next function_body_length
@@ -408,7 +413,12 @@ extension RoomFlowCoordinator {
                 return .inviteUsersScreen(previousState: fromState)
             case (.inviteUsersScreen(let previousState), .dismissInviteUsersScreen):
                 return previousState
-                
+
+            case (_, .presentInviteToNewRoomScreen):
+                return .inviteToNewRoomScreen(previousState: fromState)
+            case (.inviteToNewRoomScreen(let previousState), .dismissInviteToNewRoomScreen):
+                return previousState
+
             case (_, .presentTransferOwnershipScreen):
                 return .transferOwnershipScreen(previousState: fromState)
             case (.transferOwnershipScreen(let previousState), .dismissedTransferOwnershipScreen):

--- a/ElementX/Sources/FlowCoordinators/RoomMembersFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomMembersFlowCoordinator.swift
@@ -261,25 +261,27 @@ final class RoomMembersFlowCoordinator: FlowCoordinatorProtocol {
     private func presentInviteUsersScreen() {
         let stackCoordinator = NavigationStackCoordinator()
         let inviteParameters = InviteUsersScreenCoordinatorParameters(userSession: flowParameters.userSession,
-                                                                      roomProxy: roomProxy,
+                                                                      roomType: .room(roomProxy: roomProxy),
                                                                       isSkippable: false,
                                                                       userDiscoveryService: UserDiscoveryService(clientProxy: flowParameters.userSession.clientProxy),
                                                                       userIndicatorController: flowParameters.userIndicatorController,
                                                                       appSettings: flowParameters.appSettings)
-        
+
         let coordinator = InviteUsersScreenCoordinator(parameters: inviteParameters)
         stackCoordinator.setRootCoordinator(coordinator)
-        
+
         coordinator.actions.sink { [weak self] action in
             guard let self else { return }
-            
+
             switch action {
             case .dismiss:
                 navigationStackCoordinator.setSheetCoordinator(nil)
+            case .invite:
+                break
             }
         }
         .store(in: &cancellables)
-        
+
         navigationStackCoordinator.setSheetCoordinator(stackCoordinator) { [weak self] in
             self?.stateMachine.tryEvent(.dismissedInviteUsersScreen)
         }

--- a/ElementX/Sources/FlowCoordinators/RoomMembersFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomMembersFlowCoordinator.swift
@@ -261,18 +261,18 @@ final class RoomMembersFlowCoordinator: FlowCoordinatorProtocol {
     private func presentInviteUsersScreen() {
         let stackCoordinator = NavigationStackCoordinator()
         let inviteParameters = InviteUsersScreenCoordinatorParameters(userSession: flowParameters.userSession,
-                                                                      roomType: .room(roomProxy: roomProxy),
+                                                                      roomType: .existingRoom(roomProxy: roomProxy),
                                                                       isSkippable: false,
                                                                       userDiscoveryService: UserDiscoveryService(clientProxy: flowParameters.userSession.clientProxy),
                                                                       userIndicatorController: flowParameters.userIndicatorController,
                                                                       appSettings: flowParameters.appSettings)
-
+        
         let coordinator = InviteUsersScreenCoordinator(parameters: inviteParameters)
         stackCoordinator.setRootCoordinator(coordinator)
-
+        
         coordinator.actions.sink { [weak self] action in
             guard let self else { return }
-
+            
             switch action {
             case .dismiss:
                 navigationStackCoordinator.setSheetCoordinator(nil)
@@ -281,7 +281,7 @@ final class RoomMembersFlowCoordinator: FlowCoordinatorProtocol {
             }
         }
         .store(in: &cancellables)
-
+        
         navigationStackCoordinator.setSheetCoordinator(stackCoordinator) { [weak self] in
             self?.stateMachine.tryEvent(.dismissedInviteUsersScreen)
         }

--- a/ElementX/Sources/FlowCoordinators/RoomMembersFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomMembersFlowCoordinator.swift
@@ -276,7 +276,7 @@ final class RoomMembersFlowCoordinator: FlowCoordinatorProtocol {
             switch action {
             case .dismiss:
                 navigationStackCoordinator.setSheetCoordinator(nil)
-            case .invite:
+            case .openRoom:
                 break
             }
         }

--- a/ElementX/Sources/FlowCoordinators/SpaceSettingsFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/SpaceSettingsFlowCoordinator.swift
@@ -240,7 +240,7 @@ final class SpaceSettingsFlowCoordinator: FlowCoordinatorProtocol {
             case .transferOwnership:
                 stateMachine.tryEvent(.presentTransferOwnership)
             case .presentRecipientDetails, .presentNotificationSettingsScreen, .presentReportRoomScreen,
-                 .presentInviteUsersScreen, .presentPollsHistory, .presentCall,
+                 .presentInviteUsersScreen, .presentInviteToNewRoom, .presentPollsHistory, .presentCall,
                  .presentPinnedEventsTimeline, .presentMediaEventsTimeline, .presentKnockingRequestsListScreen:
                 fatalError("Not handled in the space context")
             }

--- a/ElementX/Sources/FlowCoordinators/StartChatFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/StartChatFlowCoordinator.swift
@@ -45,7 +45,7 @@ class StartChatFlowCoordinator: FlowCoordinatorProtocol {
     indirect enum State: StateType {
         /// The state machine hasn't started.
         case initial
-
+        
         /// Shown when the flow is started with options to create a room/DM, join by alias, use the room directory etc.
         case startChat
         /// The user is creating a new room.
@@ -55,7 +55,7 @@ class StartChatFlowCoordinator: FlowCoordinatorProtocol {
         /// The user is inviting users to a newly created room.
         case inviteUsers
     }
-
+    
     enum Event: EventType {
         /// The flow is being started.
         case start
@@ -63,12 +63,12 @@ class StartChatFlowCoordinator: FlowCoordinatorProtocol {
         case createRoom(isSpace: Bool)
         /// The user dismissed the create room screen.
         case dismissedCreateRoom
-
+        
         /// The user would like to pick an avatar for the room.
         case presentRoomAvatarPicker
         /// The user finished picking the avatar.
         case dismissedRoomAvatarPicker
-
+        
         /// The user's room was created successfully.
         case createdRoom
     }
@@ -270,7 +270,7 @@ class StartChatFlowCoordinator: FlowCoordinatorProtocol {
     
     private func presentInviteUsersScreen(roomProxy: JoinedRoomProxyProtocol, spaceRoomListProxy: SpaceRoomListProxyProtocol?) {
         let inviteParameters = InviteUsersScreenCoordinatorParameters(userSession: flowParameters.userSession,
-                                                                      roomType: .room(roomProxy: roomProxy),
+                                                                      roomType: .existingRoom(roomProxy: roomProxy),
                                                                       isSkippable: true,
                                                                       userDiscoveryService: userDiscoveryService,
                                                                       userIndicatorController: flowParameters.userIndicatorController,
@@ -290,7 +290,7 @@ class StartChatFlowCoordinator: FlowCoordinatorProtocol {
             }
         }
         .store(in: &cancellables)
-
+        
         navigationStackCoordinator.push(coordinator)
     }
 }

--- a/ElementX/Sources/FlowCoordinators/StartChatFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/StartChatFlowCoordinator.swift
@@ -285,7 +285,7 @@ class StartChatFlowCoordinator: FlowCoordinatorProtocol {
                 } else {
                     actionsSubject.send(.finished(.room(id: roomProxy.id)))
                 }
-            case .invite:
+            case .openRoom:
                 break
             }
         }

--- a/ElementX/Sources/FlowCoordinators/StartChatFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/StartChatFlowCoordinator.swift
@@ -45,7 +45,7 @@ class StartChatFlowCoordinator: FlowCoordinatorProtocol {
     indirect enum State: StateType {
         /// The state machine hasn't started.
         case initial
-        
+
         /// Shown when the flow is started with options to create a room/DM, join by alias, use the room directory etc.
         case startChat
         /// The user is creating a new room.
@@ -55,7 +55,7 @@ class StartChatFlowCoordinator: FlowCoordinatorProtocol {
         /// The user is inviting users to a newly created room.
         case inviteUsers
     }
-    
+
     enum Event: EventType {
         /// The flow is being started.
         case start
@@ -63,12 +63,12 @@ class StartChatFlowCoordinator: FlowCoordinatorProtocol {
         case createRoom(isSpace: Bool)
         /// The user dismissed the create room screen.
         case dismissedCreateRoom
-        
+
         /// The user would like to pick an avatar for the room.
         case presentRoomAvatarPicker
         /// The user finished picking the avatar.
         case dismissedRoomAvatarPicker
-        
+
         /// The user's room was created successfully.
         case createdRoom
     }
@@ -270,7 +270,7 @@ class StartChatFlowCoordinator: FlowCoordinatorProtocol {
     
     private func presentInviteUsersScreen(roomProxy: JoinedRoomProxyProtocol, spaceRoomListProxy: SpaceRoomListProxyProtocol?) {
         let inviteParameters = InviteUsersScreenCoordinatorParameters(userSession: flowParameters.userSession,
-                                                                      roomProxy: roomProxy,
+                                                                      roomType: .room(roomProxy: roomProxy),
                                                                       isSkippable: true,
                                                                       userDiscoveryService: userDiscoveryService,
                                                                       userIndicatorController: flowParameters.userIndicatorController,
@@ -285,10 +285,12 @@ class StartChatFlowCoordinator: FlowCoordinatorProtocol {
                 } else {
                     actionsSubject.send(.finished(.room(id: roomProxy.id)))
                 }
+            case .invite:
+                break
             }
         }
         .store(in: &cancellables)
-        
+
         navigationStackCoordinator.push(coordinator)
     }
 }

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -3367,8 +3367,8 @@ class ClientProxyMock: ClientProxyProtocol, @unchecked Sendable {
     var createRoomNameTopicAccessTypeIsSpaceUserIDsAvatarURLAliasLocalPartCalled: Bool {
         return createRoomNameTopicAccessTypeIsSpaceUserIDsAvatarURLAliasLocalPartCallsCount > 0
     }
-    var createRoomNameTopicAccessTypeIsSpaceUserIDsAvatarURLAliasLocalPartReceivedArguments: (name: String, topic: String?, accessType: CreateRoomAccessType, isSpace: Bool, userIDs: [String], avatarURL: URL?, aliasLocalPart: String?)?
-    var createRoomNameTopicAccessTypeIsSpaceUserIDsAvatarURLAliasLocalPartReceivedInvocations: [(name: String, topic: String?, accessType: CreateRoomAccessType, isSpace: Bool, userIDs: [String], avatarURL: URL?, aliasLocalPart: String?)] = []
+    var createRoomNameTopicAccessTypeIsSpaceUserIDsAvatarURLAliasLocalPartReceivedArguments: (name: String?, topic: String?, accessType: CreateRoomAccessType, isSpace: Bool, userIDs: [String], avatarURL: URL?, aliasLocalPart: String?)?
+    var createRoomNameTopicAccessTypeIsSpaceUserIDsAvatarURLAliasLocalPartReceivedInvocations: [(name: String?, topic: String?, accessType: CreateRoomAccessType, isSpace: Bool, userIDs: [String], avatarURL: URL?, aliasLocalPart: String?)] = []
 
     var createRoomNameTopicAccessTypeIsSpaceUserIDsAvatarURLAliasLocalPartUnderlyingReturnValue: Result<String, ClientProxyError>!
     var createRoomNameTopicAccessTypeIsSpaceUserIDsAvatarURLAliasLocalPartReturnValue: Result<String, ClientProxyError>! {
@@ -3394,9 +3394,9 @@ class ClientProxyMock: ClientProxyProtocol, @unchecked Sendable {
             }
         }
     }
-    var createRoomNameTopicAccessTypeIsSpaceUserIDsAvatarURLAliasLocalPartClosure: ((String, String?, CreateRoomAccessType, Bool, [String], URL?, String?) async -> Result<String, ClientProxyError>)?
+    var createRoomNameTopicAccessTypeIsSpaceUserIDsAvatarURLAliasLocalPartClosure: ((String?, String?, CreateRoomAccessType, Bool, [String], URL?, String?) async -> Result<String, ClientProxyError>)?
 
-    func createRoom(name: String, topic: String?, accessType: CreateRoomAccessType, isSpace: Bool, userIDs: [String], avatarURL: URL?, aliasLocalPart: String?) async -> Result<String, ClientProxyError> {
+    func createRoom(name: String?, topic: String?, accessType: CreateRoomAccessType, isSpace: Bool, userIDs: [String], avatarURL: URL?, aliasLocalPart: String?) async -> Result<String, ClientProxyError> {
         createRoomNameTopicAccessTypeIsSpaceUserIDsAvatarURLAliasLocalPartCallsCount += 1
         createRoomNameTopicAccessTypeIsSpaceUserIDsAvatarURLAliasLocalPartReceivedArguments = (name: name, topic: topic, accessType: accessType, isSpace: isSpace, userIDs: userIDs, avatarURL: avatarURL, aliasLocalPart: aliasLocalPart)
         DispatchQueue.main.async {

--- a/ElementX/Sources/Screens/InviteUsersScreen/InviteUsersScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/InviteUsersScreenCoordinator.swift
@@ -11,7 +11,8 @@ import SwiftUI
 
 struct InviteUsersScreenCoordinatorParameters {
     let userSession: UserSessionProtocol
-    let roomProxy: JoinedRoomProxyProtocol
+    let roomType: InviteUsersScreenRoomType
+    var lockedInvitees: [UserProfileProxy] = []
     let isSkippable: Bool
     let userDiscoveryService: UserDiscoveryServiceProtocol
     let userIndicatorController: UserIndicatorControllerProtocol
@@ -20,37 +21,41 @@ struct InviteUsersScreenCoordinatorParameters {
 
 enum InviteUsersScreenCoordinatorAction {
     case dismiss
+    case invite(userIDs: [String])
 }
 
 final class InviteUsersScreenCoordinator: CoordinatorProtocol {
     private let viewModel: InviteUsersScreenViewModelProtocol
     private let actionsSubject: PassthroughSubject<InviteUsersScreenCoordinatorAction, Never> = .init()
     private var cancellables = Set<AnyCancellable>()
-    
+
     var actions: AnyPublisher<InviteUsersScreenCoordinatorAction, Never> {
         actionsSubject.eraseToAnyPublisher()
     }
-    
+
     init(parameters: InviteUsersScreenCoordinatorParameters) {
         viewModel = InviteUsersScreenViewModel(userSession: parameters.userSession,
-                                               roomProxy: parameters.roomProxy,
+                                               roomType: parameters.roomType,
+                                               lockedInvitees: parameters.lockedInvitees,
                                                isSkippable: parameters.isSkippable,
                                                userDiscoveryService: parameters.userDiscoveryService,
                                                userIndicatorController: parameters.userIndicatorController,
                                                appSettings: parameters.appSettings)
     }
-    
+
     func start() {
         viewModel.actions.sink { [weak self] action in
             guard let self else { return }
             switch action {
             case .dismiss:
                 actionsSubject.send(.dismiss)
+            case .invite(let userIDs):
+                actionsSubject.send(.invite(userIDs: userIDs))
             }
         }
         .store(in: &cancellables)
     }
-    
+
     func toPresentable() -> AnyView {
         AnyView(InviteUsersScreen(context: viewModel.context))
     }

--- a/ElementX/Sources/Screens/InviteUsersScreen/InviteUsersScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/InviteUsersScreenCoordinator.swift
@@ -12,7 +12,6 @@ import SwiftUI
 struct InviteUsersScreenCoordinatorParameters {
     let userSession: UserSessionProtocol
     let roomType: InviteUsersScreenRoomType
-    var lockedInvitees: [UserProfileProxy] = []
     let isSkippable: Bool
     let userDiscoveryService: UserDiscoveryServiceProtocol
     let userIndicatorController: UserIndicatorControllerProtocol
@@ -28,21 +27,20 @@ final class InviteUsersScreenCoordinator: CoordinatorProtocol {
     private let viewModel: InviteUsersScreenViewModelProtocol
     private let actionsSubject: PassthroughSubject<InviteUsersScreenCoordinatorAction, Never> = .init()
     private var cancellables = Set<AnyCancellable>()
-
+    
     var actions: AnyPublisher<InviteUsersScreenCoordinatorAction, Never> {
         actionsSubject.eraseToAnyPublisher()
     }
-
+    
     init(parameters: InviteUsersScreenCoordinatorParameters) {
         viewModel = InviteUsersScreenViewModel(userSession: parameters.userSession,
                                                roomType: parameters.roomType,
-                                               lockedInvitees: parameters.lockedInvitees,
                                                isSkippable: parameters.isSkippable,
                                                userDiscoveryService: parameters.userDiscoveryService,
                                                userIndicatorController: parameters.userIndicatorController,
                                                appSettings: parameters.appSettings)
     }
-
+    
     func start() {
         viewModel.actions.sink { [weak self] action in
             guard let self else { return }
@@ -55,7 +53,7 @@ final class InviteUsersScreenCoordinator: CoordinatorProtocol {
         }
         .store(in: &cancellables)
     }
-
+    
     func toPresentable() -> AnyView {
         AnyView(InviteUsersScreen(context: viewModel.context))
     }

--- a/ElementX/Sources/Screens/InviteUsersScreen/InviteUsersScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/InviteUsersScreenCoordinator.swift
@@ -21,7 +21,7 @@ struct InviteUsersScreenCoordinatorParameters {
 
 enum InviteUsersScreenCoordinatorAction {
     case dismiss
-    case invite(userIDs: [String])
+    case openRoom(roomID: String)
 }
 
 final class InviteUsersScreenCoordinator: CoordinatorProtocol {
@@ -49,8 +49,8 @@ final class InviteUsersScreenCoordinator: CoordinatorProtocol {
             switch action {
             case .dismiss:
                 actionsSubject.send(.dismiss)
-            case .invite(let userIDs):
-                actionsSubject.send(.invite(userIDs: userIDs))
+            case .openRoom(let roomID):
+                actionsSubject.send(.openRoom(roomID: roomID))
             }
         }
         .store(in: &cancellables)

--- a/ElementX/Sources/Screens/InviteUsersScreen/InviteUsersScreenModels.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/InviteUsersScreenModels.swift
@@ -16,7 +16,7 @@ enum InviteUsersScreenErrorType: Error {
 
 enum InviteUsersScreenViewModelAction {
     case dismiss
-    case invite(userIDs: [String])
+    case openRoom(roomID: String)
 }
 
 enum InviteUsersScreenRoomType {

--- a/ElementX/Sources/Screens/InviteUsersScreen/InviteUsersScreenModels.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/InviteUsersScreenModels.swift
@@ -59,14 +59,6 @@ struct InviteUsersScreenViewState: BindableState {
     }
 
     let isSkippable: Bool
-
-    var actionText: String {
-        L10n.actionDone
-    }
-
-    var isActionDisabled: Bool {
-        isSkippable ? false : selectedUsers.isEmpty
-    }
 }
 
 struct InviteUsersScreenViewStateBindings {

--- a/ElementX/Sources/Screens/InviteUsersScreen/InviteUsersScreenModels.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/InviteUsersScreenModels.swift
@@ -16,6 +16,7 @@ enum InviteUsersScreenErrorType: Error {
 
 enum InviteUsersScreenViewModelAction {
     case dismiss
+    case invite(userIDs: [String])
 }
 
 enum InviteUsersScreenRoomType {
@@ -25,42 +26,44 @@ enum InviteUsersScreenRoomType {
 
 struct InviteUsersScreenViewState: BindableState {
     var bindings = InviteUsersScreenViewStateBindings()
-    
+
     var usersSection: UserDiscoverySection = .init(type: .suggestions, users: [])
-    
+
     var selectedUsers: [UserProfileProxy] = []
+    var lockedInvitees: [UserProfileProxy] = []
     var membershipState: [String: MembershipState] = .init()
     var usersToConfirm: [UserProfileProxy] = []
-    
+
     var isSearching = false
-    
+
     var hasEmptySearchResults: Bool {
         !isSearching && usersSection.type == .searchResult && usersSection.users.isEmpty
     }
-    
+
     func isUserSelected(_ user: UserProfileProxy) -> Bool {
         isUserDisabled(user) || selectedUsers.contains { $0.userID == user.userID }
     }
-    
+
     func isUserDisabled(_ user: UserProfileProxy) -> Bool {
+        if isUserLocked(user) { return true }
         let membershipState = membershipState(user)
         return membershipState == .invite || membershipState == .join
     }
-    
+
+    func isUserLocked(_ user: UserProfileProxy) -> Bool {
+        lockedInvitees.contains { $0.userID == user.userID }
+    }
+
     func membershipState(_ user: UserProfileProxy) -> MembershipState? {
         membershipState[user.userID]
     }
-    
+
     let isSkippable: Bool
-    
+
     var actionText: String {
-        if isSkippable, selectedUsers.isEmpty {
-            L10n.actionSkip
-        } else {
-            L10n.actionInvite
-        }
+        L10n.actionDone
     }
-    
+
     var isActionDisabled: Bool {
         isSkippable ? false : selectedUsers.isEmpty
     }

--- a/ElementX/Sources/Screens/InviteUsersScreen/InviteUsersScreenModels.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/InviteUsersScreenModels.swift
@@ -20,44 +20,48 @@ enum InviteUsersScreenViewModelAction {
 }
 
 enum InviteUsersScreenRoomType {
-    case draft
-    case room(roomProxy: JoinedRoomProxyProtocol)
+    case draft(mandatoryInvitees: [UserProfileProxy])
+    case existingRoom(roomProxy: JoinedRoomProxyProtocol)
 }
 
 struct InviteUsersScreenViewState: BindableState {
     var bindings = InviteUsersScreenViewStateBindings()
-
+    
     var usersSection: UserDiscoverySection = .init(type: .suggestions, users: [])
-
+    
     var selectedUsers: [UserProfileProxy] = []
-    var lockedInvitees: [UserProfileProxy] = []
+    var mandatoryInvitees: [UserProfileProxy] = []
     var membershipState: [String: MembershipState] = .init()
     var usersToConfirm: [UserProfileProxy] = []
-
+    
     var isSearching = false
-
+    
     var hasEmptySearchResults: Bool {
         !isSearching && usersSection.type == .searchResult && usersSection.users.isEmpty
     }
-
+    
+    var hasInvitableSelectedUsers: Bool {
+        selectedUsers.contains { !isInviteeMandatory($0) }
+    }
+    
     func isUserSelected(_ user: UserProfileProxy) -> Bool {
         isUserDisabled(user) || selectedUsers.contains { $0.userID == user.userID }
     }
-
+    
     func isUserDisabled(_ user: UserProfileProxy) -> Bool {
-        if isUserLocked(user) { return true }
+        if isInviteeMandatory(user) { return true }
         let membershipState = membershipState(user)
         return membershipState == .invite || membershipState == .join
     }
-
-    func isUserLocked(_ user: UserProfileProxy) -> Bool {
-        lockedInvitees.contains { $0.userID == user.userID }
+    
+    func isInviteeMandatory(_ user: UserProfileProxy) -> Bool {
+        mandatoryInvitees.contains { $0.userID == user.userID }
     }
-
+    
     func membershipState(_ user: UserProfileProxy) -> MembershipState? {
         membershipState[user.userID]
     }
-
+    
     let isSkippable: Bool
 }
 

--- a/ElementX/Sources/Screens/InviteUsersScreen/InviteUsersScreenViewModel.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/InviteUsersScreenViewModel.swift
@@ -65,7 +65,7 @@ class InviteUsersScreenViewModel: InviteUsersScreenViewModelType, InviteUsersScr
         case .proceed:
             switch roomType {
             case .draft:
-                actionsSubject.send(.invite(userIDs: state.selectedUsers.map(\.userID)))
+                createDraftRoom(userIDs: state.selectedUsers.map(\.userID))
             case .room(let roomProxy):
                 guard roomProxy.details.historySharingState != RoomHistorySharingState.hidden,
                       !state.usersToConfirm.isEmpty,
@@ -115,6 +115,29 @@ class InviteUsersScreenViewModel: InviteUsersScreenViewModelType, InviteUsersScr
         }
     }
     
+    private func createDraftRoom(userIDs: [String]) {
+        showLoadingIndicator(title: L10n.commonCreatingRoom)
+
+        Task {
+            defer { hideLoadingIndicator() }
+
+            switch await clientProxy.createRoom(name: nil,
+                                                topic: nil,
+                                                accessType: .private,
+                                                isSpace: false,
+                                                userIDs: userIDs,
+                                                avatarURL: nil,
+                                                aliasLocalPart: nil) {
+            case .success(let roomID):
+                actionsSubject.send(.openRoom(roomID: roomID))
+            case .failure:
+                state.bindings.alertInfo = .init(id: .unknown,
+                                                 title: L10n.commonError,
+                                                 message: L10n.screenStartChatErrorStartingChat)
+            }
+        }
+    }
+
     private func inviteUsers(_ users: [String], roomProxy: JoinedRoomProxyProtocol) {
         showLoadingIndicator(title: L10n.screenRoomDetailsInvitePeoplePreparing, message: L10n.screenRoomDetailsInvitePeopleDontClose)
         

--- a/ElementX/Sources/Screens/InviteUsersScreen/InviteUsersScreenViewModel.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/InviteUsersScreenViewModel.swift
@@ -18,17 +18,16 @@ class InviteUsersScreenViewModel: InviteUsersScreenViewModelType, InviteUsersScr
     private let userDiscoveryService: UserDiscoveryServiceProtocol
     private let userIndicatorController: UserIndicatorControllerProtocol
     private let appSettings: AppSettings
-
+    
     private var suggestedUsers = [UserProfileProxy]()
-
+    
     private let actionsSubject: PassthroughSubject<InviteUsersScreenViewModelAction, Never> = .init()
     var actions: AnyPublisher<InviteUsersScreenViewModelAction, Never> {
         actionsSubject.eraseToAnyPublisher()
     }
-
+    
     init(userSession: UserSessionProtocol,
          roomType: InviteUsersScreenRoomType,
-         lockedInvitees: [UserProfileProxy] = [],
          isSkippable: Bool,
          userDiscoveryService: UserDiscoveryServiceProtocol,
          userIndicatorController: UserIndicatorControllerProtocol,
@@ -39,25 +38,27 @@ class InviteUsersScreenViewModel: InviteUsersScreenViewModelType, InviteUsersScr
         self.userIndicatorController = userIndicatorController
         self.appSettings = appSettings
 
-        super.init(initialViewState: InviteUsersScreenViewState(selectedUsers: lockedInvitees,
-                                                                lockedInvitees: lockedInvitees,
+        let mandatoryInvitees: [UserProfileProxy] = if case .draft(let invitees) = roomType { invitees } else { [] }
+
+        super.init(initialViewState: InviteUsersScreenViewState(selectedUsers: mandatoryInvitees,
+                                                                mandatoryInvitees: mandatoryInvitees,
                                                                 isSkippable: isSkippable),
                    mediaProvider: userSession.mediaProvider)
-
+        
         setupSubscriptions()
         fetchMembersIfNeeded()
-
+        
         Task {
             suggestedUsers = await userSession.clientProxy.recentConversationCounterparts()
-
+            
             if state.usersSection.type == .suggestions {
                 state.usersSection = .init(type: .suggestions, users: suggestedUsers)
             }
         }
     }
-
+    
     // MARK: - Public
-
+    
     override func process(viewAction: InviteUsersScreenViewAction) {
         switch viewAction {
         case .cancel:
@@ -65,8 +66,8 @@ class InviteUsersScreenViewModel: InviteUsersScreenViewModelType, InviteUsersScr
         case .proceed:
             switch roomType {
             case .draft:
-                createDraftRoom(userIDs: state.selectedUsers.map(\.userID))
-            case .room(let roomProxy):
+                createDraftRoom(mandatoryUserIDs: state.selectedUsers.map(\.userID))
+            case .existingRoom(let roomProxy):
                 guard roomProxy.details.historySharingState != RoomHistorySharingState.hidden,
                       !state.usersToConfirm.isEmpty,
                       !state.isSkippable else {
@@ -84,7 +85,7 @@ class InviteUsersScreenViewModel: InviteUsersScreenViewModelType, InviteUsersScr
         case .confirmUnknownUsers:
             state.bindings.presentConfirmationDialog = false
             state.usersToConfirm = []
-            if case .room(let roomProxy) = roomType {
+            if case .existingRoom(let roomProxy) = roomType {
                 inviteUsers(state.selectedUsers.map(\.userID), roomProxy: roomProxy)
             }
         case .toggleUser(let user):
@@ -93,9 +94,10 @@ class InviteUsersScreenViewModel: InviteUsersScreenViewModelType, InviteUsersScr
     }
 
     // MARK: - Private
-
+    
     private func toggleUser(_ user: UserProfileProxy) {
-        guard !state.isUserLocked(user) else { return }
+        guard !state.isInviteeMandatory(user) else { return }
+
         if state.selectedUsers.contains(user) {
             state.selectedUsers.removeAll { $0.userID == user.userID }
         } else {
@@ -115,7 +117,7 @@ class InviteUsersScreenViewModel: InviteUsersScreenViewModelType, InviteUsersScr
         }
     }
     
-    private func createDraftRoom(userIDs: [String]) {
+    private func createDraftRoom(mandatoryUserIDs: [String]) {
         showLoadingIndicator(title: L10n.commonCreatingRoom)
 
         Task {
@@ -125,7 +127,7 @@ class InviteUsersScreenViewModel: InviteUsersScreenViewModelType, InviteUsersScr
                                                 topic: nil,
                                                 accessType: .private,
                                                 isSpace: false,
-                                                userIDs: userIDs,
+                                                userIDs: mandatoryUserIDs,
                                                 avatarURL: nil,
                                                 aliasLocalPart: nil) {
             case .success(let roomID):
@@ -137,7 +139,7 @@ class InviteUsersScreenViewModel: InviteUsersScreenViewModelType, InviteUsersScr
             }
         }
     }
-
+    
     private func inviteUsers(_ users: [String], roomProxy: JoinedRoomProxyProtocol) {
         showLoadingIndicator(title: L10n.screenRoomDetailsInvitePeoplePreparing, message: L10n.screenRoomDetailsInvitePeopleDontClose)
         
@@ -201,14 +203,14 @@ class InviteUsersScreenViewModel: InviteUsersScreenViewModelType, InviteUsersScr
     }
     
     private func fetchMembersIfNeeded() {
-        guard case .room(let roomProxy) = roomType else { return }
-
+        guard case .existingRoom(let roomProxy) = roomType else { return }
+        
         Task {
             showLoadingIndicator()
             await roomProxy.updateMembers()
             hideLoadingIndicator()
         }
-
+        
         roomProxy.membersPublisher
             .filter { !$0.isEmpty }
             .first()

--- a/ElementX/Sources/Screens/InviteUsersScreen/InviteUsersScreenViewModel.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/InviteUsersScreenViewModel.swift
@@ -14,60 +14,67 @@ typealias InviteUsersScreenViewModelType = StateStoreViewModel<InviteUsersScreen
 
 class InviteUsersScreenViewModel: InviteUsersScreenViewModelType, InviteUsersScreenViewModelProtocol {
     private let clientProxy: ClientProxyProtocol
-    private let roomProxy: JoinedRoomProxyProtocol
+    private let roomType: InviteUsersScreenRoomType
     private let userDiscoveryService: UserDiscoveryServiceProtocol
     private let userIndicatorController: UserIndicatorControllerProtocol
     private let appSettings: AppSettings
-    
+
     private var suggestedUsers = [UserProfileProxy]()
-    
+
     private let actionsSubject: PassthroughSubject<InviteUsersScreenViewModelAction, Never> = .init()
     var actions: AnyPublisher<InviteUsersScreenViewModelAction, Never> {
         actionsSubject.eraseToAnyPublisher()
     }
-    
+
     init(userSession: UserSessionProtocol,
-         roomProxy: JoinedRoomProxyProtocol,
+         roomType: InviteUsersScreenRoomType,
+         lockedInvitees: [UserProfileProxy] = [],
          isSkippable: Bool,
          userDiscoveryService: UserDiscoveryServiceProtocol,
          userIndicatorController: UserIndicatorControllerProtocol,
          appSettings: AppSettings) {
         clientProxy = userSession.clientProxy
-        self.roomProxy = roomProxy
+        self.roomType = roomType
         self.userDiscoveryService = userDiscoveryService
         self.userIndicatorController = userIndicatorController
         self.appSettings = appSettings
-        
-        super.init(initialViewState: InviteUsersScreenViewState(selectedUsers: [],
+
+        super.init(initialViewState: InviteUsersScreenViewState(selectedUsers: lockedInvitees,
+                                                                lockedInvitees: lockedInvitees,
                                                                 isSkippable: isSkippable),
                    mediaProvider: userSession.mediaProvider)
-                
+
         setupSubscriptions()
         fetchMembersIfNeeded()
-        
+
         Task {
             suggestedUsers = await userSession.clientProxy.recentConversationCounterparts()
-            
+
             if state.usersSection.type == .suggestions {
                 state.usersSection = .init(type: .suggestions, users: suggestedUsers)
             }
         }
     }
-    
+
     // MARK: - Public
-    
+
     override func process(viewAction: InviteUsersScreenViewAction) {
         switch viewAction {
         case .cancel:
             actionsSubject.send(.dismiss)
         case .proceed:
-            guard roomProxy.details.historySharingState != RoomHistorySharingState.hidden,
-                  !state.usersToConfirm.isEmpty,
-                  !state.isSkippable else {
-                inviteUsers(state.selectedUsers.map(\.userID), roomProxy: roomProxy)
-                return
+            switch roomType {
+            case .draft:
+                actionsSubject.send(.invite(userIDs: state.selectedUsers.map(\.userID)))
+            case .room(let roomProxy):
+                guard roomProxy.details.historySharingState != RoomHistorySharingState.hidden,
+                      !state.usersToConfirm.isEmpty,
+                      !state.isSkippable else {
+                    inviteUsers(state.selectedUsers.map(\.userID), roomProxy: roomProxy)
+                    return
+                }
+                state.bindings.presentConfirmationDialog = true
             }
-            state.bindings.presentConfirmationDialog = true
         case .removeUnknownUsers:
             state.bindings.presentConfirmationDialog = false
             state.selectedUsers.removeAll { user in
@@ -77,15 +84,18 @@ class InviteUsersScreenViewModel: InviteUsersScreenViewModelType, InviteUsersScr
         case .confirmUnknownUsers:
             state.bindings.presentConfirmationDialog = false
             state.usersToConfirm = []
-            inviteUsers(state.selectedUsers.map(\.userID), roomProxy: roomProxy)
+            if case .room(let roomProxy) = roomType {
+                inviteUsers(state.selectedUsers.map(\.userID), roomProxy: roomProxy)
+            }
         case .toggleUser(let user):
             toggleUser(user)
         }
     }
 
     // MARK: - Private
-    
+
     private func toggleUser(_ user: UserProfileProxy) {
+        guard !state.isUserLocked(user) else { return }
         if state.selectedUsers.contains(user) {
             state.selectedUsers.removeAll { $0.userID == user.userID }
         } else {
@@ -168,12 +178,14 @@ class InviteUsersScreenViewModel: InviteUsersScreenViewModelType, InviteUsersScr
     }
     
     private func fetchMembersIfNeeded() {
+        guard case .room(let roomProxy) = roomType else { return }
+
         Task {
             showLoadingIndicator()
             await roomProxy.updateMembers()
             hideLoadingIndicator()
         }
-        
+
         roomProxy.membersPublisher
             .filter { !$0.isEmpty }
             .first()

--- a/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersConfirmationSheetView.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersConfirmationSheetView.swift
@@ -61,7 +61,7 @@ struct InviteUsersConfirmationSheetView_Previews: PreviewProvider, TestablePrevi
     
     static func makeViewModel() -> InviteUsersScreenViewModel {
         let viewModel = InviteUsersScreenViewModel(userSession: UserSessionMock(.init(clientProxy: ClientProxyMock(.init()))),
-                                                   roomType: .room(roomProxy: JoinedRoomProxyMock(.init(members: []))),
+                                                   roomType: .existingRoom(roomProxy: JoinedRoomProxyMock(.init(members: []))),
                                                    isSkippable: true,
                                                    userDiscoveryService: UserDiscoveryServiceMock(),
                                                    userIndicatorController: UserIndicatorControllerMock(),

--- a/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersConfirmationSheetView.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersConfirmationSheetView.swift
@@ -61,7 +61,7 @@ struct InviteUsersConfirmationSheetView_Previews: PreviewProvider, TestablePrevi
     
     static func makeViewModel() -> InviteUsersScreenViewModel {
         let viewModel = InviteUsersScreenViewModel(userSession: UserSessionMock(.init(clientProxy: ClientProxyMock(.init()))),
-                                                   roomProxy: JoinedRoomProxyMock(.init(members: [])),
+                                                   roomType: .room(roomProxy: JoinedRoomProxyMock(.init(members: []))),
                                                    isSkippable: true,
                                                    userDiscoveryService: UserDiscoveryServiceMock(),
                                                    userIndicatorController: UserIndicatorControllerMock(),

--- a/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreen.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreen.swift
@@ -110,7 +110,9 @@ struct InviteUsersScreen: View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 8) {
                 ForEach(context.viewState.selectedUsers, id: \.userID) { user in
-                    InviteUsersScreenSelectedItem(user: user, mediaProvider: context.mediaProvider) {
+                    InviteUsersScreenSelectedItem(user: user,
+                                                  mediaProvider: context.mediaProvider,
+                                                  isLocked: context.viewState.isUserLocked(user)) {
                         deselect(user)
                     }
                     .frame(width: selectedUserCellWidth)
@@ -153,14 +155,15 @@ struct InviteUsersScreen_Previews: PreviewProvider, TestablePreview {
     static let searchingViewModel = makeViewModel(searchQuery: "Alice")
     static let selectedViewModel = makeViewModel(hasSelection: true)
     static let confirmSelectedViewModel = makeViewModel(shouldConfirm: true)
-    
+    static let draftViewModel = makeViewModel(roomType: .draft, lockedInvitees: [.mockAlice], isSkippable: false)
+
     static var previews: some View {
         ElementNavigationStack {
             InviteUsersScreen(context: viewModel.context)
         }
         .previewDisplayName("Suggestions")
         .snapshotPreferences(expect: viewModel.context.$viewState.map { !$0.usersSection.users.isEmpty })
-        
+
         ElementNavigationStack {
             InviteUsersScreen(context: searchingViewModel.context)
         }
@@ -168,46 +171,58 @@ struct InviteUsersScreen_Previews: PreviewProvider, TestablePreview {
         .snapshotPreferences(expect: searchingViewModel.context.$viewState.map {
             $0.usersSection.type == .searchResult && !$0.usersSection.users.isEmpty
         })
-        
+
         ElementNavigationStack {
             InviteUsersScreen(context: selectedViewModel.context)
         }
         .previewDisplayName("Selected")
         .snapshotPreferences(expect: selectedViewModel.context.$viewState.map { !$0.selectedUsers.isEmpty })
-        
+
         ElementNavigationStack {
             InviteUsersScreen(context: confirmSelectedViewModel.context)
         }
         .previewDisplayName("Confirm Selected")
+
+        ElementNavigationStack {
+            InviteUsersScreen(context: draftViewModel.context)
+        }
+        .previewDisplayName("Draft (locked invitee)")
+        .snapshotPreferences(expect: draftViewModel.context.$viewState.map { !$0.lockedInvitees.isEmpty })
     }
-    
-    static func makeViewModel(searchQuery: String? = nil, hasSelection: Bool = false, shouldConfirm: Bool = false) -> InviteUsersScreenViewModel {
+
+    static func makeViewModel(searchQuery: String? = nil,
+                              hasSelection: Bool = false,
+                              shouldConfirm: Bool = false,
+                              roomType: InviteUsersScreenRoomType? = nil,
+                              lockedInvitees: [UserProfileProxy] = [],
+                              isSkippable: Bool = true) -> InviteUsersScreenViewModel {
         let clientProxy = ClientProxyMock(.init())
         clientProxy.recentConversationCounterpartsReturnValue = [.mockAlice, .mockBob, .mockCharlie, .mockDan, .mockVerbose]
-        
+
         let userDiscoveryService = UserDiscoveryServiceMock()
         userDiscoveryService.searchProfilesWithReturnValue = .success([.mockAlice])
-        
+
         let viewModel = InviteUsersScreenViewModel(userSession: UserSessionMock(.init(clientProxy: clientProxy)),
-                                                   roomProxy: JoinedRoomProxyMock(.init(members: [])),
-                                                   isSkippable: true,
+                                                   roomType: roomType ?? .room(roomProxy: JoinedRoomProxyMock(.init(members: []))),
+                                                   lockedInvitees: lockedInvitees,
+                                                   isSkippable: isSkippable,
                                                    userDiscoveryService: userDiscoveryService,
                                                    userIndicatorController: UserIndicatorControllerMock(),
                                                    appSettings: AppSettings())
-        
+
         if let searchQuery {
             viewModel.context.searchQuery = searchQuery
         }
-        
+
         if hasSelection {
             viewModel.state.selectedUsers = [.mockAlice]
         }
-        
+
         if shouldConfirm {
             viewModel.state.usersToConfirm = [.mockAlice, .mockAlice, .mockAlice, .mockAlice, .mockAlice, .mockAlice, .mockAlice, .mockAlice, .mockAlice]
             viewModel.state.bindings.presentConfirmationDialog = true
         }
-        
+
         return viewModel
     }
 }

--- a/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreen.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreen.swift
@@ -135,7 +135,7 @@ struct InviteUsersScreen: View {
         }
         
         ToolbarItem(placement: .confirmationAction) {
-            Button(context.viewState.actionText) {
+            ToolbarButton(role: .confirm(title: L10n.actionInvite)) {
                 context.send(viewAction: .proceed)
             }
             .accessibilityIdentifier(A11yIdentifiers.inviteUsersScreen.proceed)

--- a/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreen.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreen.swift
@@ -112,7 +112,7 @@ struct InviteUsersScreen: View {
                 ForEach(context.viewState.selectedUsers, id: \.userID) { user in
                     InviteUsersScreenSelectedItem(user: user,
                                                   mediaProvider: context.mediaProvider,
-                                                  isLocked: context.viewState.isUserLocked(user)) {
+                                                  isLocked: context.viewState.isInviteeMandatory(user)) {
                         deselect(user)
                     }
                     .frame(width: selectedUserCellWidth)
@@ -145,7 +145,7 @@ struct InviteUsersScreen: View {
                     context.send(viewAction: .proceed)
                 }
                 .accessibilityIdentifier(A11yIdentifiers.inviteUsersScreen.proceed)
-                .disabled(context.viewState.selectedUsers.isEmpty)
+                .disabled(!context.viewState.hasInvitableSelectedUsers)
             }
         }
     }
@@ -162,15 +162,15 @@ struct InviteUsersScreen_Previews: PreviewProvider, TestablePreview {
     static let searchingViewModel = makeViewModel(searchQuery: "Alice")
     static let selectedViewModel = makeViewModel(hasSelection: true)
     static let confirmSelectedViewModel = makeViewModel(shouldConfirm: true)
-    static let draftViewModel = makeViewModel(roomType: .draft, lockedInvitees: [.mockAlice], isSkippable: false)
-
+    static let draftViewModel = makeViewModel(roomType: .draft(mandatoryInvitees: [.mockAlice]), isSkippable: false)
+    
     static var previews: some View {
         ElementNavigationStack {
             InviteUsersScreen(context: viewModel.context)
         }
         .previewDisplayName("Suggestions")
         .snapshotPreferences(expect: viewModel.context.$viewState.map { !$0.usersSection.users.isEmpty })
-
+        
         ElementNavigationStack {
             InviteUsersScreen(context: searchingViewModel.context)
         }
@@ -178,30 +178,29 @@ struct InviteUsersScreen_Previews: PreviewProvider, TestablePreview {
         .snapshotPreferences(expect: searchingViewModel.context.$viewState.map {
             $0.usersSection.type == .searchResult && !$0.usersSection.users.isEmpty
         })
-
+        
         ElementNavigationStack {
             InviteUsersScreen(context: selectedViewModel.context)
         }
         .previewDisplayName("Selected")
         .snapshotPreferences(expect: selectedViewModel.context.$viewState.map { !$0.selectedUsers.isEmpty })
-
+        
         ElementNavigationStack {
             InviteUsersScreen(context: confirmSelectedViewModel.context)
         }
         .previewDisplayName("Confirm Selected")
-
+        
         ElementNavigationStack {
             InviteUsersScreen(context: draftViewModel.context)
         }
         .previewDisplayName("Draft (locked invitee)")
-        .snapshotPreferences(expect: draftViewModel.context.$viewState.map { !$0.lockedInvitees.isEmpty })
+        .snapshotPreferences(expect: draftViewModel.context.$viewState.map { !$0.mandatoryInvitees.isEmpty })
     }
-
+    
     static func makeViewModel(searchQuery: String? = nil,
                               hasSelection: Bool = false,
                               shouldConfirm: Bool = false,
                               roomType: InviteUsersScreenRoomType? = nil,
-                              lockedInvitees: [UserProfileProxy] = [],
                               isSkippable: Bool = true) -> InviteUsersScreenViewModel {
         let clientProxy = ClientProxyMock(.init())
         clientProxy.recentConversationCounterpartsReturnValue = [.mockAlice, .mockBob, .mockCharlie, .mockDan, .mockVerbose]
@@ -210,26 +209,25 @@ struct InviteUsersScreen_Previews: PreviewProvider, TestablePreview {
         userDiscoveryService.searchProfilesWithReturnValue = .success([.mockAlice])
 
         let viewModel = InviteUsersScreenViewModel(userSession: UserSessionMock(.init(clientProxy: clientProxy)),
-                                                   roomType: roomType ?? .room(roomProxy: JoinedRoomProxyMock(.init(members: []))),
-                                                   lockedInvitees: lockedInvitees,
+                                                   roomType: roomType ?? .existingRoom(roomProxy: JoinedRoomProxyMock(.init(members: []))),
                                                    isSkippable: isSkippable,
                                                    userDiscoveryService: userDiscoveryService,
                                                    userIndicatorController: UserIndicatorControllerMock(),
                                                    appSettings: AppSettings())
-
+        
         if let searchQuery {
             viewModel.context.searchQuery = searchQuery
         }
-
+        
         if hasSelection {
             viewModel.state.selectedUsers = [.mockAlice]
         }
-
+        
         if shouldConfirm {
             viewModel.state.usersToConfirm = [.mockAlice, .mockAlice, .mockAlice, .mockAlice, .mockAlice, .mockAlice, .mockAlice, .mockAlice, .mockAlice]
             viewModel.state.bindings.presentConfirmationDialog = true
         }
-
+        
         return viewModel
     }
 }

--- a/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreen.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreen.swift
@@ -135,11 +135,18 @@ struct InviteUsersScreen: View {
         }
         
         ToolbarItem(placement: .confirmationAction) {
-            ToolbarButton(role: .confirm(title: L10n.actionInvite)) {
-                context.send(viewAction: .proceed)
+            if context.viewState.isSkippable, context.viewState.selectedUsers.isEmpty {
+                Button(L10n.actionSkip) {
+                    context.send(viewAction: .proceed)
+                }
+                .accessibilityIdentifier(A11yIdentifiers.inviteUsersScreen.proceed)
+            } else {
+                ToolbarButton(role: .confirm(title: L10n.actionInvite)) {
+                    context.send(viewAction: .proceed)
+                }
+                .accessibilityIdentifier(A11yIdentifiers.inviteUsersScreen.proceed)
+                .disabled(context.viewState.selectedUsers.isEmpty)
             }
-            .accessibilityIdentifier(A11yIdentifiers.inviteUsersScreen.proceed)
-            .disabled(context.viewState.isActionDisabled)
         }
     }
     

--- a/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreenSelectedItem.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreenSelectedItem.swift
@@ -12,33 +12,43 @@ import SwiftUI
 struct InviteUsersScreenSelectedItem: View {
     let user: UserProfileProxy
     let mediaProvider: MediaProviderProtocol?
+    var isLocked = false
     let dismissAction: () -> Void
-    
+
     var body: some View {
         VStack(spacing: 10) {
             avatar
                 .accessibilityHidden(true)
-            
+
             Text(user.displayName ?? user.userID)
                 .font(.compound.bodySM)
                 .foregroundColor(.compound.textSecondary)
                 .lineLimit(1)
         }
         .accessibilityElement(children: .combine)
-        .accessibilityAction(named: L10n.actionRemove, dismissAction)
+        .accessibilityActions {
+            if !isLocked {
+                Button(L10n.actionRemove, action: dismissAction)
+            }
+        }
     }
-    
+
     // MARK: - Private
-    
+
+    @ViewBuilder
     var avatar: some View {
-        LoadableAvatarImage(url: user.avatarURL,
-                            name: user.displayName,
-                            contentID: user.userID,
-                            avatarSize: .user(on: .inviteUsers),
-                            mediaProvider: mediaProvider)
-            .overlayRemoveItemButton(action: dismissAction)
+        let avatarImage = LoadableAvatarImage(url: user.avatarURL,
+                                              name: user.displayName,
+                                              contentID: user.userID,
+                                              avatarSize: .user(on: .inviteUsers),
+                                              mediaProvider: mediaProvider)
+        if isLocked {
+            avatarImage
+        } else {
+            avatarImage.overlayRemoveItemButton(action: dismissAction)
+        }
     }
-    
+
     var closeButtonLabel: some View {
         CompoundIcon(\.close, size: .custom(12), relativeTo: .compound.bodySM)
             .foregroundStyle(.compound.iconOnSolidPrimary)

--- a/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreenSelectedItem.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreenSelectedItem.swift
@@ -14,12 +14,12 @@ struct InviteUsersScreenSelectedItem: View {
     let mediaProvider: MediaProviderProtocol?
     var isLocked = false
     let dismissAction: () -> Void
-
+    
     var body: some View {
         VStack(spacing: 10) {
             avatar
                 .accessibilityHidden(true)
-
+            
             Text(user.displayName ?? user.userID)
                 .font(.compound.bodySM)
                 .foregroundColor(.compound.textSecondary)
@@ -32,9 +32,9 @@ struct InviteUsersScreenSelectedItem: View {
             }
         }
     }
-
+    
     // MARK: - Private
-
+    
     @ViewBuilder
     var avatar: some View {
         let avatarImage = LoadableAvatarImage(url: user.avatarURL,
@@ -48,7 +48,7 @@ struct InviteUsersScreenSelectedItem: View {
             avatarImage.overlayRemoveItemButton(action: dismissAction)
         }
     }
-
+    
     var closeButtonLabel: some View {
         CompoundIcon(\.close, size: .custom(12), relativeTo: .compound.bodySM)
             .foregroundStyle(.compound.iconOnSolidPrimary)

--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenCoordinator.swift
@@ -26,6 +26,7 @@ enum RoomDetailsScreenCoordinatorAction {
     case presentRoomDetailsEditScreen
     case presentNotificationSettingsScreen
     case presentInviteUsersScreen
+    case presentInviteToNewRoom(invitee: UserProfileProxy)
     case presentPollsHistory
     case presentRolesAndPermissionsScreen
     case presentCall(isVoiceCall: Bool)
@@ -71,6 +72,8 @@ final class RoomDetailsScreenCoordinator: CoordinatorProtocol {
                     actionsSubject.send(.presentRoomMembersList)
                 case .requestInvitePeoplePresentation:
                     actionsSubject.send(.presentInviteUsersScreen)
+                case .requestInviteToNewRoomPresentation(let invitee):
+                    actionsSubject.send(.presentInviteToNewRoom(invitee: invitee))
                 case .leftRoom:
                     actionsSubject.send(.leftRoom)
                 case .requestEditDetailsPresentation:

--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenModels.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenModels.swift
@@ -18,6 +18,7 @@ enum RoomDetailsScreenViewModelAction: Equatable {
     case requestMemberDetailsPresentation
     case requestRecipientDetailsPresentation(userID: String)
     case requestInvitePeoplePresentation
+    case requestInviteToNewRoomPresentation(selectedInvitee: UserProfileProxy)
     case leftRoom
     case requestEditDetailsPresentation
     case requestPollsHistoryPresentation
@@ -98,6 +99,7 @@ struct RoomDetailsScreenViewState: BindableState {
             }
             shortcuts.append(.videoCall)
         }
+        // The invite flow is different for DMs
         if dmRecipientInfo == nil, canInviteUsers {
             shortcuts.append(.invite)
         }

--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
@@ -110,7 +110,11 @@ class RoomDetailsScreenViewModel: RoomDetailsScreenViewModelType, RoomDetailsScr
         case .processTapPeople:
             actionsSubject.send(.requestMemberDetailsPresentation)
         case .processTapInvite:
-            actionsSubject.send(.requestInvitePeoplePresentation)
+            if let dmRecipient = state.dmRecipientInfo {
+                actionsSubject.send(.requestInviteToNewRoomPresentation(selectedInvitee: .init(member: dmRecipient.member)))
+            } else {
+                actionsSubject.send(.requestInvitePeoplePresentation)
+            }
         case .processTapLeave:
             processTapToLeave()
         case .confirmLeave:

--- a/ElementX/Sources/Screens/RoomDetailsScreen/View/RoomDetailsScreen.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/View/RoomDetailsScreen.swift
@@ -22,6 +22,11 @@ struct RoomDetailsScreen: View {
             
             aboutSection
             
+            // The invitation flow is different for DMs
+            if context.viewState.dmRecipientInfo != nil {
+                inviteToNewRoomSection
+            }
+            
             configurationSection
             
             if context.viewState.dmRecipientInfo == nil {
@@ -163,6 +168,13 @@ struct RoomDetailsScreen: View {
                     })
                     .accessibilityIdentifier(A11yIdentifiers.roomDetailsScreen.pollsHistory)
         }
+    }
+    
+    private var inviteToNewRoomSection: some View {
+        ListRow(label: .default(title: L10n.actionInvite, icon: \.userAdd),
+                kind: .navigationLink {
+                    context.send(viewAction: .processTapInvite)
+                })
     }
     
     private var configurationSection: some View {

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -499,7 +499,7 @@ class ClientProxy: ClientProxyProtocol {
         }
     }
     
-    func createRoom(name: String,
+    func createRoom(name: String?,
                     topic: String?,
                     accessType: CreateRoomAccessType,
                     isSpace: Bool,

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -183,7 +183,7 @@ protocol ClientProxyProtocol: AnyObject {
     
     func createDirectRoom(with userID: String, expectedRoomName: String?) async -> Result<String, ClientProxyError>
     
-    func createRoom(name: String,
+    func createRoom(name: String?,
                     topic: String?,
                     accessType: CreateRoomAccessType,
                     isSpace: Bool,

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/inviteUsersScreen.Draft-locked-invitee-iPad-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/inviteUsersScreen.Draft-locked-invitee-iPad-en-GB.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9413c3be57bf3882bff847d80d76616413d2c16a63ba316a760548fff2b6386
+size 151997

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/inviteUsersScreen.Draft-locked-invitee-iPad-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/inviteUsersScreen.Draft-locked-invitee-iPad-pseudo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e70eaef9bc01eccd462be75ac69e1d556784596a0287da9a8f3f7e10e4e58b0
+size 156413

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/inviteUsersScreen.Draft-locked-invitee-iPhone-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/inviteUsersScreen.Draft-locked-invitee-iPhone-en-GB.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5338f0606064bc4c3c098c2458f1923db59f206c059cfa11bdbc387d42b3af3a
+size 99061

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/inviteUsersScreen.Draft-locked-invitee-iPhone-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/inviteUsersScreen.Draft-locked-invitee-iPhone-pseudo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c9456d7cf947a55063eae44ea955c34fd3af41663ffffbe1f72ba47f791cab0
+size 102079

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/inviteUsersScreen.Selected-iPad-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/inviteUsersScreen.Selected-iPad-en-GB.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f2efff4b459ba93bc6c8290a3ff46a26a684b2c6abe2812c8a4667a86b060711
-size 151210
+oid sha256:5a87b4c36df926a3cde0d0a15022e5b5c0c0e545c97974f916b506b4862fc5ab
+size 149551

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/inviteUsersScreen.Selected-iPad-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/inviteUsersScreen.Selected-iPad-pseudo.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1a6fa5cea94e92da8768cb87d2d157b9552ec3624fbc4f1241c0c212e93f2d98
-size 155938
+oid sha256:d450d451e9ca7779f4f186f2eabf8a23cef9b2dd861e581ed1c61d0dbbb06499
+size 153569

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/inviteUsersScreen.Selected-iPhone-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/inviteUsersScreen.Selected-iPhone-en-GB.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:34bbaf989ac4635edb87a1e2855c45af93eba45aae198a56173186014b79ddb3
-size 98426
+oid sha256:c793431f951a5ad023ab9b358658a5d75244e292cf56c0fc4a808b84df654e7a
+size 97084

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/inviteUsersScreen.Selected-iPhone-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/inviteUsersScreen.Selected-iPhone-pseudo.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9cebab4fae25f0ea54e0583563719429d06d52949d7847458a98dec6c0ce746d
-size 101873
+oid sha256:68c222b7a50badb09b9f2cbdcc6010edac0a7a2727ed9f2f98713e2874ffa214
+size 100304

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/roomDetailsScreen.DM-Room-Verification-Violation-iPad-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/roomDetailsScreen.DM-Room-Verification-Violation-iPad-en-GB.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c993321bdec5ce94cdd241664bce503fb1c65dc5341355c593f4eeae7f6c222f
-size 244787
+oid sha256:6bcc46e5933065a1b02dff5c2bf8abc09c626cf6adb6b91acca6c0d27bf8d967
+size 236706

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/roomDetailsScreen.DM-Room-Verification-Violation-iPad-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/roomDetailsScreen.DM-Room-Verification-Violation-iPad-pseudo.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3a0c1fd96fe4299e6075b6ebadc330a5943fe5393e3589a93288dc5d87f73ac8
-size 253574
+oid sha256:f892f94486579fcebfdb3bd5723c233130b10fdabbadac17f687fcedab365085
+size 244369

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/roomDetailsScreen.DM-Room-Verification-Violation-iPhone-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/roomDetailsScreen.DM-Room-Verification-Violation-iPhone-en-GB.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:68b3531545e4cecc6b6be0bb009e448cae7bc7ed2cee4686b48a20a780c82bb3
-size 181065
+oid sha256:ebb51488b9ce71449d0f8ee04bba5f260f924c61186b41c0d6fe8903b06de6b9
+size 174363

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/roomDetailsScreen.DM-Room-Verification-Violation-iPhone-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/roomDetailsScreen.DM-Room-Verification-Violation-iPhone-pseudo.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:040b3df78b47409a450c6ffec62fb3ff72cbfe74e15f3e85dfbc046a5f2695a7
-size 185625
+oid sha256:f87dbe6bdd53d79ef618cb86707360df944aeb0ad5916f64a9826eaae400e2b0
+size 185369

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/roomDetailsScreen.DM-Room-Verified-iPad-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/roomDetailsScreen.DM-Room-Verified-iPad-en-GB.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c993321bdec5ce94cdd241664bce503fb1c65dc5341355c593f4eeae7f6c222f
-size 244787
+oid sha256:6bcc46e5933065a1b02dff5c2bf8abc09c626cf6adb6b91acca6c0d27bf8d967
+size 236706

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/roomDetailsScreen.DM-Room-Verified-iPad-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/roomDetailsScreen.DM-Room-Verified-iPad-pseudo.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3a0c1fd96fe4299e6075b6ebadc330a5943fe5393e3589a93288dc5d87f73ac8
-size 253574
+oid sha256:f892f94486579fcebfdb3bd5723c233130b10fdabbadac17f687fcedab365085
+size 244369

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/roomDetailsScreen.DM-Room-Verified-iPhone-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/roomDetailsScreen.DM-Room-Verified-iPhone-en-GB.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:68b3531545e4cecc6b6be0bb009e448cae7bc7ed2cee4686b48a20a780c82bb3
-size 181065
+oid sha256:ebb51488b9ce71449d0f8ee04bba5f260f924c61186b41c0d6fe8903b06de6b9
+size 174363

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/roomDetailsScreen.DM-Room-Verified-iPhone-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/roomDetailsScreen.DM-Room-Verified-iPhone-pseudo.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:040b3df78b47409a450c6ffec62fb3ff72cbfe74e15f3e85dfbc046a5f2695a7
-size 185625
+oid sha256:f87dbe6bdd53d79ef618cb86707360df944aeb0ad5916f64a9826eaae400e2b0
+size 185369

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/roomDetailsScreen.DM-Room-iPad-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/roomDetailsScreen.DM-Room-iPad-en-GB.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c993321bdec5ce94cdd241664bce503fb1c65dc5341355c593f4eeae7f6c222f
-size 244787
+oid sha256:6bcc46e5933065a1b02dff5c2bf8abc09c626cf6adb6b91acca6c0d27bf8d967
+size 236706

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/roomDetailsScreen.DM-Room-iPad-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/roomDetailsScreen.DM-Room-iPad-pseudo.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3a0c1fd96fe4299e6075b6ebadc330a5943fe5393e3589a93288dc5d87f73ac8
-size 253574
+oid sha256:f892f94486579fcebfdb3bd5723c233130b10fdabbadac17f687fcedab365085
+size 244369

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/roomDetailsScreen.DM-Room-iPhone-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/roomDetailsScreen.DM-Room-iPhone-en-GB.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:68b3531545e4cecc6b6be0bb009e448cae7bc7ed2cee4686b48a20a780c82bb3
-size 181065
+oid sha256:ebb51488b9ce71449d0f8ee04bba5f260f924c61186b41c0d6fe8903b06de6b9
+size 174363

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/roomDetailsScreen.DM-Room-iPhone-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/roomDetailsScreen.DM-Room-iPhone-pseudo.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:040b3df78b47409a450c6ffec62fb3ff72cbfe74e15f3e85dfbc046a5f2695a7
-size 185625
+oid sha256:f87dbe6bdd53d79ef618cb86707360df944aeb0ad5916f64a9826eaae400e2b0
+size 185369

--- a/UnitTests/Sources/InviteUsersViewModelTests.swift
+++ b/UnitTests/Sources/InviteUsersViewModelTests.swift
@@ -163,6 +163,50 @@ final class InviteUsersScreenViewModelTests {
         try await deferredState.fulfill()
     }
     
+    // MARK: - Draft (new room)
+
+    @Test
+    func createsNewRoomInDraftMode() async throws {
+        userDiscoveryService = UserDiscoveryServiceMock()
+        userDiscoveryService.searchProfilesWithReturnValue = .success([])
+
+        clientProxy = ClientProxyMock(.init(userID: "@mock:client.com"))
+        let newRoomID = "!newroom:example.com"
+        clientProxy.createRoomNameTopicAccessTypeIsSpaceUserIDsAvatarURLAliasLocalPartReturnValue = .success(newRoomID)
+
+        viewModel = InviteUsersScreenViewModel(userSession: UserSessionMock(.init(clientProxy: clientProxy)),
+                                               roomType: .draft,
+                                               lockedInvitees: [.mockAlice],
+                                               isSkippable: false,
+                                               userDiscoveryService: userDiscoveryService,
+                                               userIndicatorController: UserIndicatorControllerMock(),
+                                               appSettings: AppSettings())
+
+        // The locked invitee starts pre-selected and locked.
+        #expect(context.viewState.selectedUsers.map(\.userID) == [UserProfileProxy.mockAlice.userID])
+        #expect(context.viewState.isUserLocked(.mockAlice))
+
+        let deferredAction = deferFulfillment(viewModel.actions) { action in
+            if case .openRoom(let roomID) = action, roomID == newRoomID {
+                return true
+            }
+            return false
+        }
+
+        context.send(viewAction: .proceed)
+
+        try await deferredAction.fulfill()
+
+        let args = try #require(clientProxy.createRoomNameTopicAccessTypeIsSpaceUserIDsAvatarURLAliasLocalPartReceivedArguments)
+        #expect(args.name == nil)
+        #expect(args.topic == nil)
+        #expect(args.accessType == .private)
+        #expect(args.isSpace == false)
+        #expect(args.userIDs == [UserProfileProxy.mockAlice.userID])
+        #expect(args.avatarURL == nil)
+        #expect(args.aliasLocalPart == nil)
+    }
+
     // MARK: - Helpers
     
     private func setupViewModel(roomProxy: JoinedRoomProxyProtocol, isSkippable: Bool) {

--- a/UnitTests/Sources/InviteUsersViewModelTests.swift
+++ b/UnitTests/Sources/InviteUsersViewModelTests.swift
@@ -164,49 +164,73 @@ final class InviteUsersScreenViewModelTests {
     }
     
     // MARK: - Draft (new room)
-
+    
     @Test
     func createsNewRoomInDraftMode() async throws {
         userDiscoveryService = UserDiscoveryServiceMock()
         userDiscoveryService.searchProfilesWithReturnValue = .success([])
-
+        
         clientProxy = ClientProxyMock(.init(userID: "@mock:client.com"))
         let newRoomID = "!newroom:example.com"
         clientProxy.createRoomNameTopicAccessTypeIsSpaceUserIDsAvatarURLAliasLocalPartReturnValue = .success(newRoomID)
-
+        
         viewModel = InviteUsersScreenViewModel(userSession: UserSessionMock(.init(clientProxy: clientProxy)),
-                                               roomType: .draft,
-                                               lockedInvitees: [.mockAlice],
+                                               roomType: .draft(mandatoryInvitees: [.mockAlice]),
                                                isSkippable: false,
                                                userDiscoveryService: userDiscoveryService,
                                                userIndicatorController: UserIndicatorControllerMock(),
                                                appSettings: AppSettings())
-
+        
         // The locked invitee starts pre-selected and locked.
         #expect(context.viewState.selectedUsers.map(\.userID) == [UserProfileProxy.mockAlice.userID])
-        #expect(context.viewState.isUserLocked(.mockAlice))
-
+        #expect(context.viewState.isInviteeMandatory(.mockAlice))
+        // The proceed button is disabled while the only selected user is the locked invitee.
+        #expect(!context.viewState.hasInvitableSelectedUsers)
+        
+        // Selecting a non-locked user enables the proceed button.
+        var deferredState = deferFulfillment(viewModel.context.$viewState) { state in
+            state.isUserSelected(.mockBob)
+        }
+        context.send(viewAction: .toggleUser(.mockBob))
+        try await deferredState.fulfill()
+        #expect(context.viewState.hasInvitableSelectedUsers)
+        
+        // Deselecting the non-locked user disables the proceed button again.
+        deferredState = deferFulfillment(viewModel.context.$viewState) { state in
+            !state.isUserSelected(.mockBob)
+        }
+        context.send(viewAction: .toggleUser(.mockBob))
+        try await deferredState.fulfill()
+        #expect(!context.viewState.hasInvitableSelectedUsers)
+        
+        // Re-select the non-locked user before proceeding.
+        deferredState = deferFulfillment(viewModel.context.$viewState) { state in
+            state.isUserSelected(.mockBob)
+        }
+        context.send(viewAction: .toggleUser(.mockBob))
+        try await deferredState.fulfill()
+        
         let deferredAction = deferFulfillment(viewModel.actions) { action in
             if case .openRoom(let roomID) = action, roomID == newRoomID {
                 return true
             }
             return false
         }
-
+        
         context.send(viewAction: .proceed)
-
+        
         try await deferredAction.fulfill()
-
+        
         let args = try #require(clientProxy.createRoomNameTopicAccessTypeIsSpaceUserIDsAvatarURLAliasLocalPartReceivedArguments)
         #expect(args.name == nil)
         #expect(args.topic == nil)
         #expect(args.accessType == .private)
         #expect(args.isSpace == false)
-        #expect(args.userIDs == [UserProfileProxy.mockAlice.userID])
+        #expect(args.userIDs == [UserProfileProxy.mockAlice.userID, UserProfileProxy.mockBob.userID])
         #expect(args.avatarURL == nil)
         #expect(args.aliasLocalPart == nil)
     }
-
+    
     // MARK: - Helpers
     
     private func setupViewModel(roomProxy: JoinedRoomProxyProtocol, isSkippable: Bool) {
@@ -216,7 +240,7 @@ final class InviteUsersScreenViewModelTests {
         clientProxy = ClientProxyMock(.init(userID: "@mock:client.com"))
         
         let viewModel = InviteUsersScreenViewModel(userSession: UserSessionMock(.init(clientProxy: clientProxy)),
-                                                   roomType: .room(roomProxy: roomProxy),
+                                                   roomType: .existingRoom(roomProxy: roomProxy),
                                                    isSkippable: isSkippable,
                                                    userDiscoveryService: userDiscoveryService,
                                                    userIndicatorController: UserIndicatorControllerMock(),

--- a/UnitTests/Sources/InviteUsersViewModelTests.swift
+++ b/UnitTests/Sources/InviteUsersViewModelTests.swift
@@ -87,6 +87,8 @@ final class InviteUsersScreenViewModelTests {
             switch action {
             case .dismiss:
                 return true
+            case .invite:
+                return false
             }
         }
         
@@ -122,6 +124,8 @@ final class InviteUsersScreenViewModelTests {
             switch action {
             case .dismiss:
                 return true
+            case .invite:
+                return false
             }
         }
         
@@ -168,7 +172,7 @@ final class InviteUsersScreenViewModelTests {
         clientProxy = ClientProxyMock(.init(userID: "@mock:client.com"))
         
         let viewModel = InviteUsersScreenViewModel(userSession: UserSessionMock(.init(clientProxy: clientProxy)),
-                                                   roomProxy: roomProxy,
+                                                   roomType: .room(roomProxy: roomProxy),
                                                    isSkippable: isSkippable,
                                                    userDiscoveryService: userDiscoveryService,
                                                    userIndicatorController: UserIndicatorControllerMock(),

--- a/UnitTests/Sources/InviteUsersViewModelTests.swift
+++ b/UnitTests/Sources/InviteUsersViewModelTests.swift
@@ -87,7 +87,7 @@ final class InviteUsersScreenViewModelTests {
             switch action {
             case .dismiss:
                 return true
-            case .invite:
+            case .openRoom:
                 return false
             }
         }
@@ -124,7 +124,7 @@ final class InviteUsersScreenViewModelTests {
             switch action {
             case .dismiss:
                 return true
-            case .invite:
+            case .openRoom:
                 return false
             }
         }


### PR DESCRIPTION
This PR adds a new section with one single action in the RoomDetailsScreen that essentially allows to invite the current dm recipient to a new room.
You can add other people into this new, and is created without specifying name topic and anything else, is essentially just a simple private group room.
The PR changes the way the RoomScreenCoordinator works to essentially allow for the inviteUsersScreen to be configured for either inviting into the existing room (for non DM rooms) or to be used to invite the current DM recipient to a new room, and make such a room in the process, and push it on top of the details creen.

fixes #5561 