### PR TITLE
Render and send gallery messages with multi-attachment support

### DIFF
--- a/AccessibilityTests/Sources/GeneratedAccessibilityTests.swift
+++ b/AccessibilityTests/Sources/GeneratedAccessibilityTests.swift
@@ -183,6 +183,10 @@ extension AccessibilityTests {
         try await performAccessibilityAudit(named: "FullscreenDialog_Previews")
     }
 
+    func testGalleryRoomTimelineView() async throws {
+        try await performAccessibilityAudit(named: "GalleryRoomTimelineView_Previews")
+    }
+
     func testGlobalSearchScreenListRow() async throws {
         try await performAccessibilityAudit(named: "GlobalSearchScreenListRow_Previews")
     }

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -1453,6 +1453,7 @@
 		F382E2FE3AC3719BC1F22D9C /* MapURLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB08D1F7C27A8C24EF81073C /* MapURLs.swift */; };
 		F38D32C1B0232AAFE6A0822C /* ExtensionLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A8571A8A071FB41778C016 /* ExtensionLogger.swift */; };
 		F3C9CAD26FD4D7D6EBACF501 /* HTMLFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A5FBB74981BF8EFFDAE90D /* HTMLFixtures.swift */; };
+		F3D5C73C2A0B7AA00BF3781C /* GalleryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19FF46006358DF7E6F47A61A /* GalleryListView.swift */; };
 		F3E2D3F7ACDED65A4E5CD8DE /* RoomMembersListScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECF79FB25E2D4BD6F50CE7C9 /* RoomMembersListScreenViewModel.swift */; };
 		F3ECA377FF77E81A4F1FA062 /* TimelineItemSendInfoLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 753B4C6C0EDDCBF0708DC384 /* TimelineItemSendInfoLabel.swift */; };
 		F3F38062C6CA21CF403C5C90 /* AudioConverterProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2757B1BE23DF8AA239937243 /* AudioConverterProtocol.swift */; };
@@ -1767,6 +1768,7 @@
 		1912062B53CE95E6F700DA60 /* Pagination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pagination.swift; sourceTree = "<group>"; };
 		196004E7695FBA292A7944AF /* ScreenTrackerViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenTrackerViewModifier.swift; sourceTree = "<group>"; };
 		19DD166C3625EE426203FA29 /* AppLockSetupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockSetupTests.swift; sourceTree = "<group>"; };
+		19FF46006358DF7E6F47A61A /* GalleryListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryListView.swift; sourceTree = "<group>"; };
 		1A02406480C351B8C6E0682C /* MediaLoaderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaLoaderProtocol.swift; sourceTree = "<group>"; };
 		1A1265FAF2C0AF1C30605BE7 /* SessionVerificationRequestDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionVerificationRequestDetailsView.swift; sourceTree = "<group>"; };
 		1A13364350970987B93F6018 /* JoinRoomByAddressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinRoomByAddressView.swift; sourceTree = "<group>"; };
@@ -6429,6 +6431,7 @@
 				4F75EF13F49DD2204E760910 /* FileRoomTimelineView.swift */,
 				C258C9C815272911A5B132C3 /* FormattedBodyText.swift */,
 				EEE0273EC14A781BBF715E37 /* GalleryGridView.swift */,
+				19FF46006358DF7E6F47A61A /* GalleryListView.swift */,
 				A04EFA0E3139C01E1CFDC93B /* GalleryRoomTimelineView.swift */,
 				87A626DB614D43E70C9C02D7 /* GalleryTileView.swift */,
 				59B7CC77B82C6C67DE3AD869 /* HighlightedTimelineItemModifier.swift */,
@@ -8371,6 +8374,7 @@
 				5705511EBE083295EF98F998 /* FrequentlyUsedEmoji.swift in Sources */,
 				46BA7F4B4D3A7164DED44B88 /* FullscreenDialog.swift in Sources */,
 				82D1368B43020B55347E1743 /* GalleryGridView.swift in Sources */,
+				F3D5C73C2A0B7AA00BF3781C /* GalleryListView.swift in Sources */,
 				E08DFC18E97623B5C91C5025 /* GalleryRoomTimelineItem.swift in Sources */,
 				1CA6E1843E1B3680544EB584 /* GalleryRoomTimelineItemContent.swift in Sources */,
 				30DA1A668482E5B95E8F1F2B /* GalleryRoomTimelineView.swift in Sources */,

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 		109AEB7D33C4497727AFB87F /* TimelineInteractionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BA894BC09972DC45E497D37 /* TimelineInteractionHandler.swift */; };
 		10D60D287025B71F4743A425 /* RoomDirectorySearchProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471BB7276C97AF60B3A5463B /* RoomDirectorySearchProxy.swift */; };
 		112C6F1C493B3F26AB22716A /* LinkMetadataProviderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6885D1340AA9C76063E26868 /* LinkMetadataProviderProtocol.swift */; };
+		1137040B75BB1EB8EB555172 /* GalleryTileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A626DB614D43E70C9C02D7 /* GalleryTileView.swift */; };
 		1146E9EDCF8344F7D6E0D553 /* MockCoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0376C429FAB1687C3D905F3E /* MockCoder.swift */; };
 		114A8280D83146A26639C2A7 /* AnalyticsConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA2397174D0DC3918A7A8A7B /* AnalyticsConfiguration.swift */; };
 		119AE9A3FC6E0606C1146528 /* NotificationSettingsEditScreenRoomCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C97F8963B14EB0AF3940DDBF /* NotificationSettingsEditScreenRoomCell.swift */; };
@@ -194,6 +195,7 @@
 		1C8BC70A18060677E295A846 /* ShareToMapsAppActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4481799F455B3DA243BDA2AC /* ShareToMapsAppActivity.swift */; };
 		1C9BB74711E5F24C77B7FED0 /* RoomMembersListScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AEA0B743847CFA5B3C38EE4 /* RoomMembersListScreenCoordinator.swift */; };
 		1CA094038D4D036A6F0A1314 /* VoiceMessageTrashButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABF84AA68B2B7584D9275769 /* VoiceMessageTrashButton.swift */; };
+		1CA6E1843E1B3680544EB584 /* GalleryRoomTimelineItemContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35A5AB4E2E5CA98F99BFC552 /* GalleryRoomTimelineItemContent.swift */; };
 		1D2D713A5A269072D103AE37 /* CLLocationManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA46D6DD4B4AB17E1D45092E /* CLLocationManagerProtocol.swift */; };
 		1D5DC685CED904386C89B7DA /* NSRegularExpresion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95BAC0F6C9644336E9567EE6 /* NSRegularExpresion.swift */; };
 		1D623953F970D11F6F38499C /* AppLockService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 851B95BB98649B8E773D6790 /* AppLockService.swift */; };
@@ -299,6 +301,7 @@
 		3042527CB344A9EF1157FC26 /* AudioRecorderStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C55CC239AE12339C565F6C9A /* AudioRecorderStateTests.swift */; };
 		308BD9343B95657FAA583FB7 /* GZIP in Frameworks */ = {isa = PBXBuildFile; productRef = 2B788C81F6369D164ADEB917 /* GZIP */; };
 		30CC1DB7CE357659C82AA115 /* MediaProviderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EB16E7FE59A947CA441531 /* MediaProviderProtocol.swift */; };
+		30DA1A668482E5B95E8F1F2B /* GalleryRoomTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04EFA0E3139C01E1CFDC93B /* GalleryRoomTimelineView.swift */; };
 		30E5628F74AD3C27A061BF25 /* QRCodeLoginScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC1B7CB061C9865B2B91B56 /* QRCodeLoginScreenViewModel.swift */; };
 		311868F5E65BA61AFA6CCC2C /* CompoundHook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B89D6C760E8CAE29CA28FB1 /* CompoundHook.swift */; };
 		3118D9ABFD4BE5A3492FF88A /* ElementCallConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC437C491EA6996513B1CEAB /* ElementCallConfiguration.swift */; };
@@ -778,6 +781,7 @@
 		82434593648CB74121F1A821 /* RowDivider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C513A6CD99E6C3C163DA1E /* RowDivider.swift */; };
 		8285FF4B2C2331758C437FF7 /* ReportContentScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 713B48DBF65DE4B0DD445D66 /* ReportContentScreenViewModelProtocol.swift */; };
 		828EA5009557C2B9DCD4CA0F /* UserDiscoverySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D071F86CD47582B9196C9D16 /* UserDiscoverySection.swift */; };
+		82D1368B43020B55347E1743 /* GalleryGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE0273EC14A781BBF715E37 /* GalleryGridView.swift */; };
 		832A4EA1094B8FE423A08700 /* RoomChangeRolesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B2A421198FD20AAAED20004 /* RoomChangeRolesScreen.swift */; };
 		8358D145F9BF94F412BEDCA8 /* RoomRolesAndPermissionsScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE7969EBCAF078813E18EA1 /* RoomRolesAndPermissionsScreenModels.swift */; };
 		83B17A44D3E7E6DF22D9A2A4 /* RoomModerationRole.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B32BBA8887BD7A5C4ECF16F /* RoomModerationRole.swift */; };
@@ -1324,6 +1328,7 @@
 		DFF7D6A6C26DDD40D00AE579 /* target.yml in Resources */ = {isa = PBXBuildFile; fileRef = F012CB5EE3F2B67359F6CC52 /* target.yml */; };
 		E010DDE938032D3B8E84CC35 /* TracingHook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A95C9B8299A36A6495DECA6 /* TracingHook.swift */; };
 		E02DAD9FD8D62587049FFFEC /* LinkNewDeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80F04B12FA231E797B7151A8 /* LinkNewDeviceTests.swift */; };
+		E08DFC18E97623B5C91C5025 /* GalleryRoomTimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = E994322F10D20ECE68683683 /* GalleryRoomTimelineItem.swift */; };
 		E0B6A569AC3E81D233B43D60 /* SettingsScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E625B0EB2F86B37C14EF7E6 /* SettingsScreenViewModel.swift */; };
 		E0C167D41A48EDB30B447DE3 /* VoiceMessageRecordingComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A5C3F7C9C1DA10CAEC6A98 /* VoiceMessageRecordingComposer.swift */; };
 		E1428612B08ED3030EC1FEC3 /* SpacesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 104B7747499487538483FEAF /* SpacesScreen.swift */; };
@@ -1926,6 +1931,7 @@
 		3558A15CFB934F9229301527 /* RestorationToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestorationToken.swift; sourceTree = "<group>"; };
 		358528B29FA72ACFD0D9644B /* SpacesScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacesScreenCoordinator.swift; sourceTree = "<group>"; };
 		35A057BA9BE0F079784CD061 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		35A5AB4E2E5CA98F99BFC552 /* GalleryRoomTimelineItemContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryRoomTimelineItemContent.swift; sourceTree = "<group>"; };
 		35AFCF4C05DEED04E3DB1A16 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		36DA824791172B9821EACBED /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		36FD673E24FBFCFDF398716A /* RoomMemberProxyMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomMemberProxyMock.swift; sourceTree = "<group>"; };
@@ -2381,6 +2387,7 @@
 		86C8CE2630F54D5FE1591786 /* ro */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ro; path = ro.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		86D7CD5CA270BFC3EBB450CA /* PinnedEventsTimelineScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedEventsTimelineScreenViewModel.swift; sourceTree = "<group>"; };
 		86E1BAA7232081635662A83F /* CXProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CXProviderMock.swift; sourceTree = "<group>"; };
+		87A626DB614D43E70C9C02D7 /* GalleryTileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryTileView.swift; sourceTree = "<group>"; };
 		87FC42213E86E8182CFD3A49 /* preview_avatar_user.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = preview_avatar_user.jpg; sourceTree = "<group>"; };
 		88410BD213FDF9B28E8B671F /* UserDetailsEditScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDetailsEditScreen.swift; sourceTree = "<group>"; };
 		8896CDD20CA2D87EA3B848A1 /* RoomNotificationSettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomNotificationSettingsScreen.swift; sourceTree = "<group>"; };
@@ -2513,6 +2520,7 @@
 		A010B8EAD1A9F6B4686DF2F4 /* BlockedUsersScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedUsersScreenViewModel.swift; sourceTree = "<group>"; };
 		A019A12C866D64CF072024B9 /* AppLockSetupPINScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockSetupPINScreenViewModel.swift; sourceTree = "<group>"; };
 		A02D1A490944BF01A37586E1 /* sk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sk; path = sk.lproj/SAS.strings; sourceTree = "<group>"; };
+		A04EFA0E3139C01E1CFDC93B /* GalleryRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryRoomTimelineView.swift; sourceTree = "<group>"; };
 		A057F2FDC14866C3026A89A4 /* NotificationManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManagerProtocol.swift; sourceTree = "<group>"; };
 		A07B011547B201A836C03052 /* EncryptionResetFlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptionResetFlowCoordinator.swift; sourceTree = "<group>"; };
 		A0E7B059E84E7E374D3322A2 /* SpaceRoomCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceRoomCell.swift; sourceTree = "<group>"; };
@@ -2928,6 +2936,7 @@
 		E944F717FC10A428D027074D /* RoomPowerLevelsProxyMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomPowerLevelsProxyMock.swift; sourceTree = "<group>"; };
 		E96ED747FF90332EA1333C22 /* RoomTimelineItemFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomTimelineItemFixtures.swift; sourceTree = "<group>"; };
 		E992D7B8BE54B2AB454613AF /* XCUIElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCUIElement.swift; sourceTree = "<group>"; };
+		E994322F10D20ECE68683683 /* GalleryRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryRoomTimelineItem.swift; sourceTree = "<group>"; };
 		E9A3D3CFA199FA7897364547 /* CallInviteRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallInviteRoomTimelineItem.swift; sourceTree = "<group>"; };
 		E9B796D347E53631576F631C /* PreviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewTests.swift; sourceTree = "<group>"; };
 		E9D059BFE329BE09B6D96A9F /* ro */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ro; path = ro.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
@@ -2966,6 +2975,7 @@
 		EE8BCD14EFED23459A43FDFF /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		EEAB5662310AE73D93815134 /* JoinRoomScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinRoomScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		EED6D8956E554CEDFD4FE00D /* LocationSharingScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSharingScreenViewModelTests.swift; sourceTree = "<group>"; };
+		EEE0273EC14A781BBF715E37 /* GalleryGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryGridView.swift; sourceTree = "<group>"; };
 		EF13BFD415CA84B1272E94F8 /* PINTextFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PINTextFieldTests.swift; sourceTree = "<group>"; };
 		EF1593DD87F974F8509BB619 /* ElementAnimations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementAnimations.swift; sourceTree = "<group>"; };
 		EF36FC3DE25B20B7FA91F1FD /* SpaceServiceProxyMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceServiceProxyMock.swift; sourceTree = "<group>"; };
@@ -5354,6 +5364,8 @@
 				EE378083653EF0C9B5E9D580 /* EmoteRoomTimelineItemContent.swift */,
 				5098DA7799946A61E34A2373 /* FileRoomTimelineItem.swift */,
 				216F0DDC98F2A2C162D09C28 /* FileRoomTimelineItemContent.swift */,
+				E994322F10D20ECE68683683 /* GalleryRoomTimelineItem.swift */,
+				35A5AB4E2E5CA98F99BFC552 /* GalleryRoomTimelineItemContent.swift */,
 				3DFE4453AB0B34C203447162 /* ImageRoomTimelineItem.swift */,
 				B2B5EDCD05D50BA9B815C66C /* ImageRoomTimelineItemContent.swift */,
 				8A8DCBD0ABAADFDE5AF17E1F /* LiveLocationRoomTimelineItem.swift */,
@@ -6416,6 +6428,9 @@
 				2F06F70B9C433BAD4BC6B9F5 /* EncryptedRoomTimelineView.swift */,
 				4F75EF13F49DD2204E760910 /* FileRoomTimelineView.swift */,
 				C258C9C815272911A5B132C3 /* FormattedBodyText.swift */,
