### PR TITLE
Update file info sheet actions

### DIFF
--- a/ElementX/Resources/Localizations/be.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/be.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Images and videos uploaded to this room will be shown here.";
 "screen_media_browser_media_empty_state_title" = "No media uploaded yet";
 "screen_media_browser_title" = "Media and files";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Format";
 "screen_media_details_filename" = "Name";
 "screen_media_details_no_more_files_to_show" = "No more files to show";

--- a/ElementX/Resources/Localizations/bg.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/bg.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Images and videos uploaded to this room will be shown here.";
 "screen_media_browser_media_empty_state_title" = "No media uploaded yet";
 "screen_media_browser_title" = "Медия и файлове";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Format";
 "screen_media_details_filename" = "Name";
 "screen_media_details_no_more_files_to_show" = "No more files to show";

--- a/ElementX/Resources/Localizations/ca.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/ca.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Les imatges i vídeos penjats a la sala es mostraran aquí.";
 "screen_media_browser_media_empty_state_title" = "Encara no s'ha pujat multimèdia";
 "screen_media_browser_title" = "Multimèdia i documents";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Format del document";
 "screen_media_details_filename" = "Nom del document";
 "screen_media_details_no_more_files_to_show" = "No hi ha més fitxers a mostrar";

--- a/ElementX/Resources/Localizations/cs.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/cs.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Obrázky a videa nahraná do této místnosti budou zobrazeny zde.";
 "screen_media_browser_media_empty_state_title" = "Zatím nebyla nahrána žádná média";
 "screen_media_browser_title" = "Média a soubory";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Formát souboru";
 "screen_media_details_filename" = "Název souboru";
 "screen_media_details_no_more_files_to_show" = "Žádné další soubory k zobrazení";

--- a/ElementX/Resources/Localizations/cy.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/cy.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Bydd delweddau a fideos llwythwyd i'r ystafell hon yn cael eu dangos yma.";
 "screen_media_browser_media_empty_state_title" = "Dim cyfrwng wedi'i llwytho eto";
 "screen_media_browser_title" = "Cyfryngau a ffeiliau";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Fformat ffeil";
 "screen_media_details_filename" = "Enw'r ffeil";
 "screen_media_details_no_more_files_to_show" = "Dim mwy o ffeiliau i'w dangos";

--- a/ElementX/Resources/Localizations/da.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/da.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Billeder og videoer uploadet til dette rum vil blive vist her.";
 "screen_media_browser_media_empty_state_title" = "Ingen medier uploadet endnu";
 "screen_media_browser_title" = "Medier og filer";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Filformat";
 "screen_media_details_filename" = "Filnavn";
 "screen_media_details_no_more_files_to_show" = "Ikke flere filer at vise";

--- a/ElementX/Resources/Localizations/de.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/de.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "In diesen Chat hochgeladene Bilder und Videos werden hier angezeigt.";
 "screen_media_browser_media_empty_state_title" = "Noch keine Medien hochgeladen";
 "screen_media_browser_title" = "Medien und Dateien";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Dateiformat";
 "screen_media_details_filename" = "Dateiname";
 "screen_media_details_no_more_files_to_show" = "Keine weiteren Dateien zum Anzeigen";

--- a/ElementX/Resources/Localizations/el.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/el.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Οι εικόνες και τα βίντεο που μεταφορτώνονται σε αυτή την αίθουσα θα εμφανίζονται εδώ.";
 "screen_media_browser_media_empty_state_title" = "Δεν έχουν μεταφορτωθεί ακόμα πολυμέσα";
 "screen_media_browser_title" = "Πολυμέσα και αρχεία";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Μορφή αρχείου";
 "screen_media_details_filename" = "Όνομα αρχείου";
 "screen_media_details_no_more_files_to_show" = "Δεν υπάρχουν άλλα αρχεία για εμφάνιση";

--- a/ElementX/Resources/Localizations/en-US.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en-US.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Images and videos uploaded to this room will be shown here.";
 "screen_media_browser_media_empty_state_title" = "No media uploaded yet";
 "screen_media_browser_title" = "Media and files";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Format";
 "screen_media_details_filename" = "Name";
 "screen_media_details_no_more_files_to_show" = "No more files to show";

