### PR TITLE
use swift 6.2 for  dev tools

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3375518f1065bd204579536060f3858ee60d1bfe4fb263b2b392dcc1f81ad629",
+  "originHash" : "f9cac83642d1f0f788400cb79649527d50bd88bf1143dc9fad9ff5c1870c20df",
   "pins" : [
     {
       "identity" : "swift-argument-parser",

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "ca37474853a4b5f59a22c74bfdd449b1f6bc4cc2",
-        "version" : "1.8.1"
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
       }
     },
     {
@@ -34,7 +34,7 @@
       "location" : "https://github.com/element-hq/swift-command-line-tools.git",
       "state" : {
         "branch" : "main",
-        "revision" : "c085ad85c27970e4bba2dd1180c2a53ab77022ba"
+        "revision" : "17a90e116418c061d6c67ec9fd5c4f40dc2c9028"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system",
       "state" : {
-        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
-        "version" : "1.6.4"
+        "revision" : "669763cfd5806a67e21972d7e5e2d6b80b1ea985",
+        "version" : "1.6.5"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,24 @@
 {
-  "originHash" : "f9cac83642d1f0f788400cb79649527d50bd88bf1143dc9fad9ff5c1870c20df",
+  "originHash" : "ec77bc40677bd20f99d813dea09781e534f4cb4539fb504b27d997b95f98d6d0",
   "pins" : [
+    {
+      "identity" : "pkl-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/pkl-swift",
+      "state" : {
+        "revision" : "40e5decb9481c8c5d8c64389255166023c936900",
+        "version" : "0.8.2"
+      }
+    },
+    {
+      "identity" : "semanticversion",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SwiftPackageIndex/SemanticVersion",
+      "state" : {
+        "revision" : "330bab3e41aad91fb3b1b0f779d1325738e54b93",
+        "version" : "0.5.3"
+      }
+    },
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ if FileManager.default.fileExists(atPath: "Enterprise/Pipeline/Package.swift") {
 let package = Package(
     name: "Element Swift",
     platforms: [
-        .macOS(.v14)
+        .macOS(.v15)
     ],
     products: [
         .executable(name: "tools", targets: ["Tools"])

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -35,6 +35,10 @@ let package = Package(
                             .product(name: "Yams", package: "Yams"),
                             .product(name: "Logging", package: "swift-log")
                           ],
-                          path: "Tools/Sources")
+                          path: "Tools/Sources",
+                          swiftSettings: [
+                            .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+                            .enableUpcomingFeature("InferIsolatedConformances")
+                          ])
     ]
 )

--- a/Tools/Sources/Commands/BuildSDK.swift
+++ b/Tools/Sources/Commands/BuildSDK.swift
@@ -125,7 +125,7 @@ struct BuildSDK: AsyncParsableCommand {
     /// Update project.yml with the local path of the SDK.
     func updateProjectYAML() throws {
         let yamlURL = URL.projectDirectory.appendingPathComponent("project.yml")
-        let yamlString = try String(contentsOf: yamlURL)
+        let yamlString = try String(contentsOf: yamlURL, encoding: .utf8)
         guard var projectConfig = try Yams.compose(yaml: yamlString) else { throw Error.failureParsingProjectYAML }
         
         projectConfig["packages"]?.mapping?["MatrixRustSDK"]? = ["path": "../matrix-rust-sdk"]

--- a/Tools/Sources/Commands/BumpCalendarVersion.swift
+++ b/Tools/Sources/Commands/BumpCalendarVersion.swift
@@ -14,7 +14,7 @@ struct BumpCalendarVersion: ParsableCommand {
     /// Updates the project YAML with the new version.
     private func updateProjectYAML() throws {
         let yamlURL = URL.projectDirectory.appendingPathComponent("project.yml")
-        let yamlString = try String(contentsOf: yamlURL)
+        let yamlString = try String(contentsOf: yamlURL, encoding: .utf8)
         
         // Use regex instead of Yams to preserve any whitespace, comments etc in the file.
         let marketingVersionRegex = /MARKETING_VERSION:\s*([^\s]+)/

--- a/Tools/Sources/Commands/CI/CI.swift
+++ b/Tools/Sources/Commands/CI/CI.swift
@@ -25,7 +25,7 @@ struct CI: ParsableCommand {
     /// Reads the `MARKETING_VERSION` from `project.yml`.
     static func readMarketingVersion() throws -> String {
         let projectURL = URL.projectDirectory.appending(component: "project.yml")
-        let projectString = try String(contentsOf: projectURL)
+        let projectString = try String(contentsOf: projectURL, encoding: .utf8)
         
         guard let projectConfig = try Yams.compose(yaml: projectString),
               let version = projectConfig["settings"]?["MARKETING_VERSION"]?.string else {

--- a/Tools/Sources/Commands/CI/ConfigureNightly.swift
+++ b/Tools/Sources/Commands/CI/ConfigureNightly.swift
@@ -26,7 +26,7 @@ struct ConfigureNightly: AsyncParsableCommand {
     /// Adds the Nightly variant include path to `project.yml` if it isn't already present.
     private func addNightlyVariant() throws {
         let projectURL = URL.projectDirectory.appending(component: "project.yml")
-        let projectString = try String(contentsOf: projectURL)
+        let projectString = try String(contentsOf: projectURL, encoding: .utf8)
         guard var projectConfig = try Yams.compose(yaml: projectString) else {
             throw ValidationError("Failed to parse project.yml.")
         }

--- a/Tools/Sources/Commands/CI/ReleaseToGithub.swift
+++ b/Tools/Sources/Commands/CI/ReleaseToGithub.swift
@@ -119,7 +119,7 @@ struct ReleaseToGitHub: AsyncParsableCommand {
         
         let releaseDate = Date().formatted(.iso8601.year().month().day())
         
-        let existingContent = try String(contentsOf: changesURL)
+        let existingContent = try String(contentsOf: changesURL, encoding: .utf8)
         let newContent = "## Changes in \(version) (\(releaseDate))\(cleanedNotes)\n\n\(existingContent)"
         
         try newContent.write(to: changesURL, atomically: true, encoding: .utf8)


### PR DESCRIPTION
Name says it all. Was quite easy, tools already work out of the box quite easily with 6.2 and approachable concurrency

fixes #4996 