### PR TITLE
Announce chat list reordering to VoiceOver

### DIFF
--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreenContent.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreenContent.swift
@@ -54,6 +54,7 @@ struct HomeScreenContent: View {
                                     .frame(maxWidth: .infinity, minHeight: max(0, geometry.size.height - topSectionHeight))
                             } else {
                                 HomeScreenRoomList(context: context)
+                                    .accessibilityAddTraits(.updatesFrequently)
                             }
                         } header: {
                             topSection


### PR DESCRIPTION
## Content

When the order of chats in the home screen list changes (e.g. a room moves to the top after a new message), there's no `accessibilityScrollAction`/`.updatesFrequently` trait set, so VoiceOver users aren't told the list has reordered.

## Motivation and context

Frequently-reordering lists should be marked so VoiceOver knows to re-announce position changes rather than silently reordering under the user.

## Testing

- Step 1: enable VoiceOver, receive a message in a room further down the list, confirm the reorder is communicated
- Step 2: verify with VoiceOver enabled
- Step 3: verify in both light and dark mode

## Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog) (`pr-a11y`).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.