--- a/ElementX/Resources/Localizations/en.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Images and videos uploaded to this room will be shown here.";
 "screen_media_browser_media_empty_state_title" = "No media uploaded yet";
 "screen_media_browser_title" = "Media and files";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Format";
 "screen_media_details_filename" = "Name";
 "screen_media_details_no_more_files_to_show" = "No more files to show";

--- a/ElementX/Resources/Localizations/es.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/es.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Las imágenes y vídeos subidos a esta sala se mostrarán aquí.";
 "screen_media_browser_media_empty_state_title" = "Aún no se ha subido ningún medio";
 "screen_media_browser_title" = "Medios y archivos";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Formato de archivo";
 "screen_media_details_filename" = "Nombre del archivo";
 "screen_media_details_no_more_files_to_show" = "No hay más archivos que mostrar";

--- a/ElementX/Resources/Localizations/et.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/et.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Antud jututuppa üleslaaditud pildid ja videod kuvatakse siin.";
 "screen_media_browser_media_empty_state_title" = "Mitte keegi pole veel meediat üles laadinud";
 "screen_media_browser_title" = "Meedia ja failid";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Failivorming";
 "screen_media_details_filename" = "Failinimi";
 "screen_media_details_no_more_files_to_show" = "Pole enam kuvatavaid faile";

--- a/ElementX/Resources/Localizations/eu.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/eu.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Gela honetara igotako irudiak eta bideoak hemen erakutsiko dira.";
 "screen_media_browser_media_empty_state_title" = "Oraindik ez da multimedia fitxategirik igo";
 "screen_media_browser_title" = "Multimedia eta fitxategiak";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Fitxategiaren formatua";
 "screen_media_details_filename" = "Fitxategiaren izena";
 "screen_media_details_no_more_files_to_show" = "No more files to show";

--- a/ElementX/Resources/Localizations/fa.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/fa.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "تصویرها و ویدیوهای بار گذاشته در این اتاق این‌جا نشان داده خواهند شد.";
 "screen_media_browser_media_empty_state_title" = "هنوز هیچ رسانه‌ای بارگذاشته نشده";
 "screen_media_browser_title" = "رسانه‌ها و پرونده‌ها";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "قالب پرونده";
 "screen_media_details_filename" = "نام پرونده";
 "screen_media_details_no_more_files_to_show" = "No more files to show";

--- a/ElementX/Resources/Localizations/fi.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/fi.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Tähän huoneeseen lähetetyt kuvat ja videot näytetään täällä.";
 "screen_media_browser_media_empty_state_title" = "Mediaa ei ole vielä lähetetty";
 "screen_media_browser_title" = "Media ja tiedostot";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Tiedostomuoto";
 "screen_media_details_filename" = "Tiedostonimi";
 "screen_media_details_no_more_files_to_show" = "Ei enää näytettäviä tiedostoja";

--- a/ElementX/Resources/Localizations/fr.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/fr.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Les images et vidéos envoyées dans ce salon seront affichées ici.";
 "screen_media_browser_media_empty_state_title" = "Aucun média n'a encore été envoyé dans ce salon";
 "screen_media_browser_title" = "Médias et fichiers";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Format du fichier";
 "screen_media_details_filename" = "Nom du fichier";
 "screen_media_details_no_more_files_to_show" = "Il n'y a plus de fichiers à montrer";

--- a/ElementX/Resources/Localizations/hr.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/hr.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Ovdje će se prikazati slike i videozapisi preneseni u ovu sobu.";
 "screen_media_browser_media_empty_state_title" = "Još nijedan medij nije prenesen";
 "screen_media_browser_title" = "Mediji i datoteke";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Oblik datoteke";
 "screen_media_details_filename" = "Naziv datoteke";
 "screen_media_details_no_more_files_to_show" = "Nema više datoteka za prikaz";

