### PR TITLE
Force Disable E2EE for Element Pro

### DIFF
--- a/ElementX/Sources/Application/Settings/AppSettings.swift
+++ b/ElementX/Sources/Application/Settings/AppSettings.swift
@@ -24,6 +24,7 @@ nonisolated protocol CommonSettingsProtocol: AnyObject, Sendable {
     var traceLogPacks: Set<TraceLogPack> { get }
     var bugReportRageshakeURL: RemotePreference<RageshakeConfiguration> { get }
     var contentScannerURL: RemotePreference<URL?> { get }
+    var forceDisableE2EE: RemotePreference<Bool> { get }
     
     var enableOnlySignedDeviceIsolationMode: Bool { get }
     var threadsEnabled: Bool { get }
@@ -271,6 +272,12 @@ final nonisolated class AppSettings: @unchecked Sendable {
     /// The base URL of the content scanner server used to scan media before it is downloaded.
     /// `nil` when content scanning is disabled.
     let contentScannerURL: RemotePreference<URL?> = .init(nil)
+    
+    // MARK: - Encryption
+    
+    /// Whether the server forbids the use of E2EE: new rooms are created unencrypted and
+    /// enabling encryption on existing rooms is not offered.
+    let forceDisableE2EE: RemotePreference<Bool> = .init(false)
     
     // MARK: - Analytics
     

--- a/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenViewModel.swift
+++ b/ElementX/Sources/Screens/SecurityAndPrivacyScreen/SecurityAndPrivacyScreenViewModel.swift
@@ -161,7 +161,7 @@ class SecurityAndPrivacyScreenViewModel: SecurityAndPrivacyScreenViewModelType, 
         state.canEditAddress = powerLevels.canOwnUser(sendStateEvent: .roomCanonicalAlias)
         state.canEditJoinRule = powerLevels.canOwnUser(sendStateEvent: .roomJoinRules)
         state.canEditHistoryVisibility = powerLevels.canOwnUser(sendStateEvent: .roomHistoryVisibility)
-        state.canEnableEncryption = powerLevels.canOwnUser(sendStateEvent: .roomEncryption)
+        state.canEnableEncryption = powerLevels.canOwnUser(sendStateEvent: .roomEncryption) && !appSettings.forceDisableE2EE.publisher.value
     }
     
     private func setupRoomDirectoryVisibility() {

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -482,7 +482,7 @@ class ClientProxy: ClientProxyProtocol {
         do {
             let parameters = CreateRoomParameters(name: nil,
                                                   topic: nil,
-                                                  isEncrypted: true,
+                                                  isEncrypted: !appSettings.forceDisableE2EE.publisher.value,
                                                   isDirect: true,
                                                   visibility: .private,
                                                   preset: .trustedPrivateChat,
@@ -525,7 +525,7 @@ class ClientProxy: ClientProxyProtocol {
             
             let parameters = CreateRoomParameters(name: name,
                                                   topic: topic,
-                                                  isEncrypted: accessType.isEncrypted,
+                                                  isEncrypted: !appSettings.forceDisableE2EE.publisher.value && accessType.isEncrypted,
                                                   isDirect: false,
                                                   visibility: accessType.visibility,
                                                   preset: accessType.preset,

--- a/UnitTests/Sources/SecurityAndPrivacyScreenViewModelTests.swift
+++ b/UnitTests/Sources/SecurityAndPrivacyScreenViewModelTests.swift
@@ -434,13 +434,24 @@ final class SecurityAndPrivacyScreenViewModelTests {
         try await deferred.fulfill()
     }
     
+    @Test
+    func encryptionOptionAvailability() {
+        setupViewModel(joinedParentSpaces: [], joinRule: .public)
+        #expect(context.viewState.canEnableEncryption)
+        
+        setupViewModel(joinedParentSpaces: [], joinRule: .public, forceDisableE2EE: true)
+        #expect(!context.viewState.canEnableEncryption)
+    }
+    
     // MARK: - Helpers
     
     private func setupViewModel(joinedParentSpaces: [SpaceServiceRoom],
                                 topLevelSpaces: [SpaceServiceRoom] = [],
-                                joinRule: ElementX.JoinRule) {
+                                joinRule: ElementX.JoinRule,
+                                forceDisableE2EE: Bool = false) {
         let appSettings = AppSettings.volatile()
         appSettings.knockingEnabled = true
+        appSettings.forceDisableE2EE.applyRemoteValue(forceDisableE2EE)
         roomProxy = JoinedRoomProxyMock(.init(isEncrypted: false,
                                               canonicalAlias: "#room:matrix.org",
                                               members: .allMembersAsCreator,


### PR DESCRIPTION
Controlled by Element Pro, if true it will disable the creation (or the enabling) of e2ee rooms, but won't affect rooms that are already e2e encrypted.