### PR TITLE
Improve text field border contrast in the resting state

### DIFF
--- a/compound-ios/Sources/Compound/BaseStyles/CompoundTextFieldStyles.swift
+++ b/compound-ios/Sources/Compound/BaseStyles/CompoundTextFieldStyles.swift
@@ -138,7 +138,7 @@ public struct CompoundTextFieldStyle: @MainActor TextFieldStyle {
     
     /// The width of the text field's border.
     private var borderWidth: CGFloat {
-        isFocused || isError ? 1.0 : 0
+        isFocused || isError || kind.isRaised ? 1.0 : 0
     }
     
     private var accentColor: Color {


### PR DESCRIPTION
## Content

Text fields using `CompoundTextFieldStyles` have a very thin/invisible border in their resting (non-focused) state, making the field boundary and placeholder text hard to distinguish from the background for low-vision users.

## Motivation and context

Text field boundaries need sufficient contrast at rest, not just when focused, so users can identify input areas before interacting with them.

## Testing

- Step 1: view a login/search text field in its resting state, verify border and placeholder contrast with an automated contrast checker
- Step 2: verify with VoiceOver enabled
- Step 3: verify in both light and dark mode

## Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog) (`pr-a11y`).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.