### PR TITLE
Various crash fixes

### DIFF
--- a/ElementX/Sources/Other/SwiftUI/Views/LoadableImage.swift
+++ b/ElementX/Sources/Other/SwiftUI/Views/LoadableImage.swift
@@ -234,21 +234,22 @@ private struct LoadableImageContent<TransformerView: View, PlaceholderView: View
         mediaSource.url.absoluteString
     }
     
-    nonisolated func data(handler: @escaping (Result<Data, Error>) -> Void) {
-        // Kingfisher isn't annotated but invokes the provider on the main thread.
-        let gifData = MainActor.assumeIsolated { () -> Data? in
+    nonisolated func data(handler: @escaping @Sendable (Result<Data, Error>) -> Void) {
+        // Kingfisher isn't annotated and doesn't guarantee the provider is invoked on the main
+        // thread so hop onto the main actor.
+        Task { @MainActor in
             guard case let .gifData(data) = contentLoader.content else {
-                return nil
+                handler(.failure(LoadableImageError.missingGIFData))
+                return
             }
-            return data
+            
+            handler(.success(data))
         }
-        
-        guard let gifData else {
-            fatalError("Shouldn't reach this point without any gif data")
-        }
-        
-        handler(.success(gifData))
     }
+}
+
+private enum LoadableImageError: Error {
+    case missingGIFData
 }
 
 private class ContentLoader: ObservableObject {

--- a/ElementX/Sources/Screens/MediaPickerScreen/DocumentPicker.swift
+++ b/ElementX/Sources/Screens/MediaPickerScreen/DocumentPicker.swift
@@ -90,6 +90,11 @@ struct DocumentPicker: UIViewControllerRepresentable {
                 }
             }
             
+            guard !selectedURLs.isEmpty else {
+                // Every picked document failed to copy; each failure was already surfaced via .error.
+                return
+            }
+            
             documentPicker.callback(.selectedMediaAtURLs(selectedURLs))
         }
     }

--- a/ElementX/Sources/Screens/MediaPickerScreen/PhotoLibraryPicker.swift
+++ b/ElementX/Sources/Screens/MediaPickerScreen/PhotoLibraryPicker.swift
@@ -104,6 +104,11 @@ struct PhotoLibraryPicker: UIViewControllerRepresentable {
                     return selectedURLs.compactMap { $0 }
                 }
                 
+                guard !selectedURLs.isEmpty else {
+                    // Every selected item failed to load; each failure was already surfaced via .error.
+                    return
+                }
+                
                 photoLibraryPicker.callback(.selectedMediaAtURLs(selectedURLs))
             }
         }
