### PR TITLE
Fix for NSE and ShareExtension individual builds

### DIFF
--- a/ElementX/Sources/Application/TargetConfiguration.swift
+++ b/ElementX/Sources/Application/TargetConfiguration.swift
@@ -8,7 +8,9 @@
 
 import Combine
 import Foundation
+#if IS_MAIN_APP
 import MapLibre
+#endif
 import MatrixRustSDK
 
 nonisolated enum Target: String {
@@ -63,6 +65,18 @@ nonisolated enum Target: String {
         
         MXLog.configure(currentTarget: rawValue)
         
+        configureMapLibreIfAvailable()
+        
+        let hookCancellable = rageshakeURL.publisher
+            .sink { _ in
+                appHooks.tracingHook.update(tracingConfiguration, with: rageshakeURL)
+            }
+        
+        return ConfigurationResult(hookCancellable: hookCancellable)
+    }
+    
+    private func configureMapLibreIfAvailable() {
+        #if IS_MAIN_APP
         MLNLoggingConfiguration.shared.loggingLevel = .debug
         MLNLoggingConfiguration.shared.handler = { loggingLevel, _, _, message in
             switch loggingLevel {
@@ -80,13 +94,7 @@ nonisolated enum Target: String {
                 break
             }
         }
-        
-        let hookCancellable = rageshakeURL.publisher
-            .sink { _ in
-                appHooks.tracingHook.update(tracingConfiguration, with: rageshakeURL)
-            }
-        
-        return ConfigurationResult(hookCancellable: hookCancellable)
+        #endif
     }
     
     /// The result of calling ``configure(logLevel:traceLogPacks:sentryURL:)``.


### PR DESCRIPTION
Fixes #5855

Other approaches:

* Move all the compiler conditional code to the bottom of the file in an extension, including the `import`
    * Why not: I believe project convention wants to keep all imports at the top of the file
* Adjust the compiler conditional to encompass `configureMapLibreIfAvailable` (renamed to `configureMapLibre`)
    * Why not: the call site would also need the compiler conditional, in addition to the two already here
* Link `MapLibre` to the `NSE` and `ShareExtension` with no compiler conditionals
    * Why not: the extensions have no business knowing about `MapLibre` nor using it. Linking would increase their binary size and/or memory footprint in their memory-constrained environment for a completely unused component.

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [ ] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
