### PR TITLE
Constrained tests tool implementation + skill

### DIFF
--- a/.agents/skills/constrained-tests/SKILL.md
+++ b/.agents/skills/constrained-tests/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: constrained-tests
+description: Run unit tests on saturated CPU to reproduce CI-style flakiness locally. Suggest when new/reworked suite lean heavy on awaits (deferFulfillment, waitForConfirmation, TestClock, timeouts) or test fail only on CI. Not for every change.
+---
+
+# Constrained test runs
+
+CI runners shared + slow. Background tasks starve, awaits stretch, scheduler races flake there, pass locally. `--constrained` saturate CPU with hog tasks — same conditions, local.
+
+## When
+
+- PR add/rework suite heavy on timing-sensitive async: `deferFulfillment`, `waitForConfirmation`, `TestClock`, `transitionValues`, timeouts.
+- Test fail on CI, pass locally.
+- Not routine changes, not sync suites — slow, no gain.
+
+## How
+
+Full unit test workflow (what CI run):
+
+```bash
+swift run tools ci unit-tests --constrained
+```
+
+One suite, iterate on new tests (prefer while developing):
+
+```bash
+swift run tools ci run-tests --scheme UnitTests --test-name MyNewTests --constrained
+```
+
+Both take `--constrained-task-count <n>` (default 20 ≈ 2× cores). Suite survive ~10 constrained iterations → good shape.
+
+## Failures mean
+
+Failure under constraint = real bug in test (sometimes code under test): assertion race async work, transient state observation missed, timeout too tight. Fix synchronisation, no blind timeout bump. Helpers in `UnitTests/Sources/TestUtilities/` (`deferFulfillment`, `deferFailure`, `waitForConfirmation`). Wait on durable state, not transient.

--- a/.agents/skills/constrained-tests/SKILL.md
+++ b/.agents/skills/constrained-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: constrained-tests
-description: Run unit tests on saturated CPU to reproduce CI-style flakiness locally. Suggest when new/reworked suite lean heavy on awaits (deferFulfillment, waitForConfirmation, TestClock, timeouts) or test fail only on CI. Not for every change.
+description: Slow-CI simulation — run unit tests on saturated CPU to reproduce CI-style flakiness locally. Suggest when new/reworked suite lean heavy on awaits (deferFulfillment, waitForConfirmation, TestClock, timeouts) or test fail only on CI. Not for every change.
 ---
 
 # Constrained test runs
