### PR TITLE
Restrict the dynamic range of avatars to prevent them from displaying HDR content.

### DIFF
--- a/ElementX/Sources/Other/SwiftUI/Views/LoadableAvatarImage.swift
+++ b/ElementX/Sources/Other/SwiftUI/Views/LoadableAvatarImage.swift
@@ -60,6 +60,7 @@ struct LoadableAvatarImage: View {
             .frame(width: frameSize, height: frameSize)
             .background(Color.compound.bgCanvasDefault)
             .avatarShape(shape, scaledSize: _frameSize)
+            .allowedDynamicRange(.standard) // Prevent avatars from triggering HDR display.
             .environment(\.shouldAutomaticallyLoadImages, true) // We always load avatars.
     }
     


### PR DESCRIPTION
It makes no sense to scroll through the room list/timeline and have the screen going in and out of HDR. It doesn't appear that SwiftUI does any tone-mapping to the image, but it seems such a rare occurrence that it probably doesn't matter.