### PR TITLE
Advance the join room screen if we're autojoined by the server

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -437,6 +437,7 @@
 		4715FE33667C5899E64DD0E6 /* ResolveVerifiedUserSendFailureScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97287090CA64DAA95386ECED /* ResolveVerifiedUserSendFailureScreen.swift */; };
 		4716587A9BA69ED8FD1B986B /* PollOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6B19D10B102956066AF117B /* PollOptionView.swift */; };
 		47305C0911C9E1AA774A4000 /* TemplateScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA90BD288E5AE6BC643AFDDF /* TemplateScreenCoordinator.swift */; };
+		473D6362E1D1A714E07B1B0B /* RoomSDKMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A6C38B29A60E187D6A4B0A /* RoomSDKMock.swift */; };
 		4764FC9A843D1F9865EDC29C /* EditRoomAddressScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4048547AC50ADCF201684E87 /* EditRoomAddressScreen.swift */; };
 		478C363F63A5DFC3C83E334C /* MediaProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F65E4BB9E82EB8373207CF8 /* MediaProviderMock.swift */; };
 		4807E8F51DB54F56B25E1C7E /* AppLockSetupSettingsScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8C38663020DF2EB2D13F5E /* AppLockSetupSettingsScreenViewModel.swift */; };
@@ -1980,6 +1981,7 @@
 		276833816F5DEB1CE3B8BE1E /* ReportRoomScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportRoomScreen.swift; sourceTree = "<group>"; };
 		27A1AD6389A4659AF0CEAE62 /* NotificationServiceExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationServiceExtension.swift; sourceTree = "<group>"; };
 		27A5FBB74981BF8EFFDAE90D /* HTMLFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLFixtures.swift; sourceTree = "<group>"; };
+		27A6C38B29A60E187D6A4B0A /* RoomSDKMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomSDKMock.swift; sourceTree = "<group>"; };
 		27A9E3FBE8A66B5A17AD7F74 /* AppRoutes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRoutes.swift; sourceTree = "<group>"; };
 		27D0EA07BD545CC9F234DB8D /* UserDetailsEditScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDetailsEditScreenModels.swift; sourceTree = "<group>"; };
 		27DF257F5D968E5DD719583C /* BugReportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugReportTests.swift; sourceTree = "<group>"; };
@@ -7051,6 +7053,7 @@
 				580BDCD23DD02481AB5FFB47 /* LeaveSpaceHandleSDKMock.swift */,
 				C2B8AA3199BAAD066E36CB07 /* RoomListSDKMock.swift */,
 				E3454C79D9E2444BBDBF9F5A /* RoomListServiceSDKMock.swift */,
+				27A6C38B29A60E187D6A4B0A /* RoomSDKMock.swift */,
 				0EF5721148A5D59B476BA976 /* SearchServiceSDKMock.swift */,
 				90B1E4D1F0A6FAAE64B54D76 /* SpaceServiceSDKMock.swift */,
 				F70373EF23A73181D2568D79 /* SyncServiceBuilderSDKMock.swift */,
@@ -9253,6 +9256,7 @@
 				8358D145F9BF94F412BEDCA8 /* RoomRolesAndPermissionsScreenModels.swift in Sources */,
 				69B3C6010B42010F591FC3CB /* RoomRolesAndPermissionsScreenViewModel.swift in Sources */,
 				F8F47CE757EE656905F01F2C /* RoomRolesAndPermissionsScreenViewModelProtocol.swift in Sources */,
+				473D6362E1D1A714E07B1B0B /* RoomSDKMock.swift in Sources */,
 				C55A44C99F64A479ABA85B46 /* RoomScreen.swift in Sources */,
 				A851635B3255C6DC07034A12 /* RoomScreenCoordinator.swift in Sources */,
 				E8C65C19F7C40EE545172DD6 /* RoomScreenFooterView.swift in Sources */,

