### PR TITLE
Update SDK to 26.07.22

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -10389,7 +10389,7 @@
 			repositoryURL = "https://github.com/element-hq/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 26.07.20;
+				version = 26.07.22;
 			};
 		};
 		701C7BEF8F70F7A83E852DCC /* XCRemoteSwiftPackageReference "GZIP" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ed9be16560fed06ea598988a9fa7423a0bfb74cb245df6ae821e9bef9220a45d",
+  "originHash" : "8695e92a09c543da9f94741ab3087985e336ad7c44e87d1c14cede284e65b225",
   "pins" : [
     {
       "identity" : "compound-design-tokens",
@@ -167,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/matrix-rust-components-swift",
       "state" : {
-        "revision" : "bf41c1a369bae29f2a8e77c85c4cd9a718e1d973",
-        "version" : "26.7.20"
+        "revision" : "363a6c069fb4bd3000e472aa59e13478ccf01611",
+        "version" : "26.7.22"
       }
     },
     {

--- a/project.yml
+++ b/project.yml
@@ -74,7 +74,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/element-hq/matrix-rust-components-swift
-    exactVersion: 26.07.20
+    exactVersion: 26.07.22
     # path: ../matrix-rust-sdk
   Compound:
     path: compound-ios


### PR DESCRIPTION
SDK updated to 26.07.22, this should fix a decryption error with content scanner, that broke previews for safely scanned content.