### PR TITLE
Expose timeline date separators as headings

### DIFF
--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/SeparatorRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/SeparatorRoomTimelineView.swift
@@ -19,6 +19,7 @@ struct SeparatorRoomTimelineView: View {
             .multilineTextAlignment(.center)
             .padding(.horizontal, 36.0)
             .padding(.vertical, 8.0)
+            .accessibilityAddTraits(.isHeader)
     }
 }
 


### PR DESCRIPTION
Fixes #5252

Summary:
- Adds the accessibility heading trait to timeline date separators.
- Leaves date separator layout and text unchanged.

Tests:
- `xcodebuild build -quiet -project ElementX.xcodeproj -scheme UnitTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' CODE_SIGNING_ALLOWED=NO`
- `git diff --check`

Note:
- `DateTests/dateSeparatorFormatting()` was attempted locally but is locale-sensitive in this environment and failed on English Today/Yesterday expectations unrelated to this change.