### PR TITLE
Combine the poll winner icon and vote count into one accessibility element

### DIFF
--- a/ElementX/Sources/Screens/Timeline/View/Polls/PollOptionView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Polls/PollOptionView.swift
@@ -37,11 +37,12 @@ struct PollOptionView: View {
                                 CompoundIcon(asset: Asset.Images.pollWinner)
                                     .foregroundColor(.compound.iconAccentTertiary)
                                     .accessibilityLabel(L10n.a11yPollsWinningAnswer)
-                                
+
                                 Text(L10n.commonPollVotesCount(pollOption.votes))
                                     .font(.compound.bodySMSemibold)
                                     .foregroundColor(.compound.textPrimary)
                             }
+                            .accessibilityElement(children: .combine)
                         } else {
                             Text(L10n.commonPollVotesCount(pollOption.votes))
                                 .font(.compound.bodySM)


### PR DESCRIPTION
## Content

The trophy icon that marks a poll's winning option and the vote-count text next to it are exposed as two separate VoiceOver elements. Add `.accessibilityElement(children: .combine)` to the containing `HStack` so they're announced together.

## Motivation and context

Without combining these, VoiceOver users hear the vote count but never learn that this particular option won.

## Testing

- Step 1: enable VoiceOver, open a finished poll, focus the winning option, confirm winner context and vote count are announced together
- Step 2: verify with VoiceOver enabled
- Step 3: verify in both light and dark mode

## Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog) (`pr-a11y`).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [x] iPhone and iPad simulators in portrait and landscape orientations.
- [x] Dark mode enabled and disabled.
- [x] Various sizes of dynamic type.
- [x] Voiceover enabled.