### PR TITLE
Fix crashes during logout.

### DIFF
--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummary.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummary.swift
@@ -119,6 +119,34 @@ extension RoomSummary: CustomStringConvertible {
 }
 
 extension RoomSummary {
+    /// An empty summary used when the room info is momentarily unavailable (e.g. while the client tears
+    /// down on logout). Keeps the diff indices aligned with the SDK instead of crashing.
+    static func placeholder(room: Room) -> RoomSummary {
+        RoomSummary(room: room,
+                    id: room.id(),
+                    joinRequestType: nil,
+                    name: room.id(),
+                    isDirect: false,
+                    isSpace: false,
+                    avatarURL: nil,
+                    heroes: [],
+                    activeMembersCount: 0,
+                    lastMessage: nil,
+                    lastMessageDate: nil,
+                    lastMessageState: nil,
+                    unreadMessagesCount: 0,
+                    unreadMentionsCount: 0,
+                    unreadNotificationsCount: 0,
+                    notificationMode: nil,
+                    canonicalAlias: nil,
+                    alternativeAliases: [],
+                    hasOngoingCall: false,
+                    activeCallIntent: nil,
+                    isMarkedUnread: false,
+                    isFavourite: false,
+                    isTombstoned: false)
+    }
+    
     init(room: Room, id: String, settingsMode: RoomNotificationModeProxy, hasUnreadMessages: Bool, hasUnreadMentions: Bool, hasUnreadNotifications: Bool) {
         self.room = room
         self.id = id

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
@@ -260,7 +260,11 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
         let roomDetails = fetchRoomDetails(from: room)
         
         guard let roomInfo = roomDetails.roomInfo else {
-            fatalError("Missing room info for \(room.id())")
+            // The room info can be momentarily unavailable while the client tears down (e.g. on logout),
+            // where the SDK still delivers a diff but `room.roomInfo()` throws. Return a placeholder to
+            // keep the diff indices aligned with the SDK instead of crashing.
+            MXLog.error("Missing room info for \(room.id())")
+            return .placeholder(room: room)
         }
         
         var attributedLastMessage: AttributedString?


### PR DESCRIPTION
On logout the SDK can still deliver a room-list diff while the client is tearing down, at which point `room.roomInfo()` throws and `RoomSummaryProvider.buildRoomSummary(from:)` hit a `fatalError` — crashing the app instead of returning to the sign-in screen (and failing `testUserFlow`).

Now it logs the error and returns a placeholder `RoomSummary` carrying the real room id, keeping the SDK diff indices aligned. The placeholder is transient — replaced on the next update or discarded when the provider is torn down.