### PR TITLE
Re-order the call buttons to match the Figma and Element Web.

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/View/RoomCallControlsToolbar.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomCallControlsToolbar.swift
@@ -47,19 +47,20 @@ struct RoomCallControlsToolbar: ToolbarContent {
                     }
                 } else {
                     ToolbarItem(placement: .primaryAction) {
-                        Button { onCallTap(true) } label: {
-                            CompoundIcon(\.voiceCallSolid)
-                        }
-                        .accessibilityLabel(L10n.a11yStartVoiceCall)
-                        .accessibilityIdentifier(A11yIdentifiers.roomScreen.startVoiceCall)
-                        .disabled(!viewState.canJoinCall)
-                    }
-                    ToolbarItem(placement: .primaryAction) {
                         Button { onCallTap(false) } label: {
                             CompoundIcon(\.videoCallSolid)
                         }
                         .accessibilityLabel(L10n.a11yStartVideoCall)
                         .accessibilityIdentifier(A11yIdentifiers.roomScreen.startVideoCall)
+                        .disabled(!viewState.canJoinCall)
+                    }
+                    
+                    ToolbarItem(placement: .primaryAction) {
+                        Button { onCallTap(true) } label: {
+                            CompoundIcon(\.voiceCallSolid)
+                        }
+                        .accessibilityLabel(L10n.a11yStartVoiceCall)
+                        .accessibilityIdentifier(A11yIdentifiers.roomScreen.startVoiceCall)
                         .disabled(!viewState.canJoinCall)
                     }
                 }


### PR DESCRIPTION
The video call button is meant to be on the left. Again no snapshot updates (our inability to snapshot glass is kind of showing today 🙈).

<img width="402" height="121" alt="Simulator Screenshot - iPhone 17 - 2026-06-03 at 11 08 23" src="https://github.com/user-attachments/assets/154252a8-a1cd-426e-8db7-f8ba1c46438e" />
