### PR TITLE
Fix a bug where scanning a universal link as a QR code would open the app without handling the link.

### DIFF
--- a/ElementX/Sources/Application/Application.swift
+++ b/ElementX/Sources/Application/Application.swift
@@ -46,6 +46,12 @@ struct Application: App {
                 .onOpenURL { url in
                     openURL(url, isExternalURL: true)
                 }
+                .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { userActivity in
+                    // Universal Links opened from the Camera app's QR scanner (and NFC tags) are
+                    // delivered as a browsing-web user activity rather than through `onOpenURL` 🤷‍♂️
+                    guard let url = userActivity.webpageURL else { return }
+                    openURL(url, isExternalURL: true)
+                }
                 .onContinueUserActivity("INStartVideoCallIntent") { userActivity in
                     // `INStartVideoCallIntent` is to be replaced with `INStartCallIntent`
                     // but calls from Recents still send it ¯\_(ツ)_/¯


### PR DESCRIPTION
I'm not sure how long this has been the case but as mentioned by https://www.hackingwithswift.com/forums/swiftui/onopenurl-not-being-called/24714 we need to handle an `NSUserActivityTypeBrowsingWeb` activity to get the URL from a scanned QR code as `onOpenURL` isn't used for this path 🤷‍♂️