--- a/ElementX/Resources/Localizations/hu.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/hu.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Az ebbe a szobába feltöltött képek és videók itt jelennek meg.";
 "screen_media_browser_media_empty_state_title" = "Még nincs feltöltött média";
 "screen_media_browser_title" = "Média és fájlok";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Fájlformátum";
 "screen_media_details_filename" = "Fájlnév";
 "screen_media_details_no_more_files_to_show" = "Nincs több megjeleníthető fájl";

--- a/ElementX/Resources/Localizations/id.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/id.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Gambar dan video yang diunggah ke ruangan ini akan ditampilkan di sini.";
 "screen_media_browser_media_empty_state_title" = "Belum ada media yang diunggah";
 "screen_media_browser_title" = "Media dan berkas";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Format berkas";
 "screen_media_details_filename" = "Nama berkas";
 "screen_media_details_no_more_files_to_show" = "Tidak ada lagi berkas untuk ditampilkan";

--- a/ElementX/Resources/Localizations/it.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/it.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Le immagini e i video caricati in questa stanza verranno mostrati qui.";
 "screen_media_browser_media_empty_state_title" = "Nessun file multimediale ancora caricato";
 "screen_media_browser_title" = "File e contenuti multimediali";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Formato del file";
 "screen_media_details_filename" = "Nome del file";
 "screen_media_details_no_more_files_to_show" = "Nessun altro file da mostrare";

--- a/ElementX/Resources/Localizations/ja.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/ja.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "このルームに投稿された画像と動画はここに表示されます。";
 "screen_media_browser_media_empty_state_title" = "アップロードされたメディアはありません";
 "screen_media_browser_title" = "ファイルとメディア";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "ファイル形式";
 "screen_media_details_filename" = "ファイル名";
 "screen_media_details_no_more_files_to_show" = "これ以上ファイルはありません";

--- a/ElementX/Resources/Localizations/ka.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/ka.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Images and videos uploaded to this room will be shown here.";
 "screen_media_browser_media_empty_state_title" = "No media uploaded yet";
 "screen_media_browser_title" = "Media and files";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Format";
 "screen_media_details_filename" = "Name";
 "screen_media_details_no_more_files_to_show" = "No more files to show";

--- a/ElementX/Resources/Localizations/ko.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/ko.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "이 방에 업로드된 이미지와 동영상은 여기에 표시됩니다.";
 "screen_media_browser_media_empty_state_title" = "아직 미디어가 업로드되지 않았습니다.";
 "screen_media_browser_title" = "미디어 및 파일";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "파일 형식";
 "screen_media_details_filename" = "파일 명";
 "screen_media_details_no_more_files_to_show" = "더 이상 표시할 파일이 없습니다";

--- a/ElementX/Resources/Localizations/lt.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/lt.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Images and videos uploaded to this room will be shown here.";
 "screen_media_browser_media_empty_state_title" = "No media uploaded yet";
 "screen_media_browser_title" = "Media and files";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Format";
 "screen_media_details_filename" = "Name";
 "screen_media_details_no_more_files_to_show" = "No more files to show";

--- a/ElementX/Resources/Localizations/nb.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/nb.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Bilder og videoer som lastes opp til dette rommet, vises her.";
 "screen_media_browser_media_empty_state_title" = "Ingen mediefiler lastet opp ennå";
 "screen_media_browser_title" = "Medier og filer";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Filformat";
 "screen_media_details_filename" = "Filnavn";
 "screen_media_details_no_more_files_to_show" = "Ingen flere filer å vise";

--- a/ElementX/Resources/Localizations/nl.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/nl.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Images and videos uploaded to this room will be shown here.";
 "screen_media_browser_media_empty_state_title" = "No media uploaded yet";
 "screen_media_browser_title" = "Media en bestanden";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Format";
 "screen_media_details_filename" = "Name";
 "screen_media_details_no_more_files_to_show" = "No more files to show";

--- a/ElementX/Resources/Localizations/pl.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/pl.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Obrazy i filmy przesyłane w tym pokoju wyświetlą się tutaj.";
 "screen_media_browser_media_empty_state_title" = "Jeszcze nie przesłano żadnych mediów";
 "screen_media_browser_title" = "Media i pliki";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Format pliku";
 "screen_media_details_filename" = "Nazwa pliku";
 "screen_media_details_no_more_files_to_show" = "Brak plików do pokazania";

