### PR TITLE
Fix voice message recording crashes caused by an isolation assertion failure

### DIFF
--- a/ElementX/Sources/Services/VoiceMessage/VoiceMessageRecorder.swift
+++ b/ElementX/Sources/Services/VoiceMessage/VoiceMessageRecorder.swift
@@ -194,6 +194,7 @@ class VoiceMessageRecorder: VoiceMessageRecorderProtocol {
     
     private func addObservers() {
         audioRecorder.actions
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] action in
                 guard let self else { return }
                 self.handleAudioRecorderAction(action)


### PR DESCRIPTION


```
thread #144, queue = 'io.element.elementx.audio_recorder', stop reason = EXC_BREAKPOINT (code=1, subcode=0x1017db2a0)
   frame #0: 0x00000001017db2a0 libdispatch.dylib`_dispatch_assert_queue_fail + 104
   frame #1: 0x00000001017dca64 libdispatch.dylib`dispatch_assert_queue$V2.cold.1 + 132
   frame #2: 0x00000001017a6aa0 libdispatch.dylib`dispatch_assert_queue + 84
   frame #3: 0x00000002378fa284 libswift_Concurrency.dylib`_swift_task_checkIsolatedSwift + 32
   frame #4: 0x00000002378c3768 libswift_Concurrency.dylib`swift_task_isCurrentExecutorWithFlagsImpl(swift::SerialExecutorRef, swift::swift_task_is_current_executor_flag) + 356
   frame #5: 0x0000000110858bfc ElementX.debug.dylib`closure #1 in VoiceMessageRecorder.addObservers(action=didStartRecording) at VoiceMessageRecorder.swift:0
   frame #6: 0x00000001c3268fe8 Combine`Subscribers.Sink.receive(_:) + 84
   frame #7: 0x00000001c32696a0 Combine`protocol witness for Subscriber.receive(_:) in conformance Subscribers.Sink<τ_0_0, τ_0_1> + 20
   frame #8: 0x00000001c327308c Combine`PassthroughSubject.Conduit.offer(_:) + 376
   frame #9: 0x00000001c32720e0 Combine`partial apply for closure #1 in PassthroughSubject.send(_:) + 40
   frame #10: 0x00000001c329a80c Combine`ConduitList.forEach(_:) + 204
   frame #11: 0x00000001c32729d8 Combine`PassthroughSubject.send(_:) + 168
 * frame #12: 0x000000010e04b7c0 ElementX.debug.dylib`closure #1 in AudioRecorder.setInternalState(, state=recording) at AudioRecorder.swift:422:32
 ```
