### PR TITLE
Display pushes for knocks (MSC4506)

### DIFF
--- a/ElementX/Resources/Localizations/en.lproj/Untranslated.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Untranslated.strings
@@ -1,3 +1,4 @@
+"notification_knock_request_body" = "Requested to join";
 "screen_home_tab_search" = "Search";
 "screen_search_empty_state_message" = "Search for chats and messages";
 "screen_search_empty_state_title" = "Start searching...";

--- a/ElementX/Sources/Generated/Strings+Untranslated.swift
+++ b/ElementX/Sources/Generated/Strings+Untranslated.swift
@@ -10,6 +10,8 @@ import Foundation
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
 internal nonisolated enum UntranslatedL10n {
+  /// Requested to join
+  internal static var notificationKnockRequestBody: String { return UntranslatedL10n.tr("Untranslated", "notification_knock_request_body") }
   /// Search
   internal static var screenHomeTabSearch: String { return UntranslatedL10n.tr("Untranslated", "screen_home_tab_search") }
   /// Search for chats and messages

--- a/NSE/Sources/NotificationContentBuilder.swift
+++ b/NSE/Sources/NotificationContentBuilder.swift
@@ -59,28 +59,39 @@ nonisolated struct NotificationContentBuilder {
                                  notificationItem: notificationItem,
                                  mediaProvider: mediaProvider)
         case .timeline(let event):
-            guard case let .messageLike(messageContent) = try? event.content() else {
-                processEmpty(&notificationContent)
-                return
-            }
-            
-            await processMessageLike(notificationContent: &notificationContent,
-                                     notificationItem: notificationItem,
-                                     mediaProvider: mediaProvider)
-            
-            switch messageContent {
-            case .roomMessage(let messageType, _):
-                await processRoomMessage(notificationContent: &notificationContent,
+            switch try? event.content() {
+            case .messageLike(let messageContent):
+                await processMessageLike(notificationContent: &notificationContent,
                                          notificationItem: notificationItem,
-                                         messageType: messageType,
                                          mediaProvider: mediaProvider)
-            case .poll(let question):
-                notificationContent.body = L10n.commonPollSummary(question)
-            case .callInvite:
-                notificationContent.body = L10n.commonUnsupportedCall
-            case .rtcNotification:
-                notificationContent.body = L10n.notificationIncomingCall
-            default:
+
+                switch messageContent {
+                case .roomMessage(let messageType, _):
+                    await processRoomMessage(notificationContent: &notificationContent,
+                                             notificationItem: notificationItem,
+                                             messageType: messageType,
+                                             mediaProvider: mediaProvider)
+                case .poll(let question):
+                    notificationContent.body = L10n.commonPollSummary(question)
+                case .callInvite:
+                    notificationContent.body = L10n.commonUnsupportedCall
+                case .rtcNotification:
+                    notificationContent.body = L10n.notificationIncomingCall
+                default:
+                    processEmpty(&notificationContent)
+                }
+            case .state(let stateContent):
+                switch stateContent {
+                case .roomMemberContent(_, .knock):
+                    // MSCxxxx: the homeserver pushes knocks to users who can act on them.
+                    await processMessageLike(notificationContent: &notificationContent,
+                                             notificationItem: notificationItem,
+                                             mediaProvider: mediaProvider)
+                    notificationContent.body = UntranslatedL10n.notificationKnockRequestBody
+                default:
+                    processEmpty(&notificationContent)
+                }
+            case .none:
                 processEmpty(&notificationContent)
             }
         }

--- a/NSE/Sources/NotificationContentBuilder.swift
+++ b/NSE/Sources/NotificationContentBuilder.swift
@@ -83,7 +83,7 @@ nonisolated struct NotificationContentBuilder {
             case .state(let stateContent):
                 switch stateContent {
                 case .roomMemberContent(_, .knock):
-                    // MSCxxxx: the homeserver pushes knocks to users who can act on them.
+                    // MSC4506: the homeserver pushes knocks to users who can act on them.
                     await processMessageLike(notificationContent: &notificationContent,
                                              notificationItem: notificationItem,
                                              mediaProvider: mediaProvider)

--- a/NSE/Sources/NotificationContentBuilder.swift
+++ b/NSE/Sources/NotificationContentBuilder.swift
@@ -88,6 +88,13 @@ nonisolated struct NotificationContentBuilder {
                                              notificationItem: notificationItem,
                                              mediaProvider: mediaProvider)
                     notificationContent.body = UntranslatedL10n.notificationKnockRequestBody
+                case .roomMemberContent(let userID, .invite) where userID == notificationItem.receiverID:
+                    // An invite for us can resolve as a timeline member event rather than a stripped
+                    // invite when the room has already advanced past the invited state — e.g. the
+                    // server auto-joined us because our knock was accepted (synapse#16307).
+                    await processInvited(notificationContent: &notificationContent,
+                                         notificationItem: notificationItem,
+                                         mediaProvider: mediaProvider)
                 default:
                     processEmpty(&notificationContent)
                 }

--- a/NSE/Sources/NotificationHandler.swift
+++ b/NSE/Sources/NotificationHandler.swift
@@ -148,8 +148,14 @@ nonisolated class NotificationHandler {
                  .beacon:
                 return .unsupportedShouldDiscard
             }
-        case .state:
-            return .unsupportedShouldDiscard
+        case .state(let stateContent):
+            switch stateContent {
+            case .roomMemberContent(_, .knock):
+                // MSCxxxx: the homeserver pushes knocks to users who can act on them.
+                return .shouldDisplay
+            default:
+                return .unsupportedShouldDiscard
+            }
         case .none:
             return .unsupportedShouldDiscard
         }

--- a/NSE/Sources/NotificationHandler.swift
+++ b/NSE/Sources/NotificationHandler.swift
@@ -151,7 +151,7 @@ nonisolated class NotificationHandler {
         case .state(let stateContent):
             switch stateContent {
             case .roomMemberContent(_, .knock):
-                // MSCxxxx: the homeserver pushes knocks to users who can act on them.
+                // MSC4506: the homeserver pushes knocks to users who can act on them.
                 return .shouldDisplay
             case .roomMemberContent(let userID, .invite) where userID == itemProxy.receiverID:
                 // An invite for us that resolved as a timeline member event (e.g. the room

--- a/NSE/Sources/NotificationHandler.swift
+++ b/NSE/Sources/NotificationHandler.swift
@@ -153,6 +153,11 @@ nonisolated class NotificationHandler {
             case .roomMemberContent(_, .knock):
                 // MSCxxxx: the homeserver pushes knocks to users who can act on them.
                 return .shouldDisplay
+            case .roomMemberContent(let userID, .invite) where userID == itemProxy.receiverID:
+                // An invite for us that resolved as a timeline member event (e.g. the room
+                // already advanced past invited because the server auto-joined our accepted
+                // knock, synapse#16307) — rendered as a plain invite.
+                return .shouldDisplay
             default:
                 return .unsupportedShouldDiscard
             }

--- a/NSE/SupportingFiles/target.yml
+++ b/NSE/SupportingFiles/target.yml
@@ -93,6 +93,7 @@ targets:
     - path: ../../ElementX/Sources/Application/Settings
     - path: ../../ElementX/Sources/Application/TargetConfiguration.swift
     - path: ../../ElementX/Sources/Generated/Strings.swift
+    - path: ../../ElementX/Sources/Generated/Strings+Untranslated.swift
     - path: ../../ElementX/Sources/Other/Avatars.swift
     - path: ../../ElementX/Sources/Other/CurrentValuePublisher.swift
     - path: ../../ElementX/Sources/Other/ExpiringTaskRunner.swift

--- a/UnitTests/Sources/NotificationContentBuilderTests.swift
+++ b/UnitTests/Sources/NotificationContentBuilderTests.swift
@@ -8,6 +8,7 @@
 import Dynamic
 @testable import ElementX
 import MatrixRustSDK
+import MatrixRustSDKMocks
 import Testing
 import UserNotifications
 
@@ -219,6 +220,57 @@ nonisolated struct NotificationContentBuilderTests {
         #expect(notificationContent.sound == nil)
         #expect(notificationContent.threadIdentifier == "bob:matrix.org!testroom:matrix.orgthread123")
         #expect(notificationContent.attachments == [])
+    }
+    
+    @Test
+    mutating func knockNotification() async {
+        let event = TimelineEventSDKMock()
+        event.eventIdReturnValue = UUID().uuidString
+        event.contentReturnValue = .state(content: .roomMemberContent(userId: "@charlie:matrix.org", membershipState: .knock))
+        
+        let notificationItem = NotificationItemProxyMock(.init(event: .timeline(event: event),
+                                                               roomID: "!test:matrix.org",
+                                                               receiverID: "@bob:matrix.org",
+                                                               senderDisplayName: "Charlie",
+                                                               roomDisplayName: "Secret Club",
+                                                               roomJoinedMembers: 2,
+                                                               isRoomDirect: false,
+                                                               isRoomPrivate: true,
+                                                               isNoisy: true))
+        
+        await notificationContentBuilder.process(notificationContent: &notificationContent,
+                                                 notificationItem: notificationItem,
+                                                 mediaProvider: mediaProvider)
+        
+        let communicationContext = Dynamic(notificationContent, memberName: "communicationContext")
+        #expect(communicationContext.sender.displayName == "Charlie")
+        #expect(notificationContent.body == UntranslatedL10n.notificationKnockRequestBody)
+        #expect(notificationContent.categoryIdentifier == NotificationConstants.Category.message)
+        #expect(notificationContent.sound != nil)
+    }
+    
+    @Test
+    mutating func otherMembershipStateEventNotification() async {
+        let event = TimelineEventSDKMock()
+        event.eventIdReturnValue = UUID().uuidString
+        event.contentReturnValue = .state(content: .roomMemberContent(userId: "@charlie:matrix.org", membershipState: .join))
+        
+        let notificationItem = NotificationItemProxyMock(.init(event: .timeline(event: event),
+                                                               roomID: "!test:matrix.org",
+                                                               receiverID: "@bob:matrix.org",
+                                                               senderDisplayName: "Charlie",
+                                                               roomDisplayName: "Secret Club",
+                                                               roomJoinedMembers: 2,
+                                                               isRoomDirect: false,
+                                                               isRoomPrivate: true,
+                                                               isNoisy: true))
+        
+        await notificationContentBuilder.process(notificationContent: &notificationContent,
+                                                 notificationItem: notificationItem,
+                                                 mediaProvider: mediaProvider)
+        
+        // Non-knock membership state events fall back to the generic notification.
+        #expect(notificationContent.body == L10n.notification)
     }
     
     @Test


### PR DESCRIPTION
implements MSC4506 

tested via e2e test rig (flow 10)

requires rust-sdk changes (to be PR'd)

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [x] This PR has been made with the help of an LLM.
