### PR TITLE
Switch back to using the stable version of SwiftFormat.

### DIFF
--- a/Tools/Sources/Commands/SetupProject.swift
+++ b/Tools/Sources/Commands/SetupProject.swift
@@ -17,10 +17,9 @@ struct SetupProject: ParsableCommand {
     }
     
     func brewInstall() throws {
-        try Zsh.run(command: "brew install xcodegen swiftgen git-lfs sourcery mint pkl kiliankoe/formulae/swift-outdated localazy/tools/localazy peripheryapp/periphery/periphery")
-        
-        // Install swiftformat from develop (for now), making sure to avoid conflicts with an existing versioned installation.
-        try Zsh.run(command: "source ci_scripts/ci_common.sh && install_swiftformat_head")
+        // Uninstall SwiftFormat from HEAD first if it is installed.
+        try Zsh.run(command: "if brew list --versions swiftformat | grep -q HEAD; then brew uninstall swiftformat; fi")
+        try Zsh.run(command: "brew install xcodegen swiftgen swiftformat git-lfs sourcery mint pkl kiliankoe/formulae/swift-outdated localazy/tools/localazy peripheryapp/periphery/periphery")
     }
     
     func mintPackagesInstall() throws {

--- a/ci_scripts/ci_common.sh
+++ b/ci_scripts/ci_common.sh
@@ -15,15 +15,7 @@ setup_github_actions_environment() {
     unset HOMEBREW_NO_INSTALL_FROM_API
     export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
     
-    brew update && brew install xcodegen swiftlint git-lfs pkl a7ex/homebrew-formulae/xcresultparser
-    install_swiftformat_head
-}
-
-install_swiftformat_head() {
-    if brew list --versions swiftformat &>/dev/null && ! brew list --versions swiftformat | grep -q HEAD; then
-        brew uninstall swiftformat
-    fi
-    brew install swiftformat --HEAD
+    brew update && brew install xcodegen swiftlint swiftformat git-lfs pkl a7ex/homebrew-formulae/xcresultparser
 }
 
 setup_github_actions_translations_environment() {


### PR DESCRIPTION
Version 0.62.0 now supports the `--indent-blank-lines` option so we no longer need to use SwiftFormat from `HEAD`. This PR reverts the setup-project/CI changes from #5654, with the exception of uninstalling the `HEAD` version before running the normal `brew install` command.