### PR TITLE
Add local dev script hooks

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -7,3 +7,9 @@ export PATH="$PATH:/opt/homebrew/bin"
 
 # ignores updates of 'Secrets.swift' to avoid pushing sensitive data by mistake
 git update-index --assume-unchanged Secrets/Secrets.swift
+
+LOCAL_SCRIPT_PATH="$HOME/.local/elementx_local_dev/post-checkout"
+if [ -x "$LOCAL_SCRIPT_PATH" ]; then
+	export ELEMENTX_REPO="$(pwd)"
+	"$LOCAL_SCRIPT_PATH"
+fi

--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,3 +1,9 @@
 #!/bin/sh
 command -v git-lfs >/dev/null 2>&1 || { echo >&2 "\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/post-commit'.\n"; exit 2; }
 git lfs post-commit "$@"
+
+LOCAL_SCRIPT_PATH="$HOME/.local/elementx_local_dev/post-commit"
+if [ -x "$LOCAL_SCRIPT_PATH" ]; then
+	export ELEMENTX_REPO="$(pwd)"
+	"$LOCAL_SCRIPT_PATH"
+fi

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,3 +1,9 @@
 #!/bin/sh
 command -v git-lfs >/dev/null 2>&1 || { echo >&2 "\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/post-merge'.\n"; exit 2; }
 git lfs post-merge "$@"
+
+LOCAL_SCRIPT_PATH="$HOME/.local/elementx_local_dev/post-merge"
+if [ -x "$LOCAL_SCRIPT_PATH" ]; then
+	export ELEMENTX_REPO="$(pwd)"
+	"$LOCAL_SCRIPT_PATH"
+fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -10,3 +10,9 @@ then
 fi
 
 ./Tools/Scripts/validate_lfs.sh
+
+LOCAL_SCRIPT_PATH="$HOME/.local/elementx_local_dev/pre-commit"
+if [ -x "$LOCAL_SCRIPT_PATH" ]; then
+	export ELEMENTX_REPO="$(pwd)"
+	"$LOCAL_SCRIPT_PATH"
+fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,3 +1,9 @@
 #!/bin/sh
 command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
 git lfs pre-push "$@"
+
+LOCAL_SCRIPT_PATH="$HOME/.local/elementx_local_dev/pre-push"
+if [ -x "$LOCAL_SCRIPT_PATH" ]; then
+	export ELEMENTX_REPO="$(pwd)"
+	"$LOCAL_SCRIPT_PATH"
+fi


### PR DESCRIPTION
Adds optional local script execution points to each git hook. If a script exists at `~/.local/elementx_local_dev/<hook-name>`, it will be run automatically at the appropriate hook stage. The repo path is exported as `ELEMENTX_REPO` for convenience.

This allows developers to maintain local automation (e.g. managing personal build configuration) without risk of accidentally committing those changes upstream. The local scripts live entirely outside the repo and never need to be checked in.

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