--- a/ElementX/Resources/Localizations/pt-BR.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/pt-BR.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "As imagens e os vídeos enviados nesta sala serão exibidos aqui.";
 "screen_media_browser_media_empty_state_title" = "Nenhuma mídia enviada ainda";
 "screen_media_browser_title" = "Mídia e arquivos";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Formato do arquivo";
 "screen_media_details_filename" = "Nome do arquivo";
 "screen_media_details_no_more_files_to_show" = "Não há mais arquivos para mostrar";

--- a/ElementX/Resources/Localizations/pt.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/pt.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Imagens e vídeos enviados nesta sala serão mostrados aqui.";
 "screen_media_browser_media_empty_state_title" = "Ainda sem qualquer multimédia";
 "screen_media_browser_title" = "Multimédia e ficheiros";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Formato do ficheiro";
 "screen_media_details_filename" = "Nome do ficheiro";
 "screen_media_details_no_more_files_to_show" = "Sem mais ficheiros para mostrar";

--- a/ElementX/Resources/Localizations/ro.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/ro.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Imaginile și videoclipurile încărcate în această cameră vor fi afișate aici.";
 "screen_media_browser_media_empty_state_title" = "Nu a fost încărcat încă niciun fișier media";
 "screen_media_browser_title" = "Media și fișiere";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Format fişier";
 "screen_media_details_filename" = "Nume fișier";
 "screen_media_details_no_more_files_to_show" = "Nu mai există fișiere de afișat";

--- a/ElementX/Resources/Localizations/ru.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/ru.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Здесь будут показаны изображения и видео из данной комнаты.";
 "screen_media_browser_media_empty_state_title" = "Пока что нет загруженных медиа";
 "screen_media_browser_title" = "Медиа и файлы";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Формат файла";
 "screen_media_details_filename" = "Имя файла";
 "screen_media_details_no_more_files_to_show" = "Больше нет файлов для отображения";

--- a/ElementX/Resources/Localizations/sk.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/sk.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Tu sa zobrazia obrázky a videá nahrané do tejto miestnosti.";
 "screen_media_browser_media_empty_state_title" = "Žiadne médiá zatiaľ neboli nahrané";
 "screen_media_browser_title" = "Médiá a súbory";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Formát súboru";
 "screen_media_details_filename" = "Názov súboru";
 "screen_media_details_no_more_files_to_show" = "Žiadne ďalšie súbory na zobrazenie";

--- a/ElementX/Resources/Localizations/sv.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/sv.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Bilder och videor som laddas upp till detta rum kommer att visas här.";
 "screen_media_browser_media_empty_state_title" = "Ingen media uppladdad ännu";
 "screen_media_browser_title" = "Media och filer";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Filformat";
 "screen_media_details_filename" = "Filnamn";
 "screen_media_details_no_more_files_to_show" = "Inga fler filer att visa";

--- a/ElementX/Resources/Localizations/tr.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/tr.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Bu odaya yüklenen resimler ve videolar burada gösterilecektir.";
 "screen_media_browser_media_empty_state_title" = "Henüz yüklenen medya yok";
 "screen_media_browser_title" = "Medya ve dosyalar";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Dosya biçimi";
 "screen_media_details_filename" = "Dosya adı";
 "screen_media_details_no_more_files_to_show" = "Gösterilecek daha fazla dosya yok";

--- a/ElementX/Resources/Localizations/uk.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/uk.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Зображення та відео, вивантажені в цю кімнату, будуть показані тут.";
 "screen_media_browser_media_empty_state_title" = "Ще не вивантажено жодного медіафайлу";
 "screen_media_browser_title" = "Медіа та файли";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Формат файлу";
 "screen_media_details_filename" = "Назва файлу";
 "screen_media_details_no_more_files_to_show" = "Більше немає файлів для показу";

