### PR TITLE
Fixing Room List in Spaces View Not Rendering Some Rooms

### DIFF
--- a/ElementX/Sources/Screens/Spaces/Common/SpaceRoomCell.swift
+++ b/ElementX/Sources/Screens/Spaces/Common/SpaceRoomCell.swift
@@ -81,9 +81,6 @@ struct SpaceRoomCell: View {
                 }
             }
             .padding(.horizontal, horizontalInsets)
-            // Ensure the EditMode transition stays inside this cell if there are other insertions/removals in the list.
-            // Seems to slow down the animations a bit in Xcode previews but its fine in the simulator and on a device.
-            .drawingGroup()
             .accessibilityElement(children: .combine)
         }
         .buttonStyle(SpaceRoomCellButtonStyle(isHighlighted: isHighlighted))


### PR DESCRIPTION
### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).

**UI changes have been tested with:**
- [x] iPhone and iPad simulators in portrait and landscape orientations.
- [x] Dark mode enabled and disabled.
- [x] Various sizes of dynamic type.
- [x] Voiceover enabled.

Now for the issue, and its small proposed solution:

This PR fixes #5306 

drawingGroup seemed to mess things up in this list in particular. I don't actually fully understand _why_ this change fixes it. I was trying a number of things and this appeared to work. If anyone can enlighten me, that would be excellent. 