### PR TITLE
Use secondary icons in menu sheets

### DIFF
--- a/ElementX/Sources/Other/SwiftUI/Layout/MenuSheetLabelStyle.swift
+++ b/ElementX/Sources/Other/SwiftUI/Layout/MenuSheetLabelStyle.swift
@@ -43,6 +43,7 @@ private struct MenuSheetLabelStyle: LabelStyle {
     func makeBody(configuration: Configuration) -> some View {
         HStack(spacing: spacing) {
             configuration.icon
+                .foregroundStyle(.compound.iconSecondary)
             configuration.title
         }
         .multilineTextAlignment(.leading)


### PR DESCRIPTION
Fixes #5659

Summary:
- Applies the secondary icon color in the shared menu sheet label style.
- Keeps the existing action text colors, including destructive action text, unchanged.

Tests:
- `xcodebuild test -quiet -project ElementX.xcodeproj -scheme UnitTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' '-only-testing:UnitTests/TimelineMediaPreviewViewModelTests/loadingItem()' CODE_SIGNING_ALLOWED=NO`
- `git diff --check`