### PR TITLE
Group Element Pro changes into a dedicated release notes section

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,32 +3,66 @@ changelog:
     - title: ✨ Features
       labels:
         - pr-feature
+      exclude:
+        labels:
+          - element-pro
     - title: 🙌 Improvements
       labels:
         - pr-change
+      exclude:
+        labels:
+          - element-pro
     - title: 🐛 Bugfixes
       labels:
         - pr-bugfix
+      exclude:
+        labels:
+          - element-pro
     - title: ⚠️ API Changes
       labels:
         - pr-api
+      exclude:
+        labels:
+          - element-pro
     - title: 🗣 Translations
       labels:
         - pr-i18n
+      exclude:
+        labels:
+          - element-pro
     - title: 🦻 Accessibility
       labels:
         - pr-a11y
+      exclude:
+        labels:
+          - element-pro
     - title: 🧱 Build
       labels:
         - pr-build
+      exclude:
+        labels:
+          - element-pro
     - title: 📄 Documentation
       labels:
         - pr-doc
+      exclude:
+        labels:
+          - element-pro
     - title: 🚧 In development 🚧
       labels:
         - pr-wip
+      exclude:
+        labels:
+          - element-pro
 
     - title: Others
       labels:
         - pr-misc
         - "*"
+      exclude:
+        labels:
+          - element-pro
+
+    - title: 💎 Element Pro
+      labels:
+        - element-pro


### PR DESCRIPTION
This is a proposal to avoid confusion between the features than land in EX and code changes that are made only for Element Pro.

It add a new tag `element-pro` which does not start with `pr-` to pass Danger checks.
All `element-pro` PRs will land on a dedicated section at the bottom for visibility. We are losing the granularity of feature vs bugfix vs etc but we could be a separate homemade script later for proper Element Pro release notes.

I am really not sure about 💎 .


### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [x] This PR has been made with the help of an LLM.