--- a/ElementX/Sources/Mocks/RoomSummaryProviderMock.swift
+++ b/ElementX/Sources/Mocks/RoomSummaryProviderMock.swift
@@ -73,7 +73,7 @@ extension RoomSummary {
     static func mock(id: String,
                      name: String,
                      canonicalAlias: String? = nil) -> RoomSummary {
-        RoomSummary(room: RoomSDKMock(),
+        RoomSummary(room: RoomSDKMock(.init()),
                     id: id,
                     joinRequestType: nil,
                     name: name,

--- a/ElementX/Sources/Mocks/SDK/RoomSDKMock.swift
+++ b/ElementX/Sources/Mocks/SDK/RoomSDKMock.swift
@@ -1,0 +1,22 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Foundation
+import MatrixRustSDK
+import MatrixRustSDKMocks
+
+nonisolated extension RoomSDKMock {
+    struct Configuration {
+        var membership: Membership = .joined
+    }
+    
+    convenience init(_ configuration: Configuration) {
+        self.init()
+        
+        membershipReturnValue = configuration.membership
+    }
+}

--- a/ElementX/Sources/Screens/JoinRoomScreen/JoinRoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/JoinRoomScreen/JoinRoomScreenViewModel.swift
@@ -22,6 +22,7 @@ class JoinRoomScreenViewModel: JoinRoomScreenViewModelType, JoinRoomScreenViewMo
     private var room: RoomProxyType?
     private var isLoadingPreview = true
     private var membershipStateChangeCancellable: AnyCancellable?
+    private var hasSentJoinAction = false
     
     private let actionsSubject: PassthroughSubject<JoinRoomScreenViewModelAction, Never> = .init()
     var actionsPublisher: AnyPublisher<JoinRoomScreenViewModelAction, Never> {
@@ -148,27 +149,16 @@ class JoinRoomScreenViewModel: JoinRoomScreenViewModelType, JoinRoomScreenViewMo
         case .invited(let invitedRoomProxy):
             inviter = invitedRoomProxy.inviter.map(RoomInviterDetails.init)
             roomInfo = invitedRoomProxy.info
+            watchForMembershipChange(from: .invited)
         case .knocked(let knockedRoomProxy):
             roomInfo = knockedRoomProxy.info
-            membershipStateChangeCancellable = clientProxy
-                .staticRoomSummaryProvider
-                .roomListPublisher
-                .compactMap { summaries -> Void? in
-                    guard let roomSummary = summaries.first(where: { $0.id == roomInfo?.id }),
-                          roomSummary.room.membership() != .knocked else {
-                        return nil
-                    }
-                    return ()
-                }
-                .sink { [weak self] in
-                    Task { await self?.loadRoomDetails() }
-                }
+            watchForMembershipChange(from: .knocked)
         case .banned(let bannedRoomProxy):
             roomInfo = bannedRoomProxy.info
         default:
             break
         }
-        
+
         switch source {
         case .generic(let roomID, _):
             await updateGenericRoomDetails(roomID: roomID, roomInfo: roomInfo, inviter: inviter)
@@ -176,6 +166,32 @@ class JoinRoomScreenViewModel: JoinRoomScreenViewModelType, JoinRoomScreenViewMo
             await updateSpaceRoomDetails(spaceServiceRoom: spaceServiceRoom, inviter: inviter)
         }
         await updateMode()
+
+        // The homeserver can join us to the room without a join request from this client:
+        // it auto-joined us after our knock was accepted
+        // (https://github.com/element-hq/synapse/issues/16307), or the invite was accepted
+        // on another of our devices. Advance into the room as if the join button had been
+        // tapped, matching Android's RoomFlowNode.
+        if case .joined = room {
+            await finishJoinAction()
+        }
+    }
+
+    private func watchForMembershipChange(from membership: Membership) {
+        let roomID = state.roomID
+        membershipStateChangeCancellable = clientProxy
+            .staticRoomSummaryProvider
+            .roomListPublisher
+            .compactMap { summaries -> Void? in
+                guard let roomSummary = summaries.first(where: { $0.id == roomID }),
+                      roomSummary.room.membership() != membership else {
+                    return nil
+                }
+                return ()
+            }
+            .sink { [weak self] in
+                Task { await self?.loadRoomDetails() }
+            }
     }
     
     private func updateGenericRoomDetails(roomID: String, roomInfo: BaseRoomInfoProxyProtocol?, inviter: RoomInviterDetails?) async {
@@ -329,16 +345,22 @@ class JoinRoomScreenViewModel: JoinRoomScreenViewModelType, JoinRoomScreenViewMo
     }
     
     private func finishJoinAction() async {
+        // A user-initiated join and a server-side one can complete concurrently:
+        // only ever advance once.
+        guard !hasSentJoinAction else { return }
+
         let roomID = state.roomID
         appSettings.seenInvites.remove(roomID)
-        
+
         guard state.roomDetails?.isSpace == true else {
+            hasSentJoinAction = true
             actionsSubject.send(.joined(.roomID(roomID)))
             return
         }
-        
+
         switch await clientProxy.spaceService.spaceRoomList(spaceID: roomID) {
         case .success(let spaceRoomListProxy):
+            hasSentJoinAction = true
             actionsSubject.send(.joined(.space(spaceRoomListProxy)))
         case .failure(let error):
             MXLog.error("Failed to get the space room list after joining: \(error)")

--- a/ElementX/Sources/Screens/JoinRoomScreen/JoinRoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/JoinRoomScreen/JoinRoomScreenViewModel.swift
@@ -22,6 +22,7 @@ class JoinRoomScreenViewModel: JoinRoomScreenViewModelType, JoinRoomScreenViewMo
     private var room: RoomProxyType?
     private var isLoadingPreview = true
     private var membershipStateChangeCancellable: AnyCancellable?
+    private var hasSentJoinAction = false
     
     private let actionsSubject: PassthroughSubject<JoinRoomScreenViewModelAction, Never> = .init()
     var actionsPublisher: AnyPublisher<JoinRoomScreenViewModelAction, Never> {
@@ -148,21 +149,10 @@ class JoinRoomScreenViewModel: JoinRoomScreenViewModelType, JoinRoomScreenViewMo
         case .invited(let invitedRoomProxy):
             inviter = invitedRoomProxy.inviter.map(RoomInviterDetails.init)
             roomInfo = invitedRoomProxy.info
+            watchForMembershipChange(from: .invited)
         case .knocked(let knockedRoomProxy):
             roomInfo = knockedRoomProxy.info
-            membershipStateChangeCancellable = clientProxy
-                .staticRoomSummaryProvider
-                .roomListPublisher
-                .compactMap { summaries -> Void? in
-                    guard let roomSummary = summaries.first(where: { $0.id == roomInfo?.id }),
-                          roomSummary.room.membership() != .knocked else {
-                        return nil
-                    }
-                    return ()
-                }
-                .sink { [weak self] in
-                    Task { await self?.loadRoomDetails() }
-                }
+            watchForMembershipChange(from: .knocked)
         case .banned(let bannedRoomProxy):
             roomInfo = bannedRoomProxy.info
         default:
@@ -176,6 +166,32 @@ class JoinRoomScreenViewModel: JoinRoomScreenViewModelType, JoinRoomScreenViewMo
             await updateSpaceRoomDetails(spaceServiceRoom: spaceServiceRoom, inviter: inviter)
         }
         await updateMode()
+        
+        // The homeserver can join us to the room without a join request from this client:
+        // it auto-joined us after our knock was accepted
+        // (https://github.com/element-hq/synapse/issues/16307), or the invite was accepted
+        // on another of our devices. Advance into the room as if the join button had been
+        // tapped, matching Android's RoomFlowNode.
+        if case .joined = room {
+            await finishJoinAction()
+        }
+    }
+    
+    private func watchForMembershipChange(from membership: Membership) {
+        let roomID = state.roomID
+        membershipStateChangeCancellable = clientProxy
+            .staticRoomSummaryProvider
+            .roomListPublisher
+            .compactMap { summaries -> Void? in
+                guard let roomSummary = summaries.first(where: { $0.id == roomID }),
+                      roomSummary.room.membership() != membership else {
+                    return nil
+                }
+                return ()
+            }
+            .sink { [weak self] in
+                Task { await self?.loadRoomDetails() }
+            }
     }
     
     private func updateGenericRoomDetails(roomID: String, roomInfo: BaseRoomInfoProxyProtocol?, inviter: RoomInviterDetails?) async {
@@ -329,16 +345,22 @@ class JoinRoomScreenViewModel: JoinRoomScreenViewModelType, JoinRoomScreenViewMo
     }
     
     private func finishJoinAction() async {
+        // A user-initiated join and a server-side one can complete concurrently:
+        // only ever advance once.
+        guard !hasSentJoinAction else { return }
+        
         let roomID = state.roomID
         appSettings.seenInvites.remove(roomID)
         
         guard state.roomDetails?.isSpace == true else {
+            hasSentJoinAction = true
             actionsSubject.send(.joined(.roomID(roomID)))
             return
         }
         
         switch await clientProxy.spaceService.spaceRoomList(spaceID: roomID) {
         case .success(let spaceRoomListProxy):
+            hasSentJoinAction = true
             actionsSubject.send(.joined(.space(spaceRoomListProxy)))
         case .failure(let error):
             MXLog.error("Failed to get the space room list after joining: \(error)")

--- a/UnitTests/Sources/JoinRoomScreenViewModelTests.swift
+++ b/UnitTests/Sources/JoinRoomScreenViewModelTests.swift
@@ -6,6 +6,7 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+import Combine
 @testable import ElementX
 import Testing
 
@@ -16,11 +17,15 @@ final class JoinRoomScreenViewModelTests {
         case knocked
         case invited
         case banned
+        case alreadyJoined
     }
     
     var viewModel: JoinRoomScreenViewModelProtocol!
     
     var clientProxy: ClientProxyMock!
+    
+    /// Backs the client's static room summary provider so tests can push membership changes.
+    var roomListSubject: CurrentValueSubject<[RoomSummary], Never>!
     
     var context: JoinRoomScreenViewModelType.Context {
         viewModel.context
@@ -35,6 +40,7 @@ final class JoinRoomScreenViewModelTests {
     isolated deinit {
         viewModel = nil
         clientProxy = nil
+        roomListSubject = nil
     }
     
     @Test
@@ -115,6 +121,26 @@ final class JoinRoomScreenViewModelTests {
     }
     
     @Test
+    func alreadyJoinedRoomAdvancesTheScreen() async throws {
+        setupViewModel(mode: .alreadyJoined)
+        
+        let deferred = deferFulfillment(viewModel.actionsPublisher) { $0 == .joined(.roomID("1")) }
+        try await deferred.fulfill()
+    }
+    
+    @Test
+    func membershipChangeWhileInvitedAdvancesTheScreen() async throws {
+        setupViewModel(mode: .invited)
+        try await deferFulfillment(viewModel.context.$viewState) { $0.mode == .invited(isDM: false) }.fulfill()
+        
+        // Simulate the server-side join arriving through the room list.
+        clientProxy.roomForIdentifierClosure = { .joined(JoinedRoomProxyMock(.init(id: $0))) }
+        let deferred = deferFulfillment(viewModel.actionsPublisher) { $0 == .joined(.roomID("1")) }
+        roomListSubject.send([.mock(id: "1", name: "Test")])
+        try await deferred.fulfill()
+    }
+    
+    @Test
     func declineAndBlockInviteLegacyInteraction() async throws {
         setupViewModel(mode: .invited)
         clientProxy.underlyingIsReportRoomSupported = false
@@ -169,6 +195,11 @@ final class JoinRoomScreenViewModelTests {
     private func setupViewModel(throwing: Bool = false, mode: TestMode = .joined) {
         clientProxy = ClientProxyMock(.init())
         
+        roomListSubject = .init([])
+        let summaryProvider = RoomSummaryProviderMock(.init())
+        summaryProvider.roomListPublisher = roomListSubject.asCurrentValuePublisher()
+        clientProxy.staticRoomSummaryProvider = summaryProvider
+        
         clientProxy.joinRoomViaReturnValue = throwing ? .failure(.sdkError(ClientProxyMockError.generic)) : .success(())
         clientProxy.joinRoomAliasReturnValue = clientProxy.joinRoomViaReturnValue
         
@@ -197,6 +228,11 @@ final class JoinRoomScreenViewModelTests {
                 let roomProxy = BannedRoomProxyMock(.init())
                 roomProxy.forgetRoomReturnValue = .success(())
                 return .banned(roomProxy)
+            }
+        case .alreadyJoined:
+            clientProxy.roomPreviewForIdentifierViaReturnValue = .success(RoomPreviewProxyMock.joinable)
+            clientProxy.roomForIdentifierClosure = { roomID in
+                .joined(JoinedRoomProxyMock(.init(id: roomID)))
             }
         }
         


### PR DESCRIPTION
The homeserver can join a user without a join request from their client - auto-accepting a knock (element-hq/synapse#16307) or an invite accepted on another device. The join room screen only navigated on a user-initiated join and only observed membership changes while knocked, so a server-side join left it sitting on a stale invited state.

Watch for membership changes while invited too, and when the local room becomes joined, advance into the room exactly as a tapped join would - matching Android's RoomFlowNode. finishJoinAction is now idempotent so concurrent user- and server-initiated joins can't both navigate.

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**

e2e test rig (flow 10)