### PR TITLE
Revert "Fixing Room List in Spaces View Not Rendering Some Rooms (#5595)

### DIFF
--- a/ElementX/Sources/Screens/Spaces/Common/SpaceRoomCell.swift
+++ b/ElementX/Sources/Screens/Spaces/Common/SpaceRoomCell.swift
@@ -81,6 +81,9 @@ struct SpaceRoomCell: View {
                 }
             }
             .padding(.horizontal, horizontalInsets)
+            // Ensure the EditMode transition stays inside this cell if there are other insertions/removals in the list.
+            // Seems to slow down the animations a bit in Xcode previews but its fine in the simulator and on a device.
+            .drawingGroup()
             .accessibilityElement(children: .combine)
         }
         .buttonStyle(SpaceRoomCellButtonStyle(isHighlighted: isHighlighted))

--- a/ElementX/Sources/Screens/Spaces/Common/SpaceRoomCell.swift
+++ b/ElementX/Sources/Screens/Spaces/Common/SpaceRoomCell.swift
@@ -82,8 +82,7 @@ struct SpaceRoomCell: View {
             }
             .padding(.horizontal, horizontalInsets)
             // Ensure the EditMode transition stays inside this cell if there are other insertions/removals in the list.
-            // Seems to slow down the animations a bit in Xcode previews but its fine in the simulator and on a device.
-            .drawingGroup()
+            .geometryGroup()
             .accessibilityElement(children: .combine)
         }
         .buttonStyle(SpaceRoomCellButtonStyle(isHighlighted: isHighlighted))


### PR DESCRIPTION
#5595 didn't fix the issue in #5306 and the `.drawingGroup` is there to make sure the animation matches the normal system behaviour.