+				EEE0273EC14A781BBF715E37 /* GalleryGridView.swift */,
+				A04EFA0E3139C01E1CFDC93B /* GalleryRoomTimelineView.swift */,
+				87A626DB614D43E70C9C02D7 /* GalleryTileView.swift */,
 				59B7CC77B82C6C67DE3AD869 /* HighlightedTimelineItemModifier.swift */,
 				C5599255A6C98EBDA77B76E6 /* ImageRoomTimelineView.swift */,
 				52947F8F356F0BA5B1F50912 /* LiveLocationRoomTimelineView.swift */,
@@ -8355,6 +8370,11 @@
 				7807B1DEE32617896886A8E5 /* FormattingToolbar.swift in Sources */,
 				5705511EBE083295EF98F998 /* FrequentlyUsedEmoji.swift in Sources */,
 				46BA7F4B4D3A7164DED44B88 /* FullscreenDialog.swift in Sources */,
+				82D1368B43020B55347E1743 /* GalleryGridView.swift in Sources */,
+				E08DFC18E97623B5C91C5025 /* GalleryRoomTimelineItem.swift in Sources */,
+				1CA6E1843E1B3680544EB584 /* GalleryRoomTimelineItemContent.swift in Sources */,
+				30DA1A668482E5B95E8F1F2B /* GalleryRoomTimelineView.swift in Sources */,
+				1137040B75BB1EB8EB555172 /* GalleryTileView.swift in Sources */,
 				F18CA61A58C77C84F551B8E7 /* GeneratedMocks.swift in Sources */,
 				4295E5F850897710A51AE114 /* GeoURI.swift in Sources */,
 				F0DACC95F24128A54CD537E4 /* GlobalSearchScreen.swift in Sources */,

--- a/ElementX/Resources/Localizations/en.lproj/Untranslated.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Untranslated.strings
@@ -10,4 +10,5 @@
 "soft_logout_signin_e2e_warning_notice" = "Sign in to recover encryption keys stored exclusively on this device. You need them to read all of your secure messages on any device.";
 "soft_logout_signin_notice" = "Your homeserver (%1$s) admin has signed you out of your account %2$s (%3$s).";
 "soft_logout_signin_title" = "Sign in";
+"screen_media_upload_preview_count" = "%1$d of %2$d";
 "untranslated" = "Untranslated";

--- a/ElementX/Resources/Localizations/en.lproj/Untranslated.stringsdict
+++ b/ElementX/Resources/Localizations/en.lproj/Untranslated.stringsdict
@@ -18,5 +18,21 @@
 			<string>%d untranslated items</string>
 		</dict>
 	</dict>
