### PR TITLE
Mark the onboarding start screen title as an accessibility header

### DIFF
--- a/ElementX/Sources/Screens/Authentication/StartScreen/View/AuthenticationStartScreen.swift
+++ b/ElementX/Sources/Screens/Authentication/StartScreen/View/AuthenticationStartScreen.swift
@@ -80,6 +80,7 @@ struct AuthenticationStartScreen: View {
                         .font(.compound.headingLGBold)
                         .foregroundColor(.compound.textPrimary)
                         .multilineTextAlignment(.center)
+                        .accessibilityAddTraits(.isHeader)
                     Text(L10n.screenOnboardingWelcomeMessage(InfoPlistReader.main.productionAppName))
                         .font(.compound.bodyLG)
                         .foregroundColor(.compound.textPrimary)


### PR DESCRIPTION
## Content

The onboarding start screen's title text has no `.accessibilityAddTraits(.isHeader)`, so it isn't reachable via VoiceOver's heading rotor.

## Motivation and context

Screen titles need to be reachable as headers so VoiceOver users can navigate by heading, consistent with how other Element X screens are marked up.

## Testing

- Step 1: enable VoiceOver, open the rotor, choose "Headings", confirm the screen title is listed
- Step 2: verify with VoiceOver enabled
- Step 3: verify in both light and dark mode

## Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog) (`pr-a11y`).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [x] iPhone and iPad simulators in portrait and landscape orientations.
- [x] Dark mode enabled and disabled.
- [x] Various sizes of dynamic type.
- [x] Voiceover enabled.