### PR TITLE
Setup proper logging for MapLibre and location views.

### DIFF
--- a/ElementX/Sources/Application/TargetConfiguration.swift
+++ b/ElementX/Sources/Application/TargetConfiguration.swift
@@ -8,6 +8,7 @@
 
 import Combine
 import Foundation
+import MapLibre
 import MatrixRustSDK
 
 enum Target: String {
@@ -61,6 +62,24 @@ enum Target: String {
         enableSentryLogging(enabled: false)
         
         MXLog.configure(currentTarget: rawValue)
+        
+        MLNLoggingConfiguration.shared.loggingLevel = .debug
+        MLNLoggingConfiguration.shared.handler = { loggingLevel, _, _, message in
+            switch loggingLevel {
+            case .error:
+                MXLog.error(message)
+            case .warning:
+                MXLog.warning(message)
+            case .info:
+                MXLog.info(message)
+            case .debug:
+                MXLog.debug(message)
+            case .verbose:
+                MXLog.verbose(message)
+            default:
+                break
+            }
+        }
         
         let hookCancellable = rageshakeURL.publisher
             .sink { _ in

--- a/ElementX/Sources/Other/MapLibre/MapLibreStaticMapView.swift
+++ b/ElementX/Sources/Other/MapLibre/MapLibreStaticMapView.swift
@@ -66,7 +66,8 @@ struct MapLibreStaticMapView<PinAnnotation: View>: View {
                                 .aspectRatio(contentMode: .fill)
                             pinAnnotationView
                         }
-                    case .failure:
+                    case .failure(let error):
+                        let _ = MXLog.error("Failed retrieving tile with error: \(error.localizedDescription)")
                         errorView
                     @unknown default:
                         EmptyView()


### PR DESCRIPTION
Configure their print callback handler to pipe on through to MXLog and log AsyncImage errors.