### PR TITLE
Expose formatting toolbar buttons as toggle controls to VoiceOver

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/FormattingToolbar.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/View/FormattingToolbar.swift
@@ -32,6 +32,7 @@ struct FormattingToolbar: View {
                     .disabled(item.state == .disabled)
                     .accessibilityIdentifier(item.accessibilityIdentifier)
                     .accessibilityLabel(item.accessibilityLabel)
+                    .accessibilityAddTraits(item.state == .reversed ? [.isToggle, .isSelected] : .isToggle)
                 }
             }
         }


### PR DESCRIPTION
## Content

Formatting toolbar items (bold, italic, etc.) have an `accessibilityLabel` but no toggle trait, so VoiceOver announces them as plain buttons instead of toggles and never reports whether the formatting is currently active.

## Motivation and context

A control that toggles a persistent state (formatting on/off) should be exposed to VoiceOver as a toggle so its current state is announced.

## Testing

- Step 1: enable VoiceOver, open the message composer's formatting toolbar, focus a formatting button, toggle it, confirm VoiceOver announces it as a toggle with its current state
- Step 2: verify with VoiceOver enabled
- Step 3: verify in both light and dark mode

## Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog) (`pr-a11y`).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.