### PR TITLE
Send voice messages as replies when recorded while replying

### DIFF
--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -12968,30 +12968,30 @@ nonisolated class TimelineControllerMock: TimelineControllerProtocol, @unchecked
     }
     //MARK: - sendVoiceMessage
 
-    private let sendVoiceMessageUrlAudioInfoWaveformRequestHandleCallsCountLock = NSLock()
-    private nonisolated(unsafe) var sendVoiceMessageUrlAudioInfoWaveformRequestHandleUnderlyingCallsCount = 0
-    var sendVoiceMessageUrlAudioInfoWaveformRequestHandleCallsCount: Int {
-        get { sendVoiceMessageUrlAudioInfoWaveformRequestHandleCallsCountLock.withLock { sendVoiceMessageUrlAudioInfoWaveformRequestHandleUnderlyingCallsCount } }
-        set { sendVoiceMessageUrlAudioInfoWaveformRequestHandleCallsCountLock.withLock { sendVoiceMessageUrlAudioInfoWaveformRequestHandleUnderlyingCallsCount = newValue } }
+    private let sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleCallsCountLock = NSLock()
+    private nonisolated(unsafe) var sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleUnderlyingCallsCount = 0
+    var sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleCallsCount: Int {
+        get { sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleCallsCountLock.withLock { sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleUnderlyingCallsCount } }
+        set { sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleCallsCountLock.withLock { sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleUnderlyingCallsCount = newValue } }
     }
-    var sendVoiceMessageUrlAudioInfoWaveformRequestHandleCalled: Bool {
-        return sendVoiceMessageUrlAudioInfoWaveformRequestHandleCallsCount > 0
+    var sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleCalled: Bool {
+        return sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleCallsCount > 0
     }
 
-    private let sendVoiceMessageUrlAudioInfoWaveformRequestHandleReturnValueLock = NSLock()
-    private nonisolated(unsafe) var sendVoiceMessageUrlAudioInfoWaveformRequestHandleUnderlyingReturnValue: Result<Void, TimelineControllerError>!
-    var sendVoiceMessageUrlAudioInfoWaveformRequestHandleReturnValue: Result<Void, TimelineControllerError>! {
-        get { sendVoiceMessageUrlAudioInfoWaveformRequestHandleReturnValueLock.withLock { sendVoiceMessageUrlAudioInfoWaveformRequestHandleUnderlyingReturnValue } }
-        set { sendVoiceMessageUrlAudioInfoWaveformRequestHandleReturnValueLock.withLock { sendVoiceMessageUrlAudioInfoWaveformRequestHandleUnderlyingReturnValue = newValue } }
+    private let sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleReturnValueLock = NSLock()
+    private nonisolated(unsafe) var sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleUnderlyingReturnValue: Result<Void, TimelineControllerError>!
+    var sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleReturnValue: Result<Void, TimelineControllerError>! {
+        get { sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleReturnValueLock.withLock { sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleUnderlyingReturnValue } }
+        set { sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleReturnValueLock.withLock { sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleUnderlyingReturnValue = newValue } }
     }
-    nonisolated(unsafe) var sendVoiceMessageUrlAudioInfoWaveformRequestHandleClosure: ((URL, AudioInfo, [Float], @MainActor (SendAttachmentJoinHandleProtocol) -> Void) async -> Result<Void, TimelineControllerError>)?
+    nonisolated(unsafe) var sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleClosure: ((URL, AudioInfo, [Float], String?, @MainActor (SendAttachmentJoinHandleProtocol) -> Void) async -> Result<Void, TimelineControllerError>)?
 
-    @concurrent func sendVoiceMessage(url: URL, audioInfo: AudioInfo, waveform: [Float], requestHandle: @MainActor (SendAttachmentJoinHandleProtocol) -> Void) async -> Result<Void, TimelineControllerError> {
-        sendVoiceMessageUrlAudioInfoWaveformRequestHandleCallsCountLock.withLock { sendVoiceMessageUrlAudioInfoWaveformRequestHandleUnderlyingCallsCount += 1 }
-        if let sendVoiceMessageUrlAudioInfoWaveformRequestHandleClosure = sendVoiceMessageUrlAudioInfoWaveformRequestHandleClosure {
-            return await sendVoiceMessageUrlAudioInfoWaveformRequestHandleClosure(url, audioInfo, waveform, requestHandle)
+    @concurrent func sendVoiceMessage(url: URL, audioInfo: AudioInfo, waveform: [Float], inReplyToEventID: String?, requestHandle: @MainActor (SendAttachmentJoinHandleProtocol) -> Void) async -> Result<Void, TimelineControllerError> {
+        sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleCallsCountLock.withLock { sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleUnderlyingCallsCount += 1 }
+        if let sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleClosure = sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleClosure {
+            return await sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleClosure(url, audioInfo, waveform, inReplyToEventID, requestHandle)
         } else {
-            return sendVoiceMessageUrlAudioInfoWaveformRequestHandleReturnValue
+            return sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleReturnValue
         }
     }
     //MARK: - createPoll
@@ -13723,30 +13723,30 @@ nonisolated class TimelineProxyMock: TimelineProxyProtocol, @unchecked Sendable 
     }
     //MARK: - sendVoiceMessage
 
-    private let sendVoiceMessageUrlAudioInfoWaveformRequestHandleCallsCountLock = NSLock()
-    private nonisolated(unsafe) var sendVoiceMessageUrlAudioInfoWaveformRequestHandleUnderlyingCallsCount = 0
-    var sendVoiceMessageUrlAudioInfoWaveformRequestHandleCallsCount: Int {
-        get { sendVoiceMessageUrlAudioInfoWaveformRequestHandleCallsCountLock.withLock { sendVoiceMessageUrlAudioInfoWaveformRequestHandleUnderlyingCallsCount } }
-        set { sendVoiceMessageUrlAudioInfoWaveformRequestHandleCallsCountLock.withLock { sendVoiceMessageUrlAudioInfoWaveformRequestHandleUnderlyingCallsCount = newValue } }
+    private let sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleCallsCountLock = NSLock()
+    private nonisolated(unsafe) var sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleUnderlyingCallsCount = 0
+    var sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleCallsCount: Int {
+        get { sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleCallsCountLock.withLock { sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleUnderlyingCallsCount } }
+        set { sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleCallsCountLock.withLock { sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleUnderlyingCallsCount = newValue } }
     }
-    var sendVoiceMessageUrlAudioInfoWaveformRequestHandleCalled: Bool {
-        return sendVoiceMessageUrlAudioInfoWaveformRequestHandleCallsCount > 0
+    var sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleCalled: Bool {
+        return sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleCallsCount > 0
     }
 
-    private let sendVoiceMessageUrlAudioInfoWaveformRequestHandleReturnValueLock = NSLock()
-    private nonisolated(unsafe) var sendVoiceMessageUrlAudioInfoWaveformRequestHandleUnderlyingReturnValue: Result<Void, TimelineProxyError>!
-    var sendVoiceMessageUrlAudioInfoWaveformRequestHandleReturnValue: Result<Void, TimelineProxyError>! {
-        get { sendVoiceMessageUrlAudioInfoWaveformRequestHandleReturnValueLock.withLock { sendVoiceMessageUrlAudioInfoWaveformRequestHandleUnderlyingReturnValue } }
-        set { sendVoiceMessageUrlAudioInfoWaveformRequestHandleReturnValueLock.withLock { sendVoiceMessageUrlAudioInfoWaveformRequestHandleUnderlyingReturnValue = newValue } }
+    private let sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleReturnValueLock = NSLock()
+    private nonisolated(unsafe) var sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleUnderlyingReturnValue: Result<Void, TimelineProxyError>!
+    var sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleReturnValue: Result<Void, TimelineProxyError>! {
+        get { sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleReturnValueLock.withLock { sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleUnderlyingReturnValue } }
+        set { sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleReturnValueLock.withLock { sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleUnderlyingReturnValue = newValue } }
     }
-    nonisolated(unsafe) var sendVoiceMessageUrlAudioInfoWaveformRequestHandleClosure: ((URL, AudioInfo, [Float], @MainActor (SendAttachmentJoinHandleProtocol) -> Void) async -> Result<Void, TimelineProxyError>)?
+    nonisolated(unsafe) var sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleClosure: ((URL, AudioInfo, [Float], String?, @MainActor (SendAttachmentJoinHandleProtocol) -> Void) async -> Result<Void, TimelineProxyError>)?
 
-    @concurrent func sendVoiceMessage(url: URL, audioInfo: AudioInfo, waveform: [Float], requestHandle: @MainActor (SendAttachmentJoinHandleProtocol) -> Void) async -> Result<Void, TimelineProxyError> {
-        sendVoiceMessageUrlAudioInfoWaveformRequestHandleCallsCountLock.withLock { sendVoiceMessageUrlAudioInfoWaveformRequestHandleUnderlyingCallsCount += 1 }
-        if let sendVoiceMessageUrlAudioInfoWaveformRequestHandleClosure = sendVoiceMessageUrlAudioInfoWaveformRequestHandleClosure {
-            return await sendVoiceMessageUrlAudioInfoWaveformRequestHandleClosure(url, audioInfo, waveform, requestHandle)
+    @concurrent func sendVoiceMessage(url: URL, audioInfo: AudioInfo, waveform: [Float], inReplyToEventID: String?, requestHandle: @MainActor (SendAttachmentJoinHandleProtocol) -> Void) async -> Result<Void, TimelineProxyError> {
+        sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleCallsCountLock.withLock { sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleUnderlyingCallsCount += 1 }
+        if let sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleClosure = sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleClosure {
+            return await sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleClosure(url, audioInfo, waveform, inReplyToEventID, requestHandle)
         } else {
-            return sendVoiceMessageUrlAudioInfoWaveformRequestHandleReturnValue
+            return sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleReturnValue
         }
     }
     //MARK: - sendReadReceipt
@@ -15142,44 +15142,44 @@ nonisolated class VoiceMessageRecorderMock: VoiceMessageRecorderProtocol, @unche
     }
     //MARK: - sendVoiceMessage
 
-    private let sendVoiceMessageTimelineControllerAudioConverterCallsCountLock = NSLock()
-    private nonisolated(unsafe) var sendVoiceMessageTimelineControllerAudioConverterUnderlyingCallsCount = 0
-    var sendVoiceMessageTimelineControllerAudioConverterCallsCount: Int {
-        get { sendVoiceMessageTimelineControllerAudioConverterCallsCountLock.withLock { sendVoiceMessageTimelineControllerAudioConverterUnderlyingCallsCount } }
-        set { sendVoiceMessageTimelineControllerAudioConverterCallsCountLock.withLock { sendVoiceMessageTimelineControllerAudioConverterUnderlyingCallsCount = newValue } }
+    private let sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDCallsCountLock = NSLock()
+    private nonisolated(unsafe) var sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDUnderlyingCallsCount = 0
+    var sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDCallsCount: Int {
+        get { sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDCallsCountLock.withLock { sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDUnderlyingCallsCount } }
+        set { sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDCallsCountLock.withLock { sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDUnderlyingCallsCount = newValue } }
     }
-    var sendVoiceMessageTimelineControllerAudioConverterCalled: Bool {
-        return sendVoiceMessageTimelineControllerAudioConverterCallsCount > 0
+    var sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDCalled: Bool {
+        return sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDCallsCount > 0
     }
-    private let sendVoiceMessageTimelineControllerAudioConverterReceivedArgumentsLock = NSLock()
-    private nonisolated(unsafe) var sendVoiceMessageTimelineControllerAudioConverterUnderlyingReceivedArguments: (timelineController: TimelineControllerProtocol, audioConverter: AudioConverterProtocol)?
-    var sendVoiceMessageTimelineControllerAudioConverterReceivedArguments: (timelineController: TimelineControllerProtocol, audioConverter: AudioConverterProtocol)? {
-        get { sendVoiceMessageTimelineControllerAudioConverterReceivedArgumentsLock.withLock { sendVoiceMessageTimelineControllerAudioConverterUnderlyingReceivedArguments } }
-        set { sendVoiceMessageTimelineControllerAudioConverterReceivedArgumentsLock.withLock { sendVoiceMessageTimelineControllerAudioConverterUnderlyingReceivedArguments = newValue } }
+    private let sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDReceivedArgumentsLock = NSLock()
+    private nonisolated(unsafe) var sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDUnderlyingReceivedArguments: (timelineController: TimelineControllerProtocol, audioConverter: AudioConverterProtocol, inReplyToEventID: String?)?
+    var sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDReceivedArguments: (timelineController: TimelineControllerProtocol, audioConverter: AudioConverterProtocol, inReplyToEventID: String?)? {
+        get { sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDReceivedArgumentsLock.withLock { sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDUnderlyingReceivedArguments } }
+        set { sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDReceivedArgumentsLock.withLock { sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDUnderlyingReceivedArguments = newValue } }
     }
-    private let sendVoiceMessageTimelineControllerAudioConverterReceivedInvocationsLock = NSLock()
-    private nonisolated(unsafe) var sendVoiceMessageTimelineControllerAudioConverterUnderlyingReceivedInvocations: [(timelineController: TimelineControllerProtocol, audioConverter: AudioConverterProtocol)] = []
-    var sendVoiceMessageTimelineControllerAudioConverterReceivedInvocations: [(timelineController: TimelineControllerProtocol, audioConverter: AudioConverterProtocol)] {
-        get { sendVoiceMessageTimelineControllerAudioConverterReceivedInvocationsLock.withLock { sendVoiceMessageTimelineControllerAudioConverterUnderlyingReceivedInvocations } }
-        set { sendVoiceMessageTimelineControllerAudioConverterReceivedInvocationsLock.withLock { sendVoiceMessageTimelineControllerAudioConverterUnderlyingReceivedInvocations = newValue } }
+    private let sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDReceivedInvocationsLock = NSLock()
+    private nonisolated(unsafe) var sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDUnderlyingReceivedInvocations: [(timelineController: TimelineControllerProtocol, audioConverter: AudioConverterProtocol, inReplyToEventID: String?)] = []
+    var sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDReceivedInvocations: [(timelineController: TimelineControllerProtocol, audioConverter: AudioConverterProtocol, inReplyToEventID: String?)] {
+        get { sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDReceivedInvocationsLock.withLock { sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDUnderlyingReceivedInvocations } }
+        set { sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDReceivedInvocationsLock.withLock { sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDUnderlyingReceivedInvocations = newValue } }
     }
 
-    private let sendVoiceMessageTimelineControllerAudioConverterReturnValueLock = NSLock()
-    private nonisolated(unsafe) var sendVoiceMessageTimelineControllerAudioConverterUnderlyingReturnValue: Result<Void, VoiceMessageRecorderError>!
-    var sendVoiceMessageTimelineControllerAudioConverterReturnValue: Result<Void, VoiceMessageRecorderError>! {
-        get { sendVoiceMessageTimelineControllerAudioConverterReturnValueLock.withLock { sendVoiceMessageTimelineControllerAudioConverterUnderlyingReturnValue } }
-        set { sendVoiceMessageTimelineControllerAudioConverterReturnValueLock.withLock { sendVoiceMessageTimelineControllerAudioConverterUnderlyingReturnValue = newValue } }
+    private let sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDReturnValueLock = NSLock()
+    private nonisolated(unsafe) var sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDUnderlyingReturnValue: Result<Void, VoiceMessageRecorderError>!
+    var sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDReturnValue: Result<Void, VoiceMessageRecorderError>! {
+        get { sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDReturnValueLock.withLock { sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDUnderlyingReturnValue } }
+        set { sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDReturnValueLock.withLock { sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDUnderlyingReturnValue = newValue } }
     }
-    nonisolated(unsafe) var sendVoiceMessageTimelineControllerAudioConverterClosure: ((TimelineControllerProtocol, AudioConverterProtocol) async -> Result<Void, VoiceMessageRecorderError>)?
+    nonisolated(unsafe) var sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDClosure: ((TimelineControllerProtocol, AudioConverterProtocol, String?) async -> Result<Void, VoiceMessageRecorderError>)?
 
-    @concurrent func sendVoiceMessage(timelineController: TimelineControllerProtocol, audioConverter: AudioConverterProtocol) async -> Result<Void, VoiceMessageRecorderError> {
-        sendVoiceMessageTimelineControllerAudioConverterCallsCountLock.withLock { sendVoiceMessageTimelineControllerAudioConverterUnderlyingCallsCount += 1 }
-        sendVoiceMessageTimelineControllerAudioConverterReceivedArguments = (timelineController: timelineController, audioConverter: audioConverter)
-        sendVoiceMessageTimelineControllerAudioConverterReceivedInvocationsLock.withLock { sendVoiceMessageTimelineControllerAudioConverterUnderlyingReceivedInvocations.append((timelineController: timelineController, audioConverter: audioConverter)) }
-        if let sendVoiceMessageTimelineControllerAudioConverterClosure = sendVoiceMessageTimelineControllerAudioConverterClosure {
-            return await sendVoiceMessageTimelineControllerAudioConverterClosure(timelineController, audioConverter)
+    @concurrent func sendVoiceMessage(timelineController: TimelineControllerProtocol, audioConverter: AudioConverterProtocol, inReplyToEventID: String?) async -> Result<Void, VoiceMessageRecorderError> {
+        sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDCallsCountLock.withLock { sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDUnderlyingCallsCount += 1 }
+        sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDReceivedArguments = (timelineController: timelineController, audioConverter: audioConverter, inReplyToEventID: inReplyToEventID)
+        sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDReceivedInvocationsLock.withLock { sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDUnderlyingReceivedInvocations.append((timelineController: timelineController, audioConverter: audioConverter, inReplyToEventID: inReplyToEventID)) }
+        if let sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDClosure = sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDClosure {
+            return await sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDClosure(timelineController, audioConverter, inReplyToEventID)
         } else {
-            return sendVoiceMessageTimelineControllerAudioConverterReturnValue
+            return sendVoiceMessageTimelineControllerAudioConverterInReplyToEventIDReturnValue
         }
     }
 }

--- a/ElementX/Sources/Mocks/TimelineControllerMock.swift
+++ b/ElementX/Sources/Mocks/TimelineControllerMock.swift
@@ -165,12 +165,13 @@ struct TimelineControllerMockConfiguration {
             return .success(())
         }
         
-        sendVoiceMessageUrlAudioInfoWaveformRequestHandleClosure = { [weak self, timelineProxy] url, audioInfo, waveform, requestHandle in
+        sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleClosure = { [weak self, timelineProxy] url, audioInfo, waveform, inReplyToEventID, requestHandle in
             self?.callbacks.send(.messageSentOrEdited)
             if let timelineProxy {
                 return await timelineProxy.sendVoiceMessage(url: url,
                                                             audioInfo: audioInfo,
                                                             waveform: waveform,
+                                                            inReplyToEventID: inReplyToEventID,
                                                             requestHandle: requestHandle).mapError(TimelineControllerError.timelineProxyError)
             }
             return .success(())

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarModels.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarModels.swift
@@ -20,7 +20,7 @@ enum ComposerToolbarVoiceMessageAction {
     case pausePlayback
     case scrubPlayback(scrubbing: Bool)
     case seekPlayback(progress: Double)
-    case send
+    case send(inReplyToEventID: String?)
 }
 
 enum ComposerToolbarViewModelAction {
@@ -87,7 +87,7 @@ struct ComposerToolbarViewState: BindableState {
     
     var isUploading: Bool {
         switch composerMode {
-        case .previewVoiceMessage(_, _, let isUploading):
+        case .previewVoiceMessage(_, _, let isUploading, _):
             return isUploading
         default:
             return false
@@ -334,8 +334,16 @@ enum ComposerMode: Equatable {
     case `default`
     case reply(eventID: String, replyDetails: TimelineItemReplyDetails, isThread: Bool)
     case edit(originalEventOrTransactionID: TimelineItemIdentifier.EventOrTransactionID, type: EditType)
-    case recordVoiceMessage(state: AudioRecorderState)
-    case previewVoiceMessage(state: AudioPlayerState, waveform: WaveformSource, isUploading: Bool)
+    case recordVoiceMessage(state: AudioRecorderState, replyContext: ReplyContext?)
+    case previewVoiceMessage(state: AudioPlayerState, waveform: WaveformSource, isUploading: Bool, replyContext: ReplyContext?)
+    
+    /// The reply that a voice message is being recorded for, so that it survives
+    /// the composer switching out of `reply` mode during the recording.
+    struct ReplyContext: Equatable {
+        let eventID: String
+        let replyDetails: TimelineItemReplyDetails
+        let isThread: Bool
+    }
     
     var isEdit: Bool {
         switch self {
@@ -373,6 +381,16 @@ enum ComposerMode: Equatable {
         switch self {
         case .reply(let eventID, _, _):
             return eventID
+        default:
+            return nil
+        }
+    }
+    
+    /// The preserved reply when recording or previewing a voice message.
+    var voiceMessageReplyContext: ReplyContext? {
+        switch self {
+        case .recordVoiceMessage(_, let replyContext), .previewVoiceMessage(_, _, _, let replyContext):
+            return replyContext
         default:
             return nil
         }

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarViewModel.swift
@@ -190,8 +190,11 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
             guard !state.sendButtonDisabled else { return }
             
             switch state.composerMode {
-            case .previewVoiceMessage:
-                actionsSubject.send(.voiceMessage(.send))
+            case .previewVoiceMessage(let playerState, let waveform, let isUploading, let replyContext):
+                // Capture the reply before sending: the composer resets to the default
+                // mode once the voice message is sent and must not restore the reply.
+                state.composerMode = .previewVoiceMessage(state: playerState, waveform: waveform, isUploading: isUploading, replyContext: nil)
+                actionsSubject.send(.voiceMessage(.send(inReplyToEventID: replyContext?.eventID)))
             default:
                 if context.composerFormattingEnabled {
                     actionsSubject.send(.sendMessage(plain: wysiwygViewModel.content.markdown,
@@ -205,7 +208,14 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
         case .editLastMessage:
             actionsSubject.send(.editLastMessage)
         case .cancelReply:
-            set(mode: .default)
+            switch state.composerMode {
+            case .recordVoiceMessage(let recorderState, .some):
+                state.composerMode = .recordVoiceMessage(state: recorderState, replyContext: nil)
+            case .previewVoiceMessage(let playerState, let waveform, let isUploading, .some):
+                state.composerMode = .previewVoiceMessage(state: playerState, waveform: waveform, isUploading: isUploading, replyContext: nil)
+            default:
+                set(mode: .default)
+            }
         case .cancelEdit:
             if let draft = draftService.loadVolatileDraft() {
                 handleLoadDraft(draft)
@@ -570,6 +580,8 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
     }
     
     private func set(mode: ComposerMode) {
+        let mode = preservingReplyContext(mode)
+        
         if state.composerMode.isLoadingReply, state.composerMode.replyEventID != mode.replyEventID {
             replyLoadingTask?.cancel()
         }
@@ -580,13 +592,42 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
         switch mode {
         case .default:
             break
-        case .recordVoiceMessage(let audioRecorderState):
+        case .recordVoiceMessage(let audioRecorderState, _):
             state.audioRecorderState = audioRecorderState
-        case .previewVoiceMessage(let audioPlayerState, _, _):
+        case .previewVoiceMessage(let audioPlayerState, _, _, _):
             state.audioPlayerState = audioPlayerState
         case .edit, .reply:
             // Focus composer when switching to reply/edit
             state.bindings.composerFocused = true
+        }
+    }
+    
+    /// Carries an in-progress reply into and out of the voice message modes, so that
+    /// recording a voice message while replying keeps the reply attached.
+    private func preservingReplyContext(_ mode: ComposerMode) -> ComposerMode {
+        let currentReplyContext: ComposerMode.ReplyContext? = switch state.composerMode {
+        case .reply(let eventID, let replyDetails, let isThread):
+            .init(eventID: eventID, replyDetails: replyDetails, isThread: isThread)
+        default:
+            state.composerMode.voiceMessageReplyContext
+        }
+        
+        guard let currentReplyContext else {
+            return mode
+        }
+        
+        switch mode {
+        case .recordVoiceMessage(let recorderState, nil):
+            return .recordVoiceMessage(state: recorderState, replyContext: currentReplyContext)
+        case .previewVoiceMessage(let playerState, let waveform, let isUploading, nil):
+            return .previewVoiceMessage(state: playerState, waveform: waveform, isUploading: isUploading, replyContext: currentReplyContext)
+        case .default where state.composerMode.voiceMessageReplyContext != nil:
+            // The recording was cancelled or deleted, restore the pending reply.
+            return .reply(eventID: currentReplyContext.eventID,
+                          replyDetails: currentReplyContext.replyDetails,
+                          isThread: currentReplyContext.isThread)
+        default:
+            return mode
         }
     }
     
@@ -800,7 +841,7 @@ private final class ComposerMentionReplacer: MentionReplacer {
 // MARK: - Mocks
 
 extension ComposerToolbarViewModel {
-    enum MockMode { case editing, recordVoiceMessage, previewVoiceMessage(isUploading: Bool), reply(isLoading: Bool) }
+    enum MockMode { case editing, recordVoiceMessage(replying: Bool), previewVoiceMessage(isUploading: Bool), reply(isLoading: Bool) }
     
     static func mock(focused: Bool = false,
                      message: String = "",
@@ -835,14 +876,24 @@ extension ComposerToolbarViewModel {
         switch mockMode {
         case .editing:
             viewModel.state.composerMode = .edit(originalEventOrTransactionID: .eventID(""), type: .default)
-        case .recordVoiceMessage:
-            viewModel.state.composerMode = .recordVoiceMessage(state: AudioRecorderState())
+        case .recordVoiceMessage(let replying):
+            let replyContext: ComposerMode.ReplyContext? = if replying {
+                .init(eventID: "",
+                      replyDetails: .loaded(sender: .init(id: "", displayName: "Test"),
+                                            eventID: "",
+                                            eventContent: .message(.text(.init(body: "Hello World!")))),
+                      isThread: false)
+            } else {
+                nil
+            }
+            viewModel.state.composerMode = .recordVoiceMessage(state: AudioRecorderState(), replyContext: replyContext)
         case .previewVoiceMessage(let isUploading):
             viewModel.state.composerMode = .previewVoiceMessage(state: AudioPlayerState(id: .recorderPreview,
                                                                                         title: L10n.commonVoiceMessage,
                                                                                         duration: 10.0),
                                                                 waveform: .data(Array(repeating: 1.0, count: 1000)),
-                                                                isUploading: isUploading)
+                                                                isUploading: isUploading,
+                                                                replyContext: nil)
         case .reply(let isLoading):
             let replyDetails: TimelineItemReplyDetails = if isLoading {
                 .loading(eventID: "")

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/ComposerToolbar.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/ComposerToolbar.swift
@@ -143,8 +143,16 @@ struct ComposerToolbar: View {
             .opacity(context.viewState.isVoiceMessageModeActivated ? 0 : 1)
             
             if context.viewState.isVoiceMessageModeActivated {
-                voiceMessageContent
-                    .fixedSize(horizontal: false, vertical: true)
+                VStack(spacing: 8) {
+                    if let replyContext = context.viewState.composerMode.voiceMessageReplyContext {
+                        MessageComposerReplyHeader(replyDetails: replyContext.replyDetails) {
+                            context.send(viewAction: .cancelReply)
+                        }
+                    }
+                    
+                    voiceMessageContent
+                }
+                .fixedSize(horizontal: false, vertical: true)
             }
         }
     }
@@ -277,13 +285,13 @@ struct ComposerToolbar: View {
     private var voiceMessageContent: some View {
         // Display the voice message composer above to keep the focus and keep the keyboard open if it's already open.
         switch context.viewState.composerMode {
-        case .recordVoiceMessage(let state):
+        case .recordVoiceMessage(let state, _):
             topBarLayout {
                 voiceMessageTrashButton
                     .scaledPadding(.vertical, buttonVerticalPadding, relativeTo: .compound.headingLG)
                 VoiceMessageRecordingComposer(recorderState: state)
             }
-        case .previewVoiceMessage(let state, let waveform, let isUploading):
+        case .previewVoiceMessage(let state, let waveform, let isUploading, _):
             topBarLayout {
                 voiceMessageTrashButton
                     .scaledPadding(.vertical, buttonVerticalPadding, relativeTo: .compound.headingLG)
@@ -384,7 +392,8 @@ struct ComposerToolbar_Previews: PreviewProvider, TestablePreview {
     static let viewModel = ComposerToolbarViewModel.mock()
     static let editingViewModel = ComposerToolbarViewModel.mock(message: "Hello, Wrold!", mockMode: .editing)
     static let multiLineViewModel = ComposerToolbarViewModel.mock(message: "Hello, World! This is a loooong message that wraps onto multiple lines.")
-    static let voiceMessageRecordingViewModel = ComposerToolbarViewModel.mock(mockMode: .recordVoiceMessage)
+    static let voiceMessageRecordingViewModel = ComposerToolbarViewModel.mock(mockMode: .recordVoiceMessage(replying: false))
+    static let voiceMessageRecordingWithReplyViewModel = ComposerToolbarViewModel.mock(mockMode: .recordVoiceMessage(replying: true))
     static let voiceMessagePreviewViewModel = ComposerToolbarViewModel.mock(mockMode: .previewVoiceMessage(isUploading: false))
     static let voiceMessageUploadingViewModel = ComposerToolbarViewModel.mock(mockMode: .previewVoiceMessage(isUploading: true))
     static let replyLoadingViewModel = ComposerToolbarViewModel.mock(mockMode: .reply(isLoading: true))
@@ -416,6 +425,7 @@ struct ComposerToolbar_Previews: PreviewProvider, TestablePreview {
         VStack(spacing: 8) {
             ComposerToolbar(context: replyLoadingViewModel.context)
             ComposerToolbar(context: replyLoadedViewModel.context)
+            ComposerToolbar(context: voiceMessageRecordingWithReplyViewModel.context)
         }
         .environmentObject(timelineViewModel.context)
         .previewDisplayName("Reply")

--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/MessageComposer.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/MessageComposer.swift
@@ -135,7 +135,7 @@ struct MessageComposer: View {
     }
 }
 
-private struct MessageComposerReplyHeader: View {
+struct MessageComposerReplyHeader: View {
     let replyDetails: TimelineItemReplyDetails
     let action: () -> Void
     

--- a/ElementX/Sources/Screens/Timeline/TimelineInteractionHandler.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineInteractionHandler.swift
@@ -308,9 +308,9 @@ class TimelineInteractionHandler {
         case .didStartRecording(let audioRecorder):
             let audioRecordState = AudioRecorderState()
             audioRecordState.attachAudioRecorder(audioRecorder)
-            actionsSubject.send(.composer(action: .setMode(mode: .recordVoiceMessage(state: audioRecordState))))
+            actionsSubject.send(.composer(action: .setMode(mode: .recordVoiceMessage(state: audioRecordState, replyContext: nil))))
         case .didStopRecording(let previewAudioPlayerState, let url):
-            actionsSubject.send(.composer(action: .setMode(mode: .previewVoiceMessage(state: previewAudioPlayerState, waveform: .url(url), isUploading: false))))
+            actionsSubject.send(.composer(action: .setMode(mode: .previewVoiceMessage(state: previewAudioPlayerState, waveform: .url(url), isUploading: false, replyContext: nil))))
             voiceMessageRecorderObserver = nil
         case .didFailWithError(let error):
             switch error {
@@ -355,7 +355,7 @@ class TimelineInteractionHandler {
         actionsSubject.send(.composer(action: .setMode(mode: .default)))
     }
     
-    func sendCurrentVoiceMessage() async {
+    func sendCurrentVoiceMessage(inReplyToEventID: String?) async {
         guard let audioPlayerState = voiceMessageRecorder.previewAudioPlayerState, let recordingURL = voiceMessageRecorder.recordingURL else {
             actionsSubject.send(.displayErrorToast(L10n.errorFailedUploadingVoiceMessage))
             return
@@ -363,19 +363,21 @@ class TimelineInteractionHandler {
         
         analyticsService.trackComposer(inThread: false,
                                        isEditing: false,
-                                       isReply: false,
+                                       isReply: inReplyToEventID != nil,
                                        messageType: .VoiceMessage,
                                        startsThread: nil)
         
-        actionsSubject.send(.composer(action: .setMode(mode: .previewVoiceMessage(state: audioPlayerState, waveform: .url(recordingURL), isUploading: true))))
+        actionsSubject.send(.composer(action: .setMode(mode: .previewVoiceMessage(state: audioPlayerState, waveform: .url(recordingURL), isUploading: true, replyContext: nil))))
         await voiceMessageRecorder.stopPlayback()
         
-        switch await voiceMessageRecorder.sendVoiceMessage(timelineController: timelineController, audioConverter: AudioConverter()) {
+        switch await voiceMessageRecorder.sendVoiceMessage(timelineController: timelineController,
+                                                           audioConverter: AudioConverter(),
+                                                           inReplyToEventID: inReplyToEventID) {
         case .success:
             await deleteCurrentVoiceMessage()
         case .failure(let error):
             MXLog.error("failed to send the voice message. \(error)")
-            actionsSubject.send(.composer(action: .setMode(mode: .previewVoiceMessage(state: audioPlayerState, waveform: .url(recordingURL), isUploading: false))))
+            actionsSubject.send(.composer(action: .setMode(mode: .previewVoiceMessage(state: audioPlayerState, waveform: .url(recordingURL), isUploading: false, replyContext: nil))))
             actionsSubject.send(.displayErrorToast(L10n.errorFailedUploadingVoiceMessage))
         }
     }

--- a/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
@@ -410,8 +410,8 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
             Task { await timelineInteractionHandler.cancelRecordingVoiceMessage() }
         case .deleteRecording:
             Task { await timelineInteractionHandler.deleteCurrentVoiceMessage() }
-        case .send:
-            Task { await timelineInteractionHandler.sendCurrentVoiceMessage() }
+        case .send(let inReplyToEventID):
+            Task { await timelineInteractionHandler.sendCurrentVoiceMessage(inReplyToEventID: inReplyToEventID) }
         case .startPlayback:
             Task { await timelineInteractionHandler.startPlayingRecordedVoiceMessage() }
         case .pausePlayback:

--- a/ElementX/Sources/Services/Timeline/TimelineController/TimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/TimelineController.swift
@@ -390,10 +390,13 @@ class TimelineController: TimelineControllerProtocol {
     func sendVoiceMessage(url: URL,
                           audioInfo: MatrixRustSDK.AudioInfo,
                           waveform: [Float],
+                          inReplyToEventID: String?,
                           requestHandle: @MainActor (SendAttachmentJoinHandleProtocol) -> Void) async -> Result<Void, TimelineControllerError> {
         switch await activeTimeline.sendVoiceMessage(url: url,
                                                      audioInfo: audioInfo,
-                                                     waveform: waveform, requestHandle: requestHandle).mapError(TimelineControllerError.timelineProxyError) {
+                                                     waveform: waveform,
+                                                     inReplyToEventID: inReplyToEventID,
+                                                     requestHandle: requestHandle).mapError(TimelineControllerError.timelineProxyError) {
         case .success:
             callbacks.send(.messageSentOrEdited)
             return .success(())

--- a/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerProtocol.swift
@@ -133,6 +133,7 @@ protocol TimelineControllerProtocol: Sendable {
     func sendVoiceMessage(url: URL,
                           audioInfo: AudioInfo,
                           waveform: [Float],
+                          inReplyToEventID: String?,
                           requestHandle: @MainActor (SendAttachmentJoinHandleProtocol) -> Void) async -> Result<Void, TimelineControllerError>
     
     // MARK: - Poll

--- a/ElementX/Sources/Services/Timeline/TimelineProxy.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineProxy.swift
@@ -377,6 +377,7 @@ final class TimelineProxy: TimelineProxyProtocol {
     func sendVoiceMessage(url: URL,
                           audioInfo: AudioInfo,
                           waveform: [Float],
+                          inReplyToEventID: String?,
                           requestHandle: @MainActor (SendAttachmentJoinHandleProtocol) -> Void) async -> Result<Void, TimelineProxyError> {
         MXLog.info("Sending voice message")
         
@@ -385,7 +386,7 @@ final class TimelineProxy: TimelineProxyProtocol {
                                                                      caption: nil,
                                                                      formattedCaption: nil,
                                                                      mentions: nil,
-                                                                     inReplyTo: nil),
+                                                                     inReplyTo: inReplyToEventID),
                                                        audioInfo: audioInfo,
                                                        waveform: waveform)
             

--- a/ElementX/Sources/Services/Timeline/TimelineProxyProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineProxyProtocol.swift
@@ -110,6 +110,7 @@ protocol TimelineProxyProtocol: Sendable {
     func sendVoiceMessage(url: URL,
                           audioInfo: AudioInfo,
                           waveform: [Float],
+                          inReplyToEventID: String?,
                           requestHandle: @MainActor (SendAttachmentJoinHandleProtocol) -> Void) async -> Result<Void, TimelineProxyError>
     
     func sendReadReceipt(for eventID: String, type: ReceiptType) async -> Result<Void, TimelineProxyError>

--- a/ElementX/Sources/Services/VoiceMessage/VoiceMessageRecorder.swift
+++ b/ElementX/Sources/Services/VoiceMessage/VoiceMessageRecorder.swift
@@ -146,7 +146,8 @@ class VoiceMessageRecorder: VoiceMessageRecorderProtocol {
     }
     
     func sendVoiceMessage(timelineController: TimelineControllerProtocol,
-                          audioConverter: AudioConverterProtocol) async -> Result<Void, VoiceMessageRecorderError> {
+                          audioConverter: AudioConverterProtocol,
+                          inReplyToEventID: String?) async -> Result<Void, VoiceMessageRecorderError> {
         guard let url = audioRecorder.audioFileURL else {
             return .failure(VoiceMessageRecorderError.missingRecordingFile)
         }
@@ -180,7 +181,8 @@ class VoiceMessageRecorder: VoiceMessageRecorderProtocol {
         
         let result = await timelineController.sendVoiceMessage(url: oggFile,
                                                                audioInfo: audioInfo,
-                                                               waveform: waveform) { _ in }
+                                                               waveform: waveform,
+                                                               inReplyToEventID: inReplyToEventID) { _ in }
         
         if case .failure(let error) = result {
             MXLog.error("Failed to send the voice message. \(error)")

--- a/ElementX/Sources/Services/VoiceMessage/VoiceMessageRecorderProtocol.swift
+++ b/ElementX/Sources/Services/VoiceMessage/VoiceMessageRecorderProtocol.swift
@@ -40,7 +40,8 @@ protocol VoiceMessageRecorderProtocol {
     func deleteRecording() async
     
     func sendVoiceMessage(timelineController: TimelineControllerProtocol,
-                          audioConverter: AudioConverterProtocol) async -> Result<Void, VoiceMessageRecorderError>
+                          audioConverter: AudioConverterProtocol,
+                          inReplyToEventID: String?) async -> Result<Void, VoiceMessageRecorderError>
 }
 
 // sourcery: AutoMockable

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/composerToolbar.Reply-iPad-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/composerToolbar.Reply-iPad-en-GB.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c7abaa74fc8b26901dce3bbc6c5601343803a3354647d5b91d66a9042f35cd63
-size 94809
+oid sha256:af5893c4876c16a451a4f791c822bf82e00a974b9d32db8eeb97836ba89ab634
+size 108289

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/composerToolbar.Reply-iPad-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/composerToolbar.Reply-iPad-pseudo.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a23d549c9790926a1ef579b1e97f6a6d14f570b1cc99bfcb9e3d7186d27c1434
-size 95603
+oid sha256:2f466392165be32da8015d07d38928c7784de7560b3eeda1e087596c19ac58be
+size 109100

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/composerToolbar.Reply-iPhone-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/composerToolbar.Reply-iPhone-en-GB.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f3526637075904aaf998c37a27cedbe9791d4c3d91d0759df4083bdf62a418da
-size 51749
+oid sha256:2a2f1e8921310f1be58bb43594c500f17bc752dfe618c84d922666fbc81169ff
+size 63145

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/composerToolbar.Reply-iPhone-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/composerToolbar.Reply-iPhone-pseudo.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:03166188227662c93fd3f54bc43efa8b0fef39b25aadabd7a9180c05ff904de7
-size 52511
+oid sha256:10520f49e888faded2367a92d99388bf5647533808411d680cf178a3bf1fac4d
+size 63854

--- a/UnitTests/Sources/ComposerToolbarViewModelTests.swift
+++ b/UnitTests/Sources/ComposerToolbarViewModelTests.swift
@@ -357,7 +357,8 @@ final class ComposerToolbarViewModelTests {
         viewModel.context.plainComposerText = .init(string: "Hello world!")
         viewModel.process(timelineAction: .setMode(mode: .previewVoiceMessage(state: AudioPlayerState(id: .recorderPreview, title: "", duration: 10.0),
                                                                               waveform: .data(waveformData),
-                                                                              isUploading: false)))
+                                                                              isUploading: false,
+                                                                              replyContext: nil)))
         
         await waitForConfirmation("Clear draft") { confirmation in
             draftServiceMock.clearDraftClosure = {
@@ -370,6 +371,86 @@ final class ComposerToolbarViewModelTests {
         #expect(!draftServiceMock.saveDraftCalled)
         #expect(draftServiceMock.clearDraftCallsCount == 1)
         #expect(!draftServiceMock.loadDraftCalled)
+    }
+    
+    // MARK: - Voice message replies
+    
+    @Test
+    func voiceMessageRecordingPreservesReply() {
+        viewModel.process(timelineAction: .setMode(mode: .reply(eventID: "testID", replyDetails: .loaded(sender: .init(id: "bob"),
+                                                                                                         eventID: "testID",
+                                                                                                         eventContent: .message(.text(.init(body: "Hello")))),
+            isThread: false)))
+        
+        viewModel.process(timelineAction: .setMode(mode: .recordVoiceMessage(state: AudioRecorderState(), replyContext: nil)))
+        #expect(viewModel.state.composerMode.voiceMessageReplyContext?.eventID == "testID")
+        
+        // The reply survives the transition from recording to previewing.
+        viewModel.process(timelineAction: .setMode(mode: .previewVoiceMessage(state: AudioPlayerState(id: .recorderPreview, title: "", duration: 10.0),
+                                                                              waveform: .data([]),
+                                                                              isUploading: false,
+                                                                              replyContext: nil)))
+        #expect(viewModel.state.composerMode.voiceMessageReplyContext?.eventID == "testID")
+    }
+    
+    @Test
+    func cancellingVoiceMessageRestoresReply() {
+        viewModel.process(timelineAction: .setMode(mode: .reply(eventID: "testID", replyDetails: .loaded(sender: .init(id: "bob"),
+                                                                                                         eventID: "testID",
+                                                                                                         eventContent: .message(.text(.init(body: "Hello")))),
+            isThread: false)))
+        viewModel.process(timelineAction: .setMode(mode: .recordVoiceMessage(state: AudioRecorderState(), replyContext: nil)))
+        
+        // Deleting the recording restores the reply in the composer.
+        viewModel.process(timelineAction: .setMode(mode: .default))
+        #expect(viewModel.state.composerMode.replyEventID == "testID")
+    }
+    
+    @Test
+    func cancellingReplyDuringRecordingKeepsRecording() {
+        viewModel.process(timelineAction: .setMode(mode: .reply(eventID: "testID", replyDetails: .loaded(sender: .init(id: "bob"),
+                                                                                                         eventID: "testID",
+                                                                                                         eventContent: .message(.text(.init(body: "Hello")))),
+            isThread: false)))
+        viewModel.process(timelineAction: .setMode(mode: .recordVoiceMessage(state: AudioRecorderState(), replyContext: nil)))
+        
+        viewModel.process(viewAction: .cancelReply)
+        
+        guard case .recordVoiceMessage(_, nil) = viewModel.state.composerMode else {
+            Issue.record("The composer should still be recording, with the reply detached")
+            return
+        }
+        
+        // With the reply detached, ending the recording no longer restores it.
+        viewModel.process(timelineAction: .setMode(mode: .default))
+        #expect(viewModel.state.composerMode == .default)
+    }
+    
+    @Test
+    func sendingVoiceMessagePassesReplyEventID() async throws {
+        viewModel.process(timelineAction: .setMode(mode: .reply(eventID: "testID", replyDetails: .loaded(sender: .init(id: "bob"),
+                                                                                                         eventID: "testID",
+                                                                                                         eventContent: .message(.text(.init(body: "Hello")))),
+            isThread: false)))
+        viewModel.process(timelineAction: .setMode(mode: .previewVoiceMessage(state: AudioPlayerState(id: .recorderPreview, title: "", duration: 10.0),
+                                                                              waveform: .data([]),
+                                                                              isUploading: false,
+                                                                              replyContext: nil)))
+        
+        let deferred = deferFulfillment(viewModel.actions) { action in
+            switch action {
+            case .voiceMessage(.send(let inReplyToEventID)):
+                return inReplyToEventID == "testID"
+            default:
+                return false
+            }
+        }
+        viewModel.context.send(viewAction: .sendMessage)
+        try await deferred.fulfill()
+        
+        // The reply was captured for sending and must not be restored once the composer resets.
+        viewModel.process(timelineAction: .setMode(mode: .default))
+        #expect(viewModel.state.composerMode == .default)
     }
     
     @Test

--- a/UnitTests/Sources/VoiceMessageRecorderTests.swift
+++ b/UnitTests/Sources/VoiceMessageRecorderTests.swift
@@ -210,7 +210,8 @@ struct VoiceMessageRecorderTests {
         // If there is no recording file, an error is expected
         audioRecorder.audioFileURL = nil
         guard case .failure(.missingRecordingFile) = await voiceMessageRecorder.sendVoiceMessage(timelineController: timelineController,
-                                                                                                 audioConverter: audioConverter) else {
+                                                                                                 audioConverter: audioConverter,
+                                                                                                 inReplyToEventID: nil) else {
             Issue.record("An error is expected")
             return
         }
@@ -224,7 +225,8 @@ struct VoiceMessageRecorderTests {
         
         let timelineController = TimelineControllerMock(.init())
         guard case .failure(.failedSendingVoiceMessage) = await voiceMessageRecorder.sendVoiceMessage(timelineController: timelineController,
-                                                                                                      audioConverter: audioConverter) else {
+                                                                                                      audioConverter: audioConverter,
+                                                                                                      inReplyToEventID: nil) else {
             Issue.record("An error is expected")
             return
         }
@@ -240,9 +242,10 @@ struct VoiceMessageRecorderTests {
         
         let timelineProxy = TimelineProxyMock()
         let timelineController = TimelineControllerMock(.init(timelineProxy: timelineProxy))
-        timelineProxy.sendVoiceMessageUrlAudioInfoWaveformRequestHandleReturnValue = .failure(.sdkError(SDKError.generic))
+        timelineProxy.sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleReturnValue = .failure(.sdkError(SDKError.generic))
         guard case .failure(.failedSendingVoiceMessage) = await voiceMessageRecorder.sendVoiceMessage(timelineController: timelineController,
-                                                                                                      audioConverter: audioConverter) else {
+                                                                                                      audioConverter: audioConverter,
+                                                                                                      inReplyToEventID: nil) else {
             Issue.record("An error is expected")
             return
         }
@@ -259,9 +262,10 @@ struct VoiceMessageRecorderTests {
         
         let timelineProxy = TimelineProxyMock()
         let timelineController = TimelineControllerMock(.init(timelineProxy: timelineProxy))
-        timelineProxy.sendVoiceMessageUrlAudioInfoWaveformRequestHandleReturnValue = .failure(.sdkError(SDKError.generic))
+        timelineProxy.sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleReturnValue = .failure(.sdkError(SDKError.generic))
         guard case .failure(.failedSendingVoiceMessage) = await voiceMessageRecorder.sendVoiceMessage(timelineController: timelineController,
-                                                                                                      audioConverter: audioConverter) else {
+                                                                                                      audioConverter: audioConverter,
+                                                                                                      inReplyToEventID: nil) else {
             Issue.record("An error is expected")
             return
         }
@@ -280,9 +284,10 @@ struct VoiceMessageRecorderTests {
         // If the media upload fails
         let timelineProxy = TimelineProxyMock()
         let timelineController = TimelineControllerMock(.init(timelineProxy: timelineProxy))
-        timelineProxy.sendVoiceMessageUrlAudioInfoWaveformRequestHandleReturnValue = .failure(.sdkError(SDKError.generic))
+        timelineProxy.sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleReturnValue = .failure(.sdkError(SDKError.generic))
         guard case .failure(.failedSendingVoiceMessage) = await voiceMessageRecorder.sendVoiceMessage(timelineController: timelineController,
-                                                                                                      audioConverter: audioConverter) else {
+                                                                                                      audioConverter: audioConverter,
+                                                                                                      inReplyToEventID: nil) else {
             Issue.record("An error is expected")
             return
         }
@@ -314,23 +319,24 @@ struct VoiceMessageRecorderTests {
             #expect(destination.pathExtension == "ogg")
         }
         
-        timelineProxy.sendVoiceMessageUrlAudioInfoWaveformRequestHandleClosure = { url, audioInfo, waveform, _ in
+        timelineProxy.sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleClosure = { url, audioInfo, waveform, inReplyToEventID, _ in
             #expect(url == convertedFileURL)
             #expect(audioInfo.duration == audioRecorder.currentTime)
             #expect(audioInfo.size == convertedFileSize)
             #expect(audioInfo.mimetype == "audio/ogg")
             #expect(!waveform.isEmpty)
+            #expect(inReplyToEventID == "testEventID")
             
             return .success(())
         }
         
-        guard case .success = await voiceMessageRecorder.sendVoiceMessage(timelineController: timelineController, audioConverter: audioConverter) else {
+        guard case .success = await voiceMessageRecorder.sendVoiceMessage(timelineController: timelineController, audioConverter: audioConverter, inReplyToEventID: "testEventID") else {
             Issue.record("A success is expected")
             return
         }
         
         #expect(audioConverter.convertToOpusOggSourceURLDestinationURLCalled)
-        #expect(timelineProxy.sendVoiceMessageUrlAudioInfoWaveformRequestHandleCalled)
+        #expect(timelineProxy.sendVoiceMessageUrlAudioInfoWaveformInReplyToEventIDRequestHandleCalled)
         
         // the converted file must have been deleted
         if let convertedFileURL {


### PR DESCRIPTION
### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [x] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.

## Content

Closes #5485

Tapping Reply and then recording a voice message sent the audio without the reply relation, and the reply banner disappeared as soon as recording started (the voice message composer modes replace `.reply`, dropping its context).

Changes, mirroring the Android fix (element-hq/element-x-android#6464) adapted to the iOS composer's mode-based design:

- `ComposerMode.recordVoiceMessage`/`.previewVoiceMessage` now carry an optional `ReplyContext`. `ComposerToolbarViewModel` injects it centrally when transitioning out of `.reply`, carries it from recording to preview, and restores `.reply` when a recording is cancelled or deleted.
- The reply banner (reusing `MessageComposerReplyHeader`) stays visible above the recording/preview UI; its close button detaches the reply without stopping the recording.
- On send, the reply event ID is captured into the `.voiceMessage(.send(inReplyToEventID:))` action and threaded through `TimelineInteractionHandler` → `VoiceMessageRecorder` → `TimelineController` → `TimelineProxy`, which passes it to the SDK's `sendVoiceMessage` (`UploadParameters.inReplyTo` was previously hardcoded to `nil`). The composer resets to `.default` after sending, without restoring the reply.
- The composer analytics event now reports `isReply` correctly for voice messages.

## Motivation and context

Reply + voice message parity with Element X Android; users could not answer a message with an audio recording in context.

## Screenshots / GIFs

See the updated `composerToolbar.Reply-*` snapshots in this PR (recording UI with the reply banner above it).

## Tests

- New unit tests in `ComposerToolbarViewModelTests` covering: reply preserved across record/preview transitions, reply restored on cancel/delete, banner close detaching the reply while recording, and the send action capturing the reply event ID exactly once.
- `VoiceMessageRecorderTests` updated to assert the event ID reaches `TimelineProxy.sendVoiceMessage`.
- Full UnitTests suite passes (1089 tests). `composerToolbar` preview snapshots re-recorded and passing.

Steps to test manually:
1. Long press a message, tap Reply
2. Record a voice message — the reply banner stays visible during recording and preview
3. Send — the voice message appears in the timeline as a reply
4. Repeat but cancel/delete the recording — the composer returns to reply mode
5. Record without replying — sends a normal voice message as before

## Tested devices

- [x] iPhone (simulator, snapshot tests)
- [x] iPad (simulator, snapshot tests)