### PR TITLE
Enable client pausing and resuming for all builds

### DIFF
--- a/ElementX/Sources/Application/Settings/AppSettings.swift
+++ b/ElementX/Sources/Application/Settings/AppSettings.swift
@@ -426,7 +426,7 @@ final nonisolated class AppSettings: @unchecked Sendable {
     @UserPreference(defaultValue: false)
     var automaticBackPaginationEnabled: Bool
     
-    @UserPreference(defaultValue: AppBuildType.current != .release, volatile: true)
+    @UserPreference(defaultValue: true, volatile: true)
     var clientPausingAndResumingEnabled: Bool
     
     @UserPreference(defaultValue: false)


### PR DESCRIPTION
The mechanism has been running on nightly and debug builds since it was introduced and Sentry shows background teardown panic occurring far less on nightly than on production.

Flip the default on for release builds too so store users get the fix.