### PR TITLE
Combine poll option elements and hide the redundant progress bar from VoiceOver

### DIFF
--- a/ElementX/Sources/Screens/Timeline/View/Polls/PollOptionView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Polls/PollOptionView.swift
@@ -51,8 +51,10 @@ struct PollOptionView: View {
                 }
                 
                 PollProgressView(progress: progress)
+                    .accessibilityHidden(true)
             }
         }
+        .accessibilityElement(children: .combine)
     }
     
     // MARK: - Private


### PR DESCRIPTION
## Content

Each poll option renders its selection icon, text and vote count as separate VoiceOver elements, and the `PollProgressView` progress bar underneath has no `.accessibilityHidden`, so VoiceOver announces a meaningless progress element in addition to the text.

## Motivation and context

Combining the option into a single element and hiding the purely-visual progress bar gives VoiceOver users one clear, coherent announcement per option instead of three fragments.

## Testing

- Step 1: enable VoiceOver, open an active poll, focus an option, confirm a single coherent announcement with no separate progress-bar element
- Step 2: verify with VoiceOver enabled
- Step 3: verify in both light and dark mode

## Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog) (`pr-a11y`).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [x] iPhone and iPad simulators in portrait and landscape orientations.
- [x] Dark mode enabled and disabled.
- [x] Various sizes of dynamic type.
- [x] Voiceover enabled.