### PR TITLE
Expose PIN setup title as a heading

### DIFF
--- a/ElementX/Sources/Screens/AppLock/AppLockSetupPINScreen/View/AppLockSetupPINScreen.swift
+++ b/ElementX/Sources/Screens/AppLock/AppLockSetupPINScreen/View/AppLockSetupPINScreen.swift
@@ -66,6 +66,7 @@ struct AppLockSetupPINScreen: View {
                 .font(.compound.headingMDBold)
                 .multilineTextAlignment(.center)
                 .foregroundColor(.compound.textPrimary)
+                .accessibilityAddTraits(.isHeader)
             
             Text(context.viewState.subtitle)
                 .font(.compound.bodyMD)


### PR DESCRIPTION
Fixes #5255

Summary:
- Adds the accessibility heading trait to the App Lock PIN setup title.
- Leaves the visible PIN setup screen unchanged.

Tests:
- `xcodebuild test -quiet -project ElementX.xcodeproj -scheme UnitTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' '-only-testing:UnitTests/AppLockSetupPINScreenViewModelTests/createPIN()' CODE_SIGNING_ALLOWED=NO`
- `git diff --check`