### PR TITLE
Remove custom tones menu on macOS

### DIFF
--- a/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenModels.swift
@@ -52,6 +52,7 @@ struct NotificationSettingsScreenSettings {
     /// Old clients were having specific settings for encrypted and unencrypted rooms,
     /// so it's possible for `group chats` and `direct chats` settings to be inconsistent (e.g. encrypted `direct chats` can have a different mode that unencrypted `direct chats`)
     let inconsistentSettings: [NotificationSettingsScreenInvalidSetting]
+    let customToneSelectionEnabled: Bool
 }
 
 struct NotificationSettingsScreenInvalidSetting: Equatable {

--- a/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenModels.swift
@@ -31,6 +31,8 @@ struct NotificationSettingsScreenViewState: BindableState {
     var applyingChange = false
     var selectedAlertTone: NotificationTone
     var availableCustomTones: [NotificationTone]
+    
+    let customToneSelectionEnabled: Bool
 }
 
 struct NotificationSettingsScreenViewStateBindings {
@@ -52,7 +54,6 @@ struct NotificationSettingsScreenSettings {
     /// Old clients were having specific settings for encrypted and unencrypted rooms,
     /// so it's possible for `group chats` and `direct chats` settings to be inconsistent (e.g. encrypted `direct chats` can have a different mode that unencrypted `direct chats`)
     let inconsistentSettings: [NotificationSettingsScreenInvalidSetting]
-    let customToneSelectionEnabled: Bool
 }
 
 struct NotificationSettingsScreenInvalidSetting: Equatable {

--- a/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenViewModel.swift
@@ -43,7 +43,9 @@ class NotificationSettingsScreenViewModel: NotificationSettingsScreenViewModelTy
         super.init(initialViewState: NotificationSettingsScreenViewState(bindings: bindings,
                                                                          isModallyPresented: isModallyPresented,
                                                                          selectedAlertTone: appSettings.selectedNotificationTone ?? NotificationToneManager.defaultElementXMessageTone,
-                                                                         availableCustomTones: notificationToneManager.customTones()))
+                                                                         availableCustomTones: notificationToneManager.customTones(),
+                                                                         // macos lacks default sounds and its sandbox Sounds directory is immutable
+                                                                         customToneSelectionEnabled: !ProcessInfo.processInfo.isiOSAppOnMac))
         
         // Listen for changes to AppSettings.
         appSettings.$enableNotifications
@@ -191,9 +193,7 @@ class NotificationSettingsScreenViewModel: NotificationSettingsScreenViewModelTy
                                                                           roomMentionsEnabled: roomMentionsEnabled,
                                                                           callsEnabled: callEnabled,
                                                                           invitationsEnabled: invitationsEnabled,
-                                                                          inconsistentSettings: inconsistentSettings,
-                                                                          // macos lacks default sounds and its sandbox Sounds directory is immutable
-                                                                          customToneSelectionEnabled: !ProcessInfo.processInfo.isiOSAppOnMac)
+                                                                          inconsistentSettings: inconsistentSettings)
             
             state.settings = notificationSettings
             state.bindings.roomMentionsEnabled = notificationSettings.roomMentionsEnabled ?? false

--- a/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenViewModel.swift
@@ -191,7 +191,9 @@ class NotificationSettingsScreenViewModel: NotificationSettingsScreenViewModelTy
                                                                           roomMentionsEnabled: roomMentionsEnabled,
                                                                           callsEnabled: callEnabled,
                                                                           invitationsEnabled: invitationsEnabled,
-                                                                          inconsistentSettings: inconsistentSettings)
+                                                                          inconsistentSettings: inconsistentSettings,
+                                                                          // macos lacks default sounds and its sandbox Sounds directory is immutable
+                                                                          customToneSelectionEnabled: !ProcessInfo.processInfo.isiOSAppOnMac)
             
             state.settings = notificationSettings
             state.bindings.roomMentionsEnabled = notificationSettings.roomMentionsEnabled ?? false

--- a/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/View/NotificationSettingsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/View/NotificationSettingsScreen.swift
@@ -39,7 +39,7 @@ struct NotificationSettingsScreen: View {
                         additionalSettingsSection
                     }
                     
-                    if context.viewState.settings?.customToneSelectionEnabled == true {
+                    if context.viewState.customToneSelectionEnabled {
                         soundSelectionSection
                     }
                 }

--- a/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/View/NotificationSettingsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/View/NotificationSettingsScreen.swift
@@ -39,7 +39,9 @@ struct NotificationSettingsScreen: View {
                         additionalSettingsSection
                     }
                     
-                    soundSelectionSection
+                    if context.viewState.settings?.customToneSelectionEnabled == true {
+                        soundSelectionSection
+                    }
                 }
             }
         }


### PR DESCRIPTION
Addresses #5735 by removing the custom tone selection item from the notification screen. 

Rationale: macOS lacks the default system sounds from iOS, macOS's sandbox contains an immutable `Sounds` directory, and most importantly, macOS appears to have flaky support for custom sounds in the first place.

This should probably be readdressed at some point in the future. In the meantime, it should at least work with the default tri-tone macOS notification sound, and, when its mood is right, perhaps the bundled element sound.

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [ ] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
