### PR TITLE
Avoid compressing pinned message bubbles

### DIFF
--- a/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemBubbledStylerView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemBubbledStylerView.swift
@@ -293,19 +293,18 @@ private extension EdgeInsets {
 private struct PinnedIndicatorViewModifier: ViewModifier {
     let isPinned: Bool
     let isOutgoing: Bool
+    private let indicatorSpacing: CGFloat = 8
     
+    @ViewBuilder
     func body(content: Content) -> some View {
         if isPinned {
-            HStack(alignment: .top, spacing: 8) {
-                if isOutgoing {
+            content
+                .overlay(alignment: isOutgoing ? .topLeading : .topTrailing) {
                     pinnedIndicator
+                        .alignmentGuide(isOutgoing ? .leading : .trailing) { dimensions in
+                            isOutgoing ? dimensions[.trailing] + indicatorSpacing : dimensions[.leading] - indicatorSpacing
+                        }
                 }
-                content
-                    .layoutPriority(1)
-                if !isOutgoing {
-                    pinnedIndicator
-                }
-            }
         } else {
             content
         }


### PR DESCRIPTION
Fixes #5668

Summary:
- Renders the pinned indicator as an overlay outside the message bubble instead of as a sibling in the same horizontal layout.
- Preserves the existing visual spacing while allowing long pinned message bubbles to use the available width.

Tests:
- `xcodebuild test -quiet -project ElementX.xcodeproj -scheme UnitTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' '-only-testing:UnitTests/TimelineViewModelTests/pinnedEvents()' CODE_SIGNING_ALLOWED=NO`
- `git diff --check`