### PR TITLE
WIP: support for waitingForAuth continuation sender during Link new device

### DIFF
--- a/ElementX/Sources/Screens/QRCodeLoginScreen/QRCodeLoginScreenViewModel.swift
+++ b/ElementX/Sources/Screens/QRCodeLoginScreen/QRCodeLoginScreenViewModel.swift
@@ -181,8 +181,16 @@ class QRCodeLoginScreenViewModel: QRCodeLoginScreenViewModelType, QRCodeLoginScr
                     break // Nothing to do, the state was set above.
                 case .establishingSecureChannel(let checkCodeString):
                     state.state = .displayCode(.deviceCode(checkCodeString))
-                case .waitingForAuthorisation(let url):
-                    requestOAuthAuthorization(url: url)
+                case .waitingForAuthorisation(let verificationURL, let continuationSender):
+                    // TODO: comment as to why we can confirm it immediately
+                    Task {
+                        do {
+                            try await continuationSender.confirm()
+                        } catch {
+                            // TODO:
+                        }
+                    }
+                    requestOAuthAuthorization(url: verificationURL)
                 case .syncingSecrets:
                     break // Nothing to do.
                 case .done:
@@ -221,7 +229,15 @@ class QRCodeLoginScreenViewModel: QRCodeLoginScreenViewModelType, QRCodeLoginScr
                     break // Nothing to do, we are already showing the code by the time this method is called.
                 case .qrScanned(let checkCodeSender):
                     state.state = .confirmCode(.inputCode(checkCodeSender))
-                case .waitingForAuthorisation(let url):
+                case .waitingForAuthorisation(let url, let continuationSender):
+                    // TODO: comment as to why we can confirm it immediately
+                    Task {
+                        do {
+                            try await continuationSender.confirm()
+                        } catch {
+                            // TODO:
+                        }
+                    }
                     requestOAuthAuthorization(url: url)
                 case .syncingSecrets:
                     break // Nothing to do.

--- a/ElementX/Sources/Services/Authentication/AuthenticationService.swift
+++ b/ElementX/Sources/Services/Authentication/AuthenticationService.swift
@@ -378,7 +378,7 @@ private extension HumanQrLoginError {
             .qrCodeError(.deviceNotSignedIn)
         case .UnsupportedQrCodeType:
             .qrCodeError(.invalidQRCode)
-        case .Unknown, .OAuthMetadataInvalid, .CheckCodeAlreadySent, .CheckCodeCannotBeSent:
+        case .Unknown, .OAuthMetadataInvalid, .CheckCodeAlreadySent, .CheckCodeCannotBeSent, .ContinuationAlreadySent, .ContinuationCannotBeSent:
             .qrCodeError(.unknown)
         }
     }

--- a/ElementX/Sources/Services/Authentication/LinkNewDeviceService.swift
+++ b/ElementX/Sources/Services/Authentication/LinkNewDeviceService.swift
@@ -29,7 +29,7 @@ class LinkNewDeviceService: LinkNewDeviceServiceProtocol {
         case starting
         case qrReady(UIImage)
         case qrScanned(CheckCodeSenderProxy)
-        case waitingForAuthorisation(verificationURL: URL)
+        case waitingForAuthorisation(verificationURL: URL, continuationSender: ContinuationMessageSenderProxy)
         case syncingSecrets
         case done
     }
@@ -38,7 +38,7 @@ class LinkNewDeviceService: LinkNewDeviceServiceProtocol {
     enum LinkDesktopProgress: Equatable {
         case starting
         case establishingSecureChannel(checkCodeString: String)
-        case waitingForAuthorisation(verificationURL: URL)
+        case waitingForAuthorisation(verificationURL: URL, continuationSender: ContinuationMessageSenderProxy)
         case syncingSecrets
         case done
     }
@@ -163,10 +163,10 @@ extension LinkNewDeviceService.LinkMobileProgress: CustomStringConvertible {
                 throw Error.invalidQRCodeData
             }
         case .qrScanned(let checkCodeSender): .qrScanned(.init(underlyingSender: checkCodeSender))
-        case .waitingForAuth(let verificationURI):
+        case .waitingForAuth(let verificationURI, let continuationSender):
             // verificationURI is a String; ASWebAuthenticationSession requires a URL.
             if let url = URL(string: verificationURI) {
-                .waitingForAuthorisation(verificationURL: url)
+                .waitingForAuthorisation(verificationURL: url, continuationSender: .init(underlyingSender: continuationSender))
             } else {
                 throw Error.invalidVerificationURI(verificationURI)
             }
@@ -194,10 +194,10 @@ extension LinkNewDeviceService.LinkDesktopProgress: CustomStringConvertible {
         self = switch rustProgress {
         case .starting: .starting
         case .establishingSecureChannel(_, let checkCodeString): .establishingSecureChannel(checkCodeString: checkCodeString)
-        case .waitingForAuth(let verificationURI):
+        case .waitingForAuth(let verificationURI, let continuationSender):
             // verificationURI is a String; ASWebAuthenticationSession requires a URL.
             if let url = URL(string: verificationURI) {
-                .waitingForAuthorisation(verificationURL: url)
+                .waitingForAuthorisation(verificationURL: url, continuationSender: .init(underlyingSender: continuationSender))
             } else {
                 throw Error.invalidVerificationURI(verificationURI)
             }
@@ -253,6 +253,26 @@ nonisolated class CheckCodeSenderProxy: Equatable {
     
     func send(code: UInt8) async throws {
         try await underlyingSender.send(code: code)
+    }
+}
+
+class ContinuationMessageSenderProxy: Equatable {
+    static func == (lhs: ContinuationMessageSenderProxy, rhs: ContinuationMessageSenderProxy) -> Bool {
+        lhs.underlyingSender === rhs.underlyingSender
+    }
+    
+    let underlyingSender: ContinuationMessageSenderProtocol
+    
+    init(underlyingSender: ContinuationMessageSenderProtocol) {
+        self.underlyingSender = underlyingSender
+    }
+    
+    func confirm() async throws {
+        try await underlyingSender.confirm()
+    }
+    
+    func cancel() async throws {
+        try await underlyingSender.cancel()
     }
 }
 


### PR DESCRIPTION
For use with https://github.com/matrix-org/matrix-rust-sdk/pull/6711

### Pull Request Checklist

- [ ] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [ ] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [ ] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
