### PR TITLE
Bring back the .editorconfig file without the trim rule.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.swift]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
Undo #5703 and just remove the `trim_trailing_whitespace` line.