### PR TITLE
Limit conversations a message can be forwarded to

### DIFF
--- a/ElementX/Sources/Screens/MessageForwardingScreen/MessageForwardingScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/MessageForwardingScreen/MessageForwardingScreenCoordinator.swift
@@ -10,10 +10,13 @@ import Combine
 import SwiftUI
 
 struct MessageForwardingScreenCoordinatorParameters {
+    static let defaultMaxRoomSelectionCount = 10
+    
     let forwardingItem: MessageForwardingItem
     let userSession: UserSessionProtocol
     let roomSummaryProvider: RoomSummaryProviderProtocol
     let userIndicatorController: UserIndicatorControllerProtocol
+    var maxRoomSelectionCount: Int = MessageForwardingScreenCoordinatorParameters.defaultMaxRoomSelectionCount
 }
 
 enum MessageForwardingScreenCoordinatorAction {
@@ -34,7 +37,8 @@ final class MessageForwardingScreenCoordinator: CoordinatorProtocol {
         viewModel = MessageForwardingScreenViewModel(forwardingItem: parameters.forwardingItem,
                                                      userSession: parameters.userSession,
                                                      roomSummaryProvider: parameters.roomSummaryProvider,
-                                                     userIndicatorController: parameters.userIndicatorController)
+                                                     userIndicatorController: parameters.userIndicatorController,
+                                                     maxRoomSelectionCount: parameters.maxRoomSelectionCount)
     }
     
     func start() {

--- a/ElementX/Sources/Screens/MessageForwardingScreen/MessageForwardingScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/MessageForwardingScreen/MessageForwardingScreenCoordinator.swift
@@ -10,13 +10,10 @@ import Combine
 import SwiftUI
 
 struct MessageForwardingScreenCoordinatorParameters {
-    static let defaultMaxRoomSelectionCount = 10
-    
     let forwardingItem: MessageForwardingItem
     let userSession: UserSessionProtocol
     let roomSummaryProvider: RoomSummaryProviderProtocol
     let userIndicatorController: UserIndicatorControllerProtocol
-    var maxRoomSelectionCount: Int = MessageForwardingScreenCoordinatorParameters.defaultMaxRoomSelectionCount
 }
 
 enum MessageForwardingScreenCoordinatorAction {
@@ -37,8 +34,7 @@ final class MessageForwardingScreenCoordinator: CoordinatorProtocol {
         viewModel = MessageForwardingScreenViewModel(forwardingItem: parameters.forwardingItem,
                                                      userSession: parameters.userSession,
                                                      roomSummaryProvider: parameters.roomSummaryProvider,
-                                                     userIndicatorController: parameters.userIndicatorController,
-                                                     maxRoomSelectionCount: parameters.maxRoomSelectionCount)
+                                                     userIndicatorController: parameters.userIndicatorController)
     }
     
     func start() {

--- a/ElementX/Sources/Screens/MessageForwardingScreen/MessageForwardingScreenModels.swift
+++ b/ElementX/Sources/Screens/MessageForwardingScreen/MessageForwardingScreenModels.swift
@@ -17,7 +17,7 @@ enum MessageForwardingScreenViewModelAction {
 struct MessageForwardingScreenViewState: BindableState {
     var rooms: [MessageForwardingRoom] = []
     var selectedRoomIDs: Set<String> = []
-    var maxRoomSelectionCount = MessageForwardingScreenCoordinatorParameters.defaultMaxRoomSelectionCount
+    let maxRoomSelectionCount = 10
     var bindings = MessageForwardingScreenViewStateBindings()
     
     var isAtRoomSelectionLimit: Bool {

--- a/ElementX/Sources/Screens/MessageForwardingScreen/MessageForwardingScreenModels.swift
+++ b/ElementX/Sources/Screens/MessageForwardingScreen/MessageForwardingScreenModels.swift
@@ -16,8 +16,13 @@ enum MessageForwardingScreenViewModelAction {
 
 struct MessageForwardingScreenViewState: BindableState {
     var rooms: [MessageForwardingRoom] = []
-    var selectedRoomIDs = [String]()
+    var selectedRoomIDs: Set<String> = []
+    var maxRoomSelectionCount = MessageForwardingScreenCoordinatorParameters.defaultMaxRoomSelectionCount
     var bindings = MessageForwardingScreenViewStateBindings()
+    
+    var isAtRoomSelectionLimit: Bool {
+        selectedRoomIDs.count >= maxRoomSelectionCount
+    }
 }
 
 struct MessageForwardingScreenViewStateBindings {

--- a/ElementX/Sources/Screens/MessageForwardingScreen/MessageForwardingScreenViewModel.swift
+++ b/ElementX/Sources/Screens/MessageForwardingScreen/MessageForwardingScreenViewModel.swift
@@ -26,13 +26,14 @@ class MessageForwardingScreenViewModel: MessageForwardingScreenViewModelType, Me
     init(forwardingItem: MessageForwardingItem,
          userSession: UserSessionProtocol,
          roomSummaryProvider: RoomSummaryProviderProtocol,
-         userIndicatorController: UserIndicatorControllerProtocol) {
+         userIndicatorController: UserIndicatorControllerProtocol,
+         maxRoomSelectionCount: Int = MessageForwardingScreenCoordinatorParameters.defaultMaxRoomSelectionCount) {
         self.forwardingItem = forwardingItem
         clientProxy = userSession.clientProxy
         self.roomSummaryProvider = roomSummaryProvider
         self.userIndicatorController = userIndicatorController
         
-        super.init(initialViewState: MessageForwardingScreenViewState(), mediaProvider: userSession.mediaProvider)
+        super.init(initialViewState: MessageForwardingScreenViewState(maxRoomSelectionCount: maxRoomSelectionCount), mediaProvider: userSession.mediaProvider)
         
         roomSummaryProvider.roomListPublisher
             .receive(on: DispatchQueue.main)
@@ -63,10 +64,10 @@ class MessageForwardingScreenViewModel: MessageForwardingScreenViewModelType, Me
         case .send:
             Task { await forward() }
         case .selectRoom(let roomID):
-            if let index = state.selectedRoomIDs.firstIndex(of: roomID) {
-                state.selectedRoomIDs.remove(at: index)
+            if state.selectedRoomIDs.contains(roomID) == false, state.selectedRoomIDs.count < state.maxRoomSelectionCount {
+                state.selectedRoomIDs.insert(roomID)
             } else {
-                state.selectedRoomIDs.append(roomID)
+                state.selectedRoomIDs.remove(roomID)
             }
         case .reachedTop:
             updateVisibleRange(edge: .top)

--- a/ElementX/Sources/Screens/MessageForwardingScreen/MessageForwardingScreenViewModel.swift
+++ b/ElementX/Sources/Screens/MessageForwardingScreen/MessageForwardingScreenViewModel.swift
@@ -26,14 +26,13 @@ class MessageForwardingScreenViewModel: MessageForwardingScreenViewModelType, Me
     init(forwardingItem: MessageForwardingItem,
          userSession: UserSessionProtocol,
          roomSummaryProvider: RoomSummaryProviderProtocol,
-         userIndicatorController: UserIndicatorControllerProtocol,
-         maxRoomSelectionCount: Int = MessageForwardingScreenCoordinatorParameters.defaultMaxRoomSelectionCount) {
+         userIndicatorController: UserIndicatorControllerProtocol) {
         self.forwardingItem = forwardingItem
         clientProxy = userSession.clientProxy
         self.roomSummaryProvider = roomSummaryProvider
         self.userIndicatorController = userIndicatorController
         
-        super.init(initialViewState: MessageForwardingScreenViewState(maxRoomSelectionCount: maxRoomSelectionCount), mediaProvider: userSession.mediaProvider)
+        super.init(initialViewState: MessageForwardingScreenViewState(), mediaProvider: userSession.mediaProvider)
         
         roomSummaryProvider.roomListPublisher
             .receive(on: DispatchQueue.main)

--- a/ElementX/Sources/Screens/MessageForwardingScreen/View/MessageForwardingScreen.swift
+++ b/ElementX/Sources/Screens/MessageForwardingScreen/View/MessageForwardingScreen.swift
@@ -19,6 +19,7 @@ struct MessageForwardingScreen: View {
                 ForEach(context.viewState.rooms) { room in
                     MessageForwardingListRow(room: room,
                                              isSelected: context.viewState.selectedRoomIDs.contains(room.id),
+                                             isDisabled: context.viewState.isAtRoomSelectionLimit && !context.viewState.selectedRoomIDs.contains(room.id),
                                              context: context)
                 }
                 // Replace these with ScrollView's `scrollPosition` when dropping iOS 16.
@@ -68,6 +69,7 @@ private struct MessageForwardingListRow: View {
     
     let room: MessageForwardingRoom
     let isSelected: Bool
+    let isDisabled: Bool
     let context: MessageForwardingScreenViewModel.Context
     
     var body: some View {
@@ -77,6 +79,7 @@ private struct MessageForwardingListRow: View {
                 kind: .selection(isSelected: isSelected) {
                     context.send(viewAction: .selectRoom(roomID: room.id))
                 })
+                .disabled(isDisabled)
     }
     
     @ViewBuilder


### PR DESCRIPTION
Closes #5749 - limits the number of rooms a message can be forwarded to within the app to 10 to avoid abuse. As mentioned in the issue, sharing from outside the app already only allows sending to a single user, so this only addresses in app forwarding.

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
