### PR TITLE
Remove the focused ComposerToolbar accessibility test and preview

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/ComposerToolbar.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/ComposerToolbar.swift
@@ -382,7 +382,6 @@ struct ComposerToolbar_Previews: PreviewProvider, TestablePreview {
     static let timelineViewModel = TimelineViewModel.mock
     
     static let viewModel = ComposerToolbarViewModel.mock()
-    static let focusedViewModel = ComposerToolbarViewModel.mock(focused: true, message: "Hello, World!")
     static let editingViewModel = ComposerToolbarViewModel.mock(message: "Hello, Wrold!", mockMode: .editing)
     static let multiLineViewModel = ComposerToolbarViewModel.mock(message: "Hello, World! This is a loooong message that wraps onto multiple lines.")
     static let voiceMessageRecordingViewModel = ComposerToolbarViewModel.mock(mockMode: .recordVoiceMessage)
@@ -396,7 +395,6 @@ struct ComposerToolbar_Previews: PreviewProvider, TestablePreview {
     static var previews: some View {
         VStack(spacing: 8) {
             ComposerToolbar(context: viewModel.context)
-            ComposerToolbar(context: focusedViewModel.context)
             ComposerToolbar(context: editingViewModel.context)
             ComposerToolbar(context: multiLineViewModel.context)
                 .padding(.bottom)

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/composerToolbar.iPad-en-GB-0.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/composerToolbar.iPad-en-GB-0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:26dbb222d7ae03c531acb6fd82c043fc2819aad37e22c090cb348eb88f275483
-size 148115
+oid sha256:c6f2105f18b21ec044ac813a6660440e592a337dc4045e22b8cb5e1f934ceb59
+size 138667

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/composerToolbar.iPad-pseudo-0.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/composerToolbar.iPad-pseudo-0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7ac2bbfa49173552bee41680af46dc5e6f8314bda5a868d68c4ec9c97c366e15
-size 149170
+oid sha256:da5a013fe99208a94b2a8202e034782c7ddea3ebd2041b2ab9d35208517caa7f
+size 139784

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/composerToolbar.iPhone-en-GB-0.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/composerToolbar.iPhone-en-GB-0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5a8f18909e0ea65a8589e8cfeb958000ba103272985761f6a4218c94e8eeb1f0
-size 100353
+oid sha256:a83cc66c77c262cea14b8efd474154bb3fd38331493bcfe4f56c2a0cc66844f8
+size 93078

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/composerToolbar.iPhone-pseudo-0.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/composerToolbar.iPhone-pseudo-0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:799f8f5ba8c0648e90120aab9313f76835e60b4d81e3de96508465cd665ccd66
-size 102189
+oid sha256:e1733b9e9e32df9fbfbe2d2220ca8698ac8005b60df92a30317d98d6fa14b0d4
+size 94918


### PR DESCRIPTION
The automatically focused keyboard is creating false positives when running accessibility tests and doesn't bring any value in the previews. Simplest solution is to remove it.