### PR TITLE
Fix empty state overlapping the banner

### DIFF
--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreenContent.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreenContent.swift
@@ -16,6 +16,8 @@ struct HomeScreenContent: View {
     @ObservedObject var context: HomeScreenViewModel.Context
     let scrollViewAdapter: ScrollViewAdapter
     
+    @State private var topSectionHeight: CGFloat = 0
+    
     var body: some View {
         roomList
             .sentryTrace("\(Self.self)")
@@ -47,7 +49,10 @@ struct HomeScreenContent: View {
                 case .rooms:
                     LazyVStack(spacing: 0) {
                         Section {
-                            if !context.viewState.shouldShowEmptyFilterState {
+                            if context.viewState.shouldShowEmptyFilterState {
+                                RoomListFiltersEmptyStateView(state: context.filtersState)
+                                    .frame(maxWidth: .infinity, minHeight: max(0, geometry.size.height - topSectionHeight))
+                            } else {
                                 HomeScreenRoomList(context: context)
                             }
                         } header: {
@@ -99,13 +104,6 @@ struct HomeScreenContent: View {
                     scrollView.setContentOffset(oldOffset, animated: false)
                 }
             }
-            .overlay {
-                if context.viewState.shouldShowEmptyFilterState {
-                    RoomListFiltersEmptyStateView(state: context.filtersState)
-                        .background(.compound.bgCanvasDefault)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                }
-            }
             .scrollDismissesKeyboard(.immediately)
             .scrollDisabled(context.viewState.roomListMode == .skeletons)
             .scrollBounceBehavior(context.viewState.roomListMode == .empty ? .basedOnSize : .automatic)
@@ -130,6 +128,7 @@ struct HomeScreenContent: View {
                 }
             }
             .background(Color.compound.bgCanvasDefault)
+            .onGeometryChange(for: CGFloat.self, of: \.size.height) { topSectionHeight = $0 }
         }
     }
     


### PR DESCRIPTION
Since the empty state used an overlay this would happen if the banner was present:

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone-26 4 - 2026-05-29 at 10 27 31" src="https://github.com/user-attachments/assets/3c4db88a-66b9-48a5-9f4f-8e2225464153" />

To fix this issue I have removed the usage of the overlay (it's not needed that much since we are already calculating the expected size of the empty state), and in addition subtract the height of the banner so that the empty state always looks centered below it (if present)