--- a/ElementX/Resources/Localizations/ur.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/ur.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Images and videos uploaded to this room will be shown here.";
 "screen_media_browser_media_empty_state_title" = "No media uploaded yet";
 "screen_media_browser_title" = "Media and files";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Format";
 "screen_media_details_filename" = "Name";
 "screen_media_details_no_more_files_to_show" = "No more files to show";

--- a/ElementX/Resources/Localizations/uz.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/uz.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Bu xonaga yuklangan rasm va videolar shu yerda chiqadi.";
 "screen_media_browser_media_empty_state_title" = "Hali hech qanday media yuklanmagan";
 "screen_media_browser_title" = "Media va fayllar";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Fayl formati";
 "screen_media_details_filename" = "Fayl nomi";
 "screen_media_details_no_more_files_to_show" = "Ko‘rsatish uchun boshqa fayllar yo‘q";

--- a/ElementX/Resources/Localizations/vi.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/vi.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "Images and videos uploaded to this room will be shown here.";
 "screen_media_browser_media_empty_state_title" = "No media uploaded yet";
 "screen_media_browser_title" = "Media and files";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "Format";
 "screen_media_details_filename" = "Name";
 "screen_media_details_no_more_files_to_show" = "No more files to show";

--- a/ElementX/Resources/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/zh-Hans.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "上传到此房间的图像和视频将在此处显示。";
 "screen_media_browser_media_empty_state_title" = "尚未上传任何媒体";
 "screen_media_browser_title" = "媒体与文件";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "文件格式";
 "screen_media_details_filename" = "文件名";
 "screen_media_details_no_more_files_to_show" = "没有更多文件可显示了";

--- a/ElementX/Resources/Localizations/zh-Hant-TW.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/zh-Hant-TW.lproj/Localizable.strings
@@ -951,6 +951,7 @@
 "screen_media_browser_media_empty_state_subtitle" = "上傳到此聊天室的圖片與影片將在此處顯示。";
 "screen_media_browser_media_empty_state_title" = "尚未上傳媒體";
 "screen_media_browser_title" = "媒體與檔案";
+"screen_media_details_delete_file_action" = "Delete file";
 "screen_media_details_file_format" = "檔案格式";
 "screen_media_details_filename" = "檔案名稱";
 "screen_media_details_no_more_files_to_show" = "無可顯示的檔案";

