### PR TITLE
Add a visible custom focus ring to the standard button style

### DIFF
--- a/compound-ios/Sources/Compound/BaseStyles/CompoundButtonStyle.swift
+++ b/compound-ios/Sources/Compound/BaseStyles/CompoundButtonStyle.swift
@@ -22,6 +22,7 @@ public struct CompoundButtonStyle: ButtonStyle {
     @Environment(\.isEnabled) private var isEnabled
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.accessibilityShowButtonShapes) private var accessibilityShowButtonShapes
+    @Environment(\.isFocused) private var isFocused
     
     var kind: Kind
     public enum Kind {
@@ -117,6 +118,11 @@ public struct CompoundButtonStyle: ButtonStyle {
                 makeBackground(configuration: configuration)
             }
             .contentShape(contentShape)
+            .overlay {
+                if isFocused {
+                    contentShape.stroke(.compound.borderInteractivePrimary, lineWidth: 2)
+                }
+            }
     }
     
     @ViewBuilder


### PR DESCRIPTION
## Content

The default button style has no custom focus indicator for external-keyboard users, relying entirely on the system default.

## Motivation and context

A visible, on-brand focus ring makes keyboard focus easier to track than the system default, and this repo already has an established pattern (`compound-ios`) for custom styles.

## Testing

- Step 1: connect a hardware keyboard, tab through standard buttons, confirm a visible focus ring appears
- Step 2: verify with VoiceOver enabled
- Step 3: verify in both light and dark mode

## Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog) (`pr-a11y`).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.