### PR TITLE
Remove stale reference to fastlane and Gemfile in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,6 @@ Initial setup: `swift run tools setup-project`
 CI test commands:
 - Unit tests: `swift run tools ci unit-tests`
 - CI help: `swift run tools ci --help`
-- Fastlane: `bundle exec fastlane lanes`
 
 ### Targets & Layout
 
@@ -379,7 +378,6 @@ Same pattern for publishers.
 | `.swiftformat` | SwiftFormat rules |
 | `Dangerfile.swift` | Danger PR checks |
 | `Package.swift` | SPM manifest (Tools CLI) |
-| `Gemfile` | Ruby deps (Fastlane, Danger) |
 | `localazy.json` | Localazy translation config |
 | `codecov.yml` | Codecov config |
 | `.periphery.yml` | Periphery dead-code detection |


### PR DESCRIPTION
Gemfile and fastlane were removed in https://github.com/element-hq/element-x-ios/pull/5186

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
