### PR TITLE
Fix the client sometimes staying suspended after returning from the background

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -821,7 +821,7 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
         
         showLoadingIndicator()
         
-        pauseClientServices(isBackgroundTask: false)
+        Task { await pauseClientServices(isBackgroundTask: false) }
         userSessionFlowCoordinator?.stop()
         
         guard !isSoft else {
@@ -951,7 +951,7 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
         
         navigationRootCoordinator.setRootCoordinator(PlaceholderScreenCoordinator(hideBrandChrome: appSettings.hideBrandChrome))
         
-        pauseClientServices(isBackgroundTask: false)
+        Task { await pauseClientServices(isBackgroundTask: false) }
         userSessionFlowCoordinator?.stop()
         
         // Allow for everything to deallocate properly
@@ -1080,16 +1080,14 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
     
     // MARK: - Application State
     
-    private func pauseClientServices(isBackgroundTask: Bool, completion: (() -> Void)? = nil) {
+    private func pauseClientServices(isBackgroundTask: Bool) async {
         if isBackgroundTask, UIApplication.shared.applicationState == .active {
             // Attempt to pause the background task services cleanly, only if the app not already running
             return
         }
         
-        MainActor.assumeIsolated {
-            userSession?.clientProxy.pauseServices(completion: completion)
-            clientProxyObserver = nil
-        }
+        await userSession?.clientProxy.pauseServices()
+        clientProxyObserver = nil
     }
     
     private func resumeClientServices() async {
@@ -1163,7 +1161,7 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
     @objc
     private func applicationWillTerminate() {
         MXLog.info("Application will terminate")
-        pauseClientServices(isBackgroundTask: false)
+        Task { await pauseClientServices(isBackgroundTask: false) }
     }
     
     @objc
@@ -1190,7 +1188,8 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
             // We're intentionally strongly retaining self here to an EXC_BAD_ACCESS
             // `backgroundTask` will be eventually released in `endActiveBackgroundTask`
             // https://sentry.tools.element.io/organizations/element/issues/4477794/events/9cfd04e4d045440f87498809cf718de5/
-            self.pauseClientServices(isBackgroundTask: true) {
+            Task { @MainActor in
+                await self.pauseClientServices(isBackgroundTask: true)
                 self.endActiveBackgroundTask()
             }
         }
@@ -1258,20 +1257,18 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
         // This is important for the app to keep refreshing in the background
         scheduleBackgroundAppRefresh()
         
-        // We have a lot of crashes stemming here which we previously believed are caused by pauseServices not being async
-        // on the client proxy side (see the comment on that method). We have now realised that will likely not fix anything but
-        // we also noticed this does not crash on the main thread, even though the whole AppCoordinator is on the Main actor.
-        // As such, we introduced a MainActor conformance on the expirationHandler but we are also assuming main actor
-        // isolated in the `pauseServices` method above.
+        // We have a lot of crashes stemming here which we previously believed were caused by pauseServices not being
+        // async on the client proxy side. We have now realised that will likely not fix anything but we also noticed
+        // this does not crash on the main thread, even though the whole AppCoordinator is on the Main actor. As such,
+        // we hop onto the main actor explicitly before pausing.
         // https://sentry.tools.element.io/organizations/element/issues/4477794/
         task.expirationHandler = { @Sendable [weak self] in
             MXLog.info("Background app refresh task is about to expire.")
             
             Task { @MainActor in
-                self?.pauseClientServices(isBackgroundTask: true) {
-                    MXLog.info("Marking Background app refresh task as complete.")
-                    task.setTaskCompleted(success: true)
-                }
+                await self?.pauseClientServices(isBackgroundTask: true)
+                MXLog.info("Marking Background app refresh task as complete.")
+                task.setTaskCompleted(success: true)
             }
         }
         
@@ -1294,7 +1291,8 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
                 
                 // Make sure we stop the sync loop, otherwise the ongoing request is immediately
                 // handled the next time the app refreshes, which can trigger timeout failures.
-                pauseClientServices(isBackgroundTask: true) {
+                Task {
+                    await self.pauseClientServices(isBackgroundTask: true)
                     MXLog.info("Marking Background app refresh task as complete.")
                     task.setTaskCompleted(success: true)
                 }

--- a/ElementX/Sources/Application/Settings/AppSettings.swift
+++ b/ElementX/Sources/Application/Settings/AppSettings.swift
@@ -500,7 +500,7 @@ final class AppSettings: @unchecked Sendable {
         _jumpToReadMarkerEnabled = UserPreference(key: .jumpToReadMarkerEnabled, defaultValue: false, storage: store)
         _linkNewDeviceEnabled = UserPreference(key: .linkNewDeviceEnabled, defaultValue: false, storage: store)
         _automaticBackPaginationEnabled = UserPreference(key: .automaticBackPaginationEnabled, defaultValue: false, storage: store)
-        _clientPausingAndResumingEnabled = UserPreference(key: .clientPausingAndResumingEnabled, defaultValue: false, storage: VolatileUserDefaults())
+        _clientPausingAndResumingEnabled = UserPreference(key: .clientPausingAndResumingEnabled, defaultValue: Self.appBuildType != .release, storage: VolatileUserDefaults())
         _developerOptionsEnabled = UserPreference(key: .developerOptionsEnabled, defaultValue: Self.appBuildType != .release, storage: store)
     }
     

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -2470,20 +2470,20 @@ class ClientProxyMock: ClientProxyProtocol, @unchecked Sendable {
     }
     //MARK: - pauseServices
 
-    private let pauseServicesCompletionCallsCountLock = NSLock()
-    private var pauseServicesCompletionUnderlyingCallsCount = 0
-    var pauseServicesCompletionCallsCount: Int {
-        get { pauseServicesCompletionCallsCountLock.withLock { pauseServicesCompletionUnderlyingCallsCount } }
-        set { pauseServicesCompletionCallsCountLock.withLock { pauseServicesCompletionUnderlyingCallsCount = newValue } }
+    private let pauseServicesCallsCountLock = NSLock()
+    private var pauseServicesUnderlyingCallsCount = 0
+    var pauseServicesCallsCount: Int {
+        get { pauseServicesCallsCountLock.withLock { pauseServicesUnderlyingCallsCount } }
+        set { pauseServicesCallsCountLock.withLock { pauseServicesUnderlyingCallsCount = newValue } }
     }
-    var pauseServicesCompletionCalled: Bool {
-        return pauseServicesCompletionCallsCount > 0
+    var pauseServicesCalled: Bool {
+        return pauseServicesCallsCount > 0
     }
-    var pauseServicesCompletionClosure: (((() -> Void)?) -> Void)?
+    var pauseServicesClosure: (() async -> Void)?
 
-    func pauseServices(completion: (() -> Void)?) {
-        pauseServicesCompletionCallsCountLock.withLock { pauseServicesCompletionUnderlyingCallsCount += 1 }
-        pauseServicesCompletionClosure?(completion)
+    func pauseServices() async {
+        pauseServicesCallsCountLock.withLock { pauseServicesUnderlyingCallsCount += 1 }
+        await pauseServicesClosure?()
     }
     //MARK: - expireSyncSessions
 

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -154,7 +154,12 @@ class ClientProxy: ClientProxyProtocol {
     private var hasEncounteredAuthError = false
     
     deinit {
-        pauseServices { [delegateHandle] in
+        // Stop the sync and cancel the delegate (in that order) before the client is released. No need to pause
+        // the client as it's being deallocated, so the SDK tears it down anyway. Capture the sync service strongly
+        // as `self` is being deallocated.
+        Task { [syncService, delegateHandle] in
+            await syncService.stop()
+            
             // The delegate handle needs to be cancelled always after the sync stops
             delegateHandle?.cancel()
         }
@@ -402,21 +407,7 @@ class ClientProxy: ClientProxyProtocol {
             return
         }
         
-        if appSettings.clientPausingAndResumingEnabled {
-            do {
-                MXLog.info("Resuming client")
-                try await client.resume()
-            } catch {
-                MXLog.error("Failed resuming client with error: \(error)")
-            }
-        }
-        
-        MXLog.info("Starting sync")
-        await syncService.start()
-        
-        // If we are using OAuth we want to cache the account management URL in volatile memory on the SDK side.
-        // To avoid the cache being invalidated while the app is backgrounded, we cache at every sync start.
-        await cacheAccountURL()
+        await transitionServices(to: .running).value
     }
     
     /// A stored task for restarting the sync after a failure. This is stored so that we can cancel
@@ -447,27 +438,10 @@ class ClientProxy: ClientProxyProtocol {
             restartTask = nil
         }
         
-        // Capture the sync service strongly as this method is called on deinit and so the
-        // existence of self when the Task executes is questionable and would sometimes crash.
-        // Note: This isn't strictly necessary now given the unwrap above, but leaving the code as
-        // documentation. SE-0371 will allow us to fix this by using an async deinit.
-        Task { [syncService] in
-            defer {
-                completion?()
-            }
-            
-            MXLog.info("Stopping sync")
-            await syncService.stop()
-            MXLog.info("Sync stopped")
-            
-            if appSettings.clientPausingAndResumingEnabled {
-                do {
-                    MXLog.info("Pausing client")
-                    try await client.pause()
-                } catch {
-                    MXLog.error("Failed pausing client with error: \(error)")
-                }
-            }
+        let task = transitionServices(to: .suspended)
+        Task {
+            await task.value
+            completion?()
         }
     }
     
@@ -1083,6 +1057,67 @@ class ClientProxy: ClientProxyProtocol {
             }
             .store(in: &cancellables)
     }
+    
+    // MARK: - Pausing and resuming
+    
+    private enum ServiceState { case running, suspended }
+    
+    /// The state the sync service and client *should* be in, updated by ``resumeServices()`` and ``pauseServices()``.
+    private var desiredServiceState: ServiceState = .suspended
+    
+    /// Serialises service state transitions so that pause and resume never interleave. Each request chains onto
+    /// the previous one and the reconcile always drives the SDK to the *latest* desired state, so a late background
+    /// pause can no longer strand the client suspended after a foreground resume.
+    private var serviceStateTask: Task<Void, Never>?
+    
+    @discardableResult
+    private func transitionServices(to state: ServiceState) -> Task<Void, Never> {
+        desiredServiceState = state
+        
+        let previousTask = serviceStateTask
+        let task = Task { [weak self] in
+            await previousTask?.value
+            await self?.reconcileServiceState()
+        }
+        serviceStateTask = task
+        return task
+    }
+    
+    private func reconcileServiceState() async {
+        switch desiredServiceState {
+        case .running:
+            if appSettings.clientPausingAndResumingEnabled {
+                do {
+                    MXLog.info("Resuming client")
+                    try await client.resume()
+                } catch {
+                    MXLog.error("Failed resuming client with error: \(error)")
+                }
+            }
+            
+            MXLog.info("Starting sync")
+            await syncService.start()
+            
+            // If we are using OAuth we want to cache the account management URL in volatile memory on the SDK side.
+            // To avoid the cache being invalidated while the app is backgrounded, we cache at every sync start.
+            await cacheAccountURL()
+        case .suspended:
+            MXLog.info("Stopping sync")
+            await syncService.stop()
+            MXLog.info("Sync stopped")
+            
+            if appSettings.clientPausingAndResumingEnabled {
+                do {
+                    MXLog.info("Pausing client")
+                    try await client.pause()
+                } catch {
+                    MXLog.error("Failed pausing client with error: \(error)")
+                }
+            }
+        }
+    }
+    
+    // MARK: - Other
     
     private func cacheAccountURL() async {
         // Calling this function for the first time will cache the account URL in volatile memory for 24 hrs on the SDK.

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -1033,10 +1033,12 @@ class ClientProxy: ClientProxyProtocol {
         sendQueueStatusSubject
             .combineLatest(homeserverReachabilityPublisher)
             .debounce(for: 1.0, scheduler: DispatchQueue.main)
-            .sink { [client] enabled, reachability in
+            .sink { [weak self, client] enabled, reachability in
                 MXLog.info("Send queue status changed to enabled: \(enabled), homeserver reachability: \(reachability)")
                 
-                if enabled == false, reachability == .reachable {
+                // Don't restart the send queue unless the client is meant to be running; doing so while
+                // suspended would generate network activity in the window we paused to keep quiet.
+                if enabled == false, reachability == .reachable, self?.desiredServiceState == .running {
                     MXLog.info("Enabling all send queues")
                     Task {
                         await client.enableAllSendQueues(enable: true)
@@ -1097,6 +1099,10 @@ class ClientProxy: ClientProxyProtocol {
             // If we are using OAuth we want to cache the account management URL in volatile memory on the SDK side.
             // To avoid the cache being invalidated while the app is backgrounded, we cache at every sync start.
             await cacheAccountURL()
+            
+            // Nudge the send queue listener to re-evaluate now that we're running; a resume doesn't otherwise
+            // emit, and the SDK only re-enables queues when client.resume() runs (gated behind the flag).
+            sendQueueStatusSubject.send(sendQueueStatusSubject.value)
         case .suspended:
             MXLog.info("Stopping sync")
             await syncService.stop()

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -431,18 +431,14 @@ class ClientProxy: ClientProxyProtocol {
         }
     }
     
-    func pauseServices(completion: (() -> Void)?) {
+    func pauseServices() async {
         MXLog.info("Pausing services")
         
         if restartTask != nil {
             restartTask = nil
         }
         
-        let task = transitionServices(to: .suspended)
-        Task {
-            await task.value
-            completion?()
-        }
+        await transitionServices(to: .suspended).value
     }
     
     func expireSyncSessions() async {

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -171,7 +171,7 @@ protocol ClientProxyProtocol: AnyObject {
     
     func resumeServices() async
     
-    func pauseServices(completion: (() -> Void)?) // Hopefully this will become async once we get SE-0371.
+    func pauseServices() async
     
     func expireSyncSessions() async
     


### PR DESCRIPTION
Re-enables client pausing and resuming (disabled in 5ba94609b) after fixing the timing bug that made it unsafe.

Pause and resume previously ran as independent, unsynchronised tasks, so a late background pause could land after a foreground resume, leaving the client suspended and the sync stopped while the app was active, which broke everything until the next relaunch.

This series of patches serializes the state changes and always applies the latest intended state, drops the callback from the `pauseServices` method and makes sure the send queue doesn't get re-enabled while the client is suspended.

Best reviewed commit by commit.