--- a/ElementX/Sources/Generated/Strings.swift
+++ b/ElementX/Sources/Generated/Strings.swift
@@ -2220,6 +2220,8 @@ internal enum L10n {
   internal static var screenMediaBrowserMediaEmptyStateTitle: String { return L10n.tr("Localizable", "screen_media_browser_media_empty_state_title") }
   /// Media and files
   internal static var screenMediaBrowserTitle: String { return L10n.tr("Localizable", "screen_media_browser_title") }
+  /// Delete file
+  internal static var screenMediaDetailsDeleteFileAction: String { return L10n.tr("Localizable", "screen_media_details_delete_file_action") }
   /// Format
   internal static var screenMediaDetailsFileFormat: String { return L10n.tr("Localizable", "screen_media_details_file_format") }
   /// Name

--- a/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewDetailsView.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewDetailsView.swift
@@ -41,6 +41,10 @@ struct TimelineMediaPreviewDetailsView: View {
     
     private var details: some View {
         VStack(alignment: .leading, spacing: 20) {
+            Text(L10n.screenMediaDetailsTitle)
+                .font(.compound.headingMDBold)
+                .foregroundStyle(.compound.textPrimary)
+
             DetailsRow(title: L10n.screenMediaDetailsUploadedBy) {
                 HStack(spacing: 12) {
                     LoadableAvatarImage(url: item.sender.avatarURL,
@@ -142,14 +146,7 @@ struct TimelineMediaPreviewDetailsView: View {
         let context: TimelineMediaPreviewViewModel.Context
         
         var body: some View {
-            if action == .share {
-                if let itemURL = item.fileHandle?.url {
-                    ShareLink(item: itemURL, message: item.caption.map(Text.init)) {
-                        action.label
-                    }
-                    .buttonStyle(.menuSheet)
-                }
-            } else if action == .save {
+            if action == .save {
                 if item.fileHandle?.url != nil {
                     button
                 }
@@ -162,9 +159,52 @@ struct TimelineMediaPreviewDetailsView: View {
             Button(role: action.isDestructive ? .destructive : nil) {
                 context.send(viewAction: .menuAction(action, item: item))
             } label: {
-                action.label
+                action.mediaDetailsLabel
             }
             .buttonStyle(.menuSheet)
+        }
+    }
+}
+
+@MainActor
+private extension TimelineItemMenuAction {
+    @ViewBuilder
+    var mediaDetailsLabel: some View {
+        Label {
+            Text(mediaDetailsTitle)
+        } icon: {
+            CompoundIcon(mediaDetailsIcon)
+                .foregroundStyle(.compound.iconSecondary)
+        }
+    }
+
+    var mediaDetailsTitle: String {
+        switch self {
+        case .forward:
+            L10n.actionForward
+        case .redact:
+            L10n.screenMediaDetailsDeleteFileAction
+        case .save:
+            L10n.actionDownload
+        case .viewInRoomTimeline:
+            L10n.actionViewInTimeline
+        default:
+            ""
+        }
+    }
+
+    var mediaDetailsIcon: KeyPath<CompoundIcons, Image> {
+        switch self {
+        case .forward:
+            \.forward
+        case .redact:
+            \.delete
+        case .save:
+            \.downloadIos
+        case .viewInRoomTimeline:
+            \.visibilityOn
+        default:
+            \.info
         }
     }
 }

--- a/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenuAction.swift
+++ b/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenuAction.swift
@@ -135,7 +135,7 @@ enum TimelineItemMenuAction: Identifiable, Hashable {
     
     var canAppearInMediaDetails: Bool {
         switch self {
-        case .viewInRoomTimeline, .share, .save, .redact, .forward:
+        case .viewInRoomTimeline, .save, .redact, .forward:
             true
         default:
             false

--- a/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenuActionProvider.swift
+++ b/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenuActionProvider.swift
@@ -122,7 +122,6 @@ struct TimelineItemMenuActionProvider {
             actions = actions.filter(\.canAppearInPinnedEventsTimeline)
             secondaryActions = secondaryActions.filter(\.canAppearInPinnedEventsTimeline)
         case .media:
-            actions.append(.share)
             actions.append(.save)
             actions = actions.filter(\.canAppearInMediaDetails)
             secondaryActions = secondaryActions.filter(\.canAppearInMediaDetails)

--- a/UnitTests/Sources/TimelineMediaPreviewViewModelTests.swift
+++ b/UnitTests/Sources/TimelineMediaPreviewViewModelTests.swift
@@ -40,6 +40,21 @@ struct TimelineMediaPreviewViewModelTests {
         #expect(context.viewState.currentItem == .media(context.viewState.dataSource.previewItems[0]))
         #expect(context.viewState.currentItemActions != nil)
     }
+
+    @Test
+    mutating func fileInfoActions() {
+        // Given a fresh view model.
+        setupViewModel()
+
+        guard let actions = context.viewState.currentItemActions else {
+            Issue.record("There should be actions for the current media item.")
+            return
+        }
+
+        // Then the file info sheet should offer download without duplicating the previous screen's share action.
+        #expect(actions.actions.contains(.save))
+        #expect(!actions.actions.contains(.share))
+    }
     
     @Test
     mutating func loadingItemFailure() async throws {


### PR DESCRIPTION
Fixes #5658

Summary:
- Adds the File info title to the media preview details sheet.
- Removes Share from the file info sheet because sharing is already available from the previous screen.
- Renames the sheet actions to Download and Delete file, and styles the action icons with the secondary icon color.

Tests:
- `xcodebuild test -quiet -project ElementX.xcodeproj -scheme UnitTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' '-only-testing:UnitTests/TimelineMediaPreviewViewModelTests/fileInfoActions()' CODE_SIGNING_ALLOWED=NO`
- `git diff --check`
