### PR TITLE
Add signed in flag to the developer options screen hook

### DIFF
--- a/ElementX/Sources/AppHooks/Hooks/DeveloperOptionsScreenHook.swift
+++ b/ElementX/Sources/AppHooks/Hooks/DeveloperOptionsScreenHook.swift
@@ -8,11 +8,11 @@
 import SwiftUI
 
 nonisolated protocol DeveloperOptionsScreenHookProtocol: Sendable {
-    func generalSectionRows() -> AnyView?
+    func generalSectionRows(isSignedIn: Bool) -> AnyView?
 }
 
 struct DefaultDeveloperOptionsScreenHook: DeveloperOptionsScreenHookProtocol {
-    func generalSectionRows() -> AnyView? {
+    func generalSectionRows(isSignedIn: Bool) -> AnyView? {
         nil
     }
 }

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
@@ -16,7 +16,7 @@ struct DeveloperOptionsScreenViewState: BindableState {
     let appHooks: AppHooks
     var storeSizes: [StoreSize]?
     let shouldShowClearCache: Bool
-    let isPresentedModally: Bool
+    let isSignedIn: Bool
     
     var bindings: DeveloperOptionsScreenViewStateBindings
     

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenViewModel.swift
@@ -24,7 +24,7 @@ class DeveloperOptionsScreenViewModel: DeveloperOptionsScreenViewModelType, Deve
         self.clientProxy = clientProxy
         super.init(initialViewState: .init(appHooks: appHooks,
                                            shouldShowClearCache: clientProxy != nil,
-                                           isPresentedModally: clientProxy == nil,
+                                           isSignedIn: clientProxy != nil,
                                            bindings: .init(developerOptions: developerOptions)))
         
         Task {

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
@@ -60,7 +60,7 @@ struct DeveloperOptionsScreen: View {
                 
                 context.viewState.appHooks
                     .developerOptionsScreenHook
-                    .generalSectionRows()
+                    .generalSectionRows(isSignedIn: context.viewState.isSignedIn)
             }
             
             Section("Room List") {
@@ -209,7 +209,7 @@ struct DeveloperOptionsScreen: View {
     
     @ToolbarContentBuilder
     private var toolbar: some ToolbarContent {
-        if context.viewState.isPresentedModally {
+        if !context.viewState.isSignedIn {
             ToolbarItem(placement: .primaryAction) {
                 if #available(iOS 26.0, *) {
                     Button(role: .close, action: dismiss.callAsFunction)


### PR DESCRIPTION
to differentiate between the signed in and the logged out state when presenting the dev options screen