@@ -27,7 +27,7 @@ One suite, iterate on new tests (prefer while developing):
 swift run tools ci run-tests --scheme UnitTests --test-name MyNewTests --constrained
 ```
 
-Both take `--constrained-task-count <n>` (default 20 ≈ 2× cores). Suite survive ~10 constrained iterations → good shape.
+Hog count automatic (2× cores). Suite survive ~10 constrained iterations → good shape.
 
 ## Failures mean
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,6 @@ Initial setup: `swift run tools setup-project`
 
 CI test commands:
 - Unit tests: `swift run tools ci unit-tests`
-- Slow-CI simulation: add `--constrained` (hog count: `--constrained-task-count`, default 20). Also on `ci run-tests` for one suite. New async-heavy suite? Use `constrained-tests` skill — not for every change.
 - CI help: `swift run tools ci --help`
 
 ### Targets & Layout

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ Initial setup: `swift run tools setup-project`
 
 CI test commands:
 - Unit tests: `swift run tools ci unit-tests`
+- Slow-CI simulation: add `--constrained` (hog count: `--constrained-task-count`, default 20). Also on `ci run-tests` for one suite. New async-heavy suite? Use `constrained-tests` skill — not for every change.
 - CI help: `swift run tools ci --help`
 
 ### Targets & Layout

--- a/Tools/Sources/Commands/CI/CPUConstraint.swift
+++ b/Tools/Sources/Commands/CI/CPUConstraint.swift
@@ -5,9 +5,10 @@ import Foundation
 final class CPUConstraint {
     private var processes = [Process]()
     
-    /// Starts the given number of CPU hogging tasks. 2× the machine's cores is
-    /// enough to keep the scheduler permanently oversubscribed.
-    func start(taskCount: Int) {
+    /// 2× the machine's cores is enough to keep the scheduler permanently oversubscribed.
+    private let taskCount = ProcessInfo.processInfo.processorCount * 2
+    
+    func start() {
         logger.info("\n🐌 Constraining the CPU with \(taskCount) tasks…\n")
         
         for _ in 0..<taskCount {

--- a/Tools/Sources/Commands/CI/CPUConstraint.swift
+++ b/Tools/Sources/Commands/CI/CPUConstraint.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Saturates the CPU with busy processes for the duration of a test run, approximating
+/// a loaded CI runner where timing-sensitive tests are starved of processor time.
+final class CPUConstraint {
+    private var processes = [Process]()
+    
+    /// Starts the given number of CPU hogging tasks. 2× the machine's cores is
+    /// enough to keep the scheduler permanently oversubscribed.
+    func start(taskCount: Int) {
+        logger.info("\n🐌 Constraining the CPU with \(taskCount) tasks…\n")
+        
+        for _ in 0..<taskCount {
+            let process = Process()
+            process.executableURL = URL(filePath: "/usr/bin/yes")
+            process.standardOutput = FileHandle.nullDevice
+            process.standardError = FileHandle.nullDevice
+            
+            do {
+                try process.run()
+                processes.append(process)
+            } catch {
+                logger.error("Failed to start a CPU constraining task: \(error)")
+            }
+        }
+    }
+    
+    func stop() {
+        guard !processes.isEmpty else { return }
+        
+        logger.info("\n🐌 Releasing the CPU…\n")
+        processes.forEach { $0.terminate() }
+        processes.removeAll()
+    }
+    
+    deinit {
+        stop()
+    }
+}

--- a/Tools/Sources/Commands/CI/RunTests.swift
+++ b/Tools/Sources/Commands/CI/RunTests.swift
@@ -39,6 +39,12 @@ struct RunTests: AsyncParsableCommand {
     @Option(help: "Only run a specific test (format: 'ClassName/testName').")
     var testName: String?
     
+    @Flag(help: "Run the tests on a saturated CPU to reproduce the flakiness of a busy CI runner.")
+    var constrained = false
+    
+    @Option(help: "The number of CPU hogging tasks to run when the tests are constrained.")
+    var constrainedTaskCount = 20
+    
     private var isCI: Bool {
         ProcessInfo.processInfo.environment["CI"] != nil
     }
@@ -72,6 +78,12 @@ struct RunTests: AsyncParsableCommand {
         // Ensure the output directory exists
         let outputDirectory = resultBundleURL.deletingLastPathComponent()
         try FileManager.default.createDirectory(at: outputDirectory, withIntermediateDirectories: true)
+        
+        let cpuConstraint = CPUConstraint()
+        if constrained {
+            cpuConstraint.start(taskCount: constrainedTaskCount)
+        }
+        defer { cpuConstraint.stop() }
         
         try await executeXcodeBuild()
         

--- a/Tools/Sources/Commands/CI/RunTests.swift
+++ b/Tools/Sources/Commands/CI/RunTests.swift
@@ -42,9 +42,6 @@ struct RunTests: AsyncParsableCommand {
     @Flag(help: "Run the tests on a saturated CPU to reproduce the flakiness of a busy CI runner.")
     var constrained = false
     
-    @Option(help: "The number of CPU hogging tasks to run when the tests are constrained.")
-    var constrainedTaskCount = 20
-    
     private var isCI: Bool {
         ProcessInfo.processInfo.environment["CI"] != nil
     }
@@ -81,7 +78,7 @@ struct RunTests: AsyncParsableCommand {
         
         let cpuConstraint = CPUConstraint()
         if constrained {
-            cpuConstraint.start(taskCount: constrainedTaskCount)
+            cpuConstraint.start()
         }
         defer { cpuConstraint.stop() }
         

--- a/Tools/Sources/Commands/CI/UnitTests.swift
+++ b/Tools/Sources/Commands/CI/UnitTests.swift
@@ -11,9 +11,6 @@ struct UnitTests: AsyncParsableCommand {
     @Flag(help: "Run the unit tests on a saturated CPU to reproduce the flakiness of a busy CI runner.")
     var constrained = false
     
-    @Option(help: "The number of CPU hogging tasks to run when the tests are constrained.")
-    var constrainedTaskCount = 20
-    
     private static let osVersion = CI.defaultOSVersion
     private static let device = "iPhone 17"
     
@@ -26,18 +23,17 @@ struct UnitTests: AsyncParsableCommand {
         do {
             logger.info("\n🧪 Running unit tests…\n")
             
-            let cpuConstraint = CPUConstraint()
-            if constrained {
-                cpuConstraint.start(taskCount: constrainedTaskCount)
-            }
-            defer { cpuConstraint.stop() }
-            
-            try await RunTests.parse([
+            var arguments = [
                 "--scheme", "UnitTests",
                 "--device", Self.device,
                 "--os-version", Self.osVersion,
                 "--retries", "3"
-            ]).run()
+            ]
+            if constrained {
+                arguments.append("--constrained")
+            }
+            
+            try await RunTests.parse(arguments).run()
         } catch {
             failures.append("UnitTests")
             logger.error("\n❌ Unit tests failed. \(error)\n")

--- a/Tools/Sources/Commands/CI/UnitTests.swift
+++ b/Tools/Sources/Commands/CI/UnitTests.swift
@@ -8,6 +8,12 @@ struct UnitTests: AsyncParsableCommand {
     @Flag(help: "Skip preview tests")
     var skipPreviews = false
     
+    @Flag(help: "Run the unit tests on a saturated CPU to reproduce the flakiness of a busy CI runner.")
+    var constrained = false
+    
+    @Option(help: "The number of CPU hogging tasks to run when the tests are constrained.")
+    var constrainedTaskCount = 20
+    
     private static let osVersion = CI.defaultOSVersion
     private static let device = "iPhone 17"
     
@@ -19,6 +25,13 @@ struct UnitTests: AsyncParsableCommand {
         // Run unit tests
         do {
             logger.info("\n🧪 Running unit tests…\n")
+            
+            let cpuConstraint = CPUConstraint()
+            if constrained {
+                cpuConstraint.start(taskCount: constrainedTaskCount)
+            }
+            defer { cpuConstraint.stop() }
+            
             try await RunTests.parse([
                 "--scheme", "UnitTests",
                 "--device", Self.device,


### PR DESCRIPTION
Are you tired of writing a huge suite of tests (or have your AI write them), and then just find out they work fine locally, but miserably fail on CI? With this tool you can "kinda" simulate the CPU constraints of CI, by essentially running the tests, alongside some awaiting slow processes to create a starved CPU environments. It's not intended to be used always, like the skill suggested, should be tried once, if you have build a very heavy dependant suite of tests on awaiting a lot of long sleeps.