### PR TITLE
Fix for the timestamp state change creating clipping

### DIFF
--- a/ElementX/Sources/Other/Pills/MessageText.swift
+++ b/ElementX/Sources/Other/Pills/MessageText.swift
@@ -74,7 +74,15 @@ struct MessageText: UIViewRepresentable {
     @Environment(\.openURL) private var openURLAction
     @Environment(\.timelineContext) private var viewModel
     @Environment(\.layoutDirection) private var layoutDirection
-    @State private var computedSizes = [Double: CGSize]()
+    
+    /// Cache key for `sizeThatFits`. Keyed on the reserved trailing size as well as the proposed
+    /// width to account for any changes on the send info label that happen after the first rendering.
+    private struct SizeCacheKey: Hashable {
+        let width: Double
+        let reservedSize: CGSize
+    }
+    
+    @State private var computedSizes = [SizeCacheKey: CGSize]()
     
     @State var attributedString: AttributedString {
         didSet {
@@ -204,14 +212,15 @@ struct MessageText: UIViewRepresentable {
     
     func sizeThatFits(_ proposal: ProposedViewSize, uiView: MessageTextView, context: Context) -> CGSize? {
         let proposalWidth = proposal.width ?? UIView.layoutFittingExpandedSize.width
+        let key = SizeCacheKey(width: proposalWidth, reservedSize: trailingReservedSize)
         
-        if let size = computedSizes[proposalWidth] {
+        if let size = computedSizes[key] {
             return size
         }
         
         let size = uiView.sizeThatFits(CGSize(width: proposalWidth, height: UIView.layoutFittingCompressedSize.height))
         DispatchQueue.main.async {
-            computedSizes[proposalWidth] = size
+            computedSizes[key] = size
         }
         return size
     }


### PR DESCRIPTION
When the timestamp changed after the bubble was rendered, the content of the formatted body wasn't catching any update in the content, which created clipping if the new timeastamp contained any aditional icon (like the normal -> error state transition) so we essentially include in the last `plainText` block the size as part of the id itself.