### PR TITLE
Allow voice messages to be sent as replies

### DIFF
--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -21387,9 +21387,17 @@ class TimelineControllerMock: TimelineControllerProtocol, @unchecked Sendable {
         }
     }
     var sendVoiceMessageUrlAudioInfoWaveformRequestHandleClosure: ((URL, AudioInfo, [Float], @MainActor (SendAttachmentJoinHandleProtocol) -> Void) async -> Result<Void, TimelineControllerError>)?
+    var sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleReceivedArguments: (url: URL, audioInfo: AudioInfo, waveform: [Float], inReplyToEventID: String?)?
+    var sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleReceivedInvocations: [(url: URL, audioInfo: AudioInfo, waveform: [Float], inReplyToEventID: String?)] = []
+    var sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleClosure: ((URL, AudioInfo, [Float], String?, @MainActor (SendAttachmentJoinHandleProtocol) -> Void) async -> Result<Void, TimelineControllerError>)?
 
-    func sendVoiceMessage(url: URL, audioInfo: AudioInfo, waveform: [Float], requestHandle: @MainActor (SendAttachmentJoinHandleProtocol) -> Void) async -> Result<Void, TimelineControllerError> {
+    func sendVoiceMessage(url: URL, audioInfo: AudioInfo, waveform: [Float], inReplyToEventID: String?, requestHandle: @MainActor (SendAttachmentJoinHandleProtocol) -> Void) async -> Result<Void, TimelineControllerError> {
         sendVoiceMessageUrlAudioInfoWaveformRequestHandleCallsCount += 1
+        sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleReceivedArguments = (url: url, audioInfo: audioInfo, waveform: waveform, inReplyToEventID: inReplyToEventID)
+        sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleReceivedInvocations.append((url: url, audioInfo: audioInfo, waveform: waveform, inReplyToEventID: inReplyToEventID))
+        if let sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleClosure = sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleClosure {
+            return await sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleClosure(url, audioInfo, waveform, inReplyToEventID, requestHandle)
+        }
         if let sendVoiceMessageUrlAudioInfoWaveformRequestHandleClosure = sendVoiceMessageUrlAudioInfoWaveformRequestHandleClosure {
             return await sendVoiceMessageUrlAudioInfoWaveformRequestHandleClosure(url, audioInfo, waveform, requestHandle)
         } else {
@@ -22696,9 +22704,17 @@ class TimelineProxyMock: TimelineProxyProtocol, @unchecked Sendable {
         }
     }
     var sendVoiceMessageUrlAudioInfoWaveformRequestHandleClosure: ((URL, AudioInfo, [Float], @MainActor (SendAttachmentJoinHandleProtocol) -> Void) async -> Result<Void, TimelineProxyError>)?
+    var sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleReceivedArguments: (url: URL, audioInfo: AudioInfo, waveform: [Float], inReplyToEventID: String?)?
+    var sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleReceivedInvocations: [(url: URL, audioInfo: AudioInfo, waveform: [Float], inReplyToEventID: String?)] = []
+    var sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleClosure: ((URL, AudioInfo, [Float], String?, @MainActor (SendAttachmentJoinHandleProtocol) -> Void) async -> Result<Void, TimelineProxyError>)?
 
-    func sendVoiceMessage(url: URL, audioInfo: AudioInfo, waveform: [Float], requestHandle: @MainActor (SendAttachmentJoinHandleProtocol) -> Void) async -> Result<Void, TimelineProxyError> {
+    func sendVoiceMessage(url: URL, audioInfo: AudioInfo, waveform: [Float], inReplyToEventID: String?, requestHandle: @MainActor (SendAttachmentJoinHandleProtocol) -> Void) async -> Result<Void, TimelineProxyError> {
         sendVoiceMessageUrlAudioInfoWaveformRequestHandleCallsCount += 1
+        sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleReceivedArguments = (url: url, audioInfo: audioInfo, waveform: waveform, inReplyToEventID: inReplyToEventID)
+        sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleReceivedInvocations.append((url: url, audioInfo: audioInfo, waveform: waveform, inReplyToEventID: inReplyToEventID))
+        if let sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleClosure = sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleClosure {
+            return await sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleClosure(url, audioInfo, waveform, inReplyToEventID, requestHandle)
+        }
         if let sendVoiceMessageUrlAudioInfoWaveformRequestHandleClosure = sendVoiceMessageUrlAudioInfoWaveformRequestHandleClosure {
             return await sendVoiceMessageUrlAudioInfoWaveformRequestHandleClosure(url, audioInfo, waveform, requestHandle)
         } else {
@@ -25112,12 +25128,20 @@ class VoiceMessageRecorderMock: VoiceMessageRecorderProtocol, @unchecked Sendabl
         }
     }
     var sendVoiceMessageTimelineControllerAudioConverterClosure: ((TimelineControllerProtocol, AudioConverterProtocol) async -> Result<Void, VoiceMessageRecorderError>)?
+    var sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDReceivedArguments: (timelineController: TimelineControllerProtocol, audioConverter: AudioConverterProtocol, inReplyToEventID: String?)?
+    var sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDReceivedInvocations: [(timelineController: TimelineControllerProtocol, audioConverter: AudioConverterProtocol, inReplyToEventID: String?)] = []
+    var sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDClosure: ((TimelineControllerProtocol, AudioConverterProtocol, String?) async -> Result<Void, VoiceMessageRecorderError>)?
 
-    func sendVoiceMessage(timelineController: TimelineControllerProtocol, audioConverter: AudioConverterProtocol) async -> Result<Void, VoiceMessageRecorderError> {
+    func sendVoiceMessage(timelineController: TimelineControllerProtocol, audioConverter: AudioConverterProtocol, inReplyToEventID: String?) async -> Result<Void, VoiceMessageRecorderError> {
         sendVoiceMessageTimelineControllerAudioConverterCallsCount += 1
         sendVoiceMessageTimelineControllerAudioConverterReceivedArguments = (timelineController: timelineController, audioConverter: audioConverter)
+        sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDReceivedArguments = (timelineController: timelineController, audioConverter: audioConverter, inReplyToEventID: inReplyToEventID)
         DispatchQueue.main.async {
             self.sendVoiceMessageTimelineControllerAudioConverterReceivedInvocations.append((timelineController: timelineController, audioConverter: audioConverter))
+            self.sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDReceivedInvocations.append((timelineController: timelineController, audioConverter: audioConverter, inReplyToEventID: inReplyToEventID))
+        }
+        if let sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDClosure = sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDClosure {
+            return await sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDClosure(timelineController, audioConverter, inReplyToEventID)
         }
         if let sendVoiceMessageTimelineControllerAudioConverterClosure = sendVoiceMessageTimelineControllerAudioConverterClosure {
             return await sendVoiceMessageTimelineControllerAudioConverterClosure(timelineController, audioConverter)

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarModels.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarModels.swift
@@ -20,7 +20,7 @@ enum ComposerToolbarVoiceMessageAction {
     case pausePlayback
     case scrubPlayback(scrubbing: Bool)
     case seekPlayback(progress: Double)
-    case send
+    case send(inReplyToEventID: String?)
 }
 
 enum ComposerToolbarViewModelAction {
@@ -134,12 +134,7 @@ struct ComposerToolbarViewState: BindableState {
     }
     
     var isVoiceMessageModeActivated: Bool {
-        switch composerMode {
-        case .recordVoiceMessage, .previewVoiceMessage:
-            return true
-        default:
-            return false
-        }
+        composerMode.isVoiceMessageModeActivated
     }
 }
 
@@ -351,6 +346,15 @@ enum ComposerMode: Equatable {
         case .default, .reply, .edit:
             return true
         case .recordVoiceMessage, .previewVoiceMessage:
+            return false
+        }
+    }
+
+    var isVoiceMessageModeActivated: Bool {
+        switch self {
+        case .recordVoiceMessage, .previewVoiceMessage:
+            return true
+        default:
             return false
         }
     }

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarViewModel.swift
@@ -44,6 +44,7 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
     private var currentLinkData: WysiwygLinkData?
     
     private var replyLoadingTask: Task<Void, Never>?
+    private var voiceMessageReplyEventID: String?
     
     init(initialText: String? = nil,
          roomProxy: JoinedRoomProxyProtocol,
@@ -191,7 +192,7 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
             
             switch state.composerMode {
             case .previewVoiceMessage:
-                actionsSubject.send(.voiceMessage(.send))
+                actionsSubject.send(.voiceMessage(.send(inReplyToEventID: voiceMessageReplyEventID)))
             default:
                 if context.composerFormattingEnabled {
                     actionsSubject.send(.sendMessage(plain: wysiwygViewModel.content.markdown,
@@ -457,13 +458,16 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
     private func processVoiceMessageAction(_ action: ComposerToolbarVoiceMessageAction) {
         switch action {
         case .startRecording:
+            voiceMessageReplyEventID = state.composerMode.replyEventID
             state.bindings.composerFormattingEnabled = false
             actionsSubject.send(.voiceMessage(.startRecording))
         case .stopRecording:
             actionsSubject.send(.voiceMessage(.stopRecording))
         case .cancelRecording:
+            voiceMessageReplyEventID = nil
             actionsSubject.send(.voiceMessage(.cancelRecording))
         case .deleteRecording:
+            voiceMessageReplyEventID = nil
             actionsSubject.send(.voiceMessage(.deleteRecording))
         case .startPlayback:
             actionsSubject.send(.voiceMessage(.startPlayback))
@@ -576,15 +580,21 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
         
         guard mode != state.composerMode else { return }
         
+        let previousMode = state.composerMode
         state.composerMode = mode
         switch mode {
         case .default:
-            break
+            if previousMode.isVoiceMessageModeActivated {
+                voiceMessageReplyEventID = nil
+            }
         case .recordVoiceMessage(let audioRecorderState):
             state.audioRecorderState = audioRecorderState
         case .previewVoiceMessage(let audioPlayerState, _, _):
             state.audioPlayerState = audioPlayerState
         case .edit, .reply:
+            if previousMode.isVoiceMessageModeActivated {
+                voiceMessageReplyEventID = nil
+            }
             // Focus composer when switching to reply/edit
             state.bindings.composerFocused = true
         }

--- a/ElementX/Sources/Screens/Timeline/TimelineInteractionHandler.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineInteractionHandler.swift
@@ -358,7 +358,7 @@ class TimelineInteractionHandler {
         actionsSubject.send(.composer(action: .setMode(mode: .default)))
     }
     
-    func sendCurrentVoiceMessage() async {
+    func sendCurrentVoiceMessage(inReplyToEventID: String?) async {
         guard let audioPlayerState = voiceMessageRecorder.previewAudioPlayerState, let recordingURL = voiceMessageRecorder.recordingURL else {
             actionsSubject.send(.displayErrorToast(L10n.errorFailedUploadingVoiceMessage))
             return
@@ -366,14 +366,16 @@ class TimelineInteractionHandler {
         
         analyticsService.trackComposer(inThread: false,
                                        isEditing: false,
-                                       isReply: false,
+                                       isReply: inReplyToEventID != nil,
                                        messageType: .VoiceMessage,
                                        startsThread: nil)
         
         actionsSubject.send(.composer(action: .setMode(mode: .previewVoiceMessage(state: audioPlayerState, waveform: .url(recordingURL), isUploading: true))))
         await voiceMessageRecorder.stopPlayback()
         
-        switch await voiceMessageRecorder.sendVoiceMessage(timelineController: timelineController, audioConverter: AudioConverter()) {
+        switch await voiceMessageRecorder.sendVoiceMessage(timelineController: timelineController,
+                                                           audioConverter: AudioConverter(),
+                                                           inReplyToEventID: inReplyToEventID) {
         case .success:
             await deleteCurrentVoiceMessage()
         case .failure(let error):

--- a/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
@@ -409,8 +409,8 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
             Task { await timelineInteractionHandler.cancelRecordingVoiceMessage() }
         case .deleteRecording:
             Task { await timelineInteractionHandler.deleteCurrentVoiceMessage() }
-        case .send:
-            Task { await timelineInteractionHandler.sendCurrentVoiceMessage() }
+        case .send(let inReplyToEventID):
+            Task { await timelineInteractionHandler.sendCurrentVoiceMessage(inReplyToEventID: inReplyToEventID) }
         case .startPlayback:
             Task { await timelineInteractionHandler.startPlayingRecordedVoiceMessage() }
         case .pausePlayback:

--- a/ElementX/Sources/Services/Timeline/TimelineController/MockTimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/MockTimelineController.swift
@@ -282,6 +282,7 @@ class MockTimelineController: TimelineControllerProtocol {
     func sendVoiceMessage(url: URL,
                           audioInfo: MatrixRustSDK.AudioInfo,
                           waveform: [Float],
+                          inReplyToEventID: String?,
                           requestHandle: @MainActor (SendAttachmentJoinHandleProtocol) -> Void) async -> Result<Void, TimelineControllerError> {
         callbacks.send(.messageSentOrEdited)
         
@@ -289,6 +290,7 @@ class MockTimelineController: TimelineControllerProtocol {
             return await timelineProxy.sendVoiceMessage(url: url,
                                                         audioInfo: audioInfo,
                                                         waveform: waveform,
+                                                        inReplyToEventID: inReplyToEventID,
                                                         requestHandle: requestHandle).mapError(TimelineControllerError.timelineProxyError)
         }
         

--- a/ElementX/Sources/Services/Timeline/TimelineController/TimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/TimelineController.swift
@@ -390,10 +390,13 @@ class TimelineController: TimelineControllerProtocol {
     func sendVoiceMessage(url: URL,
                           audioInfo: MatrixRustSDK.AudioInfo,
                           waveform: [Float],
+                          inReplyToEventID: String?,
                           requestHandle: @MainActor (SendAttachmentJoinHandleProtocol) -> Void) async -> Result<Void, TimelineControllerError> {
         switch await activeTimeline.sendVoiceMessage(url: url,
                                                      audioInfo: audioInfo,
-                                                     waveform: waveform, requestHandle: requestHandle).mapError(TimelineControllerError.timelineProxyError) {
+                                                     waveform: waveform,
+                                                     inReplyToEventID: inReplyToEventID,
+                                                     requestHandle: requestHandle).mapError(TimelineControllerError.timelineProxyError) {
         case .success:
             callbacks.send(.messageSentOrEdited)
             return .success(())

--- a/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerProtocol.swift
@@ -133,6 +133,7 @@ protocol TimelineControllerProtocol: Sendable {
     func sendVoiceMessage(url: URL,
                           audioInfo: AudioInfo,
                           waveform: [Float],
+                          inReplyToEventID: String?,
                           requestHandle: @MainActor (SendAttachmentJoinHandleProtocol) -> Void) async -> Result<Void, TimelineControllerError>
     
     // MARK: - Poll

--- a/ElementX/Sources/Services/Timeline/TimelineProxy.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineProxy.swift
@@ -357,6 +357,7 @@ final class TimelineProxy: TimelineProxyProtocol {
     func sendVoiceMessage(url: URL,
                           audioInfo: AudioInfo,
                           waveform: [Float],
+                          inReplyToEventID: String?,
                           requestHandle: @MainActor (SendAttachmentJoinHandleProtocol) -> Void) async -> Result<Void, TimelineProxyError> {
         MXLog.info("Sending voice message")
         
@@ -365,7 +366,7 @@ final class TimelineProxy: TimelineProxyProtocol {
                                                                      caption: nil,
                                                                      formattedCaption: nil,
                                                                      mentions: nil,
-                                                                     inReplyTo: nil),
+                                                                     inReplyTo: inReplyToEventID),
                                                        audioInfo: audioInfo,
                                                        waveform: waveform)
             

--- a/ElementX/Sources/Services/Timeline/TimelineProxyProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineProxyProtocol.swift
@@ -110,6 +110,7 @@ protocol TimelineProxyProtocol {
     func sendVoiceMessage(url: URL,
                           audioInfo: AudioInfo,
                           waveform: [Float],
+                          inReplyToEventID: String?,
                           requestHandle: @MainActor (SendAttachmentJoinHandleProtocol) -> Void) async -> Result<Void, TimelineProxyError>
     
     func sendReadReceipt(for eventID: String, type: ReceiptType) async -> Result<Void, TimelineProxyError>

--- a/ElementX/Sources/Services/VoiceMessage/VoiceMessageRecorder.swift
+++ b/ElementX/Sources/Services/VoiceMessage/VoiceMessageRecorder.swift
@@ -146,7 +146,8 @@ class VoiceMessageRecorder: VoiceMessageRecorderProtocol {
     }
     
     func sendVoiceMessage(timelineController: TimelineControllerProtocol,
-                          audioConverter: AudioConverterProtocol) async -> Result<Void, VoiceMessageRecorderError> {
+                          audioConverter: AudioConverterProtocol,
+                          inReplyToEventID: String?) async -> Result<Void, VoiceMessageRecorderError> {
         guard let url = audioRecorder.audioFileURL else {
             return .failure(VoiceMessageRecorderError.missingRecordingFile)
         }
@@ -180,7 +181,8 @@ class VoiceMessageRecorder: VoiceMessageRecorderProtocol {
         
         let result = await timelineController.sendVoiceMessage(url: oggFile,
                                                                audioInfo: audioInfo,
-                                                               waveform: waveform) { _ in }
+                                                               waveform: waveform,
+                                                               inReplyToEventID: inReplyToEventID) { _ in }
         
         if case .failure(let error) = result {
             MXLog.error("Failed to send the voice message. \(error)")

--- a/ElementX/Sources/Services/VoiceMessage/VoiceMessageRecorderProtocol.swift
+++ b/ElementX/Sources/Services/VoiceMessage/VoiceMessageRecorderProtocol.swift
@@ -40,7 +40,8 @@ protocol VoiceMessageRecorderProtocol {
     func deleteRecording() async
     
     func sendVoiceMessage(timelineController: TimelineControllerProtocol,
-                          audioConverter: AudioConverterProtocol) async -> Result<Void, VoiceMessageRecorderError>
+                          audioConverter: AudioConverterProtocol,
+                          inReplyToEventID: String?) async -> Result<Void, VoiceMessageRecorderError>
 }
 
 // sourcery: AutoMockable

--- a/UnitTests/Sources/ComposerToolbarViewModelTests.swift
+++ b/UnitTests/Sources/ComposerToolbarViewModelTests.swift
@@ -371,6 +371,32 @@ final class ComposerToolbarViewModelTests {
         #expect(draftServiceMock.clearDraftCallsCount == 1)
         #expect(!draftServiceMock.loadDraftCalled)
     }
+
+    @Test
+    func sendsVoiceMessageAsReply() async throws {
+        let replyEventID = "replyID"
+        viewModel.process(timelineAction: .setMode(mode: .reply(eventID: replyEventID,
+                                                                replyDetails: .loaded(sender: .init(id: "@alice:matrix.org"),
+                                                                                      eventID: replyEventID,
+                                                                                      eventContent: .message(.text(.init(body: "reply text")))),
+                                                                isThread: false)))
+        viewModel.process(viewAction: .voiceMessage(.startRecording))
+        viewModel.process(timelineAction: .setMode(mode: .previewVoiceMessage(state: AudioPlayerState(id: .recorderPreview, title: "", duration: 10.0),
+                                                                              waveform: .data([1.0]),
+                                                                              isUploading: false)))
+
+        let deferred = deferFulfillment(viewModel.actions) { action in
+            switch action {
+            case let .voiceMessage(.send(inReplyToEventID)):
+                return inReplyToEventID == replyEventID
+            default:
+                return false
+            }
+        }
+        viewModel.process(viewAction: .sendMessage)
+
+        try await deferred.fulfill()
+    }
     
     @Test
     func nothingToRestore() async {

--- a/UnitTests/Sources/VoiceMessageRecorderTests.swift
+++ b/UnitTests/Sources/VoiceMessageRecorderTests.swift
@@ -6,6 +6,7 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+import AVFoundation
 import Combine
 @testable import ElementX
 import Foundation
@@ -210,7 +211,8 @@ struct VoiceMessageRecorderTests {
         // If there is no recording file, an error is expected
         audioRecorder.audioFileURL = nil
         guard case .failure(.missingRecordingFile) = await voiceMessageRecorder.sendVoiceMessage(timelineController: timelineController,
-                                                                                                 audioConverter: audioConverter) else {
+                                                                                                 audioConverter: audioConverter,
+                                                                                                 inReplyToEventID: nil) else {
             Issue.record("An error is expected")
             return
         }
@@ -224,7 +226,8 @@ struct VoiceMessageRecorderTests {
         
         let timelineController = MockTimelineController()
         guard case .failure(.failedSendingVoiceMessage) = await voiceMessageRecorder.sendVoiceMessage(timelineController: timelineController,
-                                                                                                      audioConverter: audioConverter) else {
+                                                                                                      audioConverter: audioConverter,
+                                                                                                      inReplyToEventID: nil) else {
             Issue.record("An error is expected")
             return
         }
@@ -242,7 +245,8 @@ struct VoiceMessageRecorderTests {
         let timelineController = MockTimelineController(timelineProxy: timelineProxy)
         timelineProxy.sendVoiceMessageUrlAudioInfoWaveformRequestHandleReturnValue = .failure(.sdkError(SDKError.generic))
         guard case .failure(.failedSendingVoiceMessage) = await voiceMessageRecorder.sendVoiceMessage(timelineController: timelineController,
-                                                                                                      audioConverter: audioConverter) else {
+                                                                                                      audioConverter: audioConverter,
+                                                                                                      inReplyToEventID: nil) else {
             Issue.record("An error is expected")
             return
         }
@@ -261,7 +265,8 @@ struct VoiceMessageRecorderTests {
         let timelineController = MockTimelineController(timelineProxy: timelineProxy)
         timelineProxy.sendVoiceMessageUrlAudioInfoWaveformRequestHandleReturnValue = .failure(.sdkError(SDKError.generic))
         guard case .failure(.failedSendingVoiceMessage) = await voiceMessageRecorder.sendVoiceMessage(timelineController: timelineController,
-                                                                                                      audioConverter: audioConverter) else {
+                                                                                                      audioConverter: audioConverter,
+                                                                                                      inReplyToEventID: nil) else {
             Issue.record("An error is expected")
             return
         }
@@ -282,7 +287,8 @@ struct VoiceMessageRecorderTests {
         let timelineController = MockTimelineController(timelineProxy: timelineProxy)
         timelineProxy.sendVoiceMessageUrlAudioInfoWaveformRequestHandleReturnValue = .failure(.sdkError(SDKError.generic))
         guard case .failure(.failedSendingVoiceMessage) = await voiceMessageRecorder.sendVoiceMessage(timelineController: timelineController,
-                                                                                                      audioConverter: audioConverter) else {
+                                                                                                      audioConverter: audioConverter,
+                                                                                                      inReplyToEventID: nil) else {
             Issue.record("An error is expected")
             return
         }
@@ -290,12 +296,19 @@ struct VoiceMessageRecorderTests {
     
     @Test
     func sendVoiceMessage() async throws {
-        let imageFileURL = try #require(Bundle(for: UnitTestsAppCoordinator.self).url(forResource: "test_voice_message", withExtension: "m4a"), "Test audio file is missing")
+        let format = try #require(AVAudioFormat(standardFormatWithSampleRate: 44_100, channels: 1))
+        let audioFileURL = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString).appendingPathExtension("caf")
+        let audioFile = try AVAudioFile(forWriting: audioFileURL, settings: format.settings)
+        let frameCount: AVAudioFrameCount = 4_410
+        let buffer = try #require(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount))
+        buffer.frameLength = frameCount
+        try audioFile.write(from: buffer)
+        defer { try? FileManager.default.removeItem(at: audioFileURL) }
         
         let timelineProxy = TimelineProxyMock()
         let timelineController = MockTimelineController(timelineProxy: timelineProxy)
         audioRecorder.currentTime = 42
-        audioRecorder.audioFileURL = imageFileURL
+        audioRecorder.audioFileURL = audioFileURL
         _ = await voiceMessageRecorder.startRecording()
         _ = await voiceMessageRecorder.stopRecording()
         
@@ -305,26 +318,29 @@ struct VoiceMessageRecorderTests {
         audioConverter.convertToOpusOggSourceURLDestinationURLClosure = { source, destination in
             convertedFileURL = destination
             try? FileManager.default.removeItem(at: destination)
-            let internalConverter = AudioConverter()
-            try internalConverter.convertToOpusOgg(sourceURL: source, destinationURL: destination)
+            try FileManager.default.copyItem(at: source, to: destination)
             convertedFileSize = try? UInt64(FileManager.default.sizeForItem(at: destination))
             // the source URL must be the recorded file
-            #expect(source == imageFileURL)
+            #expect(source == audioFileURL)
             // check the converted file extension
             #expect(destination.pathExtension == "ogg")
         }
         
-        timelineProxy.sendVoiceMessageUrlAudioInfoWaveformRequestHandleClosure = { url, audioInfo, waveform, _ in
+        let replyEventID = "$reply"
+        timelineProxy.sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleClosure = { url, audioInfo, waveform, inReplyToEventID, _ in
             #expect(url == convertedFileURL)
             #expect(audioInfo.duration == audioRecorder.currentTime)
             #expect(audioInfo.size == convertedFileSize)
             #expect(audioInfo.mimetype == "audio/ogg")
             #expect(!waveform.isEmpty)
+            #expect(inReplyToEventID == replyEventID)
             
             return .success(())
         }
         
-        guard case .success = await voiceMessageRecorder.sendVoiceMessage(timelineController: timelineController, audioConverter: audioConverter) else {
+        guard case .success = await voiceMessageRecorder.sendVoiceMessage(timelineController: timelineController,
+                                                                          audioConverter: audioConverter,
+                                                                          inReplyToEventID: replyEventID) else {
             Issue.record("A success is expected")
             return
         }


### PR DESCRIPTION
## Summary
- Preserves the replied-to event while recording and previewing a voice message.
- Passes the reply event ID through voice-message sending so the SDK sends it as a reply instead of a normal voice message.
- Adds regression coverage for the composer action and recorder send path.

Fixes #5485

## Tests
- `xcodebuild test -quiet -project ElementX.xcodeproj -scheme UnitTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' '-only-testing:UnitTests/ComposerToolbarViewModelTests/sendsVoiceMessageAsReply()' '-only-testing:UnitTests/VoiceMessageRecorderTests/sendVoiceMessage()' CODE_SIGNING_ALLOWED=NO`
