### PR TITLE
Delete the composerAttachments UI test snapshot step

### DIFF
--- a/UITests/Sources/UserSessionScreenTests.swift
+++ b/UITests/Sources/UserSessionScreenTests.swift
@@ -74,7 +74,6 @@ class UserSessionScreenTests: XCTestCase {
         XCTAssert(latestEditedMessage.waitForExistence(timeout: 5.0))
         
         app.buttons[A11yIdentifiers.roomScreen.composerToolbar.openComposeOptions].tap(.center)
-        try await app.assertScreenshot(step: Step.composerAttachments)
     }
     
     func testUserSessionReply() async throws {

--- a/UITests/Sources/__Snapshots__/Application/userSessionScreen.testUserSessionFlows-iPad-en-GB-3.png
+++ b/UITests/Sources/__Snapshots__/Application/userSessionScreen.testUserSessionFlows-iPad-en-GB-3.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:75371a232a227525b550f8687697d84f2d3b35001744e08b7f0b5d96f3174089
-size 634890

--- a/UITests/Sources/__Snapshots__/Application/userSessionScreen.testUserSessionFlows-iPhone-en-GB-3.png
+++ b/UITests/Sources/__Snapshots__/Application/userSessionScreen.testUserSessionFlows-iPhone-en-GB-3.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b797b74eddb4e766c044aa1b3706e5abbb9cbe5ce5b7d58523f2c5157313259b
-size 423065


### PR DESCRIPTION
Because it keeps failing and because we have proper tests for all of those options