### PR TITLE
Add password fallback for OAuth login

### DIFF
--- a/ElementX/Sources/FlowCoordinators/AuthenticationFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/AuthenticationFlowCoordinator.swift
@@ -433,8 +433,12 @@ class AuthenticationFlowCoordinator: FlowCoordinatorProtocol {
             switch await presenter.authenticate(using: oAuthData) {
             case .success(let userSession):
                 stateMachine.tryEvent(.signedIn, userInfo: userSession)
+            case .failure(.oAuthError(.userCancellation)):
+                break // Nothing to do when the user explicitly cancels the flow.
             case .failure:
-                break // Nothing to do, any alerts will be handled by the presenter.
+                if authenticationService.homeserver.value.supportsPasswordLogin {
+                    stateMachine.tryEvent(.continueWithPassword)
+                }
             }
             oAuthPresenter = nil
         }

--- a/ElementX/Sources/Screens/Authentication/LoginScreen/LoginHomeserver.swift
+++ b/ElementX/Sources/Screens/Authentication/LoginScreen/LoginHomeserver.swift
@@ -14,13 +14,16 @@ struct LoginHomeserver: Equatable {
     let address: String
     /// The types login supported by the homeserver.
     var loginMode: LoginMode
+    /// Whether the homeserver supports password login, even when another login mode is preferred.
+    var supportsPasswordLogin: Bool
     
     /// Creates a new homeserver value.
-    init(address: String, loginMode: LoginMode) {
+    init(address: String, loginMode: LoginMode, supportsPasswordLogin: Bool = false) {
         let address = Self.sanitized(address).components(separatedBy: "://").last ?? address
         
         self.address = address
         self.loginMode = loginMode
+        self.supportsPasswordLogin = supportsPasswordLogin || loginMode == .password
     }
     
     /// Sanitizes a user entered homeserver address with the following rules
@@ -46,7 +49,7 @@ struct LoginHomeserver: Equatable {
 extension LoginHomeserver {
     /// A mock homeserver that is configured just like matrix.org.
     static var mockMatrixDotOrg: LoginHomeserver {
-        LoginHomeserver(address: "matrix.org", loginMode: .oAuth(supportsCreatePrompt: true))
+        LoginHomeserver(address: "matrix.org", loginMode: .oAuth(supportsCreatePrompt: true), supportsPasswordLogin: true)
     }
     
     /// A mock homeserver that supports login and registration via a password but has no OAuth support.

--- a/ElementX/Sources/Screens/Authentication/ServerConfirmationScreen/ServerConfirmationScreenModels.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerConfirmationScreen/ServerConfirmationScreenModels.swift
@@ -31,6 +31,10 @@ struct ServerConfirmationScreenViewState: BindableState {
     let authenticationFlow: AuthenticationFlow
     /// The presentation anchor used for OAuth authentication.
     var window: UIWindow?
+    /// The login mode supported by the selected homeserver.
+    var loginMode: LoginMode = .unknown
+    /// Whether the selected homeserver supports password login.
+    var supportsPasswordLogin = false
     
     var bindings = ServerConfirmationScreenBindings()
     
@@ -66,6 +70,11 @@ struct ServerConfirmationScreenViewState: BindableState {
             L10n.screenServerConfirmationMessageRegister
         }
     }
+
+    /// Whether to offer password login as a fallback from the preferred OAuth flow.
+    var canContinueWithPassword: Bool {
+        authenticationFlow == .login && loginMode.supportsOAuthFlow && supportsPasswordLogin
+    }
 }
 
 struct ServerConfirmationScreenBindings {
@@ -80,6 +89,8 @@ enum ServerConfirmationScreenViewAction {
     case updateWindow(UIWindow)
     /// The user would like to continue with the current homeserver.
     case confirm
+    /// The user would like to continue using password login instead of OAuth.
+    case continueWithPassword
     /// The user would like to change to a different homeserver.
     case changeServer
 }

--- a/ElementX/Sources/Screens/Authentication/ServerConfirmationScreen/ServerConfirmationScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerConfirmationScreen/ServerConfirmationScreenViewModel.swift
@@ -38,17 +38,25 @@ class ServerConfirmationScreenViewModel: ServerConfirmationScreenViewModelType, 
         case .confirmation: nil
         }
         
+        let homeserver = authenticationService.homeserver.value
         super.init(initialViewState: ServerConfirmationScreenViewState(mode: mode,
                                                                        authenticationFlow: authenticationFlow,
+                                                                       loginMode: homeserver.loginMode,
+                                                                       supportsPasswordLogin: homeserver.supportsPasswordLogin,
                                                                        bindings: .init(pickerSelection: pickerSelection)))
         
-        if case .confirmation = mode {
-            authenticationService.homeserver
-                .receive(on: DispatchQueue.main)
-                .map { .confirmation($0.address) }
-                .weakAssign(to: \.state.mode, on: self)
-                .store(in: &cancellables)
-        }
+        authenticationService.homeserver
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] homeserver in
+                guard let self else { return }
+
+                if case .confirmation = state.mode {
+                    state.mode = .confirmation(homeserver.address)
+                }
+                state.loginMode = homeserver.loginMode
+                state.supportsPasswordLogin = homeserver.supportsPasswordLogin
+            }
+            .store(in: &cancellables)
     }
     
     override func process(viewAction: ServerConfirmationScreenViewAction) {
@@ -65,6 +73,8 @@ class ServerConfirmationScreenViewModel: ServerConfirmationScreenViewModelType, 
                 startLoading()
                 Task { await pickServer() }
             }
