### PR TITLE
Stop message bubbles from stealing dropped files

### DIFF
--- a/ElementX/Sources/Other/Pills/MessageText.swift
+++ b/ElementX/Sources/Other/Pills/MessageText.swift
@@ -173,6 +173,11 @@ struct MessageText: UIViewRepresentable {
         
         // Otherwise links can be dragged and dropped when long pressed
         textView.textDragInteraction?.isEnabled = false
+        // Otherwise items dropped onto a bubble land on the text view instead of
+        // bubbling up to the timeline's drop handler.
+        if let textDropInteraction = textView.textDropInteraction {
+            textView.removeInteraction(textDropInteraction)
+        }
         
         textView.contentInset = .zero
         textView.contentInsetAdjustmentBehavior = .never


### PR DESCRIPTION
Each bubble's UITextView keeps `isSelectable = true` so links remain tappable, which also makes it a valid drop target — items dragged onto a bubble landed on the text view instead of bubbling up to the timeline's `.onDrop`.

<table><tr><th>Before</th><th>After</th>
<tr><td>

https://github.com/user-attachments/assets/548efbf4-21c1-480b-8c50-19ec5f41d6ed

</td>
<td>

https://github.com/user-attachments/assets/340bf13d-08a0-40ee-9f08-61e0c37c4d54

</td></tr>
</table>

**AI disclosure**: I used Claude Code w/ Opus 4.7 to diagnose the issue and fix it

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
