### PR TITLE
Connect settings app route and action from logout screen

### DIFF
--- a/ElementX/Sources/FlowCoordinators/ChatsTabFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/ChatsTabFlowCoordinator.swift
@@ -174,7 +174,9 @@ class ChatsTabFlowCoordinator: FlowCoordinatorProtocol {
             }
         case .globalSearch:
             presentGlobalSearch()
-        case .accountProvisioningLink, .oAuthCallback, .settings, .chatBackupSettings, .call:
+        case .chatBackupSettings:
+            actionsSubject.send(.showChatBackupSettings)
+        case .accountProvisioningLink, .oAuthCallback, .settings, .call:
             break // These routes cannot be handled.
         }
     }


### PR DESCRIPTION
fixes #5688

Connects the coordinator action for `.chatBackupSettings` to publish its own action `.showChatBackupSettings`, which was omitted.

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [ ] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