+        case .continueWithPassword:
+            actionsSubject.send(.continueWithPassword)
         case .changeServer:
             actionsSubject.send(.changeServer)
         }

--- a/ElementX/Sources/Screens/Authentication/ServerConfirmationScreen/View/ServerConfirmationScreen.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerConfirmationScreen/View/ServerConfirmationScreen.swift
@@ -91,6 +91,13 @@ struct ServerConfirmationScreen: View {
             .buttonStyle(.compound(.primary))
             .accessibilityIdentifier(A11yIdentifiers.serverConfirmationScreen.continue)
             
+            if context.viewState.canContinueWithPassword {
+                Button { context.send(viewAction: .continueWithPassword) } label: {
+                    Text(L10n.screenOnboardingSignInManually)
+                }
+                .buttonStyle(.compound(.secondary))
+            }
+
             if case .confirmation = context.viewState.mode {
                 Button { context.send(viewAction: .changeServer) } label: {
                     Text(L10n.screenServerConfirmationChangeServer)

--- a/ElementX/Sources/Services/Authentication/AuthenticationService.swift
+++ b/ElementX/Sources/Services/Authentication/AuthenticationService.swift
@@ -71,14 +71,16 @@ class AuthenticationService: AuthenticationServiceProtocol {
             
             let client = try await makeClient(homeserverAddress: homeserverAddress)
             let loginDetails = await client.homeserverLoginDetails()
+            let supportsPasswordLogin = loginDetails.supportsPasswordLogin()
             
             homeserver.loginMode = if loginDetails.supportsOauthLogin() {
                 .oAuth(supportsCreatePrompt: loginDetails.supportedOauthPrompts().contains(.create))
-            } else if loginDetails.supportsPasswordLogin() {
+            } else if supportsPasswordLogin {
                 .password
             } else {
                 .unsupported
             }
+            homeserver.supportsPasswordLogin = supportsPasswordLogin
             
             if flow == .login, homeserver.loginMode == .unsupported {
                 return .failure(.loginNotSupported)

--- a/UnitTests/Sources/ServerConfirmationScreenViewModelTests.swift
+++ b/UnitTests/Sources/ServerConfirmationScreenViewModelTests.swift
@@ -74,6 +74,40 @@ final class ServerConfirmationScreenViewModelTests {
         #expect(client.urlForOauthOauthConfigurationPromptLoginHintDeviceIdAdditionalScopesCallsCount == 1)
         #expect(client.urlForOauthOauthConfigurationPromptLoginHintDeviceIdAdditionalScopesReceivedArguments?.prompt == .consent)
     }
+
+    @Test
+    func passwordFallbackShownWhenOAuthServerSupportsPasswordLogin() async throws {
+        // Given a view model for login using a service configured for a homeserver that supports OAuth and password login.
+        setupViewModel(authenticationFlow: .login)
+        guard case .success = await service.configure(for: viewModel.state.homeserverAddress, flow: .login) else {
+            Issue.record("The configuration should succeed.")
+            return
+        }
+
+        // Then password login can be selected as a fallback without starting another OAuth flow.
+        try await deferFulfillment(context.observe(\.viewState)) { $0.canContinueWithPassword }.fulfill()
+        #expect(context.viewState.canContinueWithPassword)
+
+        let deferred = deferFulfillment(viewModel.actions) { $0.isContinueWithPassword }
+        context.send(viewAction: .continueWithPassword)
+        try await deferred.fulfill()
+
+        #expect(client.urlForOauthOauthConfigurationPromptLoginHintDeviceIdAdditionalScopesCallsCount == 0)
+    }
+
+    @Test
+    func passwordFallbackHiddenWhenOAuthServerDoesNotSupportPasswordLogin() async throws {
+        // Given a view model for login using a service configured for a homeserver that only supports OAuth.
+        setupViewModel(authenticationFlow: .login, supportsPasswordLogin: false)
+        guard case .success = await service.configure(for: viewModel.state.homeserverAddress, flow: .login) else {
+            Issue.record("The configuration should succeed.")
+            return
+        }
+
+        // Then password login isn't offered as a fallback.
+        try await deferFulfillment(context.observe(\.viewState)) { $0.loginMode.supportsOAuthFlow }.fulfill()
+        #expect(!context.viewState.canContinueWithPassword)
+    }
     
     @Test
     func confirmRegisterWithoutConfiguration() async throws {


### PR DESCRIPTION
## Summary
- keep OAuth as the default login path, but track whether the selected homeserver also supports password login
- show a manual password-login fallback on the server confirmation screen when both OAuth and password login are available
- route non-cancelled OAuth failures to password login when password login is supported

## Context
This is intended to avoid a dead end for self-hosted MAS homeservers where the native OAuth web authentication flow does not complete, while preserving OAuth as the preferred path.

Related issue: #5669

## Tests
- swift build
- xcodebuild test -project ElementX.xcodeproj -scheme UnitTests -destination id=CE2BDF04-317A-4509-97BA-B0BCE012285D -only-testing:UnitTests/ServerConfirmationScreenViewModelTests CODE_SIGNING_ALLOWED=NO
