### PR TITLE
Correctly handle user profile dismissals in the RoomMembersFlowCoordinator

### DIFF
--- a/ElementX/Sources/FlowCoordinators/RoomMembersFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomMembersFlowCoordinator.swift
@@ -178,6 +178,9 @@ final class RoomMembersFlowCoordinator: FlowCoordinatorProtocol {
                 
             case (_, .presentRoomMemberDetails, .roomMemberDetails(let userID, _)):
                 presentRoomMemberDetails(userID: userID, animated: animated)
+                
+            case (.roomMemberDetails, .dismissedRoomMemberDetails, .initial):
+                actionsSubject.send(.finished)
             case (.roomMemberDetails, .dismissedRoomMemberDetails, .roomMembersList):
                 break
                 
@@ -188,6 +191,9 @@ final class RoomMembersFlowCoordinator: FlowCoordinatorProtocol {
                 
             case (.roomMemberDetails, .presentUserProfile, .userProfile(let userID, _)):
                 replaceRoomMemberDetailsWithUserProfile(userID: userID)
+                
+            case (.userProfile, .dismissedUserProfile, .initial):
+                actionsSubject.send(.finished)
             case (.userProfile, .dismissedUserProfile, _):
                 break
                 
@@ -248,13 +254,7 @@ final class RoomMembersFlowCoordinator: FlowCoordinatorProtocol {
         .store(in: &cancellables)
         
         navigationStackCoordinator.push(coordinator, animated: animated) { [weak self] in
-            guard let self else { return }
-            if case let .roomMemberDetails(_, previousState) = stateMachine.state,
-               previousState == .initial {
-                actionsSubject.send(.finished)
-            } else {
-                stateMachine.tryEvent(.dismissedRoomMemberDetails)
-            }
+            self?.stateMachine.tryEvent(.dismissedRoomMemberDetails)
         }
     }
     


### PR DESCRIPTION
A user profile screen presented from the root of the MembersFlowCoordinator would go back to the initial state when dismissed. Unfortunately this wasn't being handled (like in the roomMemberDetails case) and would lead to the FlowCoordinator not finishing itself.

Both cases now go to the initial state and that's what triggers the finished call.