### PR TITLE
Fix CurrentValuePublisher.map dropping updates when the mapped publisher is chained inline

### DIFF
--- a/ElementX/Sources/Other/CurrentValuePublisher.swift
+++ b/ElementX/Sources/Other/CurrentValuePublisher.swift
@@ -13,33 +13,44 @@ import Combine
 ///
 /// `CurrentValueSubject` is documented as thread-safe but is not formally `Sendable`, hence `@unchecked`.
 nonisolated struct CurrentValuePublisher<Output, Failure: Error>: Publisher, @unchecked Sendable {
-    private let subject: CurrentValueSubject<Output, Failure>
-    /// Retains the upstream subscription feeding ``subject`` when this publisher is derived via ``map(_:)``.
-    private let cancellable: AnyCancellable?
-    
-    init(_ subject: CurrentValueSubject<Output, Failure>, cancellable: AnyCancellable? = nil) {
-        self.subject = subject
-        self.cancellable = cancellable
+    private let upstream: AnyPublisher<Output, Failure>
+    private let valueProvider: () -> Output
+
+    init(_ subject: CurrentValueSubject<Output, Failure>) {
+        upstream = subject.eraseToAnyPublisher()
+        valueProvider = { subject.value }
     }
-    
+
     init(_ value: Output) {
         self.init(CurrentValueSubject(value))
     }
-    
-    func receive<S: Subscriber>(subscriber: S) where Failure == S.Failure, Output == S.Input {
-        subject.receive(subscriber: subscriber)
+
+    private init(upstream: AnyPublisher<Output, Failure>, valueProvider: @escaping () -> Output) {
+        self.upstream = upstream
+        self.valueProvider = valueProvider
     }
-    
+
+    func receive<S: Subscriber>(subscriber: S) where Failure == S.Failure, Output == S.Input {
+        upstream.receive(subscriber: subscriber)
+    }
+
     var value: Output {
-        subject.value
+        valueProvider()
     }
 }
 
 nonisolated extension CurrentValuePublisher where Failure == Never {
+    /// Transform the published values (and ``value``), subscribing to the underlying subject
+    /// lazily, per subscriber.
+    ///
+    /// Bridging eagerly through a second subject doesn't work here: the subscription feeding it
+    /// would need to be retained by this struct, but Combine consumes publisher structs when
+    /// building a subscription, so chaining a mapped publisher inline dropped the feed and
+    /// downstream only ever received the initial value (e.g. the knock requests banner never
+    /// updated for a knock arriving while the room was open).
     func map<T>(_ transform: @escaping (Output) -> T) -> CurrentValuePublisher<T, Never> {
-        let subject = CurrentValueSubject<T, Never>(transform(value))
-        let cancellable = sink { subject.send(transform($0)) }
-        return .init(subject, cancellable: cancellable)
+        .init(upstream: upstream.map(transform).eraseToAnyPublisher(),
+              valueProvider: { transform(value) })
     }
 }
 

--- a/ElementX/Sources/Other/CurrentValuePublisher.swift
+++ b/ElementX/Sources/Other/CurrentValuePublisher.swift
@@ -15,25 +15,25 @@ import Combine
 nonisolated struct CurrentValuePublisher<Output, Failure: Error>: Publisher, @unchecked Sendable {
     private let upstream: AnyPublisher<Output, Failure>
     private let valueProvider: () -> Output
-
+    
     init(_ subject: CurrentValueSubject<Output, Failure>) {
         upstream = subject.eraseToAnyPublisher()
         valueProvider = { subject.value }
     }
-
+    
     init(_ value: Output) {
         self.init(CurrentValueSubject(value))
     }
-
+    
     private init(upstream: AnyPublisher<Output, Failure>, valueProvider: @escaping () -> Output) {
         self.upstream = upstream
         self.valueProvider = valueProvider
     }
-
+    
     func receive<S: Subscriber>(subscriber: S) where Failure == S.Failure, Output == S.Input {
         upstream.receive(subscriber: subscriber)
     }
-
+    
     var value: Output {
         valueProvider()
     }

--- a/ElementX/Sources/Other/CurrentValuePublisher.swift
+++ b/ElementX/Sources/Other/CurrentValuePublisher.swift
@@ -40,14 +40,11 @@ nonisolated struct CurrentValuePublisher<Output, Failure: Error>: Publisher, @un
 }
 
 nonisolated extension CurrentValuePublisher where Failure == Never {
-    /// Transform the published values (and ``value``), subscribing to the underlying subject
-    /// lazily, per subscriber.
+    /// Transforms the published values and ``value``.
     ///
-    /// Bridging eagerly through a second subject doesn't work here: the subscription feeding it
-    /// would need to be retained by this struct, but Combine consumes publisher structs when
-    /// building a subscription, so chaining a mapped publisher inline dropped the feed and
-    /// downstream only ever received the initial value (e.g. the knock requests banner never
-    /// updated for a knock arriving while the room was open).
+    /// The transform runs lazily, once per subscriber and per ``value`` read. It must stay lazy:
+    /// this struct is discarded when the mapped publisher is chained inline, so anything eager
+    /// (a live subscription feeding a second subject) would be cancelled and stop the updates.
     func map<T>(_ transform: @escaping (Output) -> T) -> CurrentValuePublisher<T, Never> {
         .init(upstream: upstream.map(transform).eraseToAnyPublisher(),
               valueProvider: { transform(value) })

--- a/UnitTests/Sources/CurrentValuePublisherTests.swift
+++ b/UnitTests/Sources/CurrentValuePublisherTests.swift
@@ -1,0 +1,50 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Combine
+@testable import ElementX
+import Testing
+
+struct CurrentValuePublisherTests {
+    @Test
+    func publisherReplaysCurrentValueAndDeliversSubsequentOnes() {
+        let subject = CurrentValueSubject<Int, Never>(1)
+        var received = [Int]()
+        let cancellable = subject.asCurrentValuePublisher().sink { received.append($0) }
+        subject.send(2)
+        subject.send(3)
+        #expect(received == [1, 2, 3])
+        cancellable.cancel()
+    }
+
+    @Test
+    func mappedPublisherChainedInlineDeliversSubsequentValues() {
+        let subject = CurrentValueSubject<Int, Never>(1)
+        var received = [Int]()
+        // Regression test: chain the mapped publisher inline WITHOUT storing it. The eager
+        // subject-bridging implementation of map lost its feeding subscription here (nothing
+        // retained the returned struct's cancellable), so subscribers only ever saw the
+        // initial value — hiding e.g. live knock request updates in the room screen.
+        let cancellable = subject.asCurrentValuePublisher()
+            .map { $0 * 2 }
+            .removeDuplicates()
+            .sink { received.append($0) }
+        subject.send(2)
+        subject.send(3)
+        #expect(received == [2, 4, 6])
+        cancellable.cancel()
+    }
+
+    @Test
+    func mappedPublisherValueStaysCurrent() {
+        let subject = CurrentValueSubject<Int, Never>(1)
+        let mapped = subject.asCurrentValuePublisher().map { $0 * 2 }
+        #expect(mapped.value == 2)
+        subject.send(5)
+        #expect(mapped.value == 10)
+    }
+}

--- a/UnitTests/Sources/CurrentValuePublisherTests.swift
+++ b/UnitTests/Sources/CurrentValuePublisherTests.swift
@@ -20,7 +20,7 @@ struct CurrentValuePublisherTests {
         #expect(received == [1, 2, 3])
         cancellable.cancel()
     }
-
+    
     @Test
     func mappedPublisherChainedInlineDeliversSubsequentValues() {
         let subject = CurrentValueSubject<Int, Never>(1)
@@ -38,7 +38,7 @@ struct CurrentValuePublisherTests {
         #expect(received == [2, 4, 6])
         cancellable.cancel()
     }
-
+    
     @Test
     func mappedPublisherValueStaysCurrent() {
         let subject = CurrentValueSubject<Int, Never>(1)

--- a/UnitTests/Sources/CurrentValuePublisherTests.swift
+++ b/UnitTests/Sources/CurrentValuePublisherTests.swift
@@ -25,10 +25,8 @@ struct CurrentValuePublisherTests {
     func mappedPublisherChainedInlineDeliversSubsequentValues() {
         let subject = CurrentValueSubject<Int, Never>(1)
         var received = [Int]()
-        // Regression test: chain the mapped publisher inline WITHOUT storing it. The eager
-        // subject-bridging implementation of map lost its feeding subscription here (nothing
-        // retained the returned struct's cancellable), so subscribers only ever saw the
-        // initial value — hiding e.g. live knock request updates in the room screen.
+        // The mapped publisher is intentionally chained without being stored: the struct is
+        // discarded mid-chain, which used to cancel an eager map's subscription and stop updates.
         let cancellable = subject.asCurrentValuePublisher()
             .map { $0 * 2 }
             .removeDuplicates()


### PR DESCRIPTION
This fixes a bug which the E2E test rig showed up, where EXI doesn't show new knocks if you already have the room open.

Fable-generated, with its explanation below:

> The eager implementation bridged through a second CurrentValueSubject fed by a sink whose AnyCancellable was stored on the returned struct. Combine consumes publisher structs when building a subscription, so chaining the mapped publisher inline (e.g. `publisher.map { … }.removeDuplicates(…) .sink { … }`, as RoomScreenViewModel and RoomDetailsScreenViewModel do for knock requests) dropped the only copy holding that cancellable: the feeding sink was cancelled and subscribers only ever received the initial value.
>
> In practice this meant a room admin viewing a knockable room never saw the "wants to join" banner (or a live "Requests to join" badge) for a knock arriving while the room was open — it only appeared when the knock predated opening the room. Caught by a live cross-client knocking test; the double-execution of the transform at subscription time (eager transform + current-value replay) was the giveaway.
>
>Make map lazy instead: keep the transformed AnyPublisher and a value provider, so subscribers attach straight through to the source subject (which replays its current value itself) and no keep-alive is needed. Adds a regression test chaining a mapped publisher inline.
