### PR TITLE
Do not show membership/profile events in public rooms

### DIFF
--- a/ElementX/Sources/Services/Timeline/Fixtures/RoomTimelineItemFixtures.swift
+++ b/ElementX/Sources/Services/Timeline/Fixtures/RoomTimelineItemFixtures.swift
@@ -273,7 +273,7 @@ extension TimelineItemProxy {
 private extension TimelineItemProxy {
     func buildRoomTimelineItem() -> RoomTimelineItemProtocol {
         guard case .event(let eventProxy) = self,
-              let item = RoomTimelineItemFixtures.factory.buildTimelineItem(for: eventProxy, isDM: false) else {
+              let item = RoomTimelineItemFixtures.factory.buildTimelineItem(for: eventProxy, isDM: false, joinRule: nil) else {
             fatalError()
         }
         

--- a/ElementX/Sources/Services/Timeline/TimelineController/TimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/TimelineController.swift
@@ -467,6 +467,7 @@ class TimelineController: TimelineControllerProtocol {
         let isDM = roomProxy.infoPublisher.value.isDM
         let displayName = roomProxy.infoPublisher.value.displayName
         let hasPredecessor = roomProxy.predecessorRoom != nil
+        let joinRule = roomProxy.infoPublisher.value.joinRule
         
         var newTimelineItems = await Task.detached { [timelineItemFactory, activeTimeline] in
             var newTimelineItems = [RoomTimelineItemProtocol]()
@@ -481,6 +482,7 @@ class TimelineController: TimelineControllerProtocol {
                                            isDM: isDM,
                                            hasPredecessor: hasPredecessor,
                                            roomDisplayName: displayName,
+                                           joinRule: joinRule,
                                            timelineItemFactory: timelineItemFactory,
                                            activeTimeline: activeTimeline)
                 }
@@ -520,6 +522,8 @@ class TimelineController: TimelineControllerProtocol {
             break
         }
         
+        newTimelineItems = Self.stripOrphanedDateDividers(newTimelineItems)
+        
         timelineItems = newTimelineItems
         
         callbacks.send(.updatedTimelineItems(timelineItems: newTimelineItems, isSwitchingTimelines: isNewTimeline))
@@ -530,11 +534,12 @@ class TimelineController: TimelineControllerProtocol {
                                                isDM: Bool,
                                                hasPredecessor: Bool,
                                                roomDisplayName: String?,
+                                               joinRule: JoinRule?,
                                                timelineItemFactory: RoomTimelineItemFactoryProtocol,
                                                activeTimeline: TimelineProxyProtocol) -> RoomTimelineItemProtocol? {
         switch itemProxy {
         case .event(let eventTimelineItem):
-            let timelineItem = timelineItemFactory.buildTimelineItem(for: eventTimelineItem, isDM: isDM)
+            let timelineItem = timelineItemFactory.buildTimelineItem(for: eventTimelineItem, isDM: isDM, joinRule: joinRule)
             
             if let messageTimelineItem = timelineItem as? EventBasedMessageTimelineItemProtocol {
                 // Avoid fetching this over and over again as it changes states if it keeps failing to load
@@ -649,6 +654,16 @@ class TimelineController: TimelineControllerProtocol {
             try await interaction.donate()
         } catch {
             MXLog.error("Failed donating send message intent with error: \(error)")
+        }
+    }
+    
+    /// Strips date dividers that have no items between them and the next divider (or end of timeline).
+    /// This can happen when all events in a day are filtered out.
+    static func stripOrphanedDateDividers(_ items: [RoomTimelineItemProtocol]) -> [RoomTimelineItemProtocol] {
+        items.enumerated().filter { index, item in
+            guard item is SeparatorRoomTimelineItem else { return true }
+            let nextNonPagination = items[(index + 1)...].first { !($0 is PaginationIndicatorRoomTimelineItem) }
+            return nextNonPagination.map { !($0 is SeparatorRoomTimelineItem) } ?? false
         }
     }
 }

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
@@ -25,7 +25,7 @@ struct RoomTimelineItemFactory: RoomTimelineItemFactoryProtocol {
         self.stateEventStringBuilder = stateEventStringBuilder
     }
     
-    func buildTimelineItem(for eventItemProxy: EventTimelineItemProxy, isDM: Bool) -> RoomTimelineItemProtocol? {
+    func buildTimelineItem(for eventItemProxy: EventTimelineItemProxy, isDM: Bool, joinRule: JoinRule?) -> RoomTimelineItemProtocol? {
         let isOutgoing = eventItemProxy.isOwn
         
         switch eventItemProxy.content {
@@ -56,11 +56,17 @@ struct RoomTimelineItemFactory: RoomTimelineItemFactoryProtocol {
             }
             return buildStateTimelineItem(for: eventItemProxy, state: content, isOutgoing: isOutgoing)
         case .roomMembership(userId: let userID, let displayName, change: let change, let reason):
+            if joinRule != .invite, change == .joined || change == .left {
+                return nil
+            }
             if isDM, change == .joined, userID == self.userID {
                 return nil
             }
             return buildStateMembershipChangeTimelineItem(for: eventItemProxy, memberUserID: userID, memberDisplayName: displayName, membershipChange: change, reason: reason, isOutgoing: isOutgoing)
         case .profileChange(let displayName, let prevDisplayName, let avatarUrl, let prevAvatarUrl):
+            guard joinRule == .invite else {
+                return nil
+            }
             return buildStateProfileChangeTimelineItem(for: eventItemProxy,
                                                        displayName: displayName,
                                                        previousDisplayName: prevDisplayName,

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactoryProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactoryProtocol.swift
@@ -10,6 +10,6 @@ import Foundation
 import MatrixRustSDK
 
 protocol RoomTimelineItemFactoryProtocol {
-    func buildTimelineItem(for eventItemProxy: EventTimelineItemProxy, isDM: Bool) -> RoomTimelineItemProtocol?
+    func buildTimelineItem(for eventItemProxy: EventTimelineItemProxy, isDM: Bool, joinRule: JoinRule?) -> RoomTimelineItemProtocol?
     func buildTimelineItemReply(_ details: MatrixRustSDK.InReplyToDetails) -> TimelineItemReply
 }

--- a/UnitTests/Sources/TimelineControllerTests.swift
+++ b/UnitTests/Sources/TimelineControllerTests.swift
@@ -1,0 +1,120 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+@testable import ElementX
+import Testing
+
+struct TimelineControllerTests {
+    // MARK: - Date Divider Filtering
+    
+    @Test
+    func noDividers() {
+        let items: [RoomTimelineItemProtocol] = [mockText(), mockText()]
+        let result = TimelineController.stripOrphanedDateDividers(items)
+        #expect(result.count == 2)
+    }
+    
+    @Test
+    func singleDividerWithContent() {
+        let items: [RoomTimelineItemProtocol] = [mockSeparator(), mockText()]
+        let result = TimelineController.stripOrphanedDateDividers(items)
+        #expect(result.count == 2)
+    }
+    
+    @Test
+    func singleDividerAtEnd() {
+        let items: [RoomTimelineItemProtocol] = [mockSeparator()]
+        let result = TimelineController.stripOrphanedDateDividers(items)
+        #expect(result.isEmpty)
+    }
+    
+    @Test
+    func twoDividersNoContent() {
+        let items: [RoomTimelineItemProtocol] = [mockSeparator(), mockSeparator()]
+        let result = TimelineController.stripOrphanedDateDividers(items)
+        #expect(result.count == 1)
+        #expect(result[0] is SeparatorRoomTimelineItem)
+    }
+    
+    @Test
+    func twoDividersWithContentBetween() {
+        let items: [RoomTimelineItemProtocol] = [mockSeparator(), mockText(), mockSeparator()]
+        let result = TimelineController.stripOrphanedDateDividers(items)
+        #expect(result.count == 3)
+    }
+    
+    @Test
+    func threeDividersWithContentAfterLast() {
+        let items: [RoomTimelineItemProtocol] = [mockSeparator(), mockSeparator(), mockSeparator(), mockText()]
+        let result = TimelineController.stripOrphanedDateDividers(items)
+        // The first two separators should be removed (next non-pagination is also a separator),
+        // the third should be kept (text follows).
+        #expect(result.count == 2)
+        #expect(result[0] is SeparatorRoomTimelineItem)
+        #expect(result[1] is TextRoomTimelineItem)
+    }
+    
+    @Test
+    func dividerThenPaginationThenDivider() {
+        let items: [RoomTimelineItemProtocol] = [mockSeparator(), PaginationIndicatorRoomTimelineItem(position: .start), mockSeparator()]
+        let result = TimelineController.stripOrphanedDateDividers(items)
+        #expect(result.isEmpty)
+    }
+    
+    @Test
+    func dividerThenPaginationThenContent() {
+        let items: [RoomTimelineItemProtocol] = [mockSeparator(), PaginationIndicatorRoomTimelineItem(position: .start), mockText()]
+        let result = TimelineController.stripOrphanedDateDividers(items)
+        // Divider kept — content follows (pagination indicators are ignored).
+        #expect(result.count == 3)
+    }
+    
+    @Test
+    func noItems() {
+        let items: [RoomTimelineItemProtocol] = []
+        let result = TimelineController.stripOrphanedDateDividers(items)
+        #expect(result.isEmpty)
+    }
+    
+    @Test
+    func onlyContent() {
+        let items: [RoomTimelineItemProtocol] = [mockText(), mockText(), mockText()]
+        let result = TimelineController.stripOrphanedDateDividers(items)
+        #expect(result.count == 3)
+    }
+    
+    @Test
+    func onlyPaginationIndicators() {
+        let items: [RoomTimelineItemProtocol] = [PaginationIndicatorRoomTimelineItem(position: .start), PaginationIndicatorRoomTimelineItem(position: .end)]
+        let result = TimelineController.stripOrphanedDateDividers(items)
+        #expect(result.count == 2)
+    }
+    
+    @Test
+    func dividerAtStartWithContentAfterPagination() {
+        let items: [RoomTimelineItemProtocol] = [mockSeparator(), PaginationIndicatorRoomTimelineItem(position: .start), mockText(), mockSeparator()]
+        let result = TimelineController.stripOrphanedDateDividers(items)
+        // First separator kept (content after pagination), last separator kept (end).
+        #expect(result.count == 4)
+    }
+    
+    // MARK: - Helpers
+    
+    private func mockSeparator() -> SeparatorRoomTimelineItem {
+        SeparatorRoomTimelineItem(id: .randomVirtual, timestamp: Date())
+    }
+    
+    private func mockText() -> TextRoomTimelineItem {
+        TextRoomTimelineItem(id: .randomEvent,
+                             timestamp: Date(),
+                             isOutgoing: false,
+                             isEditable: false,
+                             canBeRepliedTo: true,
+                             sender: .init(id: "@alice:matrix.org"),
+                             content: .init(body: "Hello"))
+    }
+}

--- a/UnitTests/Sources/TimelineItemFactoryTests.swift
+++ b/UnitTests/Sources/TimelineItemFactoryTests.swift
@@ -25,7 +25,7 @@ struct TimelineItemFactoryTests {
         
         let eventTimelineItemProxy = EventTimelineItemProxy(item: eventTimelineItem, uniqueID: .init("0"))
         
-        let item = try #require(factory.buildTimelineItem(for: eventTimelineItemProxy, isDM: false) as? CallInviteRoomTimelineItem,
+        let item = try #require(factory.buildTimelineItem(for: eventTimelineItemProxy, isDM: false, joinRule: nil) as? CallInviteRoomTimelineItem,
                                 "Incorrect item type")
         
         #expect(item.isReactable == false)


### PR DESCRIPTION
Port of https://github.com/element-hq/element-x-android/pull/6360
Sorry for the AI slop, didn't test it, though there are unit tests. This is pretty simple so I assume it should work as-is without problems.
The expected behavior is: "user joined/left/changed display name/avatar" are not shown if the room's join rule isn't `invite`, the current code seems to do it.

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
