### PR TITLE
Fix media loading failures when retrying with a closed store

### DIFF
--- a/ElementX/Sources/FlowCoordinators/AuthenticationFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/AuthenticationFlowCoordinator.swift
@@ -275,7 +275,7 @@ class AuthenticationFlowCoordinator: FlowCoordinatorProtocol {
         let mediaProvider = authenticationService.classicAppAccount.map { account in
             MediaProvider(mediaLoader: ClassicAppMediaLoader(classicAppAccount: account),
                           imageCache: .onlyInMemory,
-                          homeserverReachabilityPublisher: appMediator.networkMonitor.reachabilityPublisher) // Close enough approximation
+                          homeserverReachabilityPublisher: appMediator.networkMonitor.reachabilityPublisher.map(HomeserverReachability.init)) // Close enough approximation
         }
         
         let parameters = AuthenticationStartScreenParameters(authenticationService: authenticationService,

--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -285,7 +285,7 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
             .store(in: &cancellables)
         
         let reachabilityNotificationID = "io.element.elementx.reachability.notification"
-        userSession.clientProxy.homeserverConnectivityPublisher.removeDuplicates()
+        userSession.clientProxy.homeserverReachabilityPublisher.removeDuplicates()
             .combineLatest(flowParameters.appMediator.networkMonitor.reachabilityPublisher.removeDuplicates())
             .receive(on: DispatchQueue.main)
             .sink { [weak self] homeserverReachability, networkReachability in
@@ -293,16 +293,17 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
                 
                 guard let self else { return }
                 switch (networkReachability, homeserverReachability) {
-                case (.reachable, .reachable):
-                    flowParameters.userIndicatorController.retractIndicatorWithId(reachabilityNotificationID)
-                case (.reachable, .unreachable):
-                    flowParameters.userIndicatorController.submitIndicator(.init(id: reachabilityNotificationID,
-                                                                                 title: L10n.commonServerUnreachable,
-                                                                                 persistent: true))
                 case (.unreachable, _):
                     flowParameters.userIndicatorController.submitIndicator(.init(id: reachabilityNotificationID,
                                                                                  title: L10n.commonOffline,
                                                                                  persistent: true))
+                case (.reachable, .unreachable):
+                    flowParameters.userIndicatorController.submitIndicator(.init(id: reachabilityNotificationID,
+                                                                                 title: L10n.commonServerUnreachable,
+                                                                                 persistent: true))
+                // Don't alarm the user while we've intentionally suspended the client.
+                case (.reachable, .reachable), (.reachable, .suspended):
+                    flowParameters.userIndicatorController.retractIndicatorWithId(reachabilityNotificationID)
                 }
             }
             .store(in: &cancellables)

--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -285,7 +285,7 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
             .store(in: &cancellables)
         
         let reachabilityNotificationID = "io.element.elementx.reachability.notification"
-        userSession.clientProxy.homeserverReachabilityPublisher.removeDuplicates()
+        userSession.clientProxy.homeserverConnectivityPublisher.removeDuplicates()
             .combineLatest(flowParameters.appMediator.networkMonitor.reachabilityPublisher.removeDuplicates())
             .receive(on: DispatchQueue.main)
             .sink { [weak self] homeserverReachability, networkReachability in

--- a/ElementX/Sources/Mocks/ClientProxyMock.swift
+++ b/ElementX/Sources/Mocks/ClientProxyMock.swift
@@ -63,6 +63,7 @@ extension ClientProxyMock {
         loadingStatePublisher = .init(.notLoading)
         verificationStatePublisher = .init(.unknown)
         homeserverReachabilityPublisher = .init(.reachable)
+        homeserverConnectivityPublisher = .init(.reachable)
         
         userAvatarURLPublisher = .init(nil)
         userDisplayNamePublisher = .init("User display name")

--- a/ElementX/Sources/Mocks/ClientProxyMock.swift
+++ b/ElementX/Sources/Mocks/ClientProxyMock.swift
@@ -63,7 +63,6 @@ extension ClientProxyMock {
         loadingStatePublisher = .init(.notLoading)
         verificationStatePublisher = .init(.unknown)
         homeserverReachabilityPublisher = .init(.reachable)
-        homeserverConnectivityPublisher = .init(.reachable)
         
         userAvatarURLPublisher = .init(nil)
         userDisplayNamePublisher = .init("User display name")

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -2227,16 +2227,11 @@ nonisolated class ClientProxyMock: ClientProxyProtocol, @unchecked Sendable {
         set(value) { underlyingVerificationStatePublisher = value }
     }
     nonisolated(unsafe) var underlyingVerificationStatePublisher: CurrentValuePublisher<SessionVerificationState, Never>!
-    var homeserverReachabilityPublisher: CurrentValuePublisher<NetworkMonitorReachability, Never> {
+    var homeserverReachabilityPublisher: CurrentValuePublisher<HomeserverReachability, Never> {
         get { return underlyingHomeserverReachabilityPublisher }
         set(value) { underlyingHomeserverReachabilityPublisher = value }
     }
-    nonisolated(unsafe) var underlyingHomeserverReachabilityPublisher: CurrentValuePublisher<NetworkMonitorReachability, Never>!
-    var homeserverConnectivityPublisher: CurrentValuePublisher<NetworkMonitorReachability, Never> {
-        get { return underlyingHomeserverConnectivityPublisher }
-        set(value) { underlyingHomeserverConnectivityPublisher = value }
-    }
-    nonisolated(unsafe) var underlyingHomeserverConnectivityPublisher: CurrentValuePublisher<NetworkMonitorReachability, Never>!
+    nonisolated(unsafe) var underlyingHomeserverReachabilityPublisher: CurrentValuePublisher<HomeserverReachability, Never>!
     var userID: String {
         get { return underlyingUserID }
         set(value) { underlyingUserID = value }

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -2232,6 +2232,11 @@ nonisolated class ClientProxyMock: ClientProxyProtocol, @unchecked Sendable {
         set(value) { underlyingHomeserverReachabilityPublisher = value }
     }
     nonisolated(unsafe) var underlyingHomeserverReachabilityPublisher: CurrentValuePublisher<NetworkMonitorReachability, Never>!
+    var homeserverConnectivityPublisher: CurrentValuePublisher<NetworkMonitorReachability, Never> {
+        get { return underlyingHomeserverConnectivityPublisher }
+        set(value) { underlyingHomeserverConnectivityPublisher = value }
+    }
+    nonisolated(unsafe) var underlyingHomeserverConnectivityPublisher: CurrentValuePublisher<NetworkMonitorReachability, Never>!
     var userID: String {
         get { return underlyingUserID }
         set(value) { underlyingUserID = value }

--- a/ElementX/Sources/Other/CurrentValuePublisher.swift
+++ b/ElementX/Sources/Other/CurrentValuePublisher.swift
@@ -14,9 +14,12 @@ import Combine
 /// `CurrentValueSubject` is documented as thread-safe but is not formally `Sendable`, hence `@unchecked`.
 nonisolated struct CurrentValuePublisher<Output, Failure: Error>: Publisher, @unchecked Sendable {
     private let subject: CurrentValueSubject<Output, Failure>
+    /// Retains the upstream subscription feeding ``subject`` when this publisher is derived via ``map(_:)``.
+    private let cancellable: AnyCancellable?
     
-    init(_ subject: CurrentValueSubject<Output, Failure>) {
+    init(_ subject: CurrentValueSubject<Output, Failure>, cancellable: AnyCancellable? = nil) {
         self.subject = subject
+        self.cancellable = cancellable
     }
     
     init(_ value: Output) {
@@ -29,6 +32,14 @@ nonisolated struct CurrentValuePublisher<Output, Failure: Error>: Publisher, @un
     
     var value: Output {
         subject.value
+    }
+}
+
+nonisolated extension CurrentValuePublisher where Failure == Never {
+    func map<T>(_ transform: @escaping (Output) -> T) -> CurrentValuePublisher<T, Never> {
+        let subject = CurrentValueSubject<T, Never>(transform(value))
+        let cancellable = sink { subject.send(transform($0)) }
+        return .init(subject, cancellable: cancellable)
     }
 }
 

--- a/ElementX/Sources/Other/NetworkMonitor/NetworkMonitorProtocol.swift
+++ b/ElementX/Sources/Other/NetworkMonitor/NetworkMonitorProtocol.swift
@@ -13,6 +13,19 @@ enum NetworkMonitorReachability {
     case unreachable
 }
 
+enum HomeserverReachability {
+    /// The store is open and the homeserver is reachable.
+    case reachable
+    /// The homeserver can't be reached even though we're trying to sync (i.e. offline).
+    case unreachable
+    /// The client is suspended, so the store is closed and we're not trying to reach the homeserver.
+    case suspended
+    
+    init(_ reachability: NetworkMonitorReachability) {
+        self = reachability == .reachable ? .reachable : .unreachable
+    }
+}
+
 protocol NetworkMonitorProtocol {
     var reachabilityPublisher: CurrentValuePublisher<NetworkMonitorReachability, Never> { get }
 }

--- a/ElementX/Sources/Screens/SecureBackup/SecureBackupLogoutConfirmationScreen/SecureBackupLogoutConfirmationScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/SecureBackup/SecureBackupLogoutConfirmationScreen/SecureBackupLogoutConfirmationScreenCoordinator.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 struct SecureBackupLogoutConfirmationScreenCoordinatorParameters {
     let secureBackupController: SecureBackupControllerProtocol
-    let homeserverReachabilityPublisher: CurrentValuePublisher<NetworkMonitorReachability, Never>
+    let homeserverReachabilityPublisher: CurrentValuePublisher<HomeserverReachability, Never>
 }
 
 enum SecureBackupLogoutConfirmationScreenCoordinatorAction {

--- a/ElementX/Sources/Screens/SecureBackup/SecureBackupLogoutConfirmationScreen/SecureBackupLogoutConfirmationScreenViewModel.swift
+++ b/ElementX/Sources/Screens/SecureBackup/SecureBackupLogoutConfirmationScreen/SecureBackupLogoutConfirmationScreenViewModel.swift
@@ -13,7 +13,7 @@ typealias SecureBackupLogoutConfirmationScreenViewModelType = StateStoreViewMode
 
 class SecureBackupLogoutConfirmationScreenViewModel: SecureBackupLogoutConfirmationScreenViewModelType, SecureBackupLogoutConfirmationScreenViewModelProtocol {
     private let secureBackupController: SecureBackupControllerProtocol
-    private let homeserverReachabilityPublisher: CurrentValuePublisher<NetworkMonitorReachability, Never>
+    private let homeserverReachabilityPublisher: CurrentValuePublisher<HomeserverReachability, Never>
     
     private let backupUploadStateSubject: CurrentValueSubject<SecureBackupSteadyState, Never> = .init(.waiting)
     
@@ -28,7 +28,7 @@ class SecureBackupLogoutConfirmationScreenViewModel: SecureBackupLogoutConfirmat
         actionsSubject.eraseToAnyPublisher()
     }
     
-    init(secureBackupController: SecureBackupControllerProtocol, homeserverReachabilityPublisher: CurrentValuePublisher<NetworkMonitorReachability, Never>) {
+    init(secureBackupController: SecureBackupControllerProtocol, homeserverReachabilityPublisher: CurrentValuePublisher<HomeserverReachability, Never>) {
         self.secureBackupController = secureBackupController
         self.homeserverReachabilityPublisher = homeserverReachabilityPublisher
         
@@ -90,7 +90,7 @@ class SecureBackupLogoutConfirmationScreenViewModel: SecureBackupLogoutConfirmat
         }
     }
     
-    private func updateMode(backupState: SecureBackupSteadyState, reachability: NetworkMonitorReachability) {
+    private func updateMode(backupState: SecureBackupSteadyState, reachability: HomeserverReachability) {
         switch (backupState, reachability) {
         case (.waiting, .reachable):
             state.mode = .waitingToStart(hasStalled: false)
@@ -101,7 +101,7 @@ class SecureBackupLogoutConfirmationScreenViewModel: SecureBackupLogoutConfirmat
             break // Nothing to do here, it will be handled with the result.
         case (.done, .reachable):
             state.mode = .backupOngoing(progress: 1.0)
-        case (_, .unreachable):
+        case (_, .unreachable), (_, .suspended):
             state.mode = .offline
         }
     }

--- a/ElementX/Sources/Screens/SecureBackup/SecureBackupLogoutConfirmationScreen/View/SecureBackupLogoutConfirmationScreen.swift
+++ b/ElementX/Sources/Screens/SecureBackup/SecureBackupLogoutConfirmationScreen/View/SecureBackupLogoutConfirmationScreen.swift
@@ -160,7 +160,7 @@ struct SecureBackupLogoutConfirmationScreen_Previews: PreviewProvider, TestableP
             return .success(())
         }
         
-        let reachability: NetworkMonitorReachability = mode == .offline ? .unreachable : .reachable
+        let reachability: HomeserverReachability = mode == .offline ? .unreachable : .reachable
         
         let viewModel = SecureBackupLogoutConfirmationScreenViewModel(secureBackupController: secureBackupController,
                                                                       homeserverReachabilityPublisher: .init(reachability))

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -1100,6 +1100,8 @@ class ClientProxy: ClientProxyProtocol {
             MXLog.info("Starting sync")
             await syncService.start()
             
+            updateHomeserverReachability()
+            
             // If we are using OAuth we want to cache the account management URL in volatile memory on the SDK side.
             // To avoid the cache being invalidated while the app is backgrounded, we cache at every sync start.
             await cacheAccountURL()
@@ -1108,6 +1110,8 @@ class ClientProxy: ClientProxyProtocol {
             // emit, and the SDK only re-enables queues when client.resume() runs (gated behind the flag).
             sendQueueStatusSubject.send(sendQueueStatusSubject.value)
         case .suspended:
+            updateHomeserverReachability()
+            
             MXLog.info("Stopping sync")
             await syncService.stop()
             MXLog.info("Sync stopped")
@@ -1175,21 +1179,34 @@ class ClientProxy: ClientProxyProtocol {
         }
     }
     
+    /// The latest state reported by the sync service. Stored so reachability can be recomputed after a
+    /// resume, where the store reopens but the service may not emit a fresh state.
+    private var syncServiceState: SyncServiceState?
+    
     private func createSyncServiceStateObserver(_ syncService: SyncService) -> TaskHandle {
         syncService.state(listener: SDKListener.onMainActor { [weak self] state in
             guard let self else { return }
             
             MXLog.info("Received sync service update: \(state)")
             
-            switch state {
-            case .running, .terminated, .idle:
-                homeserverReachabilitySubject.send(.reachable)
-            case .offline:
-                homeserverReachabilitySubject.send(.unreachable)
-            case .error:
+            syncServiceState = state
+            
+            if case .error = state {
                 restartServices()
+            } else {
+                updateHomeserverReachability()
             }
         })
+    }
+    
+    private func updateHomeserverReachability() {
+        let reachability: NetworkMonitorReachability = if desiredServiceState == .running, syncServiceState != .offline {
+            .reachable
+        } else {
+            .unreachable
+        }
+        
+        homeserverReachabilitySubject.send(reachability)
     }
     
     private func createMediaPreviewConfigObserver() async -> TaskHandle? {

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -180,19 +180,9 @@ class ClientProxy: ClientProxyProtocol {
         verificationStateSubject.asCurrentValuePublisher()
     }
     
-    /// Reports unreachable while suspended (the store is closed) as well as when offline. Use this to gate
-    /// work that needs an open store, such as media loading.
-    private let homeserverReachabilitySubject = CurrentValueSubject<NetworkMonitorReachability, Never>(.reachable)
-    var homeserverReachabilityPublisher: CurrentValuePublisher<NetworkMonitorReachability, Never> {
+    private let homeserverReachabilitySubject = CurrentValueSubject<HomeserverReachability, Never>(.reachable)
+    var homeserverReachabilityPublisher: CurrentValuePublisher<HomeserverReachability, Never> {
         homeserverReachabilitySubject.asCurrentValuePublisher()
-    }
-    
-    /// The homeserver's reachability derived from the sync service alone, i.e. it stays reachable while the
-    /// client is suspended. Use this for user-facing messaging so we don't claim the server is unreachable
-    /// when we've simply paused syncing.
-    private let homeserverConnectivitySubject = CurrentValueSubject<NetworkMonitorReachability, Never>(.reachable)
-    var homeserverConnectivityPublisher: CurrentValuePublisher<NetworkMonitorReachability, Never> {
-        homeserverConnectivitySubject.asCurrentValuePublisher()
     }
     
     private let timelineMediaVisibilitySubject = CurrentValueSubject<TimelineMediaVisibility, Never>(.always)
@@ -1210,12 +1200,12 @@ class ClientProxy: ClientProxyProtocol {
     }
     
     private func updateHomeserverReachability() {
-        homeserverConnectivitySubject.send(syncServiceState == .offline ? .unreachable : .reachable)
-        
-        let reachability: NetworkMonitorReachability = if desiredServiceState == .running, syncServiceState != .offline {
-            .reachable
-        } else {
+        let reachability: HomeserverReachability = if desiredServiceState != .running {
+            .suspended
+        } else if syncServiceState == .offline {
             .unreachable
+        } else {
+            .reachable
         }
         
         homeserverReachabilitySubject.send(reachability)

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -180,9 +180,19 @@ class ClientProxy: ClientProxyProtocol {
         verificationStateSubject.asCurrentValuePublisher()
     }
     
+    /// Reports unreachable while suspended (the store is closed) as well as when offline. Use this to gate
+    /// work that needs an open store, such as media loading.
     private let homeserverReachabilitySubject = CurrentValueSubject<NetworkMonitorReachability, Never>(.reachable)
     var homeserverReachabilityPublisher: CurrentValuePublisher<NetworkMonitorReachability, Never> {
         homeserverReachabilitySubject.asCurrentValuePublisher()
+    }
+    
+    /// The homeserver's reachability derived from the sync service alone, i.e. it stays reachable while the
+    /// client is suspended. Use this for user-facing messaging so we don't claim the server is unreachable
+    /// when we've simply paused syncing.
+    private let homeserverConnectivitySubject = CurrentValueSubject<NetworkMonitorReachability, Never>(.reachable)
+    var homeserverConnectivityPublisher: CurrentValuePublisher<NetworkMonitorReachability, Never> {
+        homeserverConnectivitySubject.asCurrentValuePublisher()
     }
     
     private let timelineMediaVisibilitySubject = CurrentValueSubject<TimelineMediaVisibility, Never>(.always)
@@ -1200,6 +1210,8 @@ class ClientProxy: ClientProxyProtocol {
     }
     
     private func updateHomeserverReachability() {
+        homeserverConnectivitySubject.send(syncServiceState == .offline ? .unreachable : .reachable)
+        
         let reachability: NetworkMonitorReachability = if desiredServiceState == .running, syncServiceState != .offline {
             .reachable
         } else {

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -110,6 +110,8 @@ protocol ClientProxyProtocol: AnyObject {
     
     var homeserverReachabilityPublisher: CurrentValuePublisher<NetworkMonitorReachability, Never> { get }
     
+    var homeserverConnectivityPublisher: CurrentValuePublisher<NetworkMonitorReachability, Never> { get }
+    
     var userID: String { get }
     
     var deviceID: String? { get }

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -108,9 +108,7 @@ protocol ClientProxyProtocol: AnyObject {
     
     var verificationStatePublisher: CurrentValuePublisher<SessionVerificationState, Never> { get }
     
-    var homeserverReachabilityPublisher: CurrentValuePublisher<NetworkMonitorReachability, Never> { get }
-    
-    var homeserverConnectivityPublisher: CurrentValuePublisher<NetworkMonitorReachability, Never> { get }
+    var homeserverReachabilityPublisher: CurrentValuePublisher<HomeserverReachability, Never> { get }
     
     var userID: String { get }
     

--- a/ElementX/Sources/Services/Media/Provider/MediaProvider.swift
+++ b/ElementX/Sources/Services/Media/Provider/MediaProvider.swift
@@ -13,11 +13,11 @@ import UIKit
 nonisolated struct MediaProvider: MediaProviderProtocol {
     private let mediaLoader: MediaLoaderProtocol
     private let imageCache: Kingfisher.ImageCache
-    private let homeserverReachabilityPublisher: CurrentValuePublisher<NetworkMonitorReachability, Never>?
+    private let homeserverReachabilityPublisher: CurrentValuePublisher<HomeserverReachability, Never>?
     
     init(mediaLoader: MediaLoaderProtocol,
          imageCache: Kingfisher.ImageCache,
-         homeserverReachabilityPublisher: CurrentValuePublisher<NetworkMonitorReachability, Never>?) {
+         homeserverReachabilityPublisher: CurrentValuePublisher<HomeserverReachability, Never>?) {
         self.mediaLoader = mediaLoader
         self.imageCache = imageCache
         self.homeserverReachabilityPublisher = homeserverReachabilityPublisher

--- a/UnitTests/Sources/MediaProvider/MediaProviderTests.swift
+++ b/UnitTests/Sources/MediaProvider/MediaProviderTests.swift
@@ -16,7 +16,7 @@ import Testing
 struct MediaProviderTests {
     private var mediaLoader: MediaLoaderMock
     private var imageCache: MockImageCache
-    private var reachabilitySubject = CurrentValueSubject<NetworkMonitorReachability, Never>(.reachable)
+    private var reachabilitySubject = CurrentValueSubject<HomeserverReachability, Never>(.reachable)
     
     var mediaProvider: MediaProvider!
     
@@ -40,7 +40,7 @@ struct MediaProviderTests {
         
         mediaLoader.loadMediaContentForSourceClosure = { [reachabilitySubject] _ in
             switch reachabilitySubject.value {
-            case .unreachable:
+            case .unreachable, .suspended:
                 reachabilitySubject.send(.reachable)
                 throw MediaProviderTestsError.error
             case .reachable:

--- a/UnitTests/Sources/SecureBackupLogoutConfirmationScreenViewModelTests.swift
+++ b/UnitTests/Sources/SecureBackupLogoutConfirmationScreenViewModelTests.swift
@@ -18,13 +18,13 @@ struct SecureBackupLogoutConfirmationScreenViewModelTests {
     }
     
     private var secureBackupController: SecureBackupControllerMock
-    private var reachabilitySubject: CurrentValueSubject<NetworkMonitorReachability, Never>
+    private var reachabilitySubject: CurrentValueSubject<HomeserverReachability, Never>
     
     init() {
         secureBackupController = SecureBackupControllerMock()
         secureBackupController.keyBackupState = CurrentValueSubject<SecureBackupKeyBackupState, Never>(.enabled).asCurrentValuePublisher()
         
-        reachabilitySubject = CurrentValueSubject<NetworkMonitorReachability, Never>(.reachable)
+        reachabilitySubject = CurrentValueSubject<HomeserverReachability, Never>(.reachable)
         
         viewModel = SecureBackupLogoutConfirmationScreenViewModel(secureBackupController: secureBackupController,
                                                                   homeserverReachabilityPublisher: reachabilitySubject.asCurrentValuePublisher())

--- a/UnitTests/Sources/UserSessionFlowCoordinatorTests.swift
+++ b/UnitTests/Sources/UserSessionFlowCoordinatorTests.swift
@@ -19,7 +19,7 @@ struct UserSessionFlowCoordinatorTests {
     private let stateMachineFactory = PublishedStateMachineFactory()
     
     private let networkReachabilitySubject: CurrentValueSubject<NetworkMonitorReachability, Never> = .init(.reachable)
-    private let homeserverReachabilitySubject: CurrentValueSubject<NetworkMonitorReachability, Never> = .init(.reachable)
+    private let homeserverReachabilitySubject: CurrentValueSubject<HomeserverReachability, Never> = .init(.reachable)
     private var cancellables = Set<AnyCancellable>()
     
     private var tabCoordinator: NavigationTabCoordinator<UserSessionFlowCoordinator.HomeTab>? {
@@ -228,6 +228,14 @@ struct UserSessionFlowCoordinatorTests {
         // Then the indicator should be hidden now as everything is back to normal
         #expect(userIndicatorController.submitIndicatorDelayCallsCount == 3)
         #expect(retractReachabilityIndicatorCallsCount == 2)
+        
+        // When the client is suspended.
+        homeserverReachabilitySubject.send(.suspended)
+        try await Task.sleep(for: .milliseconds(100))
+        
+        // Then no unreachable indicator should be shown as the pause is intentional.
+        #expect(userIndicatorController.submitIndicatorDelayCallsCount == 3)
+        #expect(retractReachabilityIndicatorCallsCount == 3)
     }
     
     // MARK: - Helpers


### PR DESCRIPTION
`homeserverReachabilityPublisher` was driven directly by the sync service state so stopping sync on pause still reported .reachable. MediaProvider.loadImageRetryingOnReconnection would then retry against a closed store, fail, and bail out permanently because it treated the reachable state as a non-recoverable error.

Make reachability a function of both the desired service state and the latest sync state, computed in one place: store the sync state in the listener and recompute reachability from it, reporting unreachable whenever the client isn't meant to be running. Recompute on suspend and on resume.