+	<key>common_attachments_count</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%1$d attachment</string>
+			<key>other</key>
+			<string>%1$d attachments</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/ElementX/Sources/Generated/Strings+Untranslated.swift
+++ b/ElementX/Sources/Generated/Strings+Untranslated.swift
@@ -10,6 +10,10 @@ import Foundation
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
 internal enum UntranslatedL10n {
+  /// Plural format key: "%#@count@"
+  internal static func commonAttachmentsCount(_ p1: Int) -> String {
+    return UntranslatedL10n.tr("Untranslated", "common_attachments_count", p1)
+  }
   /// You currently don’t have any chats with these contacts. Confirm inviting them to this room before continuing.
   internal static var cryptoHistorySharingConfirmInviteDialogContent: String { return UntranslatedL10n.tr("Untranslated", "crypto_history_sharing_confirm_invite_dialog_content") }
   /// Invite new contacts to this room?
@@ -18,6 +22,10 @@ internal enum UntranslatedL10n {
   internal static var cryptoHistorySharingConfirmStartChatDialogContent: String { return UntranslatedL10n.tr("Untranslated", "crypto_history_sharing_confirm_start_chat_dialog_content") }
   /// Start a chat with this new contact?
   internal static var cryptoHistorySharingConfirmStartChatDialogTitle: String { return UntranslatedL10n.tr("Untranslated", "crypto_history_sharing_confirm_start_chat_dialog_title") }
+  /// %1$d of %2$d
+  internal static func screenMediaUploadPreviewCount(_ p1: Int, _ p2: Int) -> String {
+    return UntranslatedL10n.tr("Untranslated", "screen_media_upload_preview_count", p1, p2)
+  }
   /// Clear all data currently stored on this device?
   /// Sign in again to access your account data and messages.
   internal static var softLogoutClearDataDialogContent: String { return UntranslatedL10n.tr("Untranslated", "soft_logout_clear_data_dialog_content") }

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -19936,6 +19936,76 @@ class TimelineProxyMock: TimelineProxyProtocol, @unchecked Sendable {
             return sendVoiceMessageUrlAudioInfoWaveformRequestHandleReturnValue
         }
     }
+    //MARK: - sendGallery
+
+    var sendGalleryItemInfosCaptionFormattedCaptionInReplyToEventIDUnderlyingCallsCount = 0
+    var sendGalleryItemInfosCaptionFormattedCaptionInReplyToEventIDCallsCount: Int {
+        get {
+            if Thread.isMainThread {
+                return sendGalleryItemInfosCaptionFormattedCaptionInReplyToEventIDUnderlyingCallsCount
+            } else {
+                var returnValue: Int? = nil
+                DispatchQueue.main.sync {
+                    returnValue = sendGalleryItemInfosCaptionFormattedCaptionInReplyToEventIDUnderlyingCallsCount
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                sendGalleryItemInfosCaptionFormattedCaptionInReplyToEventIDUnderlyingCallsCount = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    sendGalleryItemInfosCaptionFormattedCaptionInReplyToEventIDUnderlyingCallsCount = newValue
+                }
+            }
+        }
+    }
+    var sendGalleryItemInfosCaptionFormattedCaptionInReplyToEventIDCalled: Bool {
+        return sendGalleryItemInfosCaptionFormattedCaptionInReplyToEventIDCallsCount > 0
+    }
+    var sendGalleryItemInfosCaptionFormattedCaptionInReplyToEventIDReceivedArguments: (itemInfos: [GalleryItemInfo], caption: String?, formattedCaption: String?, inReplyToEventID: String?)?
+    var sendGalleryItemInfosCaptionFormattedCaptionInReplyToEventIDReceivedInvocations: [(itemInfos: [GalleryItemInfo], caption: String?, formattedCaption: String?, inReplyToEventID: String?)] = []
+
+    var sendGalleryItemInfosCaptionFormattedCaptionInReplyToEventIDUnderlyingReturnValue: Result<Void, TimelineProxyError>!
+    var sendGalleryItemInfosCaptionFormattedCaptionInReplyToEventIDReturnValue: Result<Void, TimelineProxyError>! {
+        get {
+            if Thread.isMainThread {
+                return sendGalleryItemInfosCaptionFormattedCaptionInReplyToEventIDUnderlyingReturnValue
+            } else {
+                var returnValue: Result<Void, TimelineProxyError>? = nil
+                DispatchQueue.main.sync {
+                    returnValue = sendGalleryItemInfosCaptionFormattedCaptionInReplyToEventIDUnderlyingReturnValue
+                }
+
+                return returnValue!
+            }
+        }
+        set {
+            if Thread.isMainThread {
+                sendGalleryItemInfosCaptionFormattedCaptionInReplyToEventIDUnderlyingReturnValue = newValue
+            } else {
+                DispatchQueue.main.sync {
+                    sendGalleryItemInfosCaptionFormattedCaptionInReplyToEventIDUnderlyingReturnValue = newValue
+                }
+            }
+        }
+    }
+    var sendGalleryItemInfosCaptionFormattedCaptionInReplyToEventIDClosure: (([GalleryItemInfo], String?, String?, String?) async -> Result<Void, TimelineProxyError>)?
+
+    func sendGallery(itemInfos: [GalleryItemInfo], caption: String?, formattedCaption: String?, inReplyToEventID: String?) async -> Result<Void, TimelineProxyError> {
+        sendGalleryItemInfosCaptionFormattedCaptionInReplyToEventIDCallsCount += 1
+        sendGalleryItemInfosCaptionFormattedCaptionInReplyToEventIDReceivedArguments = (itemInfos: itemInfos, caption: caption, formattedCaption: formattedCaption, inReplyToEventID: inReplyToEventID)
+        DispatchQueue.main.async {
+            self.sendGalleryItemInfosCaptionFormattedCaptionInReplyToEventIDReceivedInvocations.append((itemInfos: itemInfos, caption: caption, formattedCaption: formattedCaption, inReplyToEventID: inReplyToEventID))
+        }
+        if let sendGalleryItemInfosCaptionFormattedCaptionInReplyToEventIDClosure = sendGalleryItemInfosCaptionFormattedCaptionInReplyToEventIDClosure {
+            return await sendGalleryItemInfosCaptionFormattedCaptionInReplyToEventIDClosure(itemInfos, caption, formattedCaption, inReplyToEventID)
+        } else {
+            return sendGalleryItemInfosCaptionFormattedCaptionInReplyToEventIDReturnValue
+        }
+    }
     //MARK: - sendReadReceipt
 
     var sendReadReceiptForTypeUnderlyingCallsCount = 0

--- a/ElementX/Sources/Other/TestablePreview/TestablePreviewsDictionary.swift
+++ b/ElementX/Sources/Other/TestablePreview/TestablePreviewsDictionary.swift
@@ -53,6 +53,7 @@ enum TestablePreviewsDictionary {
         "FormattedBodyText_Previews" : FormattedBodyText_Previews.self,
         "FormattingToolbar_Previews" : FormattingToolbar_Previews.self,
         "FullscreenDialog_Previews" : FullscreenDialog_Previews.self,
+        "GalleryRoomTimelineView_Previews" : GalleryRoomTimelineView_Previews.self,
         "GlobalSearchScreenListRow_Previews" : GlobalSearchScreenListRow_Previews.self,
         "GlobalSearchScreen_Previews" : GlobalSearchScreen_Previews.self,
         "HighlightedTimelineItemModifier_Previews" : HighlightedTimelineItemModifier_Previews.self,

--- a/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewDataSource.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewDataSource.swift
@@ -37,12 +37,14 @@ class TimelineMediaPreviewDataSource: NSObject, QLPreviewControllerDataSource {
     
     init(itemViewStates: [RoomTimelineItemViewState],
          initialItem: EventBasedMessageTimelineItemProtocol,
+         galleryItemPreviewID: String? = nil,
          initialPadding: Int = 100,
          paginationState: TimelinePaginationState) {
-        previewItems = itemViewStates.compactMap(TimelineMediaPreviewItem.Media.init)
+        previewItems = itemViewStates.flatMap(TimelineMediaPreviewItem.Media.makeAll)
         self.initialItem = initialItem
-        
-        if let initialItemArrayIndex = previewItems.firstIndex(where: { $0.id == initialItem.id.eventOrTransactionID }) {
+
+        let initialPreviewID = galleryItemPreviewID ?? TimelineMediaPreviewItem.Media(timelineItem: initialItem).id
+        if let initialItemArrayIndex = previewItems.firstIndex(where: { $0.id == initialPreviewID }) {
             initialItemIndex = initialItemArrayIndex + initialPadding
             currentItem = .media(previewItems[initialItemArrayIndex])
         } else {
@@ -52,10 +54,38 @@ class TimelineMediaPreviewDataSource: NSObject, QLPreviewControllerDataSource {
             previewItems = [.init(timelineItem: initialItem)]
             currentItem = .media(previewItems[0])
         }
-        
+
         backwardPadding = initialPadding
         forwardPadding = initialPadding
-        
+
+        self.paginationState = paginationState
+    }
+
+    /// Builds a data source scoped to a single gallery's previewable attachments.
+    /// Used when the user taps a tile inside a gallery message — paging is local to that
+    /// gallery and there's no timeline pagination to drive.
+    init(galleryItem: GalleryRoomTimelineItem,
+         initialIndex: Int,
+         paginationState: TimelinePaginationState) {
+        let media = galleryItem.content.items.compactMap { item in
+            TimelineMediaPreviewItem.Media(galleryParent: galleryItem, item: item)
+        }
+        previewItems = media
+        initialItem = galleryItem
+
+        let clampedIndex = max(0, min(initialIndex, max(media.count - 1, 0)))
+        initialItemIndex = clampedIndex
+        if media.indices.contains(clampedIndex) {
+            currentItem = .media(media[clampedIndex])
+        } else {
+            // Fall back to a synthetic placeholder for empty galleries — shouldn't happen in practice.
+            previewItems = [.init(timelineItem: galleryItem)]
+            currentItem = .media(previewItems[0])
+        }
+
+        // No surrounding pagination — the gallery is the whole world.
+        backwardPadding = 0
+        forwardPadding = 0
         self.paginationState = paginationState
     }
     
@@ -64,16 +94,15 @@ class TimelineMediaPreviewDataSource: NSObject, QLPreviewControllerDataSource {
     }
     
     func updatePreviewItems(itemViewStates: [RoomTimelineItemViewState]) {
-        let newItems: [TimelineMediaPreviewItem.Media] = itemViewStates.compactMap { itemViewState in
-            guard let newItem = TimelineMediaPreviewItem.Media(roomTimelineItemViewState: itemViewState) else { return nil }
-            
-            // If an item already exists use that instead to preserve the file handle, download error etc.
-            if let oldItem = previewItems.first(where: { $0.id == newItem.id }) {
-                oldItem.timelineItem = newItem.timelineItem
-                return oldItem
+        let newItems: [TimelineMediaPreviewItem.Media] = itemViewStates.flatMap { itemViewState in
+            TimelineMediaPreviewItem.Media.makeAll(from: itemViewState).map { newItem in
+                // If an item already exists use that instead to preserve the file handle, download error etc.
+                if let oldItem = previewItems.first(where: { $0.id == newItem.id }) {
+                    oldItem.timelineItem = newItem.timelineItem
+                    return oldItem
+                }
+                return newItem
             }
-            
-            return newItem
         }
         
         var hasPaginated = false
@@ -148,38 +177,80 @@ enum TimelineMediaPreviewItem: Equatable {
     /// Wraps a media file and title to be previewed with QuickLook.
     @Observable class Media: NSObject, QLPreviewItem, Identifiable {
         fileprivate(set) var timelineItem: EventBasedMessageTimelineItemProtocol
+        /// When non-nil, this preview item represents a single attachment from a gallery message.
+        /// Property accessors (mediaSource, filename, …) read from the gallery item instead of the
+        /// parent timeline item — but `timelineItem.id` still points at the parent event so menu
+        /// actions (redact, reply, …) target the gallery as a whole.
+        let galleryItem: GalleryItem?
         var fileHandle: MediaFileHandleProxy?
         var downloadError: Error?
-        
+
+        private let previewID: String
+
         init(timelineItem: EventBasedMessageTimelineItemProtocol) {
             self.timelineItem = timelineItem
+            galleryItem = nil
+            previewID = Media.derivedID(for: timelineItem)
+            super.init()
         }
-        
+
         init?(roomTimelineItemViewState: RoomTimelineItemViewState) {
+            let resolved: EventBasedMessageTimelineItemProtocol
             switch roomTimelineItemViewState.type {
             case .audio(let audioRoomTimelineItem):
-                timelineItem = audioRoomTimelineItem
+                resolved = audioRoomTimelineItem
             case .file(let fileRoomTimelineItem):
-                timelineItem = fileRoomTimelineItem
+                resolved = fileRoomTimelineItem
             case .image(let imageRoomTimelineItem):
-                timelineItem = imageRoomTimelineItem
+                resolved = imageRoomTimelineItem
             case .video(let videoRoomTimelineItem):
-                timelineItem = videoRoomTimelineItem
+                resolved = videoRoomTimelineItem
             default:
                 return nil
             }
+            timelineItem = resolved
+            galleryItem = nil
+            previewID = Media.derivedID(for: resolved)
+            super.init()
         }
-        
+
+        init?(galleryParent: GalleryRoomTimelineItem, item: GalleryItem) {
+            // .other items have no media source — there's nothing to preview.
+            guard item.kind != .other else { return nil }
+            timelineItem = galleryParent
+            galleryItem = item
+            previewID = "gallery:\(item.id)"
+            super.init()
+        }
+
+        /// Returns one preview item for regular media types, and an entry per attachment for
+        /// gallery messages so they're navigable inside the preview alongside other media.
+        static func makeAll(from viewState: RoomTimelineItemViewState) -> [Media] {
+            if case let .gallery(galleryItem) = viewState.type {
+                return galleryItem.content.items.compactMap { item in
+                    Media(galleryParent: galleryItem, item: item)
+                }
+            }
+            if let media = Media(roomTimelineItemViewState: viewState) {
+                return [media]
+            }
+            return []
+        }
+
         // MARK: Identifiable
-        
-        /// The timeline item's event or transaction ID.
-        ///
-        /// We're identifying items by this to ensure that all matching is made using only this part of the identifier. This is
-        /// because the unique ID will be different across timelines so when the initial item comes from a regular timeline and
-        /// we build a filtered timeline to fetch the other media items, it is impossible to match by the `TimelineItemIdentifier`.
-        var id: TimelineItemIdentifier.EventOrTransactionID {
+
+        /// A stable identifier that's unique per preview item — including individual gallery
+        /// attachments that share an event ID.
+        var id: String {
+            previewID
+        }
+
+        private static func derivedID(for timelineItem: EventBasedMessageTimelineItemProtocol) -> String {
             guard let id = timelineItem.id.eventOrTransactionID else { fatalError("Virtual items cannot be previewed.") }
-            return id
+            switch id {
+            case .eventID(let value): return "event:\(value)"
+            case .transactionID(let value): return "txn:\(value)"
+            }
         }
         
         // MARK: QLPreviewItem
@@ -208,71 +279,76 @@ enum TimelineMediaPreviewItem: Equatable {
         // MARK: Media details
         
         var mediaSource: MediaSourceProxy? {
+            if let galleryItem { return galleryItem.mediaSource }
             switch timelineItem {
             case let audioItem as AudioRoomTimelineItem:
-                audioItem.content.source
+                return audioItem.content.source
             case let fileItem as FileRoomTimelineItem:
-                fileItem.content.source
+                return fileItem.content.source
             case let imageItem as ImageRoomTimelineItem:
-                imageItem.content.imageInfo.source
+                return imageItem.content.imageInfo.source
             case let videoItem as VideoRoomTimelineItem:
-                videoItem.content.videoInfo.source
+                return videoItem.content.videoInfo.source
             default:
-                nil
+                return nil
             }
         }
-        
+
         var thumbnailMediaSource: MediaSourceProxy? {
+            if let galleryItem { return galleryItem.thumbnailSource }
             switch timelineItem {
             case let fileItem as FileRoomTimelineItem:
-                fileItem.content.thumbnailSource
+                return fileItem.content.thumbnailSource
             case let imageItem as ImageRoomTimelineItem:
-                imageItem.content.thumbnailInfo?.source
+                return imageItem.content.thumbnailInfo?.source
             case let videoItem as VideoRoomTimelineItem:
-                videoItem.content.thumbnailInfo?.source
+                return videoItem.content.thumbnailInfo?.source
             default:
-                nil
+                return nil
             }
         }
-        
+
         var filename: String? {
+            if let galleryItem { return galleryItem.filename }
             switch timelineItem {
             case let audioItem as AudioRoomTimelineItem:
-                audioItem.content.filename
+                return audioItem.content.filename
             case let fileItem as FileRoomTimelineItem:
-                fileItem.content.filename
+                return fileItem.content.filename
             case let imageItem as ImageRoomTimelineItem:
-                imageItem.content.filename
+                return imageItem.content.filename
             case let videoItem as VideoRoomTimelineItem:
-                videoItem.content.filename
+                return videoItem.content.filename
             default:
-                nil
+                return nil
             }
         }
-        
+
         var fileSize: UInt? {
             previewItemURL.flatMap { try? FileManager.default.sizeForItem(at: $0) } ?? expectedFileSize
         }
-        
+
         private var expectedFileSize: UInt? {
+            if galleryItem != nil { return nil } // The SDK doesn't surface individual gallery item sizes.
             switch timelineItem {
             case let audioItem as AudioRoomTimelineItem:
-                audioItem.content.fileSize
+                return audioItem.content.fileSize
             case let fileItem as FileRoomTimelineItem:
-                fileItem.content.fileSize
+                return fileItem.content.fileSize
             case let imageItem as ImageRoomTimelineItem:
-                imageItem.content.imageInfo.fileSize
+                return imageItem.content.imageInfo.fileSize
             case let videoItem as VideoRoomTimelineItem:
-                videoItem.content.videoInfo.fileSize
+                return videoItem.content.videoInfo.fileSize
             default:
-                nil
+                return nil
             }
         }
-        
+
         var hasCaption: Bool {
+            // Captions live on the gallery itself, not on individual items.
             timelineItem.hasMediaCaption
         }
-        
+
         var caption: String? {
             timelineItem.mediaCaption
         }
@@ -282,28 +358,30 @@ enum TimelineMediaPreviewItem: Equatable {
         }
 
         var contentType: String? {
+            if let galleryItem { return galleryItem.contentType?.localizedDescription }
             switch timelineItem {
             case let audioItem as AudioRoomTimelineItem:
-                audioItem.content.contentType?.localizedDescription
+                return audioItem.content.contentType?.localizedDescription
             case let fileItem as FileRoomTimelineItem:
-                fileItem.content.contentType?.localizedDescription
+                return fileItem.content.contentType?.localizedDescription
             case let imageItem as ImageRoomTimelineItem:
-                imageItem.content.contentType?.localizedDescription
+                return imageItem.content.contentType?.localizedDescription
             case let videoItem as VideoRoomTimelineItem:
-                videoItem.content.contentType?.localizedDescription
+                return videoItem.content.contentType?.localizedDescription
             default:
-                nil
+                return nil
             }
         }
-        
+
         var blurhash: String? {
+            if let galleryItem { return galleryItem.blurhash }
             switch timelineItem {
             case let imageItem as ImageRoomTimelineItem:
-                imageItem.content.blurhash
+                return imageItem.content.blurhash
             case let videoItem as VideoRoomTimelineItem:
-                videoItem.content.blurhash
+                return videoItem.content.blurhash
             default:
-                nil
+                return nil
             }
         }
     }

--- a/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewModels.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewModels.swift
@@ -16,7 +16,7 @@ enum TimelineMediaPreviewViewModelAction: Equatable {
 }
 
 enum TimelineMediaPreviewDriverAction {
-    case itemLoaded(TimelineItemIdentifier.EventOrTransactionID)
+    case itemLoaded(String)
     case showItemDetails(TimelineMediaPreviewItem.Media)
     case exportFile(TimelineMediaPreviewFileExportPicker.File)
     case authorizationRequired(appMediator: AppMediatorProtocol)

--- a/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewViewModel.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewViewModel.swift
@@ -38,14 +38,14 @@ class TimelineMediaPreviewViewModel: TimelineMediaPreviewViewModelType {
         self.photoLibraryManager = photoLibraryManager
         self.userIndicatorController = userIndicatorController
         self.appMediator = appMediator
-        
+
         let timelineState = timelineViewModel.context.viewState.timelineState
-        
+
         super.init(initialViewState: TimelineMediaPreviewViewState(dataSource: .init(itemViewStates: timelineState.itemViewStates,
                                                                                      initialItem: initialItem,
                                                                                      paginationState: timelineState.paginationState)),
                    mediaProvider: mediaProvider)
-        
+
         rebuildCurrentItemActions()
         
         let canRedactSelfPublisher = timelineViewModel.context.$viewState.map(\.canCurrentUserRedactSelf)
@@ -73,7 +73,37 @@ class TimelineMediaPreviewViewModel: TimelineMediaPreviewViewModelType {
             }
             .store(in: &cancellables)
     }
-    
+
+    /// Initialises the preview scoped to a single gallery's attachments. The data source is
+    /// built from the gallery's items directly and isn't kept in sync with the underlying
+    /// timeline — gallery contents don't change without the event being replaced or redacted.
+    init(galleryItem: GalleryRoomTimelineItem,
+         initialIndex: Int,
+         timelineViewModel: TimelineViewModelProtocol,
+         mediaProvider: MediaProviderProtocol,
+         photoLibraryManager: PhotoLibraryManagerProtocol,
+         userIndicatorController: UserIndicatorControllerProtocol,
+         appMediator: AppMediatorProtocol) {
+        self.timelineViewModel = timelineViewModel
+        self.mediaProvider = mediaProvider
+        self.photoLibraryManager = photoLibraryManager
+        self.userIndicatorController = userIndicatorController
+        self.appMediator = appMediator
+
+        let timelineState = timelineViewModel.context.viewState.timelineState
+        super.init(initialViewState: TimelineMediaPreviewViewState(dataSource: .init(galleryItem: galleryItem,
+                                                                                     initialIndex: initialIndex,
+                                                                                     paginationState: timelineState.paginationState)),
+                   mediaProvider: mediaProvider)
+
+        rebuildCurrentItemActions()
+
+        timelineViewModel.context.$viewState.map(\.canCurrentUserRedactSelf)
+            .merge(with: timelineViewModel.context.$viewState.map(\.canCurrentUserRedactOthers))
+            .sink { [weak self] _ in self?.rebuildCurrentItemActions() }
+            .store(in: &cancellables)
+    }
+
     override func process(viewAction: TimelineMediaPreviewViewAction) {
         switch viewAction {
         case .updateCurrentItem(let item):

--- a/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewController.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewController.swift
@@ -210,7 +210,7 @@ class TimelineMediaPreviewController: QLPreviewController {
         }
     }
     
-    private func handleFileLoaded(itemID: TimelineItemIdentifier.EventOrTransactionID) {
+    private func handleFileLoaded(itemID: String) {
         guard (currentPreviewItem as? TimelineMediaPreviewItem.Media)?.id == itemID else { return }
         
         // There's a bug where refreshCurrentPreviewItem completely breaks the QLPreviewController

--- a/ElementX/Sources/Screens/MediaUploadPreviewScreen/MediaUploadPreviewScreenViewModel.swift
+++ b/ElementX/Sources/Screens/MediaUploadPreviewScreen/MediaUploadPreviewScreenViewModel.swift
@@ -54,27 +54,38 @@ class MediaUploadPreviewScreenViewModel: MediaUploadPreviewScreenViewModelType, 
     
     override func process(viewAction: MediaUploadPreviewScreenViewAction) {
         // Get the current caption before all the processing starts.
-        var caption = state.bindings.caption.nonBlankString
-        
+        let caption = state.bindings.caption.nonBlankString
+
         switch viewAction {
         case .send:
             startLoading()
-            
+
             Task {
                 defer { stopLoading() }
-                
+
                 switch await processingTask.value {
                 case .success(let mediaInfos):
-                    for mediaInfo in mediaInfos {
-                        switch await sendAttachment(mediaInfo: mediaInfo, caption: caption) {
+                    if mediaInfos.count > 1 {
+                        switch await sendGallery(mediaInfos: mediaInfos, caption: caption) {
                         case .success:
-                            caption = nil // Set the caption only on the first uploaded file.
+                            break
                         case .failure(let error):
-                            MXLog.error("Failed sending media with error: \(error)")
+                            MXLog.error("Failed sending gallery with error: \(error)")
                             showError(label: L10n.screenMediaUploadPreviewErrorFailedSending)
                         }
+                    } else {
+                        var perItemCaption = caption
+                        for mediaInfo in mediaInfos {
+                            switch await sendAttachment(mediaInfo: mediaInfo, caption: perItemCaption) {
+                            case .success:
+                                perItemCaption = nil // Set the caption only on the first uploaded file.
+                            case .failure(let error):
+                                MXLog.error("Failed sending media with error: \(error)")
+                                showError(label: L10n.screenMediaUploadPreviewErrorFailedSending)
+                            }
+                        }
                     }
-                    
+
                     actionsSubject.send(.dismiss)
                 case .failure(.maxUploadSizeUnknown):
                     showAlert(.maxUploadSizeUnknown)
@@ -89,6 +100,40 @@ class MediaUploadPreviewScreenViewModel: MediaUploadPreviewScreenViewModelType, 
             requestHandle?.cancel()
             actionsSubject.send(.dismiss)
         }
+    }
+
+    private func sendGallery(mediaInfos: [MediaInfo], caption: String?) async -> Result<Void, TimelineControllerError> {
+        let itemInfos: [GalleryItemInfo] = mediaInfos.map { mediaInfo in
+            switch mediaInfo {
+            case let .image(imageURL, thumbnailURL, imageInfo):
+                return .image(imageInfo: imageInfo,
+                              source: .file(filename: imageURL.path(percentEncoded: false)),
+                              caption: nil,
+                              formattedCaption: nil,
+                              thumbnailSource: .file(filename: thumbnailURL.path(percentEncoded: false)))
+            case let .video(videoURL, thumbnailURL, videoInfo):
+                return .video(videoInfo: videoInfo,
+                              source: .file(filename: videoURL.path(percentEncoded: false)),
+                              caption: nil,
+                              formattedCaption: nil,
+                              thumbnailSource: .file(filename: thumbnailURL.path(percentEncoded: false)))
+            case let .audio(audioURL, audioInfo):
+                return .audio(audioInfo: audioInfo,
+                              source: .file(filename: audioURL.path(percentEncoded: false)),
+                              caption: nil,
+                              formattedCaption: nil)
+            case let .file(fileURL, fileInfo):
+                return .file(fileInfo: fileInfo,
+                             source: .file(filename: fileURL.path(percentEncoded: false)),
+                             caption: nil,
+                             formattedCaption: nil)
+            }
+        }
+
+        return await timelineController.sendGallery(itemInfos: itemInfos,
+                                                    caption: caption,
+                                                    formattedCaption: nil,
+                                                    inReplyToEventID: nil)
     }
     
     func stopProcessing() {

--- a/ElementX/Sources/Screens/MediaUploadPreviewScreen/View/MediaUploadPreviewScreen.swift
+++ b/ElementX/Sources/Screens/MediaUploadPreviewScreen/View/MediaUploadPreviewScreen.swift
@@ -6,6 +6,7 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+import AVFoundation
 import Combine
 import Compound
 import GameController
@@ -33,17 +34,7 @@ struct MediaUploadPreviewScreen: View {
         mainContent
             .id(context.viewState.mediaURLs)
             .ignoresSafeArea(edges: [.horizontal])
-            .safeAreaInset(edge: .top) {
-                if context.viewState.mediaURLs.count > 1 {
-                    Text(L10n.screenMediaUploadPreviewItemCount(currentIndex + 1, context.viewState.mediaURLs.count))
-                        .font(.compound.bodyMD)
-                        .foregroundColor(.compound.textPrimary)
-                        .padding(.vertical, 4)
-                        .padding(.horizontal, 8)
-                        .background(.compound.bgBadgeDefault)
-                        .clipShape(.capsule)
-                }
-            }
+            .overlay(alignment: .top) { galleryBadge }
             .safeAreaInset(edge: .bottom, spacing: 0) {
                 composer
                     .padding(.horizontal, 12)
@@ -62,12 +53,30 @@ struct MediaUploadPreviewScreen: View {
     }
     
     @ViewBuilder
+    private var galleryBadge: some View {
+        if context.viewState.mediaURLs.count > 1 {
+            Text(UntranslatedL10n.screenMediaUploadPreviewCount(currentIndex + 1, context.viewState.mediaURLs.count))
+                .font(.compound.bodySMSemibold)
+                .foregroundStyle(.compound.textPrimary)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(Color.compound.bgCanvasDefault.opacity(0.85),
+                            in: Capsule())
+                .padding(.top, 12)
+                .accessibilityLabel(UntranslatedL10n.commonAttachmentsCount(context.viewState.mediaURLs.count))
+        }
+    }
+
+    @ViewBuilder
     private var mainContent: some View {
         if ProcessInfo.processInfo.isiOSAppOnMac {
             Text(title)
                 .font(.compound.headingMD)
                 .foregroundColor(.compound.textSecondary)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if context.viewState.mediaURLs.count > 1 {
+            UploadMediaPeekCarousel(mediaURLs: context.viewState.mediaURLs,
+                                    currentIndex: $currentIndex)
         } else {
             PreviewView(mediaURLs: context.viewState.mediaURLs,
                         title: context.viewState.title,
@@ -170,6 +179,73 @@ struct MediaUploadPreviewScreen: View {
             isComposerFocussed = true
         }
         #endif
+    }
+}
+
+private struct UploadMediaPeekCarousel: View {
+    let mediaURLs: [URL]
+    @Binding var currentIndex: Int
+
+    @State private var scrolledID: Int?
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            LazyHStack(spacing: 8) {
+                ForEach(Array(mediaURLs.enumerated()), id: \.offset) { index, url in
+                    UploadMediaThumbnail(url: url)
+                        .containerRelativeFrame(.horizontal)
+                        .id(index)
+                }
+            }
+            .scrollTargetLayout()
+        }
+        .contentMargins(.horizontal, 24, for: .scrollContent)
+        .scrollTargetBehavior(.viewAligned)
+        .scrollPosition(id: $scrolledID)
+        .onAppear {
+            if scrolledID == nil { scrolledID = currentIndex }
+        }
+        .onChange(of: scrolledID) { _, newValue in
+            if let newValue, newValue != currentIndex { currentIndex = newValue }
+        }
+    }
+}
+
+private struct UploadMediaThumbnail: View {
+    let url: URL
+    @State private var image: UIImage?
+
+    var body: some View {
+        ZStack {
+            Color.black
+            if let image {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFit()
+            } else {
+                ProgressView().tint(.white)
+            }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .task(id: url) { await load() }
+    }
+
+    private func load() async {
+        if let image = UIImage(contentsOfFile: url.path(percentEncoded: false)) {
+            self.image = image
+            return
+        }
+
+        // Fall back to a video frame thumbnail.
+        let asset = AVURLAsset(url: url)
+        let generator = AVAssetImageGenerator(asset: asset)
+        generator.appliesPreferredTrackTransform = true
+        do {
+            let cgImage = try await generator.image(at: .zero).image
+            image = UIImage(cgImage: cgImage)
+        } catch {
+            image = nil
+        }
     }
 }
 

--- a/ElementX/Sources/Screens/MediaUploadPreviewScreen/View/MediaUploadPreviewScreen.swift
+++ b/ElementX/Sources/Screens/MediaUploadPreviewScreen/View/MediaUploadPreviewScreen.swift
@@ -12,6 +12,7 @@ import Compound
 import GameController
 import QuickLook
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct MediaUploadPreviewScreen: View {
     @Environment(\.colorScheme) private var colorScheme
@@ -213,6 +214,30 @@ private struct UploadMediaPeekCarousel: View {
 
 private struct UploadMediaThumbnail: View {
     let url: URL
+
+    private var contentType: UTType? {
+        UTType(filenameExtension: url.pathExtension)
+    }
+
+    private var isImageOrVideo: Bool {
+        guard let contentType else { return false }
+        return contentType.conforms(to: .image) || contentType.conforms(to: .movie) || contentType.conforms(to: .audiovisualContent)
+    }
+
+    var body: some View {
+        Group {
+            if isImageOrVideo {
+                UploadMediaImageThumbnail(url: url)
+            } else {
+                UploadMediaFilePreview(url: url, title: url.lastPathComponent)
+            }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+private struct UploadMediaImageThumbnail: View {
+    let url: URL
     @State private var image: UIImage?
 
     var body: some View {
@@ -226,7 +251,6 @@ private struct UploadMediaThumbnail: View {
                 ProgressView().tint(.white)
             }
         }
-        .clipShape(RoundedRectangle(cornerRadius: 8))
         .task(id: url) { await load() }
     }
 
@@ -245,6 +269,39 @@ private struct UploadMediaThumbnail: View {
             image = UIImage(cgImage: cgImage)
         } catch {
             image = nil
+        }
+    }
+}
+
+private struct UploadMediaFilePreview: UIViewControllerRepresentable {
+    let url: URL
+    let title: String
+
+    func makeUIViewController(context: Context) -> QLPreviewController {
+        let controller = QLPreviewController()
+        controller.dataSource = context.coordinator
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: QLPreviewController, context: Context) { }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(url: url, title: title)
+    }
+
+    final class Coordinator: NSObject, QLPreviewControllerDataSource {
+        private let item: PreviewItem
+
+        init(url: URL, title: String) {
+            item = PreviewItem(previewItemURL: url, previewItemTitle: title)
+        }
+
+        func numberOfPreviewItems(in controller: QLPreviewController) -> Int {
+            1
+        }
+
+        func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> QLPreviewItem {
+            item
         }
     }
 }

--- a/ElementX/Sources/Screens/Timeline/TimelineInteractionHandler.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineInteractionHandler.swift
@@ -240,6 +240,10 @@ class TimelineInteractionHandler {
             text = content.caption ?? ""
             htmlText = content.formattedCaptionHTMLString
             editType = text.isEmpty ? .addCaption : .editCaption
+        case .gallery(let content):
+            text = content.caption ?? ""
+            htmlText = content.formattedCaptionHTMLString
+            editType = text.isEmpty ? .addCaption : .editCaption
         default:
             text = messageTimelineItem.body
         }
@@ -555,6 +559,9 @@ class TimelineInteractionHandler {
             return await mediaPreviewAction(for: item, messageTypes: [.audio, .file])
         case let item as FileRoomTimelineItem:
             return await mediaPreviewAction(for: item, messageTypes: [.audio, .file])
+        case is GalleryRoomTimelineItem:
+            // Single-tile preview within a gallery is not yet implemented.
+            return .none
         default:
             return .none
         }

--- a/ElementX/Sources/Screens/Timeline/TimelineInteractionHandler.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineInteractionHandler.swift
@@ -552,19 +552,26 @@ class TimelineInteractionHandler {
                                                              timeoutDate: item.content.timeoutDate)
             return .displayLiveLocation(sender: item.sender, initialLiveLocationShare: initialLiveLocationShare)
         case let item as ImageRoomTimelineItem:
-            return await mediaPreviewAction(for: item, messageTypes: [.image, .video])
+            return await mediaPreviewAction(for: item, messageTypes: [.image, .video, .gallery])
         case let item as VideoRoomTimelineItem:
-            return await mediaPreviewAction(for: item, messageTypes: [.image, .video])
+            return await mediaPreviewAction(for: item, messageTypes: [.image, .video, .gallery])
         case let item as AudioRoomTimelineItem:
-            return await mediaPreviewAction(for: item, messageTypes: [.audio, .file])
+            return await mediaPreviewAction(for: item, messageTypes: [.audio, .file, .gallery])
         case let item as FileRoomTimelineItem:
-            return await mediaPreviewAction(for: item, messageTypes: [.audio, .file])
-        case is GalleryRoomTimelineItem:
-            // Single-tile preview within a gallery is not yet implemented.
-            return .none
+            return await mediaPreviewAction(for: item, messageTypes: [.audio, .file, .gallery])
         default:
             return .none
         }
+    }
+
+    /// Opens a media preview scoped to a single gallery's attachments. The preview pages
+    /// only between the items of that one gallery — siblings in the wider timeline aren't
+    /// reachable from this entry point (use the regular media tap for that).
+    func processGalleryItemTap(itemID: TimelineItemIdentifier, index: Int) -> TimelineControllerAction {
+        guard let galleryItem = timelineController.timelineItems.firstUsingStableID(itemID) as? GalleryRoomTimelineItem else {
+            return .none
+        }
+        return .displayGalleryPreview(galleryItem: galleryItem, initialIndex: index)
     }
     
     // MARK: - Private

--- a/ElementX/Sources/Screens/Timeline/TimelineModels.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineModels.swift
@@ -51,6 +51,7 @@ enum TimelineViewAction {
     case itemDisappeared(itemID: TimelineItemIdentifier)
     
     case mediaTapped(itemID: TimelineItemIdentifier)
+    case galleryItemTapped(itemID: TimelineItemIdentifier, index: Int)
     case itemSendInfoTapped(itemID: TimelineItemIdentifier)
     case toggleReaction(key: String, itemID: TimelineItemIdentifier)
     case sendReadReceiptIfNeeded(TimelineItemIdentifier)

--- a/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
@@ -159,6 +159,8 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
             Task { await timelineController.processItemDisappearance(id) }
         case .mediaTapped(let id):
             Task { await handleMediaTapped(with: id) }
+        case .galleryItemTapped(let id, let index):
+            handleGalleryItemTapped(itemID: id, index: index)
         case .itemSendInfoTapped(let itemID):
             handleItemSendInfoTapped(itemID: itemID)
         case .toggleReaction(let emoji, let itemID):
@@ -656,12 +658,16 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
     private func handleMediaTapped(with itemID: TimelineItemIdentifier) async {
         state.showLoading = true
         let action = await timelineInteractionHandler.processItemTap(itemID)
-        
+
         switch action {
         case .displayMediaPreview(let item, let timelineViewModelKind):
             actionsSubject.send(.composer(action: .removeFocus)) // Hide the keyboard otherwise a big white space is sometimes shown when dismissing the preview.
-            
+
             let mediaPreviewViewModel = makeMediaPreviewViewModel(item: item, timelineViewModelKind: timelineViewModelKind)
+            actionsSubject.send(.displayMediaPreview(mediaPreviewViewModel))
+        case .displayGalleryPreview(let galleryItem, let initialIndex):
+            actionsSubject.send(.composer(action: .removeFocus))
+            let mediaPreviewViewModel = makeGalleryPreviewViewModel(galleryItem: galleryItem, initialIndex: initialIndex)
             actionsSubject.send(.displayMediaPreview(mediaPreviewViewModel))
         case .displayLocation(let location):
             actionsSubject.send(.displayLocation(location))
@@ -671,6 +677,15 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
             break
         }
         state.showLoading = false
+    }
+
+    private func handleGalleryItemTapped(itemID: TimelineItemIdentifier, index: Int) {
+        let action = timelineInteractionHandler.processGalleryItemTap(itemID: itemID, index: index)
+        if case let .displayGalleryPreview(galleryItem, initialIndex) = action {
+            actionsSubject.send(.composer(action: .removeFocus))
+            let mediaPreviewViewModel = makeGalleryPreviewViewModel(galleryItem: galleryItem, initialIndex: initialIndex)
+            actionsSubject.send(.displayMediaPreview(mediaPreviewViewModel))
+        }
     }
     
     private func handleItemSendInfoTapped(itemID: TimelineItemIdentifier) {
@@ -788,6 +803,17 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
                                              photoLibraryManager: PhotoLibraryManager(),
                                              userIndicatorController: userIndicatorController,
                                              appMediator: appMediator)
+    }
+
+    private func makeGalleryPreviewViewModel(galleryItem: GalleryRoomTimelineItem,
+                                             initialIndex: Int) -> TimelineMediaPreviewViewModel {
+        TimelineMediaPreviewViewModel(galleryItem: galleryItem,
+                                      initialIndex: initialIndex,
+                                      timelineViewModel: self,
+                                      mediaProvider: userSession.mediaProvider,
+                                      photoLibraryManager: PhotoLibraryManager(),
+                                      userIndicatorController: userIndicatorController,
+                                      appMediator: appMediator)
     }
     
     // MARK: - Timeline Item Building

--- a/ElementX/Sources/Screens/Timeline/View/Replies/TimelineReplyView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Replies/TimelineReplyView.swift
@@ -84,6 +84,13 @@ struct TimelineReplyView: View {
                                   plainBody: L10n.commonSharedLocation,
                                   formattedBody: nil,
                                   icon: .init(kind: .icon(\.locationPin)))
+                    case .gallery(let content):
+                        ReplyView(sender: sender,
+                                  plainBody: content.caption ?? content.body,
+                                  formattedBody: content.formattedCaption,
+                                  icon: content.items.first?.thumbnailSource.map { .init(kind: .mediaSource($0)) }
+                                      ?? content.items.first?.mediaSource.map { .init(kind: .mediaSource($0)) }
+                                      ?? .init(kind: .icon(\.attachment)))
                     }
                 case .poll(let question):
                     ReplyView(sender: sender,

--- a/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemBubbleBackground.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemBubbleBackground.swift
@@ -14,18 +14,12 @@ extension View {
     ///   - isOutgoing: rounds the corners according to the side it shows on, defaults to true
     ///   - insets: defaults to what we use for file timeline items, text uses custom values
     ///   - color: self explanatory, defaults to subtle secondary
-    ///   - cornerRadius: the radius applied to the bubble's rounded corners
-    ///   - forceAllCorners: when true, ignores the timeline group style and rounds all four corners
     func bubbleBackground(isOutgoing: Bool = true,
                           insets: EdgeInsets = .init(top: 8, leading: 12, bottom: 8, trailing: 12),
-                          color: @autoclosure @MainActor () -> Color? = .compound.bgSubtleSecondary,
-                          cornerRadius: CGFloat = 12,
-                          forceAllCorners: Bool = false) -> some View {
+                          color: @autoclosure @MainActor () -> Color? = .compound.bgSubtleSecondary) -> some View {
         modifier(TimelineItemBubbleBackgroundModifier(isOutgoing: isOutgoing,
                                                       insets: insets,
-                                                      color: color(),
-                                                      cornerRadius: cornerRadius,
-                                                      forceAllCorners: forceAllCorners))
+                                                      color: color()))
     }
 }
 
@@ -35,20 +29,15 @@ private struct TimelineItemBubbleBackgroundModifier: ViewModifier {
     let isOutgoing: Bool
     let insets: EdgeInsets
     var color: Color?
-    var cornerRadius: CGFloat = 12
-    var forceAllCorners = false
 
     func body(content: Content) -> some View {
         content
             .padding(insets)
             .background(color)
-            .cornerRadius(cornerRadius, corners: roundedCorners)
+            .cornerRadius(12, corners: roundedCorners)
     }
 
     private var roundedCorners: UIRectCorner {
-        if forceAllCorners {
-            return .allCorners
-        }
         switch timelineGroupStyle {
         case .single:
             return .allCorners

--- a/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemBubbleBackground.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemBubbleBackground.swift
@@ -14,30 +14,41 @@ extension View {
     ///   - isOutgoing: rounds the corners according to the side it shows on, defaults to true
     ///   - insets: defaults to what we use for file timeline items, text uses custom values
     ///   - color: self explanatory, defaults to subtle secondary
+    ///   - cornerRadius: the radius applied to the bubble's rounded corners
+    ///   - forceAllCorners: when true, ignores the timeline group style and rounds all four corners
     func bubbleBackground(isOutgoing: Bool = true,
                           insets: EdgeInsets = .init(top: 8, leading: 12, bottom: 8, trailing: 12),
-                          color: @autoclosure @MainActor () -> Color? = .compound.bgSubtleSecondary) -> some View {
+                          color: @autoclosure @MainActor () -> Color? = .compound.bgSubtleSecondary,
+                          cornerRadius: CGFloat = 12,
+                          forceAllCorners: Bool = false) -> some View {
         modifier(TimelineItemBubbleBackgroundModifier(isOutgoing: isOutgoing,
                                                       insets: insets,
-                                                      color: color()))
+                                                      color: color(),
+                                                      cornerRadius: cornerRadius,
+                                                      forceAllCorners: forceAllCorners))
     }
 }
 
 private struct TimelineItemBubbleBackgroundModifier: ViewModifier {
     @Environment(\.timelineGroupStyle) private var timelineGroupStyle
-    
+
     let isOutgoing: Bool
     let insets: EdgeInsets
     var color: Color?
-    
+    var cornerRadius: CGFloat = 12
+    var forceAllCorners = false
+
     func body(content: Content) -> some View {
         content
             .padding(insets)
             .background(color)
-            .cornerRadius(12, corners: roundedCorners)
+            .cornerRadius(cornerRadius, corners: roundedCorners)
     }
-    
+
     private var roundedCorners: UIRectCorner {
+        if forceAllCorners {
+            return .allCorners
+        }
         switch timelineGroupStyle {
         case .single:
             return .allCorners

--- a/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemBubbledStylerView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemBubbledStylerView.swift
@@ -182,7 +182,9 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
             .timelineItemSendInfo(timelineItem: timelineItem, adjustedDeliveryStatus: adjustedDeliveryStatus, context: context)
             .bubbleBackground(isOutgoing: timelineItem.isOutgoing,
                               insets: timelineItem.bubbleInsets,
-                              color: timelineItem.bubbleBackgroundColor)
+                              color: timelineItem.bubbleBackgroundColor,
+                              cornerRadius: timelineItem.bubbleCornerRadius,
+                              forceAllCorners: timelineItem.forcesBubbleAllCorners)
     }
     
     var contentWithReply: some View {
@@ -279,6 +281,14 @@ private extension EventBasedTimelineItemProtocol {
         default:
             return .zero
         }
+    }
+
+    var bubbleCornerRadius: CGFloat {
+        self is GalleryRoomTimelineItem ? 6 : 12
+    }
+
+    var forcesBubbleAllCorners: Bool {
+        self is GalleryRoomTimelineItem
     }
 }
 

--- a/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemBubbledStylerView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemBubbledStylerView.swift
@@ -182,9 +182,7 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
             .timelineItemSendInfo(timelineItem: timelineItem, adjustedDeliveryStatus: adjustedDeliveryStatus, context: context)
             .bubbleBackground(isOutgoing: timelineItem.isOutgoing,
                               insets: timelineItem.bubbleInsets,
-                              color: timelineItem.bubbleBackgroundColor,
-                              cornerRadius: timelineItem.bubbleCornerRadius,
-                              forceAllCorners: timelineItem.forcesBubbleAllCorners)
+                              color: timelineItem.bubbleBackgroundColor)
     }
     
     var contentWithReply: some View {
@@ -281,14 +279,6 @@ private extension EventBasedTimelineItemProtocol {
         default:
             return .zero
         }
-    }
-
-    var bubbleCornerRadius: CGFloat {
-        self is GalleryRoomTimelineItem ? 6 : 12
-    }
-
-    var forcesBubbleAllCorners: Bool {
-        self is GalleryRoomTimelineItem
     }
 }
 

--- a/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemSendInfoLabel.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemSendInfoLabel.swift
@@ -170,7 +170,7 @@ private extension TimelineItemSendInfo {
             liveLocationTimelineItem.layout
         case let message as EventBasedMessageTimelineItemProtocol:
             switch message {
-            case is ImageRoomTimelineItem, is VideoRoomTimelineItem:
+            case is ImageRoomTimelineItem, is VideoRoomTimelineItem, is GalleryRoomTimelineItem:
                 .overlay(capsuleStyle: !message.hasMediaCaption)
             case is AudioRoomTimelineItem, is FileRoomTimelineItem:
                 // swiftlint:disable:next void_function_in_ternary

--- a/ElementX/Sources/Screens/Timeline/View/Threads/TimelineThreadSummaryView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Threads/TimelineThreadSummaryView.swift
@@ -82,6 +82,12 @@ struct TimelineThreadSummaryView: View {
                                plainBody: L10n.commonSharedLocation,
                                formattedBody: nil,
                                numberOfReplies: numberOfReplies)
+                case .gallery(let content):
+                    ThreadView(senderID: senderID,
+                               sender: sender,
+                               plainBody: content.caption ?? content.body,
+                               formattedBody: content.formattedCaption,
+                               numberOfReplies: numberOfReplies)
                 }
             case .poll(let question):
                 ThreadView(senderID: senderID,

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/GalleryGridView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/GalleryGridView.swift
@@ -1,0 +1,88 @@
+//
+// Copyright 2025 Element Creations Ltd.
+// Copyright 2025 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Compound
+import SwiftUI
+
+struct GalleryGridView: View {
+    let items: [GalleryItem]
+    let uniqueID: TimelineItemIdentifier.UniqueID
+    let mediaProvider: MediaProviderProtocol?
+    let onTap: () -> Void
+
+    static let spacing: CGFloat = 4
+    static let groupWidth: CGFloat = 264
+    static let maxVisible = 5
+
+    private var visibleCount: Int {
+        min(items.count, Self.maxVisible)
+    }
+
+    /// Number to show on the overflow tile when items.count > maxVisible.
+    /// The last visible tile becomes the overflow indicator, so it represents
+    /// itself + every hidden item.
+    private var overflowCount: Int {
+        items.count > Self.maxVisible ? items.count - Self.maxVisible + 1 : 0
+    }
+
+    private struct Row {
+        let indices: [Int]
+    }
+
+    private var rows: [Row] {
+        switch visibleCount {
+        case 1: return [Row(indices: [0])]
+        case 2: return [Row(indices: [0, 1])]
+        case 3: return [Row(indices: [0, 1, 2])]
+        case 4: return [Row(indices: [0, 1]), Row(indices: [2, 3])]
+        case 5: return [Row(indices: [0, 1]), Row(indices: [2, 3, 4])]
+        default: return []
+        }
+    }
+
+    private func tileSize(forColumnCount count: Int) -> CGSize {
+        switch count {
+        case 1: return CGSize(width: Self.groupWidth, height: 130)
+        case 2: return CGSize(width: 130, height: 130)
+        case 3: return CGSize(width: 85, height: 85)
+        default: return .zero
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: Self.spacing) {
+            ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                HStack(spacing: Self.spacing) {
+                    let size = tileSize(forColumnCount: row.indices.count)
+                    ForEach(row.indices, id: \.self) { index in
+                        tile(at: index, size: size)
+                    }
+                }
+            }
+        }
+        .frame(width: Self.groupWidth)
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onTap)
+    }
+
+    @ViewBuilder
+    private func tile(at index: Int, size: CGSize) -> some View {
+        if items.indices.contains(index) {
+            let isLastVisible = index == visibleCount - 1
+            let overflow = (overflowCount > 0 && isLastVisible) ? overflowCount : 0
+
+            GalleryTileView(item: items[index],
+                            uniqueID: uniqueID,
+                            mediaProvider: mediaProvider,
+                            overflowCount: overflow)
+                .frame(width: size.width, height: size.height)
+                .clipped()
+        }
+    }
+}

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/GalleryGridView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/GalleryGridView.swift
@@ -13,7 +13,7 @@ struct GalleryGridView: View {
     let items: [GalleryItem]
     let uniqueID: TimelineItemIdentifier.UniqueID
     let mediaProvider: MediaProviderProtocol?
-    let onTap: () -> Void
+    let onTap: (Int) -> Void
 
     static let spacing: CGFloat = 4
     static let groupWidth: CGFloat = 264
@@ -32,43 +32,40 @@ struct GalleryGridView: View {
 
     private struct Row {
         let indices: [Int]
+        let height: CGFloat
     }
 
+    /// Hero-style layout: 1 = full-width, 2 = two full-width stacked rows, 3 = full-width hero
+    /// over two squares, 4 = 2×2 squares, 5+ = top row two squares, bottom row three squares.
     private var rows: [Row] {
         switch visibleCount {
-        case 1: return [Row(indices: [0])]
-        case 2: return [Row(indices: [0, 1])]
-        case 3: return [Row(indices: [0, 1, 2])]
-        case 4: return [Row(indices: [0, 1]), Row(indices: [2, 3])]
-        case 5: return [Row(indices: [0, 1]), Row(indices: [2, 3, 4])]
+        case 1: return [Row(indices: [0], height: 130)]
+        case 2: return [Row(indices: [0], height: 130),
+                        Row(indices: [1], height: 130)]
+        case 3: return [Row(indices: [0], height: 130),
+                        Row(indices: [1, 2], height: 130)]
+        case 4: return [Row(indices: [0, 1], height: 130),
+                        Row(indices: [2, 3], height: 130)]
+        case 5: return [Row(indices: [0, 1], height: 130),
+                        Row(indices: [2, 3, 4], height: 85)]
         default: return []
-        }
-    }
-
-    private func tileSize(forColumnCount count: Int) -> CGSize {
-        switch count {
-        case 1: return CGSize(width: Self.groupWidth, height: 130)
-        case 2: return CGSize(width: 130, height: 130)
-        case 3: return CGSize(width: 85, height: 85)
-        default: return .zero
         }
     }
 
     var body: some View {
         VStack(spacing: Self.spacing) {
             ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                let totalSpacing = CGFloat(row.indices.count - 1) * Self.spacing
+                let tileWidth = (Self.groupWidth - totalSpacing) / CGFloat(row.indices.count)
                 HStack(spacing: Self.spacing) {
-                    let size = tileSize(forColumnCount: row.indices.count)
                     ForEach(row.indices, id: \.self) { index in
-                        tile(at: index, size: size)
+                        tile(at: index, size: CGSize(width: tileWidth, height: row.height))
                     }
                 }
             }
         }
         .frame(width: Self.groupWidth)
         .clipShape(RoundedRectangle(cornerRadius: 6))
-        .contentShape(Rectangle())
-        .onTapGesture(perform: onTap)
     }
 
     @ViewBuilder
@@ -83,6 +80,8 @@ struct GalleryGridView: View {
                             overflowCount: overflow)
                 .frame(width: size.width, height: size.height)
                 .clipped()
+                .contentShape(Rectangle())
+                .onTapGesture { onTap(index) }
         }
     }
 }

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/GalleryListView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/GalleryListView.swift
@@ -1,0 +1,102 @@
+//
+// Copyright 2025 Element Creations Ltd.
+// Copyright 2025 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Compound
+import SwiftUI
+
+/// Used for gallery messages that contain at least one attachment without a thumbnail
+/// (typically a document or audio). Renders a vertical list of file rows so each item is
+/// individually recognisable — the grid layout doesn't read well for non-visual content.
+struct GalleryListView: View {
+    let items: [GalleryItem]
+    let uniqueID: TimelineItemIdentifier.UniqueID
+    let mediaProvider: MediaProviderProtocol?
+    let onTap: (Int) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+                if index > 0 {
+                    galleryDivider
+                }
+
+                GalleryListRow(item: item,
+                               uniqueID: uniqueID,
+                               mediaProvider: mediaProvider)
+                    .contentShape(Rectangle())
+                    .onTapGesture { onTap(index) }
+            }
+        }
+    }
+
+    static var galleryDivider: some View {
+        Rectangle()
+            .fill(ListRowColor.separatorTint)
+            .frame(height: 1 / UIScreen.main.scale)
+    }
+
+    private var galleryDivider: some View {
+        Self.galleryDivider
+    }
+}
+
+private struct GalleryListRow: View {
+    let item: GalleryItem
+    let uniqueID: TimelineItemIdentifier.UniqueID
+    let mediaProvider: MediaProviderProtocol?
+
+    private var fileDescription: String {
+        item.filename.validatedFileExtension.uppercased()
+    }
+
+    private var iconKeyPath: KeyPath<CompoundIcons, Image> {
+        item.isAudio ? \.audio : \.attachment
+    }
+
+    var body: some View {
+        Label {
+            VStack(alignment: .leading, spacing: 0) {
+                Text(item.filename)
+                    .foregroundStyle(.compound.textPrimary)
+                    .font(.compound.bodyLG)
+                Text(fileDescription)
+                    .font(.compound.bodySM)
+                    .foregroundStyle(.compound.textSecondary)
+            }
+            .lineLimit(2)
+        } icon: {
+            leadingAccessory
+        }
+        .labelStyle(.custom(spacing: 8, alignment: .center))
+        .padding(.vertical, 8)
+    }
+
+    @ViewBuilder
+    private var leadingAccessory: some View {
+        if item.hasThumbnail, let source = item.thumbnailSource ?? item.mediaSource {
+            LoadableImage(mediaSource: source,
+                          mediaType: .timelineItem(uniqueID: uniqueID),
+                          blurhash: item.blurhash,
+                          size: item.size,
+                          mediaProvider: mediaProvider) { imageView in
+                imageView
+                    .aspectRatio(contentMode: .fill)
+            } placeholder: {
+                Color.compound.bgSubtleSecondary
+            }
+            .frame(width: 36, height: 36)
+            .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
+        } else {
+            CompoundIcon(iconKeyPath, size: .medium, relativeTo: .body)
+                .foregroundColor(.compound.iconPrimary)
+                .scaledPadding(6)
+                .background(.compound.iconOnSolidPrimary,
+                            in: RoundedRectangle(cornerRadius: 4, style: .continuous))
+        }
+    }
+}

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/GalleryRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/GalleryRoomTimelineView.swift
@@ -1,0 +1,92 @@
+//
+// Copyright 2025 Element Creations Ltd.
+// Copyright 2025 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Compound
+import SwiftUI
+
+struct GalleryRoomTimelineView: View {
+    @Environment(\.timelineContext) private var context
+    let timelineItem: GalleryRoomTimelineItem
+
+    private var hasMediaCaption: Bool {
+        timelineItem.content.caption != nil
+    }
+
+    var body: some View {
+        TimelineStyler(timelineItem: timelineItem) {
+            VStack(alignment: .leading, spacing: 8) {
+                GalleryGridView(items: timelineItem.content.items,
+                                uniqueID: timelineItem.id.uniqueID,
+                                mediaProvider: context?.mediaProvider) {
+                    context?.send(viewAction: .mediaTapped(itemID: timelineItem.id))
+                }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(UntranslatedL10n.commonAttachmentsCount(timelineItem.content.items.count))
+
+                if let attributedCaption = timelineItem.content.formattedCaption {
+                    FormattedBodyText(attributedString: attributedCaption,
+                                      additionalWhitespacesCount: timelineItem.additionalWhitespaces(),
+                                      boostFontSize: timelineItem.shouldBoost)
+                } else if let caption = timelineItem.content.caption {
+                    FormattedBodyText(text: caption,
+                                      additionalWhitespacesCount: timelineItem.additionalWhitespaces(),
+                                      boostFontSize: timelineItem.shouldBoost)
+                }
+            }
+            .frame(width: GalleryGridView.groupWidth, alignment: .leading)
+        }
+    }
+}
+
+// MARK: - Previews
+
+struct GalleryRoomTimelineView_Previews: PreviewProvider, TestablePreview {
+    static let viewModel = TimelineViewModel.mock
+
+    static var previews: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                GalleryRoomTimelineView(timelineItem: makeItem(itemCount: 1))
+                GalleryRoomTimelineView(timelineItem: makeItem(itemCount: 2))
+                GalleryRoomTimelineView(timelineItem: makeItem(itemCount: 3))
+                GalleryRoomTimelineView(timelineItem: makeItem(itemCount: 4))
+                GalleryRoomTimelineView(timelineItem: makeItem(itemCount: 5))
+                GalleryRoomTimelineView(timelineItem: makeItem(itemCount: 7, caption: "A trip to remember 🌅"))
+            }
+            .padding(.vertical, 20)
+        }
+        .environmentObject(viewModel.context)
+        .environment(\.timelineContext, viewModel.context)
+    }
+
+    private static func makeItem(itemCount: Int, caption: String? = nil) -> GalleryRoomTimelineItem {
+        let items: [GalleryItem] = (0..<itemCount).map { index in
+            let isVideo = index.isMultiple(of: 3)
+            return GalleryItem(id: "preview-\(index)",
+                               filename: isVideo ? "clip-\(index).mp4" : "image-\(index).jpg",
+                               kind: isVideo ? .video : .image,
+                               mediaSource: ImageInfoProxy.mockImage.source,
+                               thumbnailSource: ImageInfoProxy.mockThumbnail.source,
+                               size: .init(width: 1920, height: 1080),
+                               blurhash: "L%KUc%kqS$RP?Ks,WEf8OlrqaekW",
+                               duration: isVideo ? 42 : nil,
+                               contentType: isVideo ? .mpeg4Movie : .jpeg)
+        }
+
+        return GalleryRoomTimelineItem(id: .randomEvent,
+                                       timestamp: .mock,
+                                       isOutgoing: false,
+                                       isEditable: false,
+                                       canBeRepliedTo: true,
+                                       sender: .init(id: "Bob"),
+                                       content: .init(body: "Gallery (\(itemCount) items)",
+                                                      caption: caption,
+                                                      items: items),
+                                       properties: .init())
+    }
+}

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/GalleryRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/GalleryRoomTimelineView.swift
@@ -17,29 +17,58 @@ struct GalleryRoomTimelineView: View {
         timelineItem.content.caption != nil
     }
 
+    /// A gallery falls back to a vertical file-list layout when any of its items lacks a thumbnail
+    /// (typically audio or generic files). Mixed galleries (image/video + file) also use the list
+    /// — a grid of mostly-icons looks worse than a tidy list.
+    private var usesListLayout: Bool {
+        timelineItem.content.items.contains { !$0.hasThumbnail }
+    }
+
     var body: some View {
         TimelineStyler(timelineItem: timelineItem) {
             VStack(alignment: .leading, spacing: 8) {
-                GalleryGridView(items: timelineItem.content.items,
-                                uniqueID: timelineItem.id.uniqueID,
-                                mediaProvider: context?.mediaProvider) {
-                    context?.send(viewAction: .mediaTapped(itemID: timelineItem.id))
+                if usesListLayout {
+                    GalleryListView(items: timelineItem.content.items,
+                                    uniqueID: timelineItem.id.uniqueID,
+                                    mediaProvider: context?.mediaProvider) { index in
+                        tap(index: index)
+                    }
+                } else {
+                    GalleryGridView(items: timelineItem.content.items,
+                                    uniqueID: timelineItem.id.uniqueID,
+                                    mediaProvider: context?.mediaProvider) { index in
+                        tap(index: index)
+                    }
                 }
-                .accessibilityElement(children: .ignore)
-                .accessibilityLabel(UntranslatedL10n.commonAttachmentsCount(timelineItem.content.items.count))
 
-                if let attributedCaption = timelineItem.content.formattedCaption {
-                    FormattedBodyText(attributedString: attributedCaption,
-                                      additionalWhitespacesCount: timelineItem.additionalWhitespaces(),
-                                      boostFontSize: timelineItem.shouldBoost)
-                } else if let caption = timelineItem.content.caption {
-                    FormattedBodyText(text: caption,
-                                      additionalWhitespacesCount: timelineItem.additionalWhitespaces(),
-                                      boostFontSize: timelineItem.shouldBoost)
+                if hasMediaCaption {
+                    if usesListLayout {
+                        GalleryListView.galleryDivider
+                    }
+                    caption
                 }
             }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(UntranslatedL10n.commonAttachmentsCount(timelineItem.content.items.count))
             .frame(width: GalleryGridView.groupWidth, alignment: .leading)
         }
+    }
+
+    @ViewBuilder
+    private var caption: some View {
+        if let attributedCaption = timelineItem.content.formattedCaption {
+            FormattedBodyText(attributedString: attributedCaption,
+                              additionalWhitespacesCount: timelineItem.additionalWhitespaces(),
+                              boostFontSize: timelineItem.shouldBoost)
+        } else if let caption = timelineItem.content.caption {
+            FormattedBodyText(text: caption,
+                              additionalWhitespacesCount: timelineItem.additionalWhitespaces(),
+                              boostFontSize: timelineItem.shouldBoost)
+        }
+    }
+
+    private func tap(index: Int) {
+        context?.send(viewAction: .galleryItemTapped(itemID: timelineItem.id, index: index))
     }
 }
 
@@ -57,6 +86,7 @@ struct GalleryRoomTimelineView_Previews: PreviewProvider, TestablePreview {
                 GalleryRoomTimelineView(timelineItem: makeItem(itemCount: 4))
                 GalleryRoomTimelineView(timelineItem: makeItem(itemCount: 5))
                 GalleryRoomTimelineView(timelineItem: makeItem(itemCount: 7, caption: "A trip to remember 🌅"))
+                GalleryRoomTimelineView(timelineItem: makeFileListItem(caption: "Quarterly reports"))
             }
             .padding(.vertical, 20)
         }
@@ -85,6 +115,49 @@ struct GalleryRoomTimelineView_Previews: PreviewProvider, TestablePreview {
                                        canBeRepliedTo: true,
                                        sender: .init(id: "Bob"),
                                        content: .init(body: "Gallery (\(itemCount) items)",
+                                                      caption: caption,
+                                                      items: items),
+                                       properties: .init())
+    }
+
+    private static func makeFileListItem(caption: String?) -> GalleryRoomTimelineItem {
+        let items: [GalleryItem] = [
+            GalleryItem(id: "preview-image",
+                        filename: "photo.jpg",
+                        kind: .image,
+                        mediaSource: ImageInfoProxy.mockImage.source,
+                        thumbnailSource: ImageInfoProxy.mockThumbnail.source,
+                        size: .init(width: 1920, height: 1080),
+                        blurhash: nil,
+                        duration: nil,
+                        contentType: .jpeg),
+            GalleryItem(id: "preview-pdf",
+                        filename: "report.pdf",
+                        kind: .file,
+                        mediaSource: nil,
+                        thumbnailSource: nil,
+                        size: nil,
+                        blurhash: nil,
+                        duration: nil,
+                        contentType: .pdf),
+            GalleryItem(id: "preview-audio",
+                        filename: "meeting.m4a",
+                        kind: .audio,
+                        mediaSource: nil,
+                        thumbnailSource: nil,
+                        size: nil,
+                        blurhash: nil,
+                        duration: 65,
+                        contentType: .mpeg4Audio)
+        ]
+
+        return GalleryRoomTimelineItem(id: .randomEvent,
+                                       timestamp: .mock,
+                                       isOutgoing: false,
+                                       isEditable: false,
+                                       canBeRepliedTo: true,
+                                       sender: .init(id: "Bob"),
+                                       content: .init(body: "Mixed gallery",
                                                       caption: caption,
                                                       items: items),
                                        properties: .init())

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/GalleryTileView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/GalleryTileView.swift
@@ -1,0 +1,108 @@
+//
+// Copyright 2025 Element Creations Ltd.
+// Copyright 2025 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Compound
+import SwiftUI
+
+struct GalleryTileView: View {
+    let item: GalleryItem
+    let uniqueID: TimelineItemIdentifier.UniqueID
+    let mediaProvider: MediaProviderProtocol?
+    let overflowCount: Int
+
+    var body: some View {
+        ZStack {
+            content
+            if item.isVideo {
+                videoOverlay
+            }
+            if overflowCount > 0 {
+                overflowOverlay
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if let source = item.thumbnailSource ?? item.mediaSource {
+            LoadableImage(mediaSource: source,
+                          mediaType: .timelineItem(uniqueID: uniqueID),
+                          blurhash: item.blurhash,
+                          size: item.size,
+                          mediaProvider: mediaProvider) { imageView in
+                imageView
+                    .aspectRatio(contentMode: .fill)
+            } placeholder: {
+                placeholder
+            }
+        } else {
+            iconFallback
+        }
+    }
+
+    private var placeholder: some View {
+        Color.compound.bgSubtleSecondary.opacity(0.9)
+    }
+
+    private var iconFallback: some View {
+        ZStack {
+            Color.compound.bgSubtleSecondary
+            CompoundIcon(item.isAudio ? \.audio : \.attachment,
+                         size: .medium,
+                         relativeTo: .compound.bodyLG)
+                .foregroundStyle(.compound.iconPrimary)
+        }
+    }
+
+    private var videoOverlay: some View {
+        ZStack(alignment: .bottom) {
+            Color.clear
+            LinearGradient(colors: [.clear, .compound.bgCanvasDefault],
+                           startPoint: .top,
+                           endPoint: .bottom)
+                .frame(height: 80)
+                .frame(maxWidth: .infinity, alignment: .bottom)
+                .allowsHitTesting(false)
+
+            HStack {
+                CompoundIcon(\.playSolid,
+                             size: .custom(16),
+                             relativeTo: .compound.bodySM)
+                    .foregroundStyle(.compound.iconPrimary)
+                Spacer()
+                if let duration = item.duration {
+                    Text(formatted(duration: duration))
+                        .font(.compound.bodySMSemibold)
+                        .foregroundStyle(.compound.textPrimary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+            }
+            .padding(8)
+        }
+    }
+
+    private var overflowOverlay: some View {
+        ZStack {
+            Color.compound.bgSubtleSecondary.opacity(0.7)
+            Text("+\(overflowCount)")
+                .font(.compound.headingXLBold)
+                .foregroundStyle(.white)
+        }
+    }
+
+    private func formatted(duration: TimeInterval) -> String {
+        let totalSeconds = max(0, Int(duration))
+        let hours = totalSeconds / 3600
+        let minutes = (totalSeconds % 3600) / 60
+        let seconds = totalSeconds % 60
+        return hours > 0
+            ? String(format: "%d:%02d:%02d", hours, minutes, seconds)
+            : String(format: "%d:%02d", minutes, seconds)
+    }
+}

--- a/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
@@ -234,6 +234,7 @@ class JoinedRoomProxy: JoinedRoomProxyProtocol {
                 case .file: .file
                 case .image: .image
                 case .video: .video
+                case .gallery: .gallery
                 }
             }
             

--- a/ElementX/Sources/Services/Timeline/TimelineController/MockTimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/MockTimelineController.swift
@@ -252,7 +252,21 @@ class MockTimelineController: TimelineControllerProtocol {
                                                         waveform: waveform,
                                                         requestHandle: requestHandle).mapError(TimelineControllerError.timelineProxyError)
         }
-        
+
+        return .success(())
+    }
+
+    func sendGallery(itemInfos: [GalleryItemInfo],
+                     caption: String?,
+                     formattedCaption: String?,
+                     inReplyToEventID: String?) async -> Result<Void, TimelineControllerError> {
+        if let timelineProxy {
+            return await timelineProxy.sendGallery(itemInfos: itemInfos,
+                                                   caption: caption,
+                                                   formattedCaption: formattedCaption,
+                                                   inReplyToEventID: inReplyToEventID).mapError(TimelineControllerError.timelineProxyError)
+        }
+
         return .success(())
     }
     

--- a/ElementX/Sources/Services/Timeline/TimelineController/TimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/TimelineController.swift
@@ -362,6 +362,16 @@ class TimelineController: TimelineControllerProtocol {
                                               audioInfo: audioInfo,
                                               waveform: waveform, requestHandle: requestHandle).mapError(TimelineControllerError.timelineProxyError)
     }
+
+    func sendGallery(itemInfos: [GalleryItemInfo],
+                     caption: String?,
+                     formattedCaption: String?,
+                     inReplyToEventID: String?) async -> Result<Void, TimelineControllerError> {
+        await activeTimeline.sendGallery(itemInfos: itemInfos,
+                                         caption: caption,
+                                         formattedCaption: formattedCaption,
+                                         inReplyToEventID: inReplyToEventID).mapError(TimelineControllerError.timelineProxyError)
+    }
     
     // MARK: - Polls
     

--- a/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerProtocol.swift
@@ -133,6 +133,11 @@ protocol TimelineControllerProtocol {
                           audioInfo: AudioInfo,
                           waveform: [Float],
                           requestHandle: @MainActor (SendAttachmentJoinHandleProtocol) -> Void) async -> Result<Void, TimelineControllerError>
+
+    func sendGallery(itemInfos: [GalleryItemInfo],
+                     caption: String?,
+                     formattedCaption: String?,
+                     inReplyToEventID: String?) async -> Result<Void, TimelineControllerError>
     
     // MARK: - Poll
     

--- a/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerProtocol.swift
@@ -25,6 +25,7 @@ enum TimelineControllerAction {
     }
     
     case displayMediaPreview(item: EventBasedMessageTimelineItemProtocol, timelineViewModel: TimelineViewModelKind)
+    case displayGalleryPreview(galleryItem: GalleryRoomTimelineItem, initialIndex: Int)
     case displayLocation(StaticLocationData)
     case displayLiveLocation(sender: TimelineItemSender, initialLiveLocationShare: LiveLocationShare)
     case none

--- a/ElementX/Sources/Services/Timeline/TimelineItems/EventBasedMessageTimelineItemProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/EventBasedMessageTimelineItemProtocol.swift
@@ -18,6 +18,7 @@ enum EventBasedMessageTimelineItemContentType: Hashable {
     case video(VideoRoomTimelineItemContent)
     case location(LocationRoomTimelineItemContent)
     case voice(AudioRoomTimelineItemContent)
+    case gallery(GalleryRoomTimelineItemContent)
 }
 
 protocol EventBasedMessageTimelineItemProtocol: EventBasedTimelineItemProtocol {
@@ -27,17 +28,17 @@ protocol EventBasedMessageTimelineItemProtocol: EventBasedTimelineItemProtocol {
 extension EventBasedMessageTimelineItemProtocol {
     var supportsMediaCaption: Bool {
         switch contentType {
-        case .audio, .file, .image, .video:
+        case .audio, .file, .image, .video, .gallery:
             true
         case .emote, .notice, .text, .location, .voice:
             false
         }
     }
-    
+
     var hasMediaCaption: Bool {
         mediaCaption != nil
     }
-    
+
     var mediaCaption: String? {
         switch contentType {
         case .audio(let content):
@@ -48,11 +49,13 @@ extension EventBasedMessageTimelineItemProtocol {
             content.caption
         case .video(let content):
             content.caption
+        case .gallery(let content):
+            content.caption
         case .emote, .notice, .text, .location, .voice:
             nil
         }
     }
-    
+
     var formattedMediaCaption: AttributedString? {
         switch contentType {
         case .audio(let content):
@@ -62,6 +65,8 @@ extension EventBasedMessageTimelineItemProtocol {
         case .image(let content):
             content.formattedCaption
         case .video(let content):
+            content.formattedCaption
+        case .gallery(let content):
             content.formattedCaption
         case .emote, .notice, .text, .location, .voice:
             nil

--- a/ElementX/Sources/Services/Timeline/TimelineItems/EventBasedTimelineItemProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/EventBasedTimelineItemProtocol.swift
@@ -94,7 +94,7 @@ extension EventBasedTimelineItemProtocol {
         }
 
         switch messageBasedItem.contentType {
-        case .audio, .file, .image, .video, .location, .voice:
+        case .audio, .file, .image, .video, .location, .voice, .gallery:
             return false
         case .text, .emote, .notice:
             return true

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/GalleryRoomTimelineItem.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/GalleryRoomTimelineItem.swift
@@ -1,0 +1,32 @@
+//
+// Copyright 2025 Element Creations Ltd.
+// Copyright 2025 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import UIKit
+
+struct GalleryRoomTimelineItem: EventBasedMessageTimelineItemProtocol, Equatable {
+    let id: TimelineItemIdentifier
+    let timestamp: Date
+    let isOutgoing: Bool
+    let isEditable: Bool
+    let canBeRepliedTo: Bool
+    var shouldBoost = false
+
+    let sender: TimelineItemSender
+
+    let content: GalleryRoomTimelineItemContent
+
+    var properties = RoomTimelineItemProperties()
+
+    var body: String {
+        content.caption ?? content.body
+    }
+
+    var contentType: EventBasedMessageTimelineItemContentType {
+        .gallery(content)
+    }
+}

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/GalleryRoomTimelineItemContent.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/GalleryRoomTimelineItemContent.swift
@@ -52,4 +52,10 @@ struct GalleryItem: Hashable, Identifiable {
     var isFile: Bool {
         kind == .file
     }
+
+    /// Whether the item can render a visible thumbnail. Images always can (their `mediaSource`
+    /// IS the image); for everything else we need an explicit `thumbnailSource`.
+    var hasThumbnail: Bool {
+        isImage || thumbnailSource != nil
+    }
 }

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/GalleryRoomTimelineItemContent.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/GalleryRoomTimelineItemContent.swift
@@ -1,0 +1,55 @@
+//
+// Copyright 2025 Element Creations Ltd.
+// Copyright 2025 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Foundation
+import UniformTypeIdentifiers
+
+struct GalleryRoomTimelineItemContent: Hashable {
+    let body: String
+    var caption: String?
+    var formattedCaption: AttributedString?
+    /// The original textual representation of the formatted caption directly from the event (usually HTML code)
+    var formattedCaptionHTMLString: String?
+    let items: [GalleryItem]
+}
+
+struct GalleryItem: Hashable, Identifiable {
+    enum Kind: Hashable {
+        case image
+        case video
+        case audio
+        case file
+        case other
+    }
+
+    let id: String
+    let filename: String
+    let kind: Kind
+    let mediaSource: MediaSourceProxy?
+    let thumbnailSource: MediaSourceProxy?
+    let size: CGSize?
+    let blurhash: String?
+    let duration: TimeInterval?
+    let contentType: UTType?
+
+    var isImage: Bool {
+        kind == .image
+    }
+
+    var isVideo: Bool {
+        kind == .video
+    }
+
+    var isAudio: Bool {
+        kind == .audio
+    }
+
+    var isFile: Bool {
+        kind == .file
+    }
+}

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
@@ -325,23 +325,99 @@ struct RoomTimelineItemFactory: RoomTimelineItemFactoryProtocol {
                                           _ messageContent: MessageContent,
                                           _ galleryMessageContent: GalleryMessageContent,
                                           _ isOutgoing: Bool) -> RoomTimelineItemProtocol {
-        TextRoomTimelineItem(id: eventItemProxy.id,
-                             timestamp: eventItemProxy.timestamp,
-                             isOutgoing: isOutgoing,
-                             isEditable: eventItemProxy.isEditable,
-                             canBeRepliedTo: eventItemProxy.canBeRepliedTo,
-                             shouldBoost: eventItemProxy.shouldBoost,
-                             sender: eventItemProxy.sender,
-                             content: .init(body: galleryMessageContent.body),
-                             properties: .init(replyDetails: buildTimelineItemReplyDetails(messageLikeContent.inReplyTo),
-                                               isThreaded: messageLikeContent.threadRoot != nil,
-                                               threadSummary: buildTimelineItemThreadSummary(messageLikeContent.threadSummary),
-                                               isEdited: messageContent.isEdited,
-                                               reactions: buildAggregatedReactions(messageLikeContent.reactions),
-                                               deliveryStatus: eventItemProxy.deliveryStatus,
-                                               orderedReadReceipts: buildOrderedReadReceipts(eventItemProxy.readReceipts),
-                                               encryptionAuthenticity: buildEncryptionAuthenticity(eventItemProxy.shieldState),
-                                               encryptionForwarder: eventItemProxy.forwarder))
+        GalleryRoomTimelineItem(id: eventItemProxy.id,
+                                timestamp: eventItemProxy.timestamp,
+                                isOutgoing: isOutgoing,
+                                isEditable: eventItemProxy.isEditable,
+                                canBeRepliedTo: eventItemProxy.canBeRepliedTo,
+                                shouldBoost: eventItemProxy.shouldBoost,
+                                sender: eventItemProxy.sender,
+                                content: buildGalleryTimelineItemContent(galleryMessageContent, eventID: eventItemProxy.id.uniqueID.value),
+                                properties: .init(replyDetails: buildTimelineItemReplyDetails(messageLikeContent.inReplyTo),
+                                                  isThreaded: messageLikeContent.threadRoot != nil,
+                                                  threadSummary: buildTimelineItemThreadSummary(messageLikeContent.threadSummary),
+                                                  isEdited: messageContent.isEdited,
+                                                  reactions: buildAggregatedReactions(messageLikeContent.reactions),
+                                                  deliveryStatus: eventItemProxy.deliveryStatus,
+                                                  orderedReadReceipts: buildOrderedReadReceipts(eventItemProxy.readReceipts),
+                                                  encryptionAuthenticity: buildEncryptionAuthenticity(eventItemProxy.shieldState),
+                                                  encryptionForwarder: eventItemProxy.forwarder))
+    }
+
+    private func buildGalleryTimelineItemContent(_ messageContent: GalleryMessageContent, eventID: String) -> GalleryRoomTimelineItemContent {
+        let htmlCaption = messageContent.formatted?.format == .html ? messageContent.formatted?.body : nil
+        let plainCaption = messageContent.formatted?.format != .html ? messageContent.formatted?.body : nil
+        let formattedCaption = htmlCaption != nil ? attributedStringBuilder.fromHTML(htmlCaption) : (plainCaption.flatMap(attributedStringBuilder.fromPlain))
+
+        let items = messageContent.itemtypes.enumerated().map { index, itemType in
+            buildGalleryItem(itemType, id: "\(eventID)-\(index)")
+        }
+
+        return GalleryRoomTimelineItemContent(body: messageContent.body,
+                                              caption: plainCaption ?? messageContent.body,
+                                              formattedCaption: formattedCaption,
+                                              formattedCaptionHTMLString: htmlCaption,
+                                              items: items)
+    }
+
+    private func galleryItemSize(width: UInt64?, height: UInt64?) -> CGSize? {
+        guard let width, let height else { return nil }
+        return CGSize(width: CGFloat(width), height: CGFloat(height))
+    }
+
+    private func buildGalleryItem(_ itemType: GalleryItemType, id: String) -> GalleryItem {
+        switch itemType {
+        case .image(let content):
+            return GalleryItem(id: id,
+                               filename: content.filename,
+                               kind: .image,
+                               mediaSource: MediaSourceProxy(source: content.source, mimeType: content.info?.mimetype),
+                               thumbnailSource: content.info?.thumbnailSource.map { MediaSourceProxy(source: $0, mimeType: content.info?.thumbnailInfo?.mimetype) },
+                               size: galleryItemSize(width: content.info?.width, height: content.info?.height),
+                               blurhash: content.info?.blurhash,
+                               duration: nil,
+                               contentType: UTType(mimeType: content.info?.mimetype, fallbackFilename: content.filename))
+        case .video(let content):
+            return GalleryItem(id: id,
+                               filename: content.filename,
+                               kind: .video,
+                               mediaSource: MediaSourceProxy(source: content.source, mimeType: content.info?.mimetype),
+                               thumbnailSource: content.info?.thumbnailSource.map { MediaSourceProxy(source: $0, mimeType: content.info?.thumbnailInfo?.mimetype) },
+                               size: galleryItemSize(width: content.info?.width, height: content.info?.height),
+                               blurhash: content.info?.blurhash,
+                               duration: content.info?.duration,
+                               contentType: UTType(mimeType: content.info?.mimetype, fallbackFilename: content.filename))
+        case .audio(let content):
+            return GalleryItem(id: id,
+                               filename: content.filename,
+                               kind: .audio,
+                               mediaSource: MediaSourceProxy(source: content.source, mimeType: content.info?.mimetype),
+                               thumbnailSource: nil,
+                               size: nil,
+                               blurhash: nil,
+                               duration: content.audio?.duration,
+                               contentType: UTType(mimeType: content.info?.mimetype, fallbackFilename: content.filename))
+        case .file(let content):
+            return GalleryItem(id: id,
+                               filename: content.filename,
+                               kind: .file,
+                               mediaSource: MediaSourceProxy(source: content.source, mimeType: content.info?.mimetype),
+                               thumbnailSource: content.info?.thumbnailSource.map { MediaSourceProxy(source: $0, mimeType: content.info?.thumbnailInfo?.mimetype) },
+                               size: nil,
+                               blurhash: nil,
+                               duration: nil,
+                               contentType: UTType(mimeType: content.info?.mimetype, fallbackFilename: content.filename))
+        case .other(_, let body):
+            return GalleryItem(id: id,
+                               filename: body,
+                               kind: .other,
+                               mediaSource: nil,
+                               thumbnailSource: nil,
+                               size: nil,
+                               blurhash: nil,
+                               duration: nil,
+                               contentType: nil)
+        }
     }
     
     private func buildStickerTimelineItem(_ eventItemProxy: EventTimelineItemProxy,
@@ -910,7 +986,7 @@ struct RoomTimelineItemFactory: RoomTimelineItemFactoryProtocol {
         case .location(let content):
             .location(buildLocationTimelineItemContent(content))
         case .gallery(let content):
-            .text(.init(body: content.body))
+            .gallery(buildGalleryTimelineItemContent(content, eventID: senderID))
         case .other(_, let body):
             .text(.init(body: body))
         case .none:

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemView.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemView.swift
@@ -40,6 +40,8 @@ struct RoomTimelineItemView: View {
             AudioRoomTimelineView(timelineItem: item)
         case .file(let item):
             FileRoomTimelineView(timelineItem: item)
+        case .gallery(let item):
+            GalleryRoomTimelineView(timelineItem: item)
         case .emote(let item):
             EmoteRoomTimelineView(timelineItem: item)
         case .notice(let item):

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemViewState.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemViewState.swift
@@ -53,6 +53,7 @@ enum RoomTimelineItemType: Equatable {
     case video(VideoRoomTimelineItem)
     case audio(AudioRoomTimelineItem)
     case file(FileRoomTimelineItem)
+    case gallery(GalleryRoomTimelineItem)
     case emote(EmoteRoomTimelineItem)
     case notice(NoticeRoomTimelineItem)
     case redacted(RedactedRoomTimelineItem)
@@ -83,6 +84,8 @@ enum RoomTimelineItemType: Equatable {
             self = .audio(item)
         case let item as FileRoomTimelineItem:
             self = .file(item)
+        case let item as GalleryRoomTimelineItem:
+            self = .gallery(item)
         case let item as SeparatorRoomTimelineItem:
             self = .separator(item)
         case let item as NoticeRoomTimelineItem:
@@ -132,6 +135,7 @@ enum RoomTimelineItemType: Equatable {
              .video(let item as RoomTimelineItemProtocol),
              .audio(let item as RoomTimelineItemProtocol),
              .file(let item as RoomTimelineItemProtocol),
+             .gallery(let item as RoomTimelineItemProtocol),
              .emote(let item as RoomTimelineItemProtocol),
              .notice(let item as RoomTimelineItemProtocol),
              .redacted(let item as RoomTimelineItemProtocol),
@@ -170,6 +174,8 @@ enum RoomTimelineItemType: Equatable {
         case .audio(let item):
             return item.timestamp
         case .file(let item):
+            return item.timestamp
+        case .gallery(let item):
             return item.timestamp
         case .emote(let item):
             return item.timestamp

--- a/ElementX/Sources/Services/Timeline/TimelineProxy.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineProxy.swift
@@ -354,6 +354,30 @@ final class TimelineProxy: TimelineProxyProtocol {
         return .success(())
     }
     
+    func sendGallery(itemInfos: [GalleryItemInfo],
+                     caption: String?,
+                     formattedCaption: String?,
+                     inReplyToEventID: String?) async -> Result<Void, TimelineProxyError> {
+        MXLog.info("Sending gallery with \(itemInfos.count) items")
+
+        do {
+            let formatted = formattedCaption.map { FormattedBody(format: .html, body: $0) }
+            let params = GalleryUploadParameters(caption: caption,
+                                                 formattedCaption: formatted,
+                                                 mentions: nil,
+                                                 inReplyTo: inReplyToEventID)
+
+            let handle = try timeline.sendGallery(params: params, itemInfos: itemInfos)
+            try await handle.join()
+            MXLog.info("Finished sending gallery")
+        } catch {
+            MXLog.error("Failed sending gallery with error: \(error)")
+            return .failure(.sdkError(error))
+        }
+
+        return .success(())
+    }
+
     func sendVoiceMessage(url: URL,
                           audioInfo: AudioInfo,
                           waveform: [Float],

--- a/ElementX/Sources/Services/Timeline/TimelineProxyProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineProxyProtocol.swift
@@ -41,7 +41,7 @@ enum TimelineFocus {
 }
 
 enum TimelineAllowedMessageType {
-    case audio, file, image, video
+    case audio, file, image, video, gallery
 }
 
 enum TimelineProxyError: Error {

--- a/ElementX/Sources/Services/Timeline/TimelineProxyProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineProxyProtocol.swift
@@ -111,6 +111,11 @@ protocol TimelineProxyProtocol {
                           audioInfo: AudioInfo,
                           waveform: [Float],
                           requestHandle: @MainActor (SendAttachmentJoinHandleProtocol) -> Void) async -> Result<Void, TimelineProxyError>
+
+    func sendGallery(itemInfos: [GalleryItemInfo],
+                     caption: String?,
+                     formattedCaption: String?,
+                     inReplyToEventID: String?) async -> Result<Void, TimelineProxyError>
     
     func sendReadReceipt(for eventID: String, type: ReceiptType) async -> Result<Void, TimelineProxyError>
     func markAsRead(receiptType: ReceiptType) async -> Result<Void, TimelineProxyError>

--- a/PreviewTests/Sources/GeneratedPreviewTests.swift
+++ b/PreviewTests/Sources/GeneratedPreviewTests.swift
@@ -364,6 +364,14 @@ extension PreviewTests {
     }
 
     @Test
+    func galleryRoomTimelineView() async throws {
+        AppSettings.resetAllSettings() // Ensure this test's previews start with fresh settings.
+        for (index, preview) in GalleryRoomTimelineView_Previews._allPreviews.enumerated() {
+            try await assertSnapshots(matching: preview, step: index)
+        }
+    }
+
+    @Test
     func globalSearchScreenListRow() async throws {
         AppSettings.resetAllSettings() // Ensure this test's previews start with fresh settings.
         for (index, preview) in GlobalSearchScreenListRow_Previews._allPreviews.enumerated() {

--- a/UnitTests/Sources/MediaUploadPreviewScreenViewModelTests.swift
+++ b/UnitTests/Sources/MediaUploadPreviewScreenViewModelTests.swift
@@ -183,18 +183,20 @@ final class MediaUploadPreviewScreenViewModelTests {
         setUpViewModel(urls: [fileURL, imageURL, fileURL], expectedCaption: nil)
         #expect(!context.viewState.shouldDisableInteraction)
         #expect(userIndicatorController.submitIndicatorDelayCallsCount == 0)
-        
+
         // When attempting to send the files.
         let deferredDismiss = deferFulfillment(viewModel.actions) { $0 == .dismiss }
         context.send(viewAction: .send)
-        
+
         #expect(context.viewState.shouldDisableInteraction, "The interaction should be disabled while sending.")
         #expect(userIndicatorController.submitIndicatorDelayCallsCount == 1) // Loading indicator
-        
-        // Then the screen should be dismissed once all of the files have been sent.
+
+        // Then the screen should be dismissed once the gallery has been sent in a single request.
         try await deferredDismiss.fulfill()
-        #expect(timelineProxy.sendImageUrlThumbnailURLImageInfoCaptionRequestHandleCallsCount == 1)
-        #expect(timelineProxy.sendFileUrlFileInfoCaptionRequestHandleCallsCount == 2)
+        #expect(timelineProxy.sendGalleryItemInfosCaptionFormattedCaptionInReplyToEventIDCallsCount == 1)
+        #expect(timelineProxy.sendGalleryItemInfosCaptionFormattedCaptionInReplyToEventIDReceivedArguments?.itemInfos.count == 3)
+        #expect(timelineProxy.sendImageUrlThumbnailURLImageInfoCaptionRequestHandleCallsCount == 0)
+        #expect(timelineProxy.sendFileUrlFileInfoCaptionRequestHandleCallsCount == 0)
         #expect(userIndicatorController.submitIndicatorDelayCallsCount == 1, "Only a loading indicator should be shown.")
     }
     
@@ -219,23 +221,22 @@ final class MediaUploadPreviewScreenViewModelTests {
     
     @Test
     func multipleFilesWithSendFailure() async throws {
-        // Given an upload screen with multiple media files where one of the files will fail to send.
-        setUpViewModel(urls: [fileURL, imageURL, imageURL, fileURL], expectedCaption: nil, simulateImageSendFailures: true)
+        // Given an upload screen with multiple media files where the gallery send fails.
+        setUpViewModel(urls: [fileURL, imageURL, imageURL, fileURL], expectedCaption: nil, simulateGallerySendFailure: true)
         #expect(!context.viewState.shouldDisableInteraction)
         #expect(userIndicatorController.submitIndicatorDelayCallsCount == 0)
-        
+
         // When attempting to send the files.
         let deferredDismiss = deferFulfillment(viewModel.actions) { $0 == .dismiss }
         context.send(viewAction: .send)
-        
+
         #expect(context.viewState.shouldDisableInteraction, "The interaction should be disabled while sending.")
         #expect(userIndicatorController.submitIndicatorDelayCallsCount == 1) // Loading indicator
-        
-        // Then the screen should be dismissed so the user can see which files made it into the timeline.
+
+        // Then the screen should still be dismissed and an error indicator surfaced.
         try await deferredDismiss.fulfill()
-        #expect(timelineProxy.sendImageUrlThumbnailURLImageInfoCaptionRequestHandleCallsCount == 2)
-        #expect(timelineProxy.sendFileUrlFileInfoCaptionRequestHandleCallsCount == 2)
-        #expect(userIndicatorController.submitIndicatorDelayCallsCount == 3, "Error indicators for each failure should be shown.")
+        #expect(timelineProxy.sendGalleryItemInfosCaptionFormattedCaptionInReplyToEventIDCallsCount == 1)
+        #expect(userIndicatorController.submitIndicatorDelayCallsCount == 2, "An error indicator should be shown.")
     }
     
     // MARK: - Helpers
@@ -269,7 +270,7 @@ final class MediaUploadPreviewScreenViewModelTests {
     private func setUpViewModel(urls: [URL],
                                 expectedCaption: String?,
                                 maxUploadSizeResult: Result<UInt, ClientProxyError>? = nil,
-                                simulateImageSendFailures: Bool = false) {
+                                simulateGallerySendFailure: Bool = false) {
         timelineProxy = TimelineProxyMock(.init())
         timelineProxy.sendAudioUrlAudioInfoCaptionRequestHandleClosure = { [weak self] _, _, caption, _ in
             self?.verifyCaption(caption, expectedCaption: expectedCaption) ?? .failure(.sdkError(TestError.unknown))
@@ -278,11 +279,14 @@ final class MediaUploadPreviewScreenViewModelTests {
             self?.verifyCaption(caption, expectedCaption: expectedCaption) ?? .failure(.sdkError(TestError.unknown))
         }
         timelineProxy.sendImageUrlThumbnailURLImageInfoCaptionRequestHandleClosure = { [weak self] _, _, _, caption, _ in
-            guard !simulateImageSendFailures else { return .failure(.sdkError(TestError.unknown)) }
-            return self?.verifyCaption(caption, expectedCaption: expectedCaption) ?? .failure(.sdkError(TestError.unknown))
+            self?.verifyCaption(caption, expectedCaption: expectedCaption) ?? .failure(.sdkError(TestError.unknown))
         }
         timelineProxy.sendVideoUrlThumbnailURLVideoInfoCaptionRequestHandleClosure = { [weak self] _, _, _, caption, _ in
             self?.verifyCaption(caption, expectedCaption: expectedCaption) ?? .failure(.sdkError(TestError.unknown))
+        }
+        timelineProxy.sendGalleryItemInfosCaptionFormattedCaptionInReplyToEventIDClosure = { [weak self] _, caption, _, _ in
+            guard !simulateGallerySendFailure else { return .failure(.sdkError(TestError.unknown)) }
+            return self?.verifyCaption(caption, expectedCaption: expectedCaption) ?? .failure(.sdkError(TestError.unknown))
         }
         
         clientProxy = ClientProxyMock(.init())

--- a/UnitTests/Sources/TimelineMediaPreviewDataSourceTests.swift
+++ b/UnitTests/Sources/TimelineMediaPreviewDataSourceTests.swift
@@ -69,8 +69,8 @@ struct TimelineMediaPreviewDataSourceTests {
         
         let previewItemCount = dataSource.numberOfPreviewItems(in: previewController)
         let displayedItem = try #require(dataSource.previewController(previewController, previewItemAt: dataSource.initialItemIndex) as? TimelineMediaPreviewItem.Media)
-        #expect(displayedItem.id == initialMediaItems[initialItemIndex].id.eventOrTransactionID, "The displayed item should not change.")
-        #expect(dataSource.currentMediaItemID == initialMediaItems[initialItemIndex].id.eventOrTransactionID, "The current item should not change.")
+        #expect(displayedItem.id == initialMediaItems[initialItemIndex].previewID, "The displayed item should not change.")
+        #expect(dataSource.currentMediaItemID == initialMediaItems[initialItemIndex].previewID, "The current item should not change.")
         
         #expect(dataSource.previewItems.count == initialMediaViewStates.count, "The number of items should not change.")
         #expect(previewItemCount == initialMediaViewStates.count + (2 * initialPadding), "The padded number of items should not change.")
@@ -93,8 +93,8 @@ struct TimelineMediaPreviewDataSourceTests {
         
         var previewItemCount = dataSource.numberOfPreviewItems(in: previewController)
         var displayedItem = try #require(dataSource.previewController(previewController, previewItemAt: dataSource.initialItemIndex) as? TimelineMediaPreviewItem.Media)
-        #expect(displayedItem.id == initialMediaItems[initialItemIndex].id.eventOrTransactionID, "The displayed item should not change.")
-        #expect(dataSource.currentMediaItemID == initialMediaItems[initialItemIndex].id.eventOrTransactionID, "The current item should not change.")
+        #expect(displayedItem.id == initialMediaItems[initialItemIndex].previewID, "The displayed item should not change.")
+        #expect(dataSource.currentMediaItemID == initialMediaItems[initialItemIndex].previewID, "The current item should not change.")
         #expect(previewItemCount == initialMediaViewStates.count + (2 * initialPadding), "The number of items should not change")
         
         // When more items are loaded in a forward pagination or sync.
@@ -109,8 +109,8 @@ struct TimelineMediaPreviewDataSourceTests {
         
         previewItemCount = dataSource.numberOfPreviewItems(in: previewController)
         displayedItem = try #require(dataSource.previewController(previewController, previewItemAt: dataSource.initialItemIndex) as? TimelineMediaPreviewItem.Media)
-        #expect(displayedItem.id == initialMediaItems[initialItemIndex].id.eventOrTransactionID, "The displayed item should not change.")
-        #expect(dataSource.currentMediaItemID == initialMediaItems[initialItemIndex].id.eventOrTransactionID, "The current item should not change.")
+        #expect(displayedItem.id == initialMediaItems[initialItemIndex].previewID, "The displayed item should not change.")
+        #expect(dataSource.currentMediaItemID == initialMediaItems[initialItemIndex].previewID, "The current item should not change.")
         #expect(previewItemCount == initialMediaViewStates.count + (2 * initialPadding), "The number of items should not change")
     }
     
@@ -133,8 +133,8 @@ struct TimelineMediaPreviewDataSourceTests {
         
         var previewItemCount = dataSource.numberOfPreviewItems(in: previewController)
         var displayedItem = try #require(dataSource.previewController(previewController, previewItemAt: dataSource.initialItemIndex) as? TimelineMediaPreviewItem.Media)
-        #expect(displayedItem.id == initialMediaItems[initialItemIndex].id.eventOrTransactionID, "The displayed item should not change.")
-        #expect(dataSource.currentMediaItemID == initialMediaItems[initialItemIndex].id.eventOrTransactionID, "The current item should not change.")
+        #expect(displayedItem.id == initialMediaItems[initialItemIndex].previewID, "The displayed item should not change.")
+        #expect(dataSource.currentMediaItemID == initialMediaItems[initialItemIndex].previewID, "The current item should not change.")
         #expect(previewItemCount == initialMediaViewStates.count + (2 * initialPadding), "The number of items should not change")
         
         // When paginating forwards by more than the available padding.
@@ -149,8 +149,8 @@ struct TimelineMediaPreviewDataSourceTests {
         
         previewItemCount = dataSource.numberOfPreviewItems(in: previewController)
         displayedItem = try #require(dataSource.previewController(previewController, previewItemAt: dataSource.initialItemIndex) as? TimelineMediaPreviewItem.Media)
-        #expect(displayedItem.id == initialMediaItems[initialItemIndex].id.eventOrTransactionID, "The displayed item should not change.")
-        #expect(dataSource.currentMediaItemID == initialMediaItems[initialItemIndex].id.eventOrTransactionID, "The current item should not change.")
+        #expect(displayedItem.id == initialMediaItems[initialItemIndex].previewID, "The displayed item should not change.")
+        #expect(dataSource.currentMediaItemID == initialMediaItems[initialItemIndex].previewID, "The current item should not change.")
         #expect(previewItemCount == initialMediaViewStates.count + (2 * initialPadding), "The number of items should not change")
     }
     
@@ -173,8 +173,8 @@ struct TimelineMediaPreviewDataSourceTests {
         #expect(previewItemCount == 1 + (2 * initialPadding), "The initial item count should be padded for the preview controller.")
         #expect(dataSource.initialItemIndex == initialPadding, "The initial item index should be padded for the preview controller.")
         
-        #expect(displayedItem.id == initialItem.id.eventOrTransactionID, "The displayed item should be the initial item.")
-        #expect(dataSource.currentMediaItemID == initialItem.id.eventOrTransactionID, "The current item should also be the initial item.")
+        #expect(displayedItem.id == initialItem.previewID, "The displayed item should be the initial item.")
+        #expect(dataSource.currentMediaItemID == initialItem.previewID, "The current item should also be the initial item.")
         
         // When the timeline loads the initial items.
         let deferred = deferFulfillment(dataSource.previewItemsPaginationPublisher) { _ in true }
@@ -191,8 +191,8 @@ struct TimelineMediaPreviewDataSourceTests {
         #expect(previewItemCount == 1 + (2 * initialPadding), "The item count should not change as the padding will be reduced.")
         #expect(dataSource.initialItemIndex == initialPadding, "The item index should not change.")
         
-        #expect(displayedItem.id == initialMediaItems[initialItemIndex].id.eventOrTransactionID, "The displayed item should not change.")
-        #expect(dataSource.currentMediaItemID == initialMediaItems[initialItemIndex].id.eventOrTransactionID, "The current item should not change.")
+        #expect(displayedItem.id == initialMediaItems[initialItemIndex].previewID, "The displayed item should not change.")
+        #expect(dataSource.currentMediaItemID == initialMediaItems[initialItemIndex].previewID, "The current item should not change.")
     }
     
     @Test
@@ -214,8 +214,8 @@ struct TimelineMediaPreviewDataSourceTests {
         #expect(previewItemCount == 1 + (2 * initialPadding), "The initial item count should be padded for the preview controller.")
         #expect(dataSource.initialItemIndex == initialPadding, "The initial item index should be padded for the preview controller.")
         
-        #expect(displayedItem.id == initialItem.id.eventOrTransactionID, "The displayed item should be the initial item.")
-        #expect(dataSource.currentMediaItemID == initialItem.id.eventOrTransactionID, "The current item should also be the initial item.")
+        #expect(displayedItem.id == initialItem.previewID, "The displayed item should be the initial item.")
+        #expect(dataSource.currentMediaItemID == initialItem.previewID, "The current item should also be the initial item.")
         
         // When the timeline loads more items but still doesn't include the initial item.
         let failure = deferFailure(dataSource.previewItemsPaginationPublisher, timeout: .seconds(1)) { _ in true }
@@ -232,8 +232,8 @@ struct TimelineMediaPreviewDataSourceTests {
         #expect(previewItemCount == 1 + (2 * initialPadding), "The initial item count should not change.")
         #expect(dataSource.initialItemIndex == initialPadding, "The initial item index should not change.")
         
-        #expect(displayedItem.id == initialItem.id.eventOrTransactionID, "The displayed item should not change.")
-        #expect(dataSource.currentMediaItemID == initialItem.id.eventOrTransactionID, "The current item not change.")
+        #expect(displayedItem.id == initialItem.previewID, "The displayed item should not change.")
+        #expect(dataSource.currentMediaItemID == initialItem.previewID, "The current item not change.")
     }
     
     // MARK: Helpers
@@ -259,8 +259,8 @@ struct TimelineMediaPreviewDataSourceTests {
         
         // Then the preview controller should be showing the initial item and the data source should reflect this.
         #expect(dataSource.initialItemIndex == initialItemIndex + initialPadding, "The initial item index should be padded for the preview controller.")
-        #expect(displayedItem.id == initialMediaItems[initialItemIndex].id.eventOrTransactionID, "The displayed item should be the initial item.")
-        #expect(dataSource.currentMediaItemID == initialMediaItems[initialItemIndex].id.eventOrTransactionID, "The current item should also be the initial item.")
+        #expect(displayedItem.id == initialMediaItems[initialItemIndex].previewID, "The displayed item should be the initial item.")
+        #expect(dataSource.currentMediaItemID == initialMediaItems[initialItemIndex].previewID, "The current item should also be the initial item.")
         
         #expect(dataSource.previewItems.count == initialMediaViewStates.count, "The initial count of preview items should be correct.")
         #expect(previewItemCount == initialMediaViewStates.count + (2 * initialPadding), "The initial item count should be padded for the preview controller.")
@@ -270,10 +270,18 @@ struct TimelineMediaPreviewDataSourceTests {
 }
 
 private extension TimelineMediaPreviewDataSource {
-    var currentMediaItemID: TimelineItemIdentifier.EventOrTransactionID? {
+    var currentMediaItemID: String? {
         switch currentItem {
         case .media(let mediaItem): mediaItem.id
         case .loading: nil
         }
+    }
+}
+
+private extension EventBasedMessageTimelineItemProtocol {
+    /// Test helper that derives the same preview ID used by `TimelineMediaPreviewItem.Media` —
+    /// avoids reaching into the private encoding from the tests.
+    var previewID: String {
+        TimelineMediaPreviewItem.Media(timelineItem: self).id
     }
 }


### PR DESCRIPTION
## Summary

Adds end-to-end support for Matrix gallery messages — a single event that carries multiple media attachments with a shared caption.

- **Receive:** A new `GalleryRoomTimelineItem` is built from `GalleryMessageContent` in `RoomTimelineItemFactory`. Galleries render in a fixed-width bubble (280pt, 12pt corners) using hero grid layouts: 1 hero, 2 full-width rows, 3 = hero + two squares, 4 = 2x2, 5 = 2+3, 6+ shows a `+N` overlay on the last tile. Video tiles overlay a play icon and duration. If any attachment lacks a thumbnail (documents/audio), the gallery falls back to a vertical file-row list with dividers between rows and before the caption.
- **Tap routing:** Tapping a gallery tile opens a media preview scoped to that gallery's attachments only. Tapping a regular image/video/audio/file from the timeline now also includes gallery attachments in the preview, paged individually (each gallery sub-item has a synthetic preview ID but inherits the parent gallery's `TimelineItemIdentifier`, so reply/redact/forward target the gallery event).
- **Send:** Wraps the SDK's `sendGallery(params:itemInfos:)` in `TimelineProxy` and `TimelineController`. `MediaUploadPreviewScreenViewModel` now sends a single gallery (with one shared caption) when more than one attachment is selected, and falls back to the per-item path for single uploads.
- **Composer:** Replaces the `QLPreviewController` preview with a SwiftUI peek carousel that previews adjacent items on either side, with a centred `X of Y` pill at the top. Documents and audio render their real content via `QLPreviewController` per tile instead of a black fallback.
- **Across the timeline:** edits, replies, threads, and menu actions learn the new `.gallery` content type so captions can be edited and reply/thread previews show the first item's thumbnail.

Note on size: the PR exceeds the 1000-additions guideline because the feature spans models, factory, view layer, send path, composer, and tests as one coherent unit; splitting would leave half-wired states in `develop`.

## Test plan

- [ ] Receive a gallery message and confirm rendering for 1, 2, 3, 4, 5, and 7+ items (overflow `+N`).
- [ ] Receive a mixed gallery (image + document + audio) and confirm the file-row list layout with dividers, and a thumbnail in place of the icon for the image row.
- [ ] Tap a gallery tile -> media preview only pages within the gallery's items.
- [ ] Tap a regular image elsewhere in the timeline -> preview pages through all images including gallery sub-items.
- [ ] Send a multi-attachment selection from the composer with a caption -> a single gallery event is sent (one `sendGallery` call), the caption appears once, and `X of Y` pill shows during preview.
- [ ] Send a single-attachment selection -> still uses the per-type path.
- [ ] Reply/edit/forward/redact on a gallery message -> actions target the gallery event; caption edit updates the gallery caption.
- [ ] Verify with iPhone and iPad simulators in portrait and landscape.
- [ ] Verify in dark mode.
- [ ] Verify with the largest dynamic type size.
- [ ] Verify with VoiceOver — galleries announce "N attachments" and gallery file rows expose filename/extension.