### PR TITLE
Generate AppSettings preference accessors with Sourcery instead of @UserPreference

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -1052,6 +1052,7 @@
 		AA5924D3B67F7ACD98BBEFDC /* OrientationManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4756240773D26AB74C22668 /* OrientationManagerProtocol.swift */; };
 		AA93B3F9B5DD097DEF79F981 /* NotificationSettingsEditScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBB0328F2887BF0A65BC5D49 /* NotificationSettingsEditScreen.swift */; };
 		AAA551AD8768309024D4907B /* KnockRequestsListScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1511B1DCECC0DC75EB267328 /* KnockRequestsListScreen.swift */; };
+		AABBA2E550431295639E06FF /* AppSettings+Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FD970E459AED8D9BB31E6F5 /* AppSettings+Preferences.swift */; };
 		AADE7C2497A7B55D8BED7BD6 /* IdentityConfirmedScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8319173DD66C07F45DC48848 /* IdentityConfirmedScreenViewModelProtocol.swift */; };
 		AAF0BBED840DF4A53EE85E77 /* MatrixRustSDK in Frameworks */ = {isa = PBXBuildFile; productRef = C2C69B8BA5A9702E7A8BC08F /* MatrixRustSDK */; };
 		ABD29E06DD1224812E750AF8 /* ReadReceiptCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D75941CBD7D336F831924EC /* ReadReceiptCell.swift */; };
@@ -1393,6 +1394,7 @@
 		E82E13CC3EB923CCB8F8273C /* TimelineProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9E543072DE58E751F028998 /* TimelineProxy.swift */; };
 		E84ADFE9696936C18C2424B5 /* SecureBackupScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A00BB9CD12CF6AC98D5485 /* SecureBackupScreen.swift */; };
 		E8AE3BE5C5D2E6C91751A2A6 /* StateMachineFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC73285743189AE4498A51DD /* StateMachineFactory.swift */; };
+		E8B1D69F19E1CF14F522B59A /* AppSettings+Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FD970E459AED8D9BB31E6F5 /* AppSettings+Preferences.swift */; };
 		E8B290CBB7E5FF5E3C1B6124 /* KnockRequestsListEmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 627A8B5E798CC778C363655E /* KnockRequestsListEmptyStateView.swift */; };
 		E8BBCFF3B1380F56C73690BC /* ClassicAppManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C78D5FF15343724902EB20 /* ClassicAppManager.swift */; };
 		E8C4D9F93F0DCED211D5F187 /* HTMLParserStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3877D3CFAC1D33823359BAF /* HTMLParserStyle.swift */; };
@@ -1460,6 +1462,7 @@
 		F252C0EA49088801F4CA6006 /* landscape_test_image.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 96CE9D6642DD487D8CC90C9C /* landscape_test_image.jpg */; };
 		F255083E18CDBFDF7E640FB1 /* Avatars.swift in Sources */ = {isa = PBXBuildFile; fileRef = C142248014E08E885E323E56 /* Avatars.swift */; };
 		F2D5C0E1351DA7BD16867629 /* TimelineStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CD4823EAB4B4E8BAB4F6B8C /* TimelineStyle.swift */; };
+		F2E1114DA333F69FA1827213 /* AppSettings+Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FD970E459AED8D9BB31E6F5 /* AppSettings+Preferences.swift */; };
 		F2E580C0FBFBEFFE9D69893B /* RoomPreviewProxyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 739077686814E4EA339B1C83 /* RoomPreviewProxyProtocol.swift */; };
 		F34D06F86C29E219E7132E87 /* AuthenticationStartScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F71A54CB96DAA1E72C6541D /* AuthenticationStartScreenViewModel.swift */; };
 		F35FAD1B1B289E221A07D719 /* ManageRoomMemberSheetViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB7B588A06911B455AC0B4C9 /* ManageRoomMemberSheetViewModelProtocol.swift */; };
