### PR TITLE
Label the avatar edit button on the own-profile edit screen

### DIFF
--- a/ElementX/Sources/Screens/Settings/UserDetailsEditScreen/View/UserDetailsEditScreen.swift
+++ b/ElementX/Sources/Screens/Settings/UserDetailsEditScreen/View/UserDetailsEditScreen.swift
@@ -73,6 +73,7 @@ struct UserDetailsEditScreen: View {
         }
         .buttonStyle(EditAvatarButtonStyle())
         .disabled(!context.viewState.canEditAvatar)
+        .accessibilityLabel(L10n.a11yEditAvatar)
         .frame(maxWidth: .infinity, alignment: .center)
         .listRowBackground(Color.clear)
     }


### PR DESCRIPTION
## Content

The avatar button on the user's own profile edit screen has no `accessibilityLabel`. An existing localized string for this purpose (`L10n.a11yEditAvatar`) is already used on the create-room screen but not applied here.

## Motivation and context

Reuse the existing `L10n.a11yEditAvatar` string so VoiceOver users get a clear, consistent description of what the avatar button does on this screen too.

## Testing

- Step 1: enable VoiceOver, open Settings > profile edit, focus the avatar button, confirm it announces a meaningful label
- Step 2: verify with VoiceOver enabled
- Step 3: verify in both light and dark mode

## Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog) (`pr-a11y`).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.