@@ -114,6 +119,9 @@ struct PhotoLibraryPicker: UIViewControllerRepresentable {
             let provider = result.itemProvider
             
             guard let contentType = provider.preferredContentType else {
+                Task { @MainActor in
+                    photoLibraryPicker.callback(.error(.failedLoadingFileRepresentation(nil)))
+                }
                 return nil
             }
             

--- a/ElementX/Sources/Screens/Timeline/TimelineTableViewController.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineTableViewController.swift
@@ -420,10 +420,13 @@ class TimelineTableViewController: UIViewController {
     
     /// Scrolls to the oldest item in the timeline.
     private func scrollToOldestItem(animated: Bool) {
-        guard !timelineItemsIDs.isEmpty else {
+        // The data source can lag behind timelineItemsIDs, so scroll against the table's actual
+        // contents to avoid targeting a section or row that doesn't exist yet.
+        guard tableView.numberOfSections > 1,
+              tableView.numberOfRows(inSection: 1) > 0 else {
             return
         }
-        tableView.scrollToRow(at: IndexPath(item: timelineItemsIDs.count - 1, section: 1), at: .bottom, animated: animated)
+        tableView.scrollToRow(at: IndexPath(item: tableView.numberOfRows(inSection: 1) - 1, section: 1), at: .bottom, animated: animated)
         scrollDirectionPublisher.send(.top)
     }
     

--- a/ElementX/Sources/Services/AlertTones/NotificationToneManager.swift
+++ b/ElementX/Sources/Services/AlertTones/NotificationToneManager.swift
@@ -54,7 +54,10 @@ nonisolated struct NotificationToneManager: NotificationToneManagerProtocol {
             try FileManager.default.createDirectory(at: NotificationToneManager.libraryLocation, withIntermediateDirectories: true)
             try FileManager.default.createDirectory(at: Self.selectedToneLocation.deletingLastPathComponent(), withIntermediateDirectories: true)
         } catch {
-            fatalError("Catastrophic error setting up tone manager: \(error)")
+            // Don't crash on a recoverable file system error. The underlying problem (directory creation
+            // failing on launch, e.g. a background launch before the container is writable) is acknowledged
+            // and will be treated separately.
+            MXLog.error("Failed setting up tone manager directories: \(error)")
         }
     }
     

--- a/ElementX/Sources/Services/Audio/Recorder/AudioRecorder.swift
+++ b/ElementX/Sources/Services/Audio/Recorder/AudioRecorder.swift
@@ -166,7 +166,15 @@ nonisolated class AudioRecorder: AudioRecorderProtocol, @unchecked Sendable {
             
             let inputNode = audioEngine.inputNode
             let inputFormat = inputNode.outputFormat(forBus: 0)
-            let hardwareSampleRate = audioEngine.inputNode.outputFormat(forBus: 0).sampleRate
+            let hardwareSampleRate = inputFormat.sampleRate
+            
+            // The input format can be invalid (e.g. a zero sample rate) when no input route is
+            // available, which would crash AVAudioEngine when connecting nodes or installing the tap.
+            guard inputFormat.sampleRate > 0, inputFormat.channelCount > 0 else {
+                MXLog.error("Invalid input audio format, can't record: \(inputFormat)")
+                completion(.failure(.unsupportedAudioFormat))
+                return
+            }
             
             // Define a recording audio format. Force the sample rate to 48000 to ensure OGGEncoder won't crash
             guard let recordingFormat = AVAudioFormat(standardFormatWithSampleRate: 48000, channels: 1) else {


### PR DESCRIPTION
Address some of the Sentry crashes. Treat this as an experiment in Claude <-> SentryMCP interactions.

| Sentry | Commit | Problem | Fix |
|---|---|---|---|
| 60N | da934a545 | `NotificationToneManager.init` fatalError'd when `createDirectory` failed (sandbox permission, NSCocoaError 513) — e.g. background launch before the container is writable | Log the error instead of crashing; root cause acknowledged for separate treatment |
| 61D | 1568e28d9 | `LoadableImage` GIF provider used `MainActor.assumeIsolated` (libdispatch crash when Kingfisher called off-main) + fatalError when content wasn't GIF | Hop onto the main actor and return `.failure`; handler is `@Sendable` per Kingfisher's protocol |
| PG | c8489e2bd | Photo/document pickers emitted `.selectedMediaAtURLs([])` when every selected item failed to load/export — an empty "success" consumers fatalError'd on | Both `PhotoLibraryPicker` & `DocumentPicker` skip the empty emission (failures already go through `.error`); also report `.error` for the silent missing-content-type case |
| VV | d4edf0150 | `AudioRecorder.startRecording` crashed AVAudioEngine (IsFormatSampleRateAndChannelCountValid) when the input format was invalid (0 sample rate, no input route) | Guard `sampleRate > 0 && channelCount > 0` and bail with `.unsupportedAudioFormat` before connecting nodes / installing the tap |
| DS | 30e5d2f44 | `TimelineTableViewController.scrollToOldestItem` targeted `(timelineItemsIDs.count - 1, section: 1)` before the data source applied that section → out-of-bounds NSRangeException | Scroll against the table's actual `numberOfSections`/`numberOfRows(inSection:)` |
