### PR TITLE
Group Element Pro changes into a dedicated release notes section

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -28,6 +28,10 @@ changelog:
       labels:
         - pr-wip
 
+    - title: 💼 Element Pro
+      labels:
+        - pr-element-pro
+
     - title: Others
       labels:
         - pr-misc


### PR DESCRIPTION
This PR replaces #5897 with a simpler approach using a simple new [`pr-element-pro`](https://github.com/element-hq/element-x-ios/labels?q=pr-element-pro) label.