### PR TITLE
Resolve Some Warnings

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -8,6 +8,7 @@
 --disable consistentSwitchCaseSpacing
 --disable docCommentsBeforeModifiers # throwing false positives in AuthenticationServiceProtocol on v0.58.0
 --disable emptyExtensions
+--disable redundantSendable
 
 --commas inline
 --ifdef no-indent

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,6 +3,7 @@ disabled_rules:
   - unused_setter_value
   - redundant_discardable_let
   - identifier_name
+  - redundant_sendable
 
 opt_in_rules:
   - force_unwrapping

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -792,6 +792,7 @@
 		8544657DEEE717ED2E22E382 /* RoomNotificationSettingsProxyMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D1BAA90F3A073D91B4F16B /* RoomNotificationSettingsProxyMock.swift */; };
 		854E82E064BA53CD0BC45600 /* LocationRoomTimelineItemContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6613DE16AD26B3A74DA1F5 /* LocationRoomTimelineItemContent.swift */; };
 		8587A53DE8EF94FD796DC375 /* RoomAvatarImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF5FE93A06F563B477F024A /* RoomAvatarImage.swift */; };
+		8591370C1A79182552321554 /* WeakSendableBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16313A45468434912B1F0788 /* WeakSendableBox.swift */; };
 		859E2CA2EDF343BD24DE52EB /* RoomDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6404166CBF5CC88673FF9E2 /* RoomDetails.swift */; };
 		85BD82E144AB99518A57DDEC /* preview_avatar_room.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 12FD5280AF55AB7F50F8E47D /* preview_avatar_room.jpg */; };
 		85F89F3F320F4FADCFFFE68B /* ServerSelectionScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3059CFA00C67D8787273B20 /* ServerSelectionScreenViewModel.swift */; };
@@ -1019,6 +1020,7 @@
 		A851635B3255C6DC07034A12 /* RoomScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8108C8F0ACF6A7EB72D0117 /* RoomScreenCoordinator.swift */; };
 		A87DC550659C5176AC1829DE /* ElementTextFieldStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7673F2B0B038FAB2A8D16AD /* ElementTextFieldStyle.swift */; };
 		A88328D7E17F73AB64501B51 /* SwiftSoup in Frameworks */ = {isa = PBXBuildFile; productRef = EDFB92E97D9AC4BA8540C18C /* SwiftSoup */; };
+		A8ADD9547F7A149911F472F2 /* SendableBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62FDC7F092C00B44C7865F65 /* SendableBox.swift */; };
 		A8DB299C5C891EDAE74A22F4 /* UserLocationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7482D5D1526E3399B00174 /* UserLocationCell.swift */; };
 		A8E324E700E596E36B0A311B /* BootDetectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F054DE7D47849687662C9D9 /* BootDetectionManager.swift */; };
 		A8FA7671948E3DF27F320026 /* BugReportFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7367B3B9A8CAF902220F31D1 /* BugReportFlowCoordinator.swift */; };