@@ -1926,6 +1929,7 @@
 		2F36C5D9B37E50915ECBD3EE /* RoomMemberProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomMemberProxy.swift; sourceTree = "<group>"; };
 		2F65178687F725E8924B723C /* TimelineFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineFixtures.swift; sourceTree = "<group>"; };
 		2F926D08EB3D622A480BCA71 /* TimelineEventContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineEventContent.swift; sourceTree = "<group>"; };
+		2FD970E459AED8D9BB31E6F5 /* AppSettings+Preferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppSettings+Preferences.swift"; sourceTree = "<group>"; };
 		303D9438EFB481F57A366E82 /* EncryptionResetPasswordScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptionResetPasswordScreenViewModel.swift; sourceTree = "<group>"; };
 		303FCADE77DF1F3670C086ED /* BugReportScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugReportScreenViewModel.swift; sourceTree = "<group>"; };
 		306AB507E1027D6C5C147EB6 /* EncryptionResetScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptionResetScreenModels.swift; sourceTree = "<group>"; };
@@ -3956,6 +3960,7 @@
 		337015ADFBA3AB96660DB3A6 /* Generated */ = {
 			isa = PBXGroup;
 			children = (
+				2FD970E459AED8D9BB31E6F5 /* AppSettings+Preferences.swift */,
 				71D52BAA5BADB06E5E8C295D /* Assets.swift */,
 				47EBB5D698CE9A25BB553A2D /* Strings.swift */,
 				B172057567E049007A5C4D92 /* Strings+SAS.swift */,
@@ -7714,7 +7719,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which sourcery >/dev/null; then\n    sourcery --config Tools/Sourcery/AutoMockableConfig.yml\nelse\n    echo \"warning: Sourcery not installed, run swift run tools setup-project\"\nfi\n";
+			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which sourcery >/dev/null; then\n    sourcery --config Tools/Sourcery/AutoMockableConfig.yml\n    sourcery --config Tools/Sourcery/AppSettingsPreferencesConfig.yml\nelse\n    echo \"warning: Sourcery not installed, run swift run tools setup-project\"\nfi\n";
 		};
 		98CA896D84BFD53B2554E891 /* ⚠️ SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -7819,6 +7824,7 @@
 				4E9ED3E6E979C6C7FEC1D011 /* AnalyticsConsentState.swift in Sources */,
 				68C3AF257678F6E7BB238C3F /* AppAppearance.swift in Sources */,
 				A2172B5A26976F9174228B8A /* AppHooks.swift in Sources */,
+				F2E1114DA333F69FA1827213 /* AppSettings+Preferences.swift in Sources */,
 				E1DE8A5422643F759385290F /* AppSettings.swift in Sources */,
 				484202C5D50983442D24D061 /* AttributedString.swift in Sources */,
 				CDCA8A559E098503DDE29477 /* AttributedStringBuilder.swift in Sources */,
@@ -8073,6 +8079,7 @@
 				585DCA0487A0A6F4E59EF5CA /* AnalyticsConsentState.swift in Sources */,
 				88887E40301FF0543ED5B59F /* AppAppearance.swift in Sources */,
 				944EAB7BC2408B2C6570E722 /* AppHooks.swift in Sources */,
+				E8B1D69F19E1CF14F522B59A /* AppSettings+Preferences.swift in Sources */,
 				2CC3F27CD76DB00A747BEA6C /* AppSettings.swift in Sources */,
 				56C18ACF91DD20463B242460 /* AudioPlaybackSpeed.swift in Sources */,
 				2F2906AE9BC3D0E79A6F98F8 /* Bundle.swift in Sources */,
@@ -8203,6 +8210,7 @@
 				A36AD251013402EDBD666C75 /* AppMediatorMock.swift in Sources */,
 				4BBF6C8E3EFC944B55231B19 /* AppMediatorProtocol.swift in Sources */,
 				355B11D08CE0CEF97A813236 /* AppRoutes.swift in Sources */,
+				AABBA2E550431295639E06FF /* AppSettings+Preferences.swift in Sources */,
 				D304343515CE0464C5089537 /* AppSettings.swift in Sources */,
 				4EAC427267424192964B16B3 /* AppSettingsHook.swift in Sources */,
 				9462C62798F47E39DCC182D2 /* Application.swift in Sources */,

--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -170,7 +170,7 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
         
         registerBackgroundAppRefresh()
         
-        appSettings.$analyticsConsentState
+        appSettings.analyticsConsentStatePublisher
             .dropFirst() // Sentry is configured during init; only reconfigure when consent state actually changes
             .sink { [bugReportService, analyticsService, appSettings] _ in
                 Self.setupSentry(bugReportService: bugReportService, appSettings: appSettings, analytics: analyticsService)
@@ -221,7 +221,7 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
     func toPresentable() -> AnyView {
         AnyView(navigationRootCoordinator.toPresentable()
             .environment(\.analyticsService, analyticsService)
-            .onReceive(appSettings.$appAppearance) { [weak self] appAppearance in
+            .onReceive(appSettings.appAppearancePublisher) { [weak self] appAppearance in
                 guard let self else { return }
                 
                 windowManager.windows.forEach { window in

--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -357,9 +357,7 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
     }
     
     func handleUserActivity(_ userActivity: NSUserActivity) {
-        // `INStartVideoCallIntent` is to be replaced with `INStartCallIntent`
-        // but calls from Recents still send it ¯\_(ツ)_/¯
-        guard let intent = userActivity.interaction?.intent as? INStartVideoCallIntent,
+        guard let intent = userActivity.interaction?.intent as? INStartCallIntent,
               let contact = intent.contacts?.first,
               let roomIdentifier = contact.personHandle?.value else {
             MXLog.error("Failed retrieving information from userActivity: \(userActivity)")
@@ -367,7 +365,7 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationFlowCoordinatorDeleg
         }
         
         MXLog.info("Starting call in room: \(roomIdentifier)")
-        handleAppRoute(AppRoute.call(roomID: roomIdentifier, isVoiceCall: false), windowType: nil)
+        handleAppRoute(AppRoute.call(roomID: roomIdentifier, isVoiceCall: intent.callCapability == .audioCall), windowType: nil)
     }
     
     // MARK: - AuthenticationFlowCoordinatorDelegate

--- a/ElementX/Sources/Application/Application.swift
+++ b/ElementX/Sources/Application/Application.swift
@@ -46,9 +46,7 @@ struct Application: App {
                 .onOpenURL { url in
                     openURL(url, isExternalURL: true)
                 }
-                .onContinueUserActivity("INStartVideoCallIntent") { userActivity in
-                    // `INStartVideoCallIntent` is to be replaced with `INStartCallIntent`
-                    // but calls from Recents still send it ¯\_(ツ)_/¯
+                .onContinueUserActivity("INStartCallIntent") { userActivity in
                     appCoordinator.handleUserActivity(userActivity)
                 }
                 .task {

--- a/ElementX/Sources/Application/Settings/AppSettings.swift
+++ b/ElementX/Sources/Application/Settings/AppSettings.swift
@@ -174,17 +174,14 @@ final nonisolated class AppSettings: @unchecked Sendable {
     /// The last known version of the app that was launched on this device, which is
     /// used to detect when migrations should be run. When `nil` the app may have been
     /// deleted between runs so should clear data in the shared container and keychain.
-    @UserPreference
-    nonisolated(unsafe) var lastVersionLaunched: String?
+    let _lastVersionLaunched: UserPreference<String?>
     
     /// The Set of room identifiers of invites that the user already saw in the invites list.
     /// This Set is being used to implement badges for unread invites.
-    @UserPreference
-    nonisolated(unsafe) var seenInvites: Set<String>
+    let _seenInvites: UserPreference<Set<String>> // sourcery: publisher
     
     /// Defaults to `true` for new users, and we use a migration to set it to `false` for existing users.
-    @UserPreference
-    nonisolated(unsafe) var hasSeenNewSoundBanner: Bool
+    let _hasSeenNewSoundBanner: UserPreference<Bool> // sourcery: publisher
     
     /// The initial set of account providers shown to the user in the authentication flow.
     ///
@@ -228,8 +225,7 @@ final nonisolated class AppSettings: @unchecked Sendable {
     /// **Note:** This property isn't overridable as it in unexpected for forks to come across the error (or to even have a "Pro" app).
     let elementProAppStoreURL: URL = "https://apps.apple.com/app/element-pro-for-work/id6502951615"
     
-    @UserPreference
-    nonisolated(unsafe) var appAppearance: AppAppearance
+    let _appAppearance: UserPreference<AppAppearance> // sourcery: publisher
     
     // MARK: - Security
     
@@ -240,8 +236,7 @@ final nonisolated class AppSettings: @unchecked Sendable {
     /// Any codes that the user isn't allowed to use for their PIN.
     let appLockPINCodeBlockList = ["0000", "1234"]
     /// The number of attempts the user has made to unlock the app with a PIN code (resets when unlocked).
-    @UserPreference
-    nonisolated(unsafe) var appLockNumberOfPINAttempts: Int
+    let _appLockNumberOfPINAttempts: UserPreference<Int> // sourcery: publisher
     
     // MARK: - Authentication
     
@@ -281,34 +276,26 @@ final nonisolated class AppSettings: @unchecked Sendable {
         pushGatewayBaseURL.appending(path: "_matrix/push/v1/notify")
     }
     
-    @UserPreference
-    nonisolated(unsafe) var enableNotifications: Bool
+    let _enableNotifications: UserPreference<Bool> // sourcery: publisher
     
-    @UserPreference
-    nonisolated(unsafe) var enableInAppNotifications: Bool
+    let _enableInAppNotifications: UserPreference<Bool>
     
-    @UserPreference
-    nonisolated(unsafe) var hideQuietNotificationAlerts: Bool
+    let _hideQuietNotificationAlerts: UserPreference<Bool>
     
     /// Tag describing which set of device specific rules a pusher executes.
-    @UserPreference
-    nonisolated(unsafe) var pusherProfileTag: String?
+    let _pusherProfileTag: UserPreference<String?>
     
     /// The device's last boot time as recorded by the NSE.
-    @UserPreference
-    nonisolated(unsafe) var lastNotificationBootTime: TimeInterval?
+    let _lastNotificationBootTime: UserPreference<TimeInterval?>
     
     /// The sound played when delivering noisy notifications. If nil, use the ElementX default
-    @UserPreference
-    nonisolated(unsafe) var selectedNotificationTone: NotificationTone?
+    let _selectedNotificationTone: UserPreference<NotificationTone?> // sourcery: publisher
     
     // MARK: - Logging
     
-    @UserPreference
-    nonisolated(unsafe) var logLevel: LogLevel
+    let _logLevel: UserPreference<LogLevel>
     
-    @UserPreference
-    nonisolated(unsafe) var traceLogPacks: Set<TraceLogPack>
+    let _traceLogPacks: UserPreference<Set<TraceLogPack>>
     
     // MARK: - Bug report
     
@@ -335,47 +322,35 @@ final nonisolated class AppSettings: @unchecked Sendable {
     }
     
     /// Whether the user has opted in to send analytics.
-    @UserPreference
-    nonisolated(unsafe) var analyticsConsentState: AnalyticsConsentState
+    let _analyticsConsentState: UserPreference<AnalyticsConsentState> // sourcery: publisher
     
-    @UserPreference
-    nonisolated(unsafe) var hasRunNotificationPermissionsOnboarding: Bool
+    let _hasRunNotificationPermissionsOnboarding: UserPreference<Bool>
     
-    @UserPreference
-    nonisolated(unsafe) var hasRunIdentityConfirmationOnboarding: Bool
+    let _hasRunIdentityConfirmationOnboarding: UserPreference<Bool>
     
-    @UserPreference
-    nonisolated(unsafe) var hasRequestedLocationAlwaysLocationAuthorization: Bool
+    let _hasRequestedLocationAlwaysLocationAuthorization: UserPreference<Bool>
     
-    @UserPreference
-    nonisolated(unsafe) var frequentlyUsedSystemEmojis: [FrequentlyUsedEmoji]
+    let _frequentlyUsedSystemEmojis: UserPreference<[FrequentlyUsedEmoji]>
     
     // MARK: - Live Location
     
-    @UserPreference
-    nonisolated(unsafe) var liveLocationSharingSessionsByRoomID: [String: LiveLocationSession]
+    let _liveLocationSharingSessionsByRoomID: UserPreference<[String: LiveLocationSession]> // sourcery: publisher
     
-    @UserPreference
-    nonisolated(unsafe) var liveLocationMinimumDistanceUpdate: Int
+    let _liveLocationMinimumDistanceUpdate: UserPreference<Int> // sourcery: publisher
     
-    @UserPreference
-    nonisolated(unsafe) var liveLocationDisclaimerDisplayed: Bool
+    let _liveLocationDisclaimerDisplayed: UserPreference<Bool>
     
     // MARK: - Home Screen
     
-    @UserPreference
-    nonisolated(unsafe) var roomListActivityVisibility: RoomListActivityVisibility
+    let _roomListActivityVisibility: UserPreference<RoomListActivityVisibility> // sourcery: publisher
     
     // MARK: - Room Screen
     
-    @UserPreference
-    nonisolated(unsafe) var viewSourceEnabled: Bool
+    let _viewSourceEnabled: UserPreference<Bool> // sourcery: publisher
     
-    @UserPreference
-    nonisolated(unsafe) var optimizeMediaUploads: Bool
+    let _optimizeMediaUploads: UserPreference<Bool>
     
-    @UserPreference
-    nonisolated(unsafe) var voiceMessagePlaybackSpeed: AudioPlaybackSpeed
+    let _voiceMessagePlaybackSpeed: UserPreference<AudioPlaybackSpeed> // sourcery: publisher
     
     /// Whether or not to show a warning on the media caption composer so the user knows
     /// that captions might not be visible to users who are using other Matrix clients.
@@ -393,8 +368,7 @@ final nonisolated class AppSettings: @unchecked Sendable {
     let elementCallPosthogAPIKey = "phc_rXGHx9vDmyEvyRxPziYtdVIv0ahEv8A9uLWFcCi1WcU"
     let elementCallPosthogSentryDSN = "https://3bd2f95ba5554d4497da7153b552ffb5@sentry.tools.element.io/41"
     
-    @UserPreference
-    nonisolated(unsafe) var elementCallBaseURLOverride: URL?
+    let _elementCallBaseURLOverride: UserPreference<URL?>
     
     // MARK: - Users
     
@@ -416,54 +390,39 @@ final nonisolated class AppSettings: @unchecked Sendable {
     
     // MARK: - Presence
     
-    @UserPreference
-    nonisolated(unsafe) var sharePresence: Bool
+    let _sharePresence: UserPreference<Bool> // sourcery: publisher
     
     // MARK: - Feature Flags
     
     /// Others
-    @UserPreference
-    nonisolated(unsafe) var fuzzyRoomListSearchEnabled: Bool
+    let _fuzzyRoomListSearchEnabled: UserPreference<Bool>
     
-    @UserPreference
-    nonisolated(unsafe) var lowPriorityFilterEnabled: Bool
+    let _lowPriorityFilterEnabled: UserPreference<Bool>
     
     /// Configuration to enable only signed device isolation mode for  crypto. In this mode only devices signed by their owner will be considered in e2ee rooms.
-    @UserPreference
-    nonisolated(unsafe) var enableOnlySignedDeviceIsolationMode: Bool
+    let _enableOnlySignedDeviceIsolationMode: UserPreference<Bool>
     
-    @UserPreference
-    nonisolated(unsafe) var knockingEnabled: Bool
+    let _knockingEnabled: UserPreference<Bool> // sourcery: publisher
     
-    @UserPreference
-    nonisolated(unsafe) var threadsEnabled: Bool
+    let _threadsEnabled: UserPreference<Bool> // sourcery: publisher
     
-    @UserPreference
-    nonisolated(unsafe) var roomThreadListEnabled: Bool
+    let _roomThreadListEnabled: UserPreference<Bool> // sourcery: publisher
     
-    @UserPreference
-    nonisolated(unsafe) var globalSearchEnabled: Bool
+    let _globalSearchEnabled: UserPreference<Bool>
     
-    @UserPreference
-    nonisolated(unsafe) var focusEventOnNotificationTap: Bool
+    let _focusEventOnNotificationTap: UserPreference<Bool>
     
-    @UserPreference
-    nonisolated(unsafe) var linkPreviewsEnabled: Bool
+    let _linkPreviewsEnabled: UserPreference<Bool>
     
-    @UserPreference
-    nonisolated(unsafe) var jumpToReadMarkerEnabled: Bool
+    let _jumpToReadMarkerEnabled: UserPreference<Bool> // sourcery: publisher
     
-    @UserPreference
-    nonisolated(unsafe) var linkNewDeviceEnabled: Bool
+    let _linkNewDeviceEnabled: UserPreference<Bool> // sourcery: publisher
     
-    @UserPreference
-    nonisolated(unsafe) var automaticBackPaginationEnabled: Bool
+    let _automaticBackPaginationEnabled: UserPreference<Bool>
     
-    @UserPreference
-    nonisolated(unsafe) var clientPausingAndResumingEnabled: Bool
+    let _clientPausingAndResumingEnabled: UserPreference<Bool>
     
-    @UserPreference
-    nonisolated(unsafe) var developerOptionsEnabled: Bool
+    let _developerOptionsEnabled: UserPreference<Bool> // sourcery: publisher
     
     init(store: UserDefaultsProtocol) {
         // UserDefaults to be used on reads and writes.

--- a/ElementX/Sources/Application/Settings/UserPreference.swift
+++ b/ElementX/Sources/Application/Settings/UserPreference.swift
@@ -12,6 +12,14 @@ import Foundation
 /// A property wrapper that allows storing data in a keyed storage while also exposing a Combine publisher
 /// to listen for value changes. The publisher does not skip consecutive duplicates, as there is no
 /// `Equatable` enforcement at this level.
+///
+/// Note: `AppSettings` does **not** use the `@UserPreference` attribute. The module defaults to `MainActor`
+/// isolation, so `AppSettings` is `nonisolated`, which forces `nonisolated` onto its stored properties.
+/// A wrapped property is stored as `var`, requiring `nonisolated(unsafe)`, which emits an unsilenceable
+/// "`nonisolated(unsafe)` has no effect" warning on the wrapper's projection. So `AppSettings` instead holds
+/// each preference as a plain `let _foo: UserPreference<T>` and the `foo`/`fooPublisher` accessors are
+/// code-generated (Sourcery) into `AppSettings+Preferences.swift` from the `// sourcery: publisher`
+/// annotations. This type is still a `@propertyWrapper` because the unit tests exercise it as one.
 @propertyWrapper
 final nonisolated class UserPreference<T: Codable> {
     static var remotePrefix: String {

--- a/ElementX/Sources/Generated/AppSettings+Preferences.swift
+++ b/ElementX/Sources/Generated/AppSettings+Preferences.swift
@@ -1,0 +1,237 @@
+// Generated using Sourcery 2.3.0 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+// swiftlint:disable all
+// swiftformat:disable all
+// Generated using Sourcery. DO NOT EDIT.
+
+import Combine
+import Foundation
+
+// Exposes each `_foo: UserPreference<T>` backing as a `foo` value accessor (and, when annotated
+// `// sourcery: publisher`, a `fooPublisher`). Generated rather than hand-written because the
+// declarations can't use the `@UserPreference` property wrapper without emitting a spurious
+// "nonisolated(unsafe) has no effect" warning – see UserPreference.swift.
+nonisolated extension AppSettings {
+    var lastVersionLaunched: String? {
+        get { _lastVersionLaunched.wrappedValue }
+        set { _lastVersionLaunched.wrappedValue = newValue }
+    }
+    var seenInvites: Set<String> {
+        get { _seenInvites.wrappedValue }
+        set { _seenInvites.wrappedValue = newValue }
+    }
+    var seenInvitesPublisher: AnyPublisher<Set<String>, Never> {
+        _seenInvites.projectedValue
+    }
+    var hasSeenNewSoundBanner: Bool {
+        get { _hasSeenNewSoundBanner.wrappedValue }
+        set { _hasSeenNewSoundBanner.wrappedValue = newValue }
+    }
+    var hasSeenNewSoundBannerPublisher: AnyPublisher<Bool, Never> {
+        _hasSeenNewSoundBanner.projectedValue
+    }
+    var appAppearance: AppAppearance {
+        get { _appAppearance.wrappedValue }
+        set { _appAppearance.wrappedValue = newValue }
+    }
+    var appAppearancePublisher: AnyPublisher<AppAppearance, Never> {
+        _appAppearance.projectedValue
+    }
+    var appLockNumberOfPINAttempts: Int {
+        get { _appLockNumberOfPINAttempts.wrappedValue }
+        set { _appLockNumberOfPINAttempts.wrappedValue = newValue }
+    }
+    var appLockNumberOfPINAttemptsPublisher: AnyPublisher<Int, Never> {
+        _appLockNumberOfPINAttempts.projectedValue
+    }
+    var enableNotifications: Bool {
+        get { _enableNotifications.wrappedValue }
+        set { _enableNotifications.wrappedValue = newValue }
+    }
+    var enableNotificationsPublisher: AnyPublisher<Bool, Never> {
+        _enableNotifications.projectedValue
+    }
+    var enableInAppNotifications: Bool {
+        get { _enableInAppNotifications.wrappedValue }
+        set { _enableInAppNotifications.wrappedValue = newValue }
+    }
+    var hideQuietNotificationAlerts: Bool {
+        get { _hideQuietNotificationAlerts.wrappedValue }
+        set { _hideQuietNotificationAlerts.wrappedValue = newValue }
+    }
+    var pusherProfileTag: String? {
+        get { _pusherProfileTag.wrappedValue }
+        set { _pusherProfileTag.wrappedValue = newValue }
+    }
+    var lastNotificationBootTime: TimeInterval? {
+        get { _lastNotificationBootTime.wrappedValue }
+        set { _lastNotificationBootTime.wrappedValue = newValue }
+    }
+    var selectedNotificationTone: NotificationTone? {
+        get { _selectedNotificationTone.wrappedValue }
+        set { _selectedNotificationTone.wrappedValue = newValue }
+    }
+    var selectedNotificationTonePublisher: AnyPublisher<NotificationTone?, Never> {
+        _selectedNotificationTone.projectedValue
+    }
+    var logLevel: LogLevel {
+        get { _logLevel.wrappedValue }
+        set { _logLevel.wrappedValue = newValue }
+    }
+    var traceLogPacks: Set<TraceLogPack> {
+        get { _traceLogPacks.wrappedValue }
+        set { _traceLogPacks.wrappedValue = newValue }
+    }
+    var analyticsConsentState: AnalyticsConsentState {
+        get { _analyticsConsentState.wrappedValue }
+        set { _analyticsConsentState.wrappedValue = newValue }
+    }
+    var analyticsConsentStatePublisher: AnyPublisher<AnalyticsConsentState, Never> {
+        _analyticsConsentState.projectedValue
+    }
+    var hasRunNotificationPermissionsOnboarding: Bool {
+        get { _hasRunNotificationPermissionsOnboarding.wrappedValue }
+        set { _hasRunNotificationPermissionsOnboarding.wrappedValue = newValue }
+    }
+    var hasRunIdentityConfirmationOnboarding: Bool {
+        get { _hasRunIdentityConfirmationOnboarding.wrappedValue }
+        set { _hasRunIdentityConfirmationOnboarding.wrappedValue = newValue }
+    }
+    var hasRequestedLocationAlwaysLocationAuthorization: Bool {
+        get { _hasRequestedLocationAlwaysLocationAuthorization.wrappedValue }
+        set { _hasRequestedLocationAlwaysLocationAuthorization.wrappedValue = newValue }
+    }
+    var frequentlyUsedSystemEmojis: [FrequentlyUsedEmoji] {
+        get { _frequentlyUsedSystemEmojis.wrappedValue }
+        set { _frequentlyUsedSystemEmojis.wrappedValue = newValue }
+    }
+    var liveLocationSharingSessionsByRoomID: [String: LiveLocationSession] {
+        get { _liveLocationSharingSessionsByRoomID.wrappedValue }
+        set { _liveLocationSharingSessionsByRoomID.wrappedValue = newValue }
+    }
+    var liveLocationSharingSessionsByRoomIDPublisher: AnyPublisher<[String: LiveLocationSession], Never> {
+        _liveLocationSharingSessionsByRoomID.projectedValue
+    }
+    var liveLocationMinimumDistanceUpdate: Int {
+        get { _liveLocationMinimumDistanceUpdate.wrappedValue }
+        set { _liveLocationMinimumDistanceUpdate.wrappedValue = newValue }
+    }
+    var liveLocationMinimumDistanceUpdatePublisher: AnyPublisher<Int, Never> {
+        _liveLocationMinimumDistanceUpdate.projectedValue
+    }
+    var liveLocationDisclaimerDisplayed: Bool {
+        get { _liveLocationDisclaimerDisplayed.wrappedValue }
+        set { _liveLocationDisclaimerDisplayed.wrappedValue = newValue }
+    }
+    var roomListActivityVisibility: RoomListActivityVisibility {
+        get { _roomListActivityVisibility.wrappedValue }
+        set { _roomListActivityVisibility.wrappedValue = newValue }
+    }
+    var roomListActivityVisibilityPublisher: AnyPublisher<RoomListActivityVisibility, Never> {
+        _roomListActivityVisibility.projectedValue
+    }
+    var viewSourceEnabled: Bool {
+        get { _viewSourceEnabled.wrappedValue }
+        set { _viewSourceEnabled.wrappedValue = newValue }
+    }
+    var viewSourceEnabledPublisher: AnyPublisher<Bool, Never> {
+        _viewSourceEnabled.projectedValue
+    }
+    var optimizeMediaUploads: Bool {
+        get { _optimizeMediaUploads.wrappedValue }
+        set { _optimizeMediaUploads.wrappedValue = newValue }
+    }
+    var voiceMessagePlaybackSpeed: AudioPlaybackSpeed {
+        get { _voiceMessagePlaybackSpeed.wrappedValue }
+        set { _voiceMessagePlaybackSpeed.wrappedValue = newValue }
+    }
+    var voiceMessagePlaybackSpeedPublisher: AnyPublisher<AudioPlaybackSpeed, Never> {
+        _voiceMessagePlaybackSpeed.projectedValue
+    }
+    var elementCallBaseURLOverride: URL? {
+        get { _elementCallBaseURLOverride.wrappedValue }
+        set { _elementCallBaseURLOverride.wrappedValue = newValue }
+    }
+    var sharePresence: Bool {
+        get { _sharePresence.wrappedValue }
+        set { _sharePresence.wrappedValue = newValue }
+    }
+    var sharePresencePublisher: AnyPublisher<Bool, Never> {
+        _sharePresence.projectedValue
+    }
+    var fuzzyRoomListSearchEnabled: Bool {
+        get { _fuzzyRoomListSearchEnabled.wrappedValue }
+        set { _fuzzyRoomListSearchEnabled.wrappedValue = newValue }
+    }
+    var lowPriorityFilterEnabled: Bool {
+        get { _lowPriorityFilterEnabled.wrappedValue }
+        set { _lowPriorityFilterEnabled.wrappedValue = newValue }
+    }
+    var enableOnlySignedDeviceIsolationMode: Bool {
+        get { _enableOnlySignedDeviceIsolationMode.wrappedValue }
+        set { _enableOnlySignedDeviceIsolationMode.wrappedValue = newValue }
+    }
+    var knockingEnabled: Bool {
+        get { _knockingEnabled.wrappedValue }
+        set { _knockingEnabled.wrappedValue = newValue }
+    }
+    var knockingEnabledPublisher: AnyPublisher<Bool, Never> {
+        _knockingEnabled.projectedValue
+    }
+    var threadsEnabled: Bool {
+        get { _threadsEnabled.wrappedValue }
+        set { _threadsEnabled.wrappedValue = newValue }
+    }
+    var threadsEnabledPublisher: AnyPublisher<Bool, Never> {
+        _threadsEnabled.projectedValue
+    }
+    var roomThreadListEnabled: Bool {
+        get { _roomThreadListEnabled.wrappedValue }
+        set { _roomThreadListEnabled.wrappedValue = newValue }
+    }
+    var roomThreadListEnabledPublisher: AnyPublisher<Bool, Never> {
+        _roomThreadListEnabled.projectedValue
+    }
+    var globalSearchEnabled: Bool {
+        get { _globalSearchEnabled.wrappedValue }
+        set { _globalSearchEnabled.wrappedValue = newValue }
+    }
+    var focusEventOnNotificationTap: Bool {
+        get { _focusEventOnNotificationTap.wrappedValue }
+        set { _focusEventOnNotificationTap.wrappedValue = newValue }
+    }
+    var linkPreviewsEnabled: Bool {
+        get { _linkPreviewsEnabled.wrappedValue }
+        set { _linkPreviewsEnabled.wrappedValue = newValue }
+    }
+    var jumpToReadMarkerEnabled: Bool {
+        get { _jumpToReadMarkerEnabled.wrappedValue }
+        set { _jumpToReadMarkerEnabled.wrappedValue = newValue }
+    }
+    var jumpToReadMarkerEnabledPublisher: AnyPublisher<Bool, Never> {
+        _jumpToReadMarkerEnabled.projectedValue
+    }
+    var linkNewDeviceEnabled: Bool {
+        get { _linkNewDeviceEnabled.wrappedValue }
+        set { _linkNewDeviceEnabled.wrappedValue = newValue }
+    }
+    var linkNewDeviceEnabledPublisher: AnyPublisher<Bool, Never> {
+        _linkNewDeviceEnabled.projectedValue
+    }
+    var automaticBackPaginationEnabled: Bool {
+        get { _automaticBackPaginationEnabled.wrappedValue }
+        set { _automaticBackPaginationEnabled.wrappedValue = newValue }
+    }
+    var clientPausingAndResumingEnabled: Bool {
+        get { _clientPausingAndResumingEnabled.wrappedValue }
+        set { _clientPausingAndResumingEnabled.wrappedValue = newValue }
+    }
+    var developerOptionsEnabled: Bool {
+        get { _developerOptionsEnabled.wrappedValue }
+        set { _developerOptionsEnabled.wrappedValue = newValue }
+    }
+    var developerOptionsEnabledPublisher: AnyPublisher<Bool, Never> {
+        _developerOptionsEnabled.projectedValue
+    }
+}

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -118,21 +118,21 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
             .weakAssign(to: \.state.selectedRoomID, on: self)
             .store(in: &cancellables)
         
-        appSettings.$roomListActivityVisibility
+        appSettings.roomListActivityVisibilityPublisher
             .sink { [weak self] value in
                 self?.state.roomListActivityVisibility = value
                 self?.updateRooms()
             }
             .store(in: &cancellables)
         
-        appSettings.$seenInvites
+        appSettings.seenInvitesPublisher
             .removeDuplicates()
             .sink { [weak self] _ in
                 self?.updateRooms()
             }
             .store(in: &cancellables)
         
-        appSettings.$hasSeenNewSoundBanner
+        appSettings.hasSeenNewSoundBannerPublisher
             .sink { [weak self] hasSeenNewSoundBanner in
                 self?.state.shouldShowNewSoundBanner = !hasSeenNewSoundBanner
             }

--- a/ElementX/Sources/Screens/LocationSharing/LocationSharingScreenViewModel.swift
+++ b/ElementX/Sources/Screens/LocationSharing/LocationSharingScreenViewModel.swift
@@ -173,7 +173,7 @@ class LocationSharingScreenViewModel: LocationSharingScreenViewModelType, Locati
         }
         .store(in: &cancellables)
         
-        appSettings.$liveLocationSharingSessionsByRoomID
+        appSettings.liveLocationSharingSessionsByRoomIDPublisher
             .map { [roomID = roomProxy.id] sessions in sessions[roomID] != nil }
             .removeDuplicates()
             .sink { [weak self] isSharingLiveLocationOnThisDevice in

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarViewModel.swift
@@ -405,7 +405,7 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
         
         repeat { // Don't enumerate and mutate at the same time, big no no
             shouldMakeAnotherPass = false
-            attributedString.enumerateAttribute(.link, in: .init(location: 0, length: attributedString.length), options: []) { @Sendable value, range, stop in
+            attributedString.enumerateAttribute(.link, in: .init(location: 0, length: attributedString.length), options: []) { value, range, stop in
                 guard let value else { return }
                 shouldMakeAnotherPass = true
                 
@@ -429,7 +429,7 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
         
         repeat {
             shouldMakeAnotherPass = false
-            attributedString.enumerateAttribute(.MatrixAllUsersMention, in: .init(location: 0, length: attributedString.length), options: []) { @Sendable value, range, stop in
+            attributedString.enumerateAttribute(.MatrixAllUsersMention, in: .init(location: 0, length: attributedString.length), options: []) { value, range, stop in
                 guard value != nil else { return }
                 
                 shouldMakeAnotherPass = true

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -163,11 +163,11 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
     // MARK: - Private
     
     private func setupSubscriptions(ongoingCallRoomIDPublisher: CurrentValuePublisher<String?, Never>) {
-        appSettings.$roomThreadListEnabled
+        appSettings.roomThreadListEnabledPublisher
             .weakAssign(to: \.state.roomThreadListEnabled, on: self)
             .store(in: &cancellables)
         
-        appSettings.$liveLocationSharingSessionsByRoomID
+        appSettings.liveLocationSharingSessionsByRoomIDPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] sessionsByRoomID in
                 guard let self else { return }

--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenViewModel.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenViewModel.swift
@@ -152,7 +152,7 @@ class SecurityAndPrivacyScreenViewModel: SecurityAndPrivacyScreenViewModelType, 
             .weakAssign(to: \.state.isSpace, on: self)
             .store(in: &cancellables)
         
-        appSettings.$knockingEnabled
+        appSettings.knockingEnabledPublisher
             .weakAssign(to: \.state.isKnockingEnabled, on: self)
             .store(in: &cancellables)
     }

--- a/ElementX/Sources/Screens/Settings/AnalyticsSettingsScreen/AnalyticsSettingsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Settings/AnalyticsSettingsScreen/AnalyticsSettingsScreenViewModel.swift
@@ -23,7 +23,7 @@ class AnalyticsSettingsScreenViewModel: AnalyticsSettingsScreenViewModelType, An
         
         super.init(initialViewState: state)
         
-        appSettings.$analyticsConsentState
+        appSettings.analyticsConsentStatePublisher
             .map { $0 == .optedIn }
             .weakAssign(to: \.state.bindings.enableAnalytics, on: self)
             .store(in: &cancellables)

--- a/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenViewModel.swift
@@ -46,11 +46,11 @@ class NotificationSettingsScreenViewModel: NotificationSettingsScreenViewModelTy
                                                                          availableCustomTones: notificationToneManager.customTones()))
         
         // Listen for changes to AppSettings.
-        appSettings.$enableNotifications
+        appSettings.enableNotificationsPublisher
             .weakAssign(to: \.state.bindings.enableNotifications, on: self)
             .store(in: &cancellables)
         
-        appSettings.$selectedNotificationTone
+        appSettings.selectedNotificationTonePublisher
             .map { $0 ?? NotificationToneManager.defaultElementXMessageTone }
             .weakAssign(to: \.state.selectedAlertTone, on: self)
             .store(in: &cancellables)

--- a/ElementX/Sources/Screens/Settings/SettingsScreen/SettingsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Settings/SettingsScreen/SettingsScreenViewModel.swift
@@ -33,11 +33,11 @@ class SettingsScreenViewModel: SettingsScreenViewModelType, SettingsScreenViewMo
                                            navigationBarVisibility: isInSecondaryWindow ? .hidden : .automatic),
                    mediaProvider: userSession.mediaProvider)
         
-        appSettings.$developerOptionsEnabled
+        appSettings.developerOptionsEnabledPublisher
             .weakAssign(to: \.state.showDeveloperOptions, on: self)
             .store(in: &cancellables)
         
-        appSettings.$linkNewDeviceEnabled
+        appSettings.linkNewDeviceEnabledPublisher
             .weakAssign(to: \.state.showLinkNewDeviceButton, on: self)
             .store(in: &cancellables)
         

--- a/ElementX/Sources/Screens/Timeline/TimelineInteractionHandler.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineInteractionHandler.swift
@@ -508,7 +508,7 @@ class TimelineInteractionHandler {
                                            duration: voiceMessageRoomTimelineItem.content.duration,
                                            waveform: voiceMessageRoomTimelineItem.content.waveform,
                                            playbackSpeed: appSettings.voiceMessagePlaybackSpeed,
-                                           playbackSpeedPublisher: appSettings.$voiceMessagePlaybackSpeed)
+                                           playbackSpeedPublisher: appSettings.voiceMessagePlaybackSpeedPublisher)
         mediaPlayerProvider.register(audioPlayerState: playerState)
         return playerState
     }

--- a/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
@@ -556,19 +556,19 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
     }
     
     private func setupAppSettingsSubscriptions() {
-        appSettings.$sharePresence
+        appSettings.sharePresencePublisher
             .weakAssign(to: \.state.showReadReceipts, on: self)
             .store(in: &cancellables)
         
-        appSettings.$viewSourceEnabled
+        appSettings.viewSourceEnabledPublisher
             .weakAssign(to: \.state.isViewSourceEnabled, on: self)
             .store(in: &cancellables)
         
-        appSettings.$threadsEnabled
+        appSettings.threadsEnabledPublisher
             .weakAssign(to: \.state.areThreadsEnabled, on: self)
             .store(in: &cancellables)
         
-        appSettings.$jumpToReadMarkerEnabled
+        appSettings.jumpToReadMarkerEnabledPublisher
             .weakAssign(to: \.state.jumpToReadMarkerEnabled, on: self)
             .store(in: &cancellables)
         

--- a/ElementX/Sources/Services/Analytics/PHGPostHogConfiguration.swift
+++ b/ElementX/Sources/Services/Analytics/PHGPostHogConfiguration.swift
@@ -10,7 +10,7 @@ import PostHog
 
 extension PostHogConfig {
     static func standard(analyticsConfiguration: AnalyticsConfiguration) -> PostHogConfig? {
-        let postHogConfiguration = PostHogConfig(apiKey: analyticsConfiguration.apiKey, host: analyticsConfiguration.host)
+        let postHogConfiguration = PostHogConfig(projectToken: analyticsConfiguration.apiKey, host: analyticsConfiguration.host)
         // We capture screens manually
         postHogConfiguration.captureScreenViews = false
         postHogConfiguration.surveys = false

--- a/ElementX/Sources/Services/AppLock/AppLockService.swift
+++ b/ElementX/Sources/Services/AppLock/AppLockService.swift
@@ -54,7 +54,7 @@ class AppLockService: AppLockServiceProtocol {
     }
     
     var numberOfPINAttempts: AnyPublisher<Int, Never> {
-        appSettings.$appLockNumberOfPINAttempts
+        appSettings.appLockNumberOfPINAttemptsPublisher
     }
     
     init(keychainController: KeychainControllerProtocol, appSettings: AppSettings, context: LAContext = .init()) {

--- a/ElementX/Sources/Services/Location/LiveLocationManager.swift
+++ b/ElementX/Sources/Services/Location/LiveLocationManager.swift
@@ -183,7 +183,7 @@ class LiveLocationManager: NSObject, LiveLocationManagerProtocol, CLLocationMana
             }
             .store(in: &cancellables)
         
-        appSettings.$liveLocationSharingSessionsByRoomID
+        appSettings.liveLocationSharingSessionsByRoomIDPublisher
             .removeDuplicates()
             .sink { [weak self] sessions in
                 guard let self else { return }
@@ -197,7 +197,7 @@ class LiveLocationManager: NSObject, LiveLocationManagerProtocol, CLLocationMana
             }
             .store(in: &cancellables)
         
-        appSettings.$liveLocationMinimumDistanceUpdate
+        appSettings.liveLocationMinimumDistanceUpdatePublisher
             .removeDuplicates()
             .debounce(for: .seconds(1), scheduler: DispatchQueue.main)
             .sink { [weak self] newValue in

--- a/ElementX/Sources/Services/Notification/Manager/NotificationManager.swift
+++ b/ElementX/Sources/Services/Notification/Manager/NotificationManager.swift
@@ -51,7 +51,7 @@ final class NotificationManager: NSObject, NotificationManagerProtocol {
         MXLog.info("App setting 'enableNotifications' is '\(notificationsEnabled)'")
         
         // Listen for changes to AppSettings.enableNotifications
-        appSettings.$enableNotifications
+        appSettings.enableNotificationsPublisher
             .sink { [weak self] newValue in
                 self?.enableNotifications(newValue)
             }

--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -170,6 +170,7 @@ targets:
         export PATH="$PATH:/opt/homebrew/bin"
         if which sourcery >/dev/null; then
             sourcery --config Tools/Sourcery/AutoMockableConfig.yml
+            sourcery --config Tools/Sourcery/AppSettingsPreferencesConfig.yml
         else
             echo "warning: Sourcery not installed, run swift run tools setup-project"
         fi

--- a/NSE/SupportingFiles/target.yml
+++ b/NSE/SupportingFiles/target.yml
@@ -88,6 +88,7 @@ targets:
     - path: ../../ElementX/Sources/AppHooks/Hooks/RemoteSettingsHook.swift
     - path: ../../Secrets/Secrets.swift
     - path: ../../ElementX/Sources/Application/Settings
+    - path: ../../ElementX/Sources/Generated/AppSettings+Preferences.swift
     - path: ../../ElementX/Sources/Application/TargetConfiguration.swift
     - path: ../../ElementX/Sources/Generated/Strings.swift
     - path: ../../ElementX/Sources/Other/Avatars.swift

--- a/ShareExtension/SupportingFiles/target.yml
+++ b/ShareExtension/SupportingFiles/target.yml
@@ -88,6 +88,7 @@ targets:
     - path: ../../ElementX/Sources/AppHooks/Hooks/RemoteSettingsHook.swift
     - path: ../../Secrets/Secrets.swift
     - path: ../../ElementX/Sources/Application/Settings
+    - path: ../../ElementX/Sources/Generated/AppSettings+Preferences.swift
     - path: ../../ElementX/Sources/Application/TargetConfiguration.swift
     - path: ../../ElementX/Sources/Services/AlertTones/NotificationTone.swift
     - path: ../../ElementX/Sources/Services/Keychain/KeychainController.swift

--- a/Tools/Sourcery/AppSettingsPreferences.stencil
+++ b/Tools/Sourcery/AppSettingsPreferences.stencil
@@ -1,0 +1,26 @@
+// swiftlint:disable all
+// swiftformat:disable all
+// Generated using Sourcery. DO NOT EDIT.
+
+import Combine
+import Foundation
+
+// Exposes each `_foo: UserPreference<T>` backing as a `foo` value accessor (and, when annotated
+// `// sourcery: publisher`, a `fooPublisher`). Generated rather than hand-written because the
+// declarations can't use the `@UserPreference` property wrapper without emitting a spurious
+// "nonisolated(unsafe) has no effect" warning – see UserPreference.swift.
+nonisolated extension AppSettings {
+{% for type in types.all where type.name == "AppSettings" %}
+{% for variable in type.instanceVariables where variable.typeName.name|hasPrefix:"UserPreference<" %}
+    var {{ variable.name|replace:"_","" }}: {{ variable.typeName.generic.typeParameters.first.typeName.name }} {
+        get { {{ variable.name }}.wrappedValue }
+        set { {{ variable.name }}.wrappedValue = newValue }
+    }
+{% if variable.annotations.publisher %}
+    var {{ variable.name|replace:"_","" }}Publisher: AnyPublisher<{{ variable.typeName.generic.typeParameters.first.typeName.name }}, Never> {
+        {{ variable.name }}.projectedValue
+    }
+{% endif %}
+{% endfor %}
+{% endfor %}
+}

--- a/Tools/Sourcery/AppSettingsPreferencesConfig.yml
+++ b/Tools/Sourcery/AppSettingsPreferencesConfig.yml
@@ -1,0 +1,7 @@
+sources:
+  include:
+    - ../../ElementX/Sources/Application/Settings/AppSettings.swift
+templates:
+  - AppSettingsPreferences.stencil
+output:
+  ../../ElementX/Sources/Generated/AppSettings+Preferences.swift

--- a/UnitTests/Sources/LiveLocationManagerTests.swift
+++ b/UnitTests/Sources/LiveLocationManagerTests.swift
@@ -190,7 +190,7 @@ final class LiveLocationManagerTests {
         try await simulateBeaconEcho(roomID: "!room:matrix.org", eventID: "$event:matrix.org")
         #expect(appSettings.liveLocationSharingSessionsByRoomID["!room:matrix.org"] != nil)
         
-        let deferred = deferFulfillment(appSettings.$liveLocationSharingSessionsByRoomID) { $0["!room:matrix.org"] == nil }
+        let deferred = deferFulfillment(appSettings.liveLocationSharingSessionsByRoomIDPublisher) { $0["!room:matrix.org"] == nil }
         beaconInfoSubject.send(LiveLocationOwnInfoUpdate(roomID: "!room:matrix.org", eventID: "$external_event:matrix.org", isLive: true))
         try await deferred.fulfill()
         
@@ -237,7 +237,7 @@ final class LiveLocationManagerTests {
     }
     
     private func simulateBeaconEcho(roomID: String, eventID: String) async throws {
-        let deferred = deferFulfillment(appSettings.$liveLocationSharingSessionsByRoomID) { $0[roomID] != nil }
+        let deferred = deferFulfillment(appSettings.liveLocationSharingSessionsByRoomIDPublisher) { $0[roomID] != nil }
         beaconInfoSubject.send(LiveLocationOwnInfoUpdate(roomID: roomID, eventID: eventID, isLive: true))
         try await deferred.fulfill()
     }


### PR DESCRIPTION
Problem
After the Swift 6 / strict concurrency / default-MainActor-isolation migration, AppSettings emits 41 "'nonisolated(unsafe)' has no effect on property" warnings. AppSettings must be `nonisolated` (it's read/written off the main actor by the NSE, background work, etc.), which forces `nonisolated` onto its stored properties. A `@UserPreference`-wrapped property is stored as a `var`, so it requires `nonisolated(unsafe)`, and the compiler then warns that the modifier has no effect on the wrapper's computed projection. The warning has no diagnostic group, so it can't be suppressed in place.

What we tried
- Dropping the annotation / using plain `nonisolated`: build error, the backing is a mutable stored property.
- Making AppSettings MainActor-isolated: warnings persist (they're about the projection, not isolation) and it breaks all off-main access.
- Per-file `-default-isolation nonisolated` / `-suppress-warnings` via XcodeGen compilerFlags: Xcode strips these (they're managed by build settings), so they never reach the compiler.
- A `@dynamicMemberLookup` facade over a Preferences holder: can't satisfy protocol requirements, and AppSettings conforms to four settings protocols (Common/Developer/Advanced/Labs) whose union needs 24 of the 41 preferences as real members - so it removed almost no boilerplate.

Solution
Drop the property wrapper. Each preference is now a plain `let _foo: UserPreference<T>`, and the `foo` value accessor (plus a `fooPublisher` for the ones annotated `// sourcery: publisher`) is code-generated by Sourcery into AppSettings+Preferences.swift. The generated accessors are plain computed properties, so there's no `nonisolated(unsafe)` and no warning, and they're real members so they still satisfy the four protocols.

Cost
`appSettings.$foo` is property-wrapper-only syntax that can't be generated, so the 23 publisher call sites now use `appSettings.fooPublisher`. All value usages are unchanged.

### Pull Request Checklist

- [ ] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [ ] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [ ] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