@@ -1745,6 +1747,7 @@
 		1575947B7A6FE08C57FE5EE4 /* NetworkMonitorProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitorProtocol.swift; sourceTree = "<group>"; };
 		161CD412E75F4086F422AE39 /* SessionVerificationScreenStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionVerificationScreenStateMachine.swift; sourceTree = "<group>"; };
 		1627F2D56477BD331F6D732C /* RoomHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomHeaderView.swift; sourceTree = "<group>"; };
+		16313A45468434912B1F0788 /* WeakSendableBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeakSendableBox.swift; sourceTree = "<group>"; };
 		166D45E1861A73B232109843 /* RoomDetailsScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomDetailsScreenViewModelTests.swift; sourceTree = "<group>"; };
 		16D09C79746BDCD9173EB3A7 /* RoomDetailsEditScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomDetailsEditScreenModels.swift; sourceTree = "<group>"; };
 		16D353E10A64172D863769BF /* TombstonedAvatarImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TombstonedAvatarImage.swift; sourceTree = "<group>"; };
@@ -2167,6 +2170,7 @@
 		62A81CCC2516D9CF9322DF01 /* MediaProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaProviderTests.swift; sourceTree = "<group>"; };
 		62B07B296D7A9D2F09120853 /* OrderedSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderedSet.swift; sourceTree = "<group>"; };
 		62EACAFB3F3E017060F9F1C5 /* TimelineProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineProviderMock.swift; sourceTree = "<group>"; };
+		62FDC7F092C00B44C7865F65 /* SendableBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendableBox.swift; sourceTree = "<group>"; };
 		633924B26ACCD29C18BEF4E8 /* DeactivateAccountScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeactivateAccountScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		633BAD3D9BB44B2AED7CBB93 /* ClassicAppManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClassicAppManagerMock.swift; sourceTree = "<group>"; };
 		638790D3F915F0909315C47A /* PollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollView.swift; sourceTree = "<group>"; };
@@ -4814,6 +4818,15 @@
 			path = Notification;
 			sourceTree = "<group>";
 		};
+		6E4FE67D51DE15CCCDC984D5 /* SendableConformance */ = {
+			isa = PBXGroup;
+			children = (
+				62FDC7F092C00B44C7865F65 /* SendableBox.swift */,
+				16313A45468434912B1F0788 /* WeakSendableBox.swift */,
+			);
+			path = SendableConformance;
+			sourceTree = "<group>";
+		};
 		6E8F16377AD462BBD4951271 /* SecureBackupRecoveryKeyScreen */ = {
 			isa = PBXGroup;
 			children = (
@@ -6246,6 +6259,7 @@
 				815092CE45A84D67A6CC7EA1 /* NetworkMonitor */,
 				9C4193C4524B35FD6B94B5A9 /* Pills */,
 				25852CD5316875417111E5CA /* Progress */,
+				6E4FE67D51DE15CCCDC984D5 /* SendableConformance */,
 				052CC920F473C10B509F9FC1 /* SwiftUI */,
 				35784B4A763838C0324B324A /* TestablePreview */,
 				B687E3E8C23415A06A3D5C65 /* UserIndicator */,
@@ -8868,6 +8882,7 @@
 				7C545FFEC9930F7247352593 /* SecurityAndPrivacyScreenViewModel.swift in Sources */,
 				0D617A152D099D94271D3BA8 /* SecurityAndPrivacyScreenViewModelProtocol.swift in Sources */,
 				A588572ED0EB18D947B32A5E /* SendInviteConfirmationView.swift in Sources */,
+				A8ADD9547F7A149911F472F2 /* SendableBox.swift in Sources */,
 				08547E55DD3686A84550996D /* SeparatorMediaEventsTimelineView.swift in Sources */,
 				14E99D27628B1A6F0CB46FEA /* SeparatorRoomTimelineItem.swift in Sources */,
 				5341D48F833E3E30F16FA2A3 /* SeparatorRoomTimelineView.swift in Sources */,
@@ -9127,6 +9142,7 @@
 				CA12AE0DCD57D49CD96C699A /* WaveformCursorView.swift in Sources */,
 				63CDC201A5980F304F6D0A1C /* WaveformInteractionModifier.swift in Sources */,
 				B773ACD8881DB18E876D950C /* WaveformSource.swift in Sources */,
+				8591370C1A79182552321554 /* WeakSendableBox.swift in Sources */,
 				08CB4BD12CEEDE6AAE4A18DD /* WindowManager.swift in Sources */,
 				AE5AAD9E32511544FDFA5560 /* WindowManagerProtocol.swift in Sources */,
 			);

--- a/ElementX/Sources/Other/SendableConformance/SendableBox.swift
+++ b/ElementX/Sources/Other/SendableConformance/SendableBox.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-/// Wraps a non-Sendable type and assures most of it's interactions are done in isolation with locking mechanisms
+/// Wraps a non-Sendable type and assures most of its interactions are done in isolation with locking mechanisms
 ///
 /// The exception is reference types. If multiple SendableBox instances are created with a reference to the same class,
 /// each SendableBox operates in isolation and ignorance of the others. When using with reference types (or value
@@ -17,7 +17,7 @@ import Foundation
 @Observable
 @dynamicMemberLookup
 final class SendableBox<Wrapped>: @unchecked Sendable {
-    private let isolationLock = NSLock()
+    private let isolationLock = NSRecursiveLock()
     
     private var _value: Wrapped
     var value: Wrapped {

--- a/ElementX/Sources/Other/SendableConformance/SendableBox.swift
+++ b/ElementX/Sources/Other/SendableConformance/SendableBox.swift
@@ -1,0 +1,45 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Foundation
+
+/// Wraps a non-Sendable type and assures most of it's interactions are done in isolation with locking mechanisms
+///
+/// The exception is reference types. If multiple SendableBox instances are created with a reference to the same class,
+/// each SendableBox operates in isolation and ignorance of the others. When using with reference types (or value
+/// types that point to reference types), make sure to only create one Box instance per instance of Wrapped.
+///
+/// Leverages the `@dynamicMemberLookup` feature in swift to be able to access properties directly on the Box.
+@dynamicMemberLookup
+final class SendableBox<Wrapped>: @unchecked Sendable {
+    private let isolationLock = NSLock()
+    
+    private var _value: Wrapped
+    var value: Wrapped {
+        get { isolationLock.withLock { _value } }
+        set { isolationLock.withLock { _value = newValue } }
+    }
+    
+    subscript<T>(dynamicMember member: WritableKeyPath<Wrapped, T>) -> T {
+        get { value[keyPath: member] }
+        set { value[keyPath: member] = newValue }
+    }
+    
+    subscript<T>(dynamicMember member: KeyPath<Wrapped, T>) -> T {
+        value[keyPath: member]
+    }
+    
+    init(_ value: Wrapped) {
+        self._value = value
+    }
+}
+
+extension SendableBox: ExpressibleByNilLiteral where Wrapped: ExpressibleByNilLiteral {
+    convenience init(nilLiteral: ()) {
+        self.init(nil)
+    }
+}

--- a/ElementX/Sources/Other/SendableConformance/SendableBox.swift
+++ b/ElementX/Sources/Other/SendableConformance/SendableBox.swift
@@ -14,6 +14,7 @@ import Foundation
 /// types that point to reference types), make sure to only create one Box instance per instance of Wrapped.
 ///
 /// Leverages the `@dynamicMemberLookup` feature in swift to be able to access properties directly on the Box.
+@Observable
 @dynamicMemberLookup
 final class SendableBox<Wrapped>: @unchecked Sendable {
     private let isolationLock = NSLock()

--- a/ElementX/Sources/Other/SendableConformance/WeakSendableBox.swift
+++ b/ElementX/Sources/Other/SendableConformance/WeakSendableBox.swift
@@ -1,0 +1,33 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Foundation
+
+/// See ``Sendable`` - Everything is the same, but the value stored with `weak` reference semantics
+@dynamicMemberLookup
+final class WeakSendableBox<Wrapped: AnyObject>: @unchecked Sendable {
+    private let isolationLock = NSLock()
+    
+    private weak var _value: Wrapped?
+    var value: Wrapped? {
+        get { isolationLock.withLock { _value } }
+        set { isolationLock.withLock { _value = newValue } }
+    }
+    
+    subscript<T>(dynamicMember member: WritableKeyPath<Wrapped, T?>) -> T? {
+        get { value?[keyPath: member] }
+        set { value?[keyPath: member] = newValue }
+    }
+    
+    subscript<T>(dynamicMember member: KeyPath<Wrapped, T>) -> T? {
+        value?[keyPath: member]
+    }
+    
+    init(_ value: Wrapped) {
+        self._value = value
+    }
+}

--- a/ElementX/Sources/Other/SendableConformance/WeakSendableBox.swift
+++ b/ElementX/Sources/Other/SendableConformance/WeakSendableBox.swift
@@ -7,10 +7,10 @@
 
 import Foundation
 
-/// See ``Sendable`` - Everything is the same, but the value stored with `weak` reference semantics
+/// See ``SendableBox`` - Mostly the same, but the value stored with `weak` reference semantics
 @dynamicMemberLookup
 final class WeakSendableBox<Wrapped: AnyObject>: @unchecked Sendable {
-    private let isolationLock = NSLock()
+    private let isolationLock = NSRecursiveLock()
     
     private weak var _value: Wrapped?
     var value: Wrapped? {

--- a/ElementX/Sources/Services/Audio/AudioConverterProtocol.swift
+++ b/ElementX/Sources/Services/Audio/AudioConverterProtocol.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-protocol AudioConverterProtocol {
+protocol AudioConverterProtocol: Sendable {
     func convertToOpusOgg(sourceURL: URL, destinationURL: URL) throws
     func convertToMPEG4AAC(sourceURL: URL, destinationURL: URL) throws
 }

--- a/ElementX/Sources/Services/Authentication/ClassicApp/ClassicAppMXAccount.swift
+++ b/ElementX/Sources/Services/Authentication/ClassicApp/ClassicAppMXAccount.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Observation
 
-struct ClassicAppAccount: Equatable, CustomStringConvertible {
+struct ClassicAppAccount: Equatable, CustomStringConvertible, Sendable {
     let userID: String
     let displayName: String?
     let avatarURL: URL?
@@ -29,20 +29,29 @@ struct ClassicAppAccount: Equatable, CustomStringConvertible {
     enum AvailableSecrets { case complete, requiresBackup, unavailable }
     
     @Observable
-    class State: Equatable {
+    final class State: Equatable, Sendable {
         static func == (lhs: State, rhs: State) -> Bool {
             lhs.isServerSupported == rhs.isServerSupported && lhs.availableSecrets == rhs.availableSecrets
         }
         
+        private let _isServerSupported: SendableBox<Bool?> = nil
         /// Whether or not the account's server is supported by Element X (or `nil` whilst determining support).
         ///
         /// The account will be hidden when this value is `false`.
-        var isServerSupported: Bool?
+        var isServerSupported: Bool? {
+            get { _isServerSupported.value }
+            set { _isServerSupported.value = newValue }
+        }
+        
+        private let _availableSecrets: SendableBox<AvailableSecrets?> = nil
         /// Information about the secrets available from Element X (or `nil` whilst determining availability).
         ///
         /// See ``AuthenticationService.refreshClassicAppAccountState`` for details about how
         /// this property's value affects the authentication flow.
-        var availableSecrets: AvailableSecrets?
+        var availableSecrets: AvailableSecrets? {
+            get { _availableSecrets.value }
+            set { _availableSecrets.value = newValue }
+        }
     }
     
     let state = State()

--- a/ElementX/Sources/Services/BugReport/BugReportService.swift
+++ b/ElementX/Sources/Services/BugReport/BugReportService.swift
@@ -49,7 +49,7 @@ class BugReportService: NSObject, BugReportServiceProtocol {
     // MARK: - BugReportServiceProtocol
     
     var crashedLastRun: Bool {
-        SentrySDK.crashedLastRun
+        SentrySDK.lastRunStatus == .didCrash
     }
     
     // swiftlint:disable:next cyclomatic_complexity

--- a/ElementX/Sources/Services/ElementCall/ElementCallWidgetDriver.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallWidgetDriver.swift
@@ -6,7 +6,7 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
-import Combine
+@preconcurrency import Combine
 import MatrixRustSDK
 import SwiftUI
 
@@ -52,7 +52,11 @@ final class ElementCallWidgetDriver: WidgetCapabilitiesProvider, ElementCallWidg
     private let room: RoomProtocol
     private let deviceID: String
     
-    private var widgetDriver: WidgetDriverAndHandle?
+    private let _widgetDriver: SendableBox<WidgetDriverAndHandle?>
+    private var widgetDriver: WidgetDriverAndHandle? {
+        get { _widgetDriver.value }
+        set { _widgetDriver.value = newValue }
+    }
     
     let widgetID = UUID().uuidString
     let messagePublisher = PassthroughSubject<String, Never>()
@@ -65,6 +69,7 @@ final class ElementCallWidgetDriver: WidgetCapabilitiesProvider, ElementCallWidg
     init(room: RoomProtocol, deviceID: String) {
         self.room = room
         self.deviceID = deviceID
+        _widgetDriver = nil
     }
     
     func start(baseURL: URL,

--- a/ElementX/Sources/Services/NotificationSettings/NotificationSettingsProxy.swift
+++ b/ElementX/Sources/Services/NotificationSettings/NotificationSettingsProxy.swift
@@ -11,17 +11,17 @@ import Foundation
 import MatrixRustSDK
 
 private final class WeakNotificationSettingsProxy: NotificationSettingsDelegate {
-    private weak var proxy: NotificationSettingsProxy?
+    private let proxy: WeakSendableBox<NotificationSettingsProxy>
     
     init(proxy: NotificationSettingsProxy) {
-        self.proxy = proxy
+        self.proxy = .init(proxy)
     }
     
     // MARK: - NotificationSettingsDelegate
     
     func settingsDidChange() {
         Task {
-            await proxy?.settingsDidChange()
+            await proxy.value?.settingsDidChange()
         }
     }
 }

--- a/ElementX/Sources/Services/Room/JoinRule.swift
+++ b/ElementX/Sources/Services/Room/JoinRule.swift
@@ -9,7 +9,7 @@ import Foundation
 import MatrixRustSDK
 
 /// The rule used for users wishing to join a room.
-public enum JoinRule: Equatable, Hashable {
+public enum JoinRule: Equatable, Hashable, Sendable {
     /// Anyone can join the room without any prior action.
     case `public`
     /// A user who wishes to join the room must first receive an invite.
@@ -52,7 +52,7 @@ public enum JoinRule: Equatable, Hashable {
 }
 
 /// An allow rule which defines a condition that allows joining a room.
-public enum AllowRule: Equatable, Hashable {
+public enum AllowRule: Equatable, Hashable, Sendable {
     /// Only a member of the `room_id` Room can join the one this rule is used in.
     case roomMembership(roomID: String)
     /// A custom allow rule implementation, containing its JSON representation as a `String`.

--- a/ElementX/Sources/Services/SessionVerification/SessionVerificationControllerProxy.swift
+++ b/ElementX/Sources/Services/SessionVerification/SessionVerificationControllerProxy.swift
@@ -11,46 +11,46 @@ import Foundation
 import MatrixRustSDK
 
 private final class WeakSessionVerificationControllerProxy: SessionVerificationControllerDelegate {
-    private weak var proxy: SessionVerificationControllerProxy?
+    private let proxy: WeakSendableBox<SessionVerificationControllerProxy>
     
     init(proxy: SessionVerificationControllerProxy) {
-        self.proxy = proxy
+        self.proxy = .init(proxy)
     }
     
     // MARK: - SessionVerificationControllerDelegate
     
     func didReceiveVerificationRequest(details: MatrixRustSDK.SessionVerificationRequestDetails) {
-        proxy?.didReceiveVerificationRequest(details: details)
+        proxy.value?.didReceiveVerificationRequest(details: details)
     }
     
     func didReceiveVerificationData(data: MatrixRustSDK.SessionVerificationData) {
         switch data {
         // We can handle only emojis for now
         case .emojis(let emojis, _):
-            proxy?.didReceiveData(emojis)
+            proxy.value?.didReceiveData(emojis)
         default:
             break
         }
     }
     
     func didAcceptVerificationRequest() {
-        proxy?.didAcceptVerificationRequest()
+        proxy.value?.didAcceptVerificationRequest()
     }
     
     func didStartSasVerification() {
-        proxy?.didStartSasVerification()
+        proxy.value?.didStartSasVerification()
     }
     
     func didFail() {
-        proxy?.didFail()
+        proxy.value?.didFail()
     }
     
     func didCancel() {
-        proxy?.didCancel()
+        proxy.value?.didCancel()
     }
     
     func didFinish() {
-        proxy?.didFinish()
+        proxy.value?.didFinish()
     }
 }
 

--- a/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerProtocol.swift
@@ -42,7 +42,7 @@ enum TimelineControllerError: Error {
 /// It, for example, permits switching from a live timeline to an event focused one, building view specific
 /// timeline items, grouping together state events, donating intents to the larger system etc.
 @MainActor
-protocol TimelineControllerProtocol {
+protocol TimelineControllerProtocol: Sendable {
     var roomID: String { get }
     var timelineKind: TimelineKind { get }
     

--- a/UnitTests/Sources/AttributedStringBuilderTests.swift
+++ b/UnitTests/Sources/AttributedStringBuilderTests.swift
@@ -149,7 +149,7 @@ struct AttributedStringBuilderTests {
         
         let attributedString = try #require(attributedStringBuilder.fromHTML(htmlString), "Could not build the attributed string")
         
-        #expect(attributedString.uiKit.attachment == nil,
+        #expect(attributedString.suppressedAttachment == nil,
                 "iFrame attachments should be removed as they're not included in the allowedHTMLTags array.")
     }
     
@@ -305,7 +305,7 @@ struct AttributedStringBuilderTests {
             foundBlockquoteAndLink = true
         }
         
-        #expect(foundBlockquoteAndLink != nil, "Couldn't find blockquote or link")
+        #expect(foundBlockquoteAndLink != false, "Couldn't find blockquote or link")
     }
     
     @Test
@@ -358,11 +358,11 @@ struct AttributedStringBuilderTests {
     func userPermalinkMentionAtachment() {
         let string = "https://matrix.to/#/@test:matrix.org"
         let attributedStringFromHTML = attributedStringBuilder.fromHTML(string)
-        #expect(attributedStringFromHTML?.attachment != nil)
+        #expect(attributedStringFromHTML?.suppressedAttachment != nil)
         #expect(attributedStringFromHTML?.userID == "@test:matrix.org")
         #expect(attributedStringFromHTML?.link?.absoluteString == string)
         let attributedStringFromPlain = attributedStringBuilder.fromPlain(string)
-        #expect(attributedStringFromPlain?.attachment != nil)
+        #expect(attributedStringFromPlain?.suppressedAttachment != nil)
         #expect(attributedStringFromPlain?.userID == "@test:matrix.org")
         #expect(attributedStringFromPlain?.link?.absoluteString == string)
     }
@@ -371,11 +371,11 @@ struct AttributedStringBuilderTests {
     func userIDMentionAtachment() {
         let string = "@test:matrix.org"
         let attributedStringFromHTML = attributedStringBuilder.fromHTML(string)
-        #expect(attributedStringFromHTML?.attachment != nil)
+        #expect(attributedStringFromHTML?.suppressedAttachment != nil)
         #expect(attributedStringFromHTML?.userID == "@test:matrix.org")
         #expect(attributedStringFromHTML?.link?.absoluteString == "https://matrix.to/#/@test:matrix.org")
         let attributedStringFromPlain = attributedStringBuilder.fromPlain(string)
-        #expect(attributedStringFromPlain?.attachment != nil)
+        #expect(attributedStringFromPlain?.suppressedAttachment != nil)
         #expect(attributedStringFromPlain?.userID == "@test:matrix.org")
         #expect(attributedStringFromPlain?.link?.absoluteString == "https://matrix.to/#/@test:matrix.org")
     }
@@ -384,11 +384,11 @@ struct AttributedStringBuilderTests {
     func roomIDPermalinkMentionAttachment() {
         let string = "https://matrix.to/#/!test:matrix.org"
         let attributedStringFromHTML = attributedStringBuilder.fromHTML(string)
-        #expect(attributedStringFromHTML?.attachment != nil)
+        #expect(attributedStringFromHTML?.suppressedAttachment != nil)
         #expect(attributedStringFromHTML?.roomID == "!test:matrix.org")
         #expect(attributedStringFromHTML?.link?.absoluteString == string)
         let attributedStringFromPlain = attributedStringBuilder.fromPlain(string)
-        #expect(attributedStringFromPlain?.attachment != nil)
+        #expect(attributedStringFromPlain?.suppressedAttachment != nil)
         #expect(attributedStringFromHTML?.roomID == "!test:matrix.org")
         #expect(attributedStringFromPlain?.link?.absoluteString == string)
     }
@@ -397,11 +397,11 @@ struct AttributedStringBuilderTests {
     func roomAliasPermalinkMentionAttachment() {
         let string = "https://matrix.to/#/#test:matrix.org"
         let attributedStringFromHTML = attributedStringBuilder.fromHTML(string)
-        #expect(attributedStringFromHTML?.attachment != nil)
+        #expect(attributedStringFromHTML?.suppressedAttachment != nil)
         #expect(attributedStringFromHTML?.roomAlias == "#test:matrix.org")
         #expect(attributedStringFromHTML?.link?.absoluteString == "https://matrix.to/#/%23test:matrix.org")
         let attributedStringFromPlain = attributedStringBuilder.fromPlain(string)
-        #expect(attributedStringFromPlain?.attachment != nil)
+        #expect(attributedStringFromPlain?.suppressedAttachment != nil)
         #expect(attributedStringFromHTML?.roomAlias == "#test:matrix.org")
         #expect(attributedStringFromPlain?.link?.absoluteString == "https://matrix.to/#/%23test:matrix.org")
     }
@@ -410,11 +410,11 @@ struct AttributedStringBuilderTests {
     func roomAliasMentionAttachment() {
         let string = "#test:matrix.org"
         let attributedStringFromHTML = attributedStringBuilder.fromHTML(string)
-        #expect(attributedStringFromHTML?.attachment != nil)
+        #expect(attributedStringFromHTML?.suppressedAttachment != nil)
         #expect(attributedStringFromHTML?.roomAlias == "#test:matrix.org")
         #expect(attributedStringFromHTML?.link?.absoluteString == "https://matrix.to/#/%23test:matrix.org")
         let attributedStringFromPlain = attributedStringBuilder.fromPlain(string)
-        #expect(attributedStringFromPlain?.attachment != nil)
+        #expect(attributedStringFromPlain?.suppressedAttachment != nil)
         #expect(attributedStringFromHTML?.roomAlias == "#test:matrix.org")
         #expect(attributedStringFromPlain?.link?.absoluteString == "https://matrix.to/#/%23test:matrix.org")
     }
@@ -423,11 +423,11 @@ struct AttributedStringBuilderTests {
     func eventRoomIDPermalinkMentionAttachment() {
         let string = "https://matrix.to/#/!test:matrix.org/$test"
         let attributedStringFromHTML = attributedStringBuilder.fromHTML(string)
-        #expect(attributedStringFromHTML?.attachment != nil)
+        #expect(attributedStringFromHTML?.suppressedAttachment != nil)
         #expect(attributedStringFromHTML?.eventOnRoomID == .some(.init(roomID: "!test:matrix.org", eventID: "$test")))
         #expect(attributedStringFromHTML?.link?.absoluteString == string)
         let attributedStringFromPlain = attributedStringBuilder.fromPlain(string)
-        #expect(attributedStringFromPlain?.attachment != nil)
+        #expect(attributedStringFromPlain?.suppressedAttachment != nil)
         #expect(attributedStringFromPlain?.eventOnRoomID == .some(.init(roomID: "!test:matrix.org", eventID: "$test")))
         #expect(attributedStringFromPlain?.link?.absoluteString == string)
     }
@@ -436,11 +436,11 @@ struct AttributedStringBuilderTests {
     func eventRoomAliasPermalinkMentionAttachment() {
         let string = "https://matrix.to/#/#test:matrix.org/$test"
         let attributedStringFromHTML = attributedStringBuilder.fromHTML(string)
-        #expect(attributedStringFromHTML?.attachment != nil)
+        #expect(attributedStringFromHTML?.suppressedAttachment != nil)
         #expect(attributedStringFromHTML?.eventOnRoomAlias == .some(.init(alias: "#test:matrix.org", eventID: "$test")))
         #expect(attributedStringFromHTML?.link?.absoluteString == "https://matrix.to/#/%23test:matrix.org/$test")
         let attributedStringFromPlain = attributedStringBuilder.fromPlain(string)
-        #expect(attributedStringFromPlain?.attachment != nil)
+        #expect(attributedStringFromPlain?.suppressedAttachment != nil)
         #expect(attributedStringFromPlain?.eventOnRoomAlias == .some(.init(alias: "#test:matrix.org", eventID: "$test")))
         #expect(attributedStringFromPlain?.link?.absoluteString == "https://matrix.to/#/%23test:matrix.org/$test")
     }
@@ -536,7 +536,7 @@ struct AttributedStringBuilderTests {
         
         #expect(attributedString?.runs.count == 1)
         
-        #expect(attributedString?.attachment == nil)
+        #expect(attributedString?.suppressedAttachment == nil)
     }
     
     @Test
@@ -546,7 +546,7 @@ struct AttributedStringBuilderTests {
         
         #expect(attributedString?.runs.count == 1)
         
-        #expect(attributedString?.attachment == nil)
+        #expect(attributedString?.suppressedAttachment == nil)
     }
     
     @Test
@@ -556,7 +556,7 @@ struct AttributedStringBuilderTests {
         
         #expect(attributedString?.runs.count == 1)
         
-        #expect(attributedString?.attachment == nil)
+        #expect(attributedString?.suppressedAttachment == nil)
     }
     
     @Test
@@ -569,7 +569,7 @@ struct AttributedStringBuilderTests {
         var foundAttachments = 0
         var foundLink: URL?
         for run in attributedStringFromHTML.runs {
-            if run.attachment != nil {
+            if run.suppressedAttachment != nil {
                 foundAttachments += 1
             }
             
@@ -585,7 +585,7 @@ struct AttributedStringBuilderTests {
         foundAttachments = 0
         foundLink = nil
         for run in attributedStringFromPlain.runs {
-            if run.attachment != nil {
+            if run.suppressedAttachment != nil {
                 foundAttachments += 1
             }
             
@@ -607,7 +607,7 @@ struct AttributedStringBuilderTests {
         var foundAttachments = 0
         var foundLink: URL?
         for run in attributedStringFromHTML.runs {
-            if run.attachment != nil {
+            if run.suppressedAttachment != nil {
                 foundAttachments += 1
             }
             
@@ -623,7 +623,7 @@ struct AttributedStringBuilderTests {
         foundAttachments = 0
         foundLink = nil
         for run in attributedStringFromPlain.runs {
-            if run.attachment != nil {
+            if run.suppressedAttachment != nil {
                 foundAttachments += 1
             }
             
@@ -983,7 +983,7 @@ struct AttributedStringBuilderTests {
         
         #expect(String(attributedString2.characters) == "This is visible. And this text and link are visible too.")
         
-        try #require(attributedString2.runs.first { $0.link != nil }?.link, "Couldn't find the link")
+        _ = try #require(attributedString2.runs.first { $0.link != nil }?.link, "Couldn't find the link")
     }
     
     // MARK: - Private
@@ -1006,10 +1006,46 @@ struct AttributedStringBuilderTests {
         
         #expect(attributedString.runs.count == expectedRuns)
         
-        for run in attributedString.runs where run.attachment != nil {
+        for run in attributedString.runs where run.suppressedAttachment != nil {
             return
         }
         
         Issue.record("Couldn't find expected value.")
+    }
+}
+
+// warning suppression
+// `NSTextAttachment` is marked `@_nonSendable(_assumed)` by Apple in the UIKit SDK, and
+// `ScopedAttributeContainer` (returned by `AttributedString.uiKit` and used by dynamic member
+// lookup on `AttributedString` and `AttributedString.Runs.Element`) is marked `Sendable`.
+// The compiler warns at every access point where a `@_nonSendable` value is read through a
+// `Sendable` container — regardless of Swift version or strict concurrency mode. There is no
+// compiler flag that suppresses this cleanly.
+//
+// Attempted fixes:
+// - `@MainActor` on the test class: does not help; the warning is not about actor isolation
+// - `@preconcurrency import UIKit`: does not help; the warning originates from the SDK type attribute
+// - Varying `-strict-concurrency` (targeted/complete) or `-swift-version` (5/6): all produce
+//   the same warning — confirmed via standalone `swiftc` repro
+//
+// The warning is safe to ignore here because no concurrency boundary is actually crossed —
+// the value is accessed synchronously within a single context and never escapes.
+//
+// These two extension properties consolidate 20+ warning sites across this file down to just
+// these two definitions taking the hit. This pattern is test-only; app code reads attachments
+// via `NSAttributedString.attribute(_:at:effectiveRange:)` which does not trigger the warning.
+
+// swiftformat:disable redundantSelf
+// self is not redundant here because these are NOT properties directly on the type, but on a
+// child through dynamicMember which requires the `self` for access
+private extension AttributedString {
+    var suppressedAttachment: NSTextAttachment? {
+        self.attachment
+    }
+}
+
+private extension AttributedString.Runs.Element {
+    var suppressedAttachment: NSTextAttachment? {
+        self.attachment
     }
 }

--- a/UnitTests/Sources/AttributedStringBuilderTests.swift
+++ b/UnitTests/Sources/AttributedStringBuilderTests.swift
@@ -305,7 +305,7 @@ struct AttributedStringBuilderTests {
             foundBlockquoteAndLink = true
         }
         
-        #expect(foundBlockquoteAndLink != false, "Couldn't find blockquote or link")
+        #expect(foundBlockquoteAndLink == true, "Couldn't find blockquote or link")
     }
     
     @Test

--- a/UnitTests/Sources/RoomDetailsScreenViewModelTests.swift
+++ b/UnitTests/Sources/RoomDetailsScreenViewModelTests.swift
@@ -27,7 +27,6 @@ struct RoomDetailsScreenViewModelTests {
     init() {
         AppSettings.resetAllSettings()
         let appSettings = AppSettings()
-        let analytics = AnalyticsService.mock(settings: appSettings)
         
         cancellables.removeAll()
         roomProxyMock = JoinedRoomProxyMock(.init(name: "Test"))


### PR DESCRIPTION
Resolves a number of compiler warnings across the project, primarily around `Sendable` conformance and a few test correctness issues.

## SendableBox / WeakSendableBox

Introduces two new utility types in `Other/SendableConformance/`:

- `SendableBox<Wrapped>` — wraps a non-`Sendable` type and synchronizes all access through an `NSRecursiveLock`. Conforms to `@unchecked Sendable`, which is safe because all mutations are lock-isolated. The recursive lock (vs. `NSLock`) is necessary because `@Observable`'s `withMutation` fires synchronously while the lock is held, and the same thread may re-enter on observation callbacks. Uses `@dynamicMemberLookup` for ergonomic property access. Also `@Observable` so wrapped values participate in SwiftUI's observation system.
- `WeakSendableBox<Wrapped: AnyObject>` — same concept with `weak` reference semantics, for breaking retain cycles in delegate patterns.

## Sendable conformances

- `JoinRule` / `AllowRule` — pure value types, no-op addition
- `AudioConverterProtocol` — stateless protocol, straightforward
- `TimelineControllerProtocol` — already `@MainActor` (implying `Sendable`), but the compiler still warned; explicit conformance resolved it
- `ClassicAppAccount` — gaining `Sendable` required `ClassicAppAccount.State` to also be `Sendable`. Making it `@MainActor` caused a cascade of `Equatable` conformance errors. Instead, each mutable property is backed by a `SendableBox`, with computed properties providing the same public interface. The indirect observation chain (through `SendableBox`'s own `@Observable` registrar) was validated in a playground.
- `ElementCallWidgetDriver`, `NotificationSettingsProxy`, `SessionVerificationControllerProxy` — non-`Sendable` stored properties wrapped in `SendableBox` / `WeakSendableBox`

## Other

- `BugReportService`: migrated from deprecated `SentrySDK.crashedLastRun` to `SentrySDK.lastRunStatus == .didCrash`
- Disabled `redundantSendable` in both SwiftLint and SwiftFormat — both were producing false positives
- `AttributedStringBuilderTests`: `NSTextAttachment` is marked `@_nonSendable(_assumed)` in the UIKit SDK, generating a warning at every `.attachment` access site. Consolidated all ~20 call sites behind two private `suppressedAttachment` extension properties that take the warning hit in one place. Also fixed `#expect(foundBlockquoteAndLink != nil)` (comparing a `Bool` to `nil` is invalid in Swift Testing) to `!= false`, and assigned away an unused `#require` result.

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
