### PR TITLE
Add dedicated message text selection

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		05FF0CD80EDAB3A7C0D4700A /* InfoPlistReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A580295A56B55A856CC4084 /* InfoPlistReader.swift */; };
 		0638CBDE3098B1C3F23AFCFA /* MXLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111B698739E3410E2CDB7144 /* MXLog.swift */; };
 		065EAB39F3F3AB4F6BD2A362 /* AppLockSetupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19DD166C3625EE426203FA29 /* AppLockSetupTests.swift */; };
+		0668BECCF11E8EE6936CDF16 /* TimelineItemMenuActionProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98C243A90369929D669873D /* TimelineItemMenuActionProviderTests.swift */; };
 		066A1E9B94723EE9F3038044 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47EBB5D698CE9A25BB553A2D /* Strings.swift */; };
 		06B55882911B4BF5B14E9851 /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 227AC5D71A4CE43512062243 /* URL.swift */; };
 		06D17F7813AA931FF18FD5D0 /* SDKListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5CD2993048222B64C45006 /* SDKListener.swift */; };
@@ -968,6 +969,7 @@
 		9A0326D2375075871D2AB537 /* ResolveVerifiedUserSendFailureScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574CB70E82D7EAEA538E4135 /* ResolveVerifiedUserSendFailureScreenViewModel.swift */; };
 		9A3B0CDF097E3838FB1B9595 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E89E530A8E92EC44301CA1 /* Bundle.swift */; };
 		9A8E6FCD86B89970EC72EFD8 /* BugReportServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7FC9580CABF797A2E6213A /* BugReportServiceMock.swift */; };
+		9AB6BEE7C1DAA8EFF1FD4E99 /* TimelineTextSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736E2343D756B63B2DB060B5 /* TimelineTextSelectionView.swift */; };
 		9AC5F8142413862A9E3A2D98 /* Collections in Frameworks */ = {isa = PBXBuildFile; productRef = 9C73F37731C9FDED1BB24C1C /* Collections */; };
 		9B03943616A1147539DF7F08 /* RoomChangePermissionsScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D041A857614A9AE13C7795 /* RoomChangePermissionsScreenViewModelTests.swift */; };
 		9B356742E035D90A8BB5CABE /* ProposedViewSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DFE0E493FB55E5A62E7852A /* ProposedViewSize.swift */; };
@@ -1329,6 +1331,7 @@
 		D6DE764B17FB4A9A12C33BF4 /* MessageComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F1DF3FFFE5ED2B8133F43A7 /* MessageComposer.swift */; };
 		D75C591C44C2510FDFA9C3D8 /* Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = AFAD718C6621B94813B960B4 /* Dynamic */; };
 		D7CDBAE82782BD0529DECB5F /* AttributedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BD6ED18E2EB61E28C340AD /* AttributedString.swift */; };
+		D7E5113BFC3AACDF1DE67574 /* TimelineTextSelectionContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C711989595763E0E17EC55B /* TimelineTextSelectionContentTests.swift */; };
 		D820B3C223E4C2E77BB2A2BF /* ElementCallServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EA2AFF6EB59FE25234D29F3 /* ElementCallServiceTests.swift */; };
 		D8459AAD6969B1431ECBE990 /* UnsupportedRoomTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E535B3388755B65C34CD10 /* UnsupportedRoomTimelineView.swift */; };
 		D8517B8EED58D24396FB71E7 /* DeactivateAccountScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BAE25A0E9E9F2F1BBA8930 /* DeactivateAccountScreenViewModel.swift */; };
@@ -2116,6 +2119,7 @@
 		4B41FABA2B0AEF4389986495 /* LoginMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginMode.swift; sourceTree = "<group>"; };
 		4B73675A21580971E9ADF66A /* LocationSharingScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSharingScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		4BD371B60E07A5324B9507EF /* AnalyticsSettingsScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsSettingsScreenCoordinator.swift; sourceTree = "<group>"; };
+		4C711989595763E0E17EC55B /* TimelineTextSelectionContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineTextSelectionContentTests.swift; sourceTree = "<group>"; };
 		4C816902BB6F450B4225B90C /* SettingsScreenUserStatusRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScreenUserStatusRow.swift; sourceTree = "<group>"; };
 		4C8D988E82A8DFA13BE46F7C /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = pl; path = pl.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		4CD6AC7546E8D7E5C73CEA48 /* ElementX.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = ElementX.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2323,6 +2327,7 @@
 		7310D8DFE01AF45F0689C3AA /* Publisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Publisher.swift; sourceTree = "<group>"; };
 		7349B71A67B765AA86002723 /* sound_01.caf */ = {isa = PBXFileReference; path = sound_01.caf; sourceTree = "<group>"; };
 		7367B3B9A8CAF902220F31D1 /* BugReportFlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugReportFlowCoordinator.swift; sourceTree = "<group>"; };
+		736E2343D756B63B2DB060B5 /* TimelineTextSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineTextSelectionView.swift; sourceTree = "<group>"; };
 		739077686814E4EA339B1C83 /* RoomPreviewProxyProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomPreviewProxyProtocol.swift; sourceTree = "<group>"; };
 		7396A6491DEC64FCB66F60A1 /* RoomThreadListServiceProxyMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomThreadListServiceProxyMock.swift; sourceTree = "<group>"; };
 		73A5C3F7C9C1DA10CAEC6A98 /* VoiceMessageRecordingComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceMessageRecordingComposer.swift; sourceTree = "<group>"; };
@@ -2831,6 +2836,7 @@
 		C90514BE9B8ACCBCF0AD2489 /* ComposerToolbarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerToolbarViewModel.swift; sourceTree = "<group>"; };
 		C95ADE8D9527523572532219 /* hu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = hu; path = hu.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		C97F8963B14EB0AF3940DDBF /* NotificationSettingsEditScreenRoomCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsEditScreenRoomCell.swift; sourceTree = "<group>"; };
+		C98C243A90369929D669873D /* TimelineItemMenuActionProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineItemMenuActionProviderTests.swift; sourceTree = "<group>"; };
 		C99FDEEB71173C4C6FA2734C /* UserSessionFlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSessionFlowCoordinator.swift; sourceTree = "<group>"; };
 		C9AC2CC94FA06F728883B694 /* KnockRequestsListScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnockRequestsListScreenViewModelTests.swift; sourceTree = "<group>"; };
 		C9E535B3388755B65C34CD10 /* UnsupportedRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedRoomTimelineView.swift; sourceTree = "<group>"; };
@@ -4599,6 +4605,7 @@
 				91FFE1F410969ECB23FE9BB2 /* TimelineItemMenu.swift */,
 				6F1C3CBBC62C566DDF5E84C1 /* TimelineItemMenuAction.swift */,
 				A9E6065FC6BC4A1B4C629E08 /* TimelineItemMenuActionProvider.swift */,
+				736E2343D756B63B2DB060B5 /* TimelineTextSelectionView.swift */,
 			);
 			path = ItemMenu;
 			sourceTree = "<group>";
@@ -5139,9 +5146,11 @@
 				6DF438EAFC732D2D95D34BF6 /* StartChatViewModelTests.swift */,
 				2CEBCB9676FCD1D0F13188DD /* StringTests.swift */,
 				9AA3AF94A06D319BB37E52DA /* TimelineItemFactoryTests.swift */,
+				C98C243A90369929D669873D /* TimelineItemMenuActionProviderTests.swift */,
 				ED0AD0C652385F69FA90FAF5 /* TimelineMediaPreviewDataSourceTests.swift */,
 				5C1F000589F2CEE6B03ECFAB /* TimelineMediaPreviewViewModelTests.swift */,
 				F968FDB68F9D4CB9010FED70 /* TimelineStateTests.swift */,
+				4C711989595763E0E17EC55B /* TimelineTextSelectionContentTests.swift */,
 				6509708F54FC883604DFDC95 /* TimelineViewModelTests.swift */,
 				76310030C831D4610A705603 /* URLComponentsTests.swift */,
 				3AB34956C87731AB094DB33A /* URLTests.swift */,
@@ -8154,9 +8163,11 @@
 				1FEC0A4EC6E6DF693C16B32A /* StringTests.swift in Sources */,
 				E75CE800B3E64D0F7F8E228D /* TemplateScreenViewModelTests.swift in Sources */,
 				0D4EB2ABAA5FE8CB10FDBCB8 /* TimelineItemFactoryTests.swift in Sources */,
+				0668BECCF11E8EE6936CDF16 /* TimelineItemMenuActionProviderTests.swift in Sources */,
 				C02DE5F62C81FB9E173C3D2F /* TimelineMediaPreviewDataSourceTests.swift in Sources */,
 				F6BF52CB027393EE03CEC523 /* TimelineMediaPreviewViewModelTests.swift in Sources */,
 				75E55A763FE8BA64FB8513E4 /* TimelineStateTests.swift in Sources */,
+				D7E5113BFC3AACDF1DE67574 /* TimelineTextSelectionContentTests.swift in Sources */,
 				2F6207CB5C4715FE313B1E95 /* TimelineViewModelTests.swift in Sources */,
 				8E650379587C31D7912ED67B /* UNNotification+Creator.swift in Sources */,
 				AF33B9044498211C3D82F1E1 /* UNTextInputNotificationResponse+Creator.swift in Sources */,
@@ -9261,6 +9272,7 @@
 				F2D5C0E1351DA7BD16867629 /* TimelineStyle.swift in Sources */,
 				7A0D335D38ECA095A575B4F7 /* TimelineStyler.swift in Sources */,
 				6583A95947E78767736CB51A /* TimelineTableViewController.swift in Sources */,
+				9AB6BEE7C1DAA8EFF1FD4E99 /* TimelineTextSelectionView.swift in Sources */,
 				7F99B6DDBEC5D5E6752C7276 /* TimelineThreadSummaryView.swift in Sources */,
 				67EFF46180B939CBF389AECD /* TimelineView.swift in Sources */,
 				98EE4259A4A49BC757BA442C /* TimelineViewModel.swift in Sources */,

--- a/ElementX/Resources/Localizations/en.lproj/Untranslated.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Untranslated.strings
@@ -1,3 +1,4 @@
+"action_select_text" = "Select text";
 "screen_home_tab_search" = "Search";
 "screen_search_empty_state_message" = "Search for chats and messages";
 "screen_search_empty_state_title" = "Start searching...";

--- a/ElementX/Sources/Generated/Strings+Untranslated.swift
+++ b/ElementX/Sources/Generated/Strings+Untranslated.swift
@@ -10,6 +10,8 @@ import Foundation
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
 internal nonisolated enum UntranslatedL10n {
+  /// Select text
+  internal static var actionSelectText: String { return UntranslatedL10n.tr("Untranslated", "action_select_text") }
   /// Search
   internal static var screenHomeTabSearch: String { return UntranslatedL10n.tr("Untranslated", "screen_home_tab_search") }
   /// Search for chats and messages

--- a/ElementX/Sources/Other/Pills/MessageText.swift
+++ b/ElementX/Sources/Other/Pills/MessageText.swift
@@ -12,6 +12,7 @@ import SwiftUI
 final class MessageTextView: UITextView, PillAttachmentViewProviderDelegate, UIGestureRecognizerDelegate {
     var timelineContext: TimelineViewModel.Context?
     var updateClosure: (() -> Void)?
+    var selectionMode = MessageText.SelectionMode.disabled
     private var pillViews = NSHashTable<UIView>.weakObjects()
     
     override func addGestureRecognizer(_ gestureRecognizer: UIGestureRecognizer) {
@@ -24,7 +25,7 @@ final class MessageTextView: UITextView, PillAttachmentViewProviderDelegate, UIG
     
     /// This prevents the magnifying glass from showing up
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        if otherGestureRecognizer is UILongPressGestureRecognizer {
+        if selectionMode == .disabled, otherGestureRecognizer is UILongPressGestureRecognizer {
             return false
         }
         return true
@@ -71,6 +72,11 @@ private final nonisolated class TransparentTextAttachment: NSTextAttachment {
 }
 
 struct MessageText: UIViewRepresentable {
+    enum SelectionMode {
+        case disabled
+        case enabled
+    }
+
     @Environment(\.openURL) private var openURLAction
     @Environment(\.timelineContext) private var viewModel
     @Environment(\.layoutDirection) private var layoutDirection
@@ -98,6 +104,7 @@ struct MessageText: UIViewRepresentable {
     /// the reserved region fits on the last line (timestamp tucks) or wraps to a new
     /// line (timestamp drops below the text).
     var trailingReservedSize: CGSize = .zero
+    var selectionMode = SelectionMode.disabled
     
     private func makeAttributedText() -> NSAttributedString? {
         guard let baseText = try? NSAttributedString(attributedString, including: \.elementX) else {
@@ -163,6 +170,7 @@ struct MessageText: UIViewRepresentable {
         // Need to use TextKit 1 for mentions
         let textView = MessageTextView(usingTextLayoutManager: false)
         textView.timelineContext = viewModel
+        textView.selectionMode = selectionMode
         textView.updateClosure = { [weak textView] in
             guard let textView else { return }
             do {
@@ -210,6 +218,11 @@ struct MessageText: UIViewRepresentable {
             computedSizes.removeAll()
         }
         context.coordinator.openURLAction = openURLAction
+        context.coordinator.selectionMode = selectionMode
+        uiView.selectionMode = selectionMode
+        if selectionMode == .disabled {
+            uiView.selectedTextRange = nil
+        }
     }
     
     func sizeThatFits(_ proposal: ProposedViewSize, uiView: MessageTextView, context: Context) -> CGSize? {
@@ -228,18 +241,20 @@ struct MessageText: UIViewRepresentable {
     }
     
     func makeCoordinator() -> Coordinator {
-        Coordinator(openURLAction: openURLAction)
+        Coordinator(openURLAction: openURLAction, selectionMode: selectionMode)
     }
     
     final class Coordinator: NSObject, UITextViewDelegate {
         var openURLAction: OpenURLAction
+        var selectionMode: SelectionMode
         
-        init(openURLAction: OpenURLAction) {
+        init(openURLAction: OpenURLAction, selectionMode: SelectionMode) {
             self.openURLAction = openURLAction
+            self.selectionMode = selectionMode
         }
         
         func textViewDidChangeSelection(_ textView: UITextView) {
-            guard !ProcessInfo.processInfo.isiOSAppOnMac else {
+            guard selectionMode == .disabled, !ProcessInfo.processInfo.isiOSAppOnMac else {
                 return
             }
             textView.selectedTextRange = nil

--- a/ElementX/Sources/Other/Pills/MessageText.swift
+++ b/ElementX/Sources/Other/Pills/MessageText.swift
@@ -181,7 +181,7 @@ struct MessageText: UIViewRepresentable {
             }
         }
         textView.isEditable = false
-        textView.isScrollEnabled = false
+        textView.isScrollEnabled = selectionMode == .enabled
         textView.adjustsFontForContentSizeCategory = true
         
         // Required to allow tapping links
@@ -220,12 +220,17 @@ struct MessageText: UIViewRepresentable {
         context.coordinator.openURLAction = openURLAction
         context.coordinator.selectionMode = selectionMode
         uiView.selectionMode = selectionMode
+        uiView.isScrollEnabled = selectionMode == .enabled
         if selectionMode == .disabled {
             uiView.selectedTextRange = nil
         }
     }
     
     func sizeThatFits(_ proposal: ProposedViewSize, uiView: MessageTextView, context: Context) -> CGSize? {
+        guard selectionMode == .disabled else {
+            return nil
+        }
+
         let proposalWidth = proposal.width ?? UIView.layoutFittingExpandedSize.width
         let key = SizeCacheKey(width: proposalWidth, reservedSize: trailingReservedSize)
         
@@ -261,6 +266,10 @@ struct MessageText: UIViewRepresentable {
         }
         
         func textView(_ textView: UITextView, primaryActionFor textItem: UITextItem, defaultAction: UIAction) -> UIAction? {
+            guard selectionMode == .disabled else {
+                return nil
+            }
+
             if case .link(let url) = textItem.content {
                 return .init(title: defaultAction.title,
                              image: defaultAction.image,
@@ -274,6 +283,10 @@ struct MessageText: UIViewRepresentable {
         }
         
         func textView(_ textView: UITextView, menuConfigurationFor textItem: UITextItem, defaultMenu: UIMenu) -> UITextItem.MenuConfiguration? {
+            guard selectionMode == .disabled else {
+                return nil
+            }
+
             switch textItem.content {
             case let .link(url):
                 guard !url.requiresConfirmation else {

--- a/ElementX/Sources/Screens/Timeline/TimelineInteractionHandler.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineInteractionHandler.swift
@@ -20,6 +20,7 @@ enum TimelineInteractionHandlerAction {
     
     case showActionMenu(TimelineItemActionMenuInfo)
     case showDebugInfo(TimelineItemDebugInfo)
+    case showTextSelection(TimelineTextSelectionContent)
     
     case displayAudioRecorderPermissionError
     case displayErrorToast(String)
@@ -116,6 +117,12 @@ class TimelineInteractionHandler {
         case .copy:
             guard let messageTimelineItem = timelineItem as? EventBasedMessageTimelineItemProtocol else { return }
             UIPasteboard.general.string = messageTimelineItem.body
+        case .selectText:
+            guard let messageTimelineItem = timelineItem as? EventBasedMessageTimelineItemProtocol,
+                  let attributedString = messageTimelineItem.selectableText else {
+                return
+            }
+            actionsSubject.send(.showTextSelection(.init(attributedString: attributedString)))
         case .copyCaption:
             guard let messageTimelineItem = timelineItem as? EventBasedMessageTimelineItemProtocol,
                   let caption = messageTimelineItem.mediaCaption else {

--- a/ElementX/Sources/Screens/Timeline/TimelineInteractionHandler.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineInteractionHandler.swift
@@ -20,7 +20,7 @@ enum TimelineInteractionHandlerAction {
     
     case showActionMenu(TimelineItemActionMenuInfo)
     case showDebugInfo(TimelineItemDebugInfo)
-    case showTextSelection(TimelineTextSelectionContent)
+    case showTextSelection(AttributedString)
     
     case displayAudioRecorderPermissionError
     case displayErrorToast(String)
@@ -122,7 +122,7 @@ class TimelineInteractionHandler {
                   let attributedString = messageTimelineItem.selectableText else {
                 return
             }
-            actionsSubject.send(.showTextSelection(.init(attributedString: attributedString)))
+            actionsSubject.send(.showTextSelection(attributedString))
         case .copyCaption:
             guard let messageTimelineItem = timelineItem as? EventBasedMessageTimelineItemProtocol,
                   let caption = messageTimelineItem.mediaCaption else {

--- a/ElementX/Sources/Screens/Timeline/TimelineModels.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineModels.swift
@@ -179,6 +179,7 @@ struct TimelineViewStateBindings {
     var debugInfo: TimelineItemDebugInfo?
     
     var actionMenuInfo: TimelineItemActionMenuInfo?
+    var textSelectionContent: TimelineTextSelectionContent?
     
     var reactionSummaryInfo: ReactionSummaryInfo?
     
@@ -188,6 +189,11 @@ struct TimelineViewStateBindings {
     
     var showTranslation = false
     var textToBeTranslated: String?
+}
+
+struct TimelineTextSelectionContent: Identifiable {
+    let id = UUID()
+    let attributedString: AttributedString
 }
 
 struct TimelineItemActionMenuInfo: Equatable, Identifiable {

--- a/ElementX/Sources/Screens/Timeline/TimelineModels.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineModels.swift
@@ -194,6 +194,118 @@ struct TimelineViewStateBindings {
 struct TimelineTextSelectionContent: Identifiable {
     let id = UUID()
     let attributedString: AttributedString
+
+    init(attributedString: AttributedString,
+         userDisplayNameForID: (String) -> String? = { _ in nil },
+         roomNameForID: (String) -> String? = { _ in nil },
+         roomNameForAlias: (String) -> String? = { _ in nil }) {
+        self.attributedString = MatrixPillTextTransformer.transform(attributedString,
+                                                                   userDisplayNameForID: userDisplayNameForID,
+                                                                   roomNameForID: roomNameForID,
+                                                                   roomNameForAlias: roomNameForAlias)
+    }
+}
+
+enum MatrixPillTextTransformer {
+    static func transform(_ attributedString: AttributedString,
+                          userDisplayNameForID: (String) -> String?,
+                          roomNameForID: (String) -> String?,
+                          roomNameForAlias: (String) -> String?) -> AttributedString {
+        guard let mutableAttributedString = try? NSMutableAttributedString(attributedString, including: \.elementX) else {
+            return AttributedString(String(attributedString.characters).replacingOccurrences(of: "\u{fffc}", with: ""))
+        }
+
+        let fullRange = NSRange(location: 0, length: mutableAttributedString.length)
+        var replacements = [(range: NSRange, text: String, attributes: [NSAttributedString.Key: Any])]()
+        mutableAttributedString.enumerateAttributes(in: fullRange) { attributes, range, _ in
+            guard let text = replacementText(for: attributes,
+                                             userDisplayNameForID: userDisplayNameForID,
+                                             roomNameForID: roomNameForID,
+                                             roomNameForAlias: roomNameForAlias) else {
+                return
+            }
+
+            var replacementAttributes = attributes
+            replacementAttributes[.attachment] = nil
+            replacementAttributes[.link] = nil
+            replacements.append((range, text, replacementAttributes))
+        }
+
+        for replacement in replacements.reversed() {
+            mutableAttributedString.replaceCharacters(in: replacement.range,
+                                                       with: NSAttributedString(string: replacement.text,
+                                                                                attributes: replacement.attributes))
+        }
+        mutableAttributedString.removeAttribute(.link,
+                                                range: NSRange(location: 0, length: mutableAttributedString.length))
+
+        guard let result = try? AttributedString(mutableAttributedString, including: \.elementX) else {
+            return AttributedString(mutableAttributedString.string)
+        }
+        return result
+    }
+
+    private static func replacementText(for attributes: [NSAttributedString.Key: Any],
+                                        userDisplayNameForID: (String) -> String?,
+                                        roomNameForID: (String) -> String?,
+                                        roomNameForAlias: (String) -> String?) -> String? {
+        if let userID = attributes[.MatrixUserID] as? String {
+            let embeddedDisplayName = attributes[.MatrixUserDisplayName] as? String
+            return PillUtilities.userPillDisplayText(username: userDisplayNameForID(userID) ?? embeddedDisplayName,
+                                                     userID: userID)
+        }
+
+        if attributes[.MatrixAllUsersMention] as? Bool == true {
+            return PillUtilities.atRoom
+        }
+
+        if let roomAlias = attributes[.MatrixRoomAlias] as? String {
+            let embeddedDisplayName = attributes[.MatrixRoomDisplayName] as? String
+            return PillUtilities.roomPillDisplayText(roomName: roomNameForAlias(roomAlias) ?? embeddedDisplayName,
+                                                     rawRoomText: roomAlias)
+        }
+
+        if let roomID = attributes[.MatrixRoomID] as? String {
+            return PillUtilities.roomPillDisplayText(roomName: roomNameForID(roomID), rawRoomText: roomID)
+        }
+
+        if let eventOnRoomID = attributes[.MatrixEventOnRoomID] as? EventOnRoomIDAttribute.Value {
+            return PillUtilities.eventPillDisplayText(roomName: roomNameForID(eventOnRoomID.roomID),
+                                                      rawRoomText: eventOnRoomID.roomID)
+        }
+
+        if let eventOnRoomAlias = attributes[.MatrixEventOnRoomAlias] as? EventOnRoomAliasAttribute.Value {
+            return PillUtilities.eventPillDisplayText(roomName: roomNameForAlias(eventOnRoomAlias.alias),
+                                                      rawRoomText: eventOnRoomAlias.alias)
+        }
+
+        guard let attachment = attributes[.attachment] as? PillTextAttachment,
+              let pillData = attachment.pillData else {
+            return nil
+        }
+
+        switch pillData.type {
+        case .user(let userID):
+            let embeddedDisplayName = attributes[.MatrixUserDisplayName] as? String
+            return PillUtilities.userPillDisplayText(username: userDisplayNameForID(userID) ?? embeddedDisplayName,
+                                                     userID: userID)
+        case .allUsers:
+            return PillUtilities.atRoom
+        case .roomAlias(let roomAlias):
+            let embeddedDisplayName = attributes[.MatrixRoomDisplayName] as? String
+            return PillUtilities.roomPillDisplayText(roomName: roomNameForAlias(roomAlias) ?? embeddedDisplayName,
+                                                     rawRoomText: roomAlias)
+        case .roomID(let roomID):
+            return PillUtilities.roomPillDisplayText(roomName: roomNameForID(roomID), rawRoomText: roomID)
+        case .event(let room):
+            switch room {
+            case .roomAlias(let roomAlias):
+                return PillUtilities.eventPillDisplayText(roomName: roomNameForAlias(roomAlias), rawRoomText: roomAlias)
+            case .roomID(let roomID):
+                return PillUtilities.eventPillDisplayText(roomName: roomNameForID(roomID), rawRoomText: roomID)
+            }
+        }
+    }
 }
 
 struct TimelineItemActionMenuInfo: Equatable, Identifiable {
@@ -352,48 +464,13 @@ extension TimelineViewState {
     /// and render with a consistent font size. This conversion is done to avoid
     /// showing markdown characters in the preview for messages with formatting.
     func buildMessagePreview(formattedBody: AttributedString?, plainBody: String) -> String {
-        guard let formattedBody,
-              let attributedString = try? NSMutableAttributedString(formattedBody, including: \.elementX) else {
+        guard let formattedBody else {
             return plainBody
         }
-        
-        let range = NSRange(location: 0, length: attributedString.length)
-        attributedString.enumerateAttributes(in: range) { attributes, range, _ in
-            if let userID = attributes[.MatrixUserID] as? String {
-                if let displayName = members[userID]?.displayName {
-                    attributedString.replaceCharacters(in: range, with: "@\(displayName)")
-                } else {
-                    attributedString.replaceCharacters(in: range, with: userID)
-                }
-            }
-            
-            if attributes[.MatrixAllUsersMention] as? Bool == true {
-                attributedString.replaceCharacters(in: range, with: PillUtilities.atRoom)
-            }
-            
-            if let roomAlias = attributes[.MatrixRoomAlias] as? String {
-                let roomName = roomNameForAliasResolver?(roomAlias)
-                attributedString.replaceCharacters(in: range, with: PillUtilities.roomPillDisplayText(roomName: roomName, rawRoomText: roomAlias))
-            }
-            
-            if let roomID = attributes[.MatrixRoomID] as? String {
-                let roomName = roomNameForIDResolver?(roomID)
-                attributedString.replaceCharacters(in: range, with: PillUtilities.roomPillDisplayText(roomName: roomName, rawRoomText: roomID))
-            }
-            
-            if let eventOnRoomID = attributes[.MatrixEventOnRoomID] as? EventOnRoomIDAttribute.Value {
-                let roomID = eventOnRoomID.roomID
-                let roomName = roomNameForIDResolver?(roomID)
-                attributedString.replaceCharacters(in: range, with: PillUtilities.eventPillDisplayText(roomName: roomName, rawRoomText: roomID))
-            }
-            
-            if let eventOnRoomAlias = attributes[.MatrixEventOnRoomAlias] as? EventOnRoomAliasAttribute.Value {
-                let roomAlias = eventOnRoomAlias.alias
-                let roomName = roomNameForAliasResolver?(roomAlias)
-                attributedString.replaceCharacters(in: range, with: PillUtilities.eventPillDisplayText(roomName: roomName, rawRoomText: eventOnRoomAlias.alias))
-            }
-        }
-        
-        return attributedString.string
+
+        return String(MatrixPillTextTransformer.transform(formattedBody,
+                                                          userDisplayNameForID: { members[$0]?.displayName },
+                                                          roomNameForID: { roomNameForIDResolver?($0) },
+                                                          roomNameForAlias: { roomNameForAliasResolver?($0) }).characters)
     }
 }

--- a/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
@@ -532,8 +532,11 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
                     }
                 case .showDebugInfo(let debugInfo):
                     state.bindings.debugInfo = debugInfo
-                case .showTextSelection(let content):
-                    state.bindings.textSelectionContent = content
+                case .showTextSelection(let attributedString):
+                    state.bindings.textSelectionContent = .init(attributedString: attributedString,
+                                                                userDisplayNameForID: { self.state.members[$0]?.displayName },
+                                                                roomNameForID: { self.state.roomNameForIDResolver?($0) },
+                                                                roomNameForAlias: { self.state.roomNameForAliasResolver?($0) })
                 case .viewInRoomTimeline(let eventID):
                     Task { await self.viewInRoomTimeline(eventID: eventID) }
                 case .displayThread(let itemID):

--- a/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
@@ -532,6 +532,8 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
                     }
                 case .showDebugInfo(let debugInfo):
                     state.bindings.debugInfo = debugInfo
+                case .showTextSelection(let content):
+                    state.bindings.textSelectionContent = content
                 case .viewInRoomTimeline(let eventID):
                     Task { await self.viewInRoomTimeline(eventID: eventID) }
                 case .displayThread(let itemID):

--- a/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenuAction.swift
+++ b/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenuAction.swift
@@ -56,6 +56,7 @@ struct TimelineItemMenuReaction: Hashable {
 
 enum TimelineItemMenuAction: Identifiable, Hashable {
     case copy
+    case selectText
     case translate
     case copyCaption
     case edit
@@ -95,7 +96,7 @@ enum TimelineItemMenuAction: Identifiable, Hashable {
     /// Whether the action should be shown for an item that failed to send.
     var canAppearInFailedEcho: Bool {
         switch self {
-        case .copy, .edit, .redact, .viewSource, .editPoll:
+        case .copy, .selectText, .edit, .redact, .viewSource, .editPoll:
             true
         default:
             false
@@ -146,6 +147,8 @@ enum TimelineItemMenuAction: Identifiable, Hashable {
         switch self {
         case .copy:
             Label(L10n.actionCopyText, icon: \.copy)
+        case .selectText:
+            Label(UntranslatedL10n.actionSelectText, icon: \.textFormatting)
         case .translate:
             Label(L10n.actionTranslate, icon: \.translate)
         case .copyCaption:

--- a/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenuActionProvider.swift
+++ b/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenuActionProvider.swift
@@ -92,11 +92,16 @@ struct TimelineItemMenuActionProvider {
             
             if !ProcessInfo.processInfo.isiOSAppOnMac {
                 // As of macOS 26.2, the sheet isn't presented, but it is easy enough
-                // to select some text and right click on Mac anyway so hide this one.
+                // to select some text and right click on Mac anyway so hide these.
+                actions.append(.selectText)
                 actions.append(.translate)
             }
         } else if item.hasMediaCaption {
             actions.append(.copyCaption)
+
+            if !ProcessInfo.processInfo.isiOSAppOnMac {
+                actions.append(.selectText)
+            }
         }
         
         if item.isEditable, item.hasMediaCaption {

--- a/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineTextSelectionView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineTextSelectionView.swift
@@ -1,0 +1,50 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import SwiftUI
+
+struct TimelineTextSelectionView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let attributedString: AttributedString
+
+    var body: some View {
+        ElementNavigationStack {
+            ScrollView {
+                FormattedBodyText(attributedString: attributedString, selectionMode: .enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(16)
+            }
+            .navigationTitle(UntranslatedL10n.actionSelectText)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    ToolbarButton(role: .close) {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Previews
+
+struct TimelineTextSelectionView_Previews: PreviewProvider, TestablePreview {
+    static let attributedStringBuilder = AttributedStringBuilder(cacheKey: "TimelineTextSelectionView", mentionBuilder: MentionBuilder())
+
+    static var previews: some View {
+        if let attributedString = attributedStringBuilder.fromHTML("""
+        <p>Select any part of this message, including <a href="https://matrix.org">links</a> and mentions such as @alice:matrix.org.</p>
+        <blockquote>A quoted message with right-to-left text: مرحبا بالعالم</blockquote>
+        <pre><code>let message = "Hello, Matrix!"</code></pre>
+        """) {
+            TimelineTextSelectionView(attributedString: attributedString)
+                .environmentObject(TimelineViewModel.mock.context)
+        }
+    }
+}

--- a/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineTextSelectionView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineTextSelectionView.swift
@@ -10,24 +10,21 @@ import SwiftUI
 struct TimelineTextSelectionView: View {
     @Environment(\.dismiss) private var dismiss
 
-    let attributedString: AttributedString
+    let content: TimelineTextSelectionContent
 
     var body: some View {
         ElementNavigationStack {
-            ScrollView {
-                FormattedBodyText(attributedString: attributedString, selectionMode: .enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(16)
-            }
-            .navigationTitle(UntranslatedL10n.actionSelectText)
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    ToolbarButton(role: .close) {
-                        dismiss()
+            FormattedBodyText(attributedString: content.attributedString, selectionMode: .enabled)
+                .padding(16)
+                .navigationTitle(UntranslatedL10n.actionSelectText)
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        ToolbarButton(role: .close) {
+                            dismiss()
+                        }
                     }
                 }
-            }
         }
     }
 }
@@ -43,7 +40,7 @@ struct TimelineTextSelectionView_Previews: PreviewProvider, TestablePreview {
         <blockquote>A quoted message with right-to-left text: مرحبا بالعالم</blockquote>
         <pre><code>let message = "Hello, Matrix!"</code></pre>
         """) {
-            TimelineTextSelectionView(attributedString: attributedString)
+            TimelineTextSelectionView(content: .init(attributedString: attributedString))
                 .environmentObject(TimelineViewModel.mock.context)
         }
     }

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/FormattedBodyText.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/FormattedBodyText.swift
@@ -66,7 +66,7 @@ struct FormattedBodyText: View {
         if selectionMode == .enabled {
             MessageText(attributedString: adjustedAttributedString, selectionMode: .enabled)
                 .tint(.compound.textLinkExternal)
-                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         } else {
             layout
                 .tint(.compound.textLinkExternal)

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/FormattedBodyText.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/FormattedBodyText.swift
@@ -12,6 +12,7 @@ struct FormattedBodyText: View {
     private let attributedString: AttributedString
     private let trailingReservedSize: CGSize
     private let boostFontSize: Bool
+    private let selectionMode: MessageText.SelectionMode
     
     private let defaultAttributesContainer: AttributeContainer = {
         var container = AttributeContainer()
@@ -21,7 +22,7 @@ struct FormattedBodyText: View {
         return container
     }()
     
-    private var attributedComponents: [AttributedStringBuilderComponent] {
+    private var adjustedAttributedString: AttributedString {
         var adjustedAttributedString = attributedString
         
         // Required to allow the underlying TextView to use  body font when no font is specified in the AttributedString.
@@ -32,29 +33,46 @@ struct FormattedBodyText: View {
         if boostFontSize, let range = adjustedAttributedString.range(of: string) {
             adjustedAttributedString[range].font = UIFont.systemFont(ofSize: 48.0)
         }
-        
-        return adjustedAttributedString.formattedComponents
+
+        return adjustedAttributedString
+    }
+
+    private var attributedComponents: [AttributedStringBuilderComponent] {
+        adjustedAttributedString.formattedComponents
     }
     
     init(attributedString: AttributedString,
          trailingReservedSize: CGSize = .zero,
-         boostFontSize: Bool = false) {
+         boostFontSize: Bool = false,
+         selectionMode: MessageText.SelectionMode = .disabled) {
         self.attributedString = attributedString
         self.trailingReservedSize = trailingReservedSize
         self.boostFontSize = boostFontSize
+        self.selectionMode = selectionMode
     }
     
-    init(text: String, trailingReservedSize: CGSize = .zero, boostFontSize: Bool = false) {
+    init(text: String,
+         trailingReservedSize: CGSize = .zero,
+         boostFontSize: Bool = false,
+         selectionMode: MessageText.SelectionMode = .disabled) {
         self.init(attributedString: AttributedString(text),
                   trailingReservedSize: trailingReservedSize,
-                  boostFontSize: boostFontSize)
+                  boostFontSize: boostFontSize,
+                  selectionMode: selectionMode)
     }
     
+    @ViewBuilder
     var body: some View {
-        layout
-            .tint(.compound.textLinkExternal)
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel(Text(attributedString))
+        if selectionMode == .enabled {
+            MessageText(attributedString: adjustedAttributedString, selectionMode: .enabled)
+                .tint(.compound.textLinkExternal)
+                .fixedSize(horizontal: false, vertical: true)
+        } else {
+            layout
+                .tint(.compound.textLinkExternal)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(Text(attributedString))
+        }
     }
     
     /// The attributed components laid out for the bubbles timeline style.

--- a/ElementX/Sources/Screens/Timeline/View/TimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineView.swift
@@ -28,7 +28,7 @@ struct TimelineView: View {
             }
             .sheet(item: $timelineContext.debugInfo) { TimelineItemDebugView(info: $0) }
             .sheet(item: $timelineContext.textSelectionContent) { content in
-                TimelineTextSelectionView(attributedString: content.attributedString)
+                TimelineTextSelectionView(content: content)
             }
             .sheet(item: $timelineContext.actionMenuInfo) { info in
                 let actions = TimelineItemMenuActionProvider(timelineItem: info.item,

--- a/ElementX/Sources/Screens/Timeline/View/TimelineView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineView.swift
@@ -27,6 +27,9 @@ struct TimelineView: View {
                 ManageRoomMemberSheetView(context: $0.context)
             }
             .sheet(item: $timelineContext.debugInfo) { TimelineItemDebugView(info: $0) }
+            .sheet(item: $timelineContext.textSelectionContent) { content in
+                TimelineTextSelectionView(attributedString: content.attributedString)
+            }
             .sheet(item: $timelineContext.actionMenuInfo) { info in
                 let actions = TimelineItemMenuActionProvider(timelineItem: info.item,
                                                              canCurrentUserSendMessage: timelineContext.viewState.canCurrentUserSendMessage,

--- a/ElementX/Sources/Services/Timeline/TimelineItems/EventBasedMessageTimelineItemProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/EventBasedMessageTimelineItemProtocol.swift
@@ -72,4 +72,19 @@ nonisolated extension EventBasedMessageTimelineItemProtocol {
             nil
         }
     }
+
+    var selectableText: AttributedString? {
+        switch contentType {
+        case .text(let content):
+            content.formattedBody ?? AttributedString(content.body)
+        case .emote(let content):
+            content.formattedBody ?? AttributedString(content.body)
+        case .notice(let content):
+            content.formattedBody ?? AttributedString(content.body)
+        case .audio, .file, .image, .video, .gallery:
+            formattedMediaCaption ?? mediaCaption.map { AttributedString($0) }
+        case .location, .voice:
+            nil
+        }
+    }
 }

--- a/UnitTests/Sources/TimelineItemMenuActionProviderTests.swift
+++ b/UnitTests/Sources/TimelineItemMenuActionProviderTests.swift
@@ -1,0 +1,100 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+@testable import ElementX
+import Foundation
+import Testing
+
+struct TimelineItemMenuActionProviderTests {
+    @Test
+    func textMessagesIncludeSelectText() throws {
+        let item = try #require(TimelineFixtures.singleMessageChunk.first)
+        let actions = try #require(makeActions(for: item))
+
+        #expect(actions.actions.contains(.copy))
+        #expect(actions.actions.contains(.selectText))
+    }
+
+    @Test
+    func mediaCaptionsIncludeSelectText() throws {
+        let item = try #require(TimelineFixtures.mediaChunk[5] as? EventBasedMessageTimelineItemProtocol)
+        let actions = try #require(makeActions(for: item))
+
+        #expect(item.hasMediaCaption)
+        #expect(actions.actions.contains(.copyCaption))
+        #expect(actions.actions.contains(.selectText))
+    }
+
+    @Test
+    func selectableTextPrefersFormattedMediaCaption() {
+        let formattedCaption = AttributedString("Formatted caption")
+        let item = ImageRoomTimelineItem(id: .randomEvent,
+                                         timestamp: .mock,
+                                         isOutgoing: false,
+                                         isEditable: false,
+                                         canBeRepliedTo: true,
+                                         sender: .init(id: "@alice:matrix.org"),
+                                         content: .init(filename: "image.jpg",
+                                                        caption: "Plain caption",
+                                                        formattedCaption: formattedCaption,
+                                                        imageInfo: .mockImage,
+                                                        thumbnailInfo: nil))
+
+        #expect(item.selectableText == formattedCaption)
+    }
+
+    @Test
+    func mediaWithoutCaptionDoesNotIncludeSelectText() throws {
+        let item = try #require(TimelineFixtures.mediaChunk[1] as? EventBasedMessageTimelineItemProtocol)
+        let actions = try #require(makeActions(for: item))
+
+        #expect(!item.hasMediaCaption)
+        #expect(item.selectableText == nil)
+        #expect(!actions.actions.contains(.selectText))
+    }
+
+    @Test
+    func selectableTextPrefersFormattedMessageBody() throws {
+        let formattedBody = AttributedString("Formatted body")
+        let item = TextRoomTimelineItem(id: .randomEvent,
+                                        timestamp: .mock,
+                                        isOutgoing: false,
+                                        isEditable: false,
+                                        canBeRepliedTo: true,
+                                        sender: .init(id: "@alice:matrix.org"),
+                                        content: .init(body: "Plain body", formattedBody: formattedBody))
+
+        #expect(item.selectableText == formattedBody)
+    }
+
+    @Test
+    func selectableTextFallsBackToPlainMessageBody() {
+        let item = TextRoomTimelineItem(id: .randomEvent,
+                                        timestamp: .mock,
+                                        isOutgoing: false,
+                                        isEditable: false,
+                                        canBeRepliedTo: true,
+                                        sender: .init(id: "@alice:matrix.org"),
+                                        content: .init(body: "Plain body"))
+
+        #expect(item.selectableText == AttributedString("Plain body"))
+    }
+
+    private func makeActions(for item: RoomTimelineItemProtocol) -> TimelineItemMenuActions? {
+        TimelineItemMenuActionProvider(timelineItem: item,
+                                       canCurrentUserSendMessage: true,
+                                       canCurrentUserRedactSelf: true,
+                                       canCurrentUserRedactOthers: false,
+                                       canCurrentUserPin: true,
+                                       pinnedEventIDs: [],
+                                       isViewSourceEnabled: true,
+                                       areThreadsEnabled: true,
+                                       timelineKind: .live,
+                                       emojiProvider: EmojiProvider(appSettings: .volatile()))
+            .makeActions()
+    }
+}

--- a/UnitTests/Sources/TimelineTextSelectionContentTests.swift
+++ b/UnitTests/Sources/TimelineTextSelectionContentTests.swift
@@ -1,0 +1,142 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+@testable import ElementX
+import Foundation
+import Testing
+import UIKit
+
+@MainActor
+struct TimelineTextSelectionContentTests {
+    @Test
+    func replacesMatrixPillsWithReadableText() throws {
+        let attributedString = NSMutableAttributedString(string: "")
+        attributedString.append(makeUserMention(userID: "@alice:matrix.org", displayName: "Alice"))
+        attributedString.append(NSAttributedString(string: " "))
+        attributedString.append(makeUserMention(userID: "@bob:matrix.org", displayName: nil))
+        attributedString.append(NSAttributedString(string: " "))
+        attributedString.append(makeAllUsersMention())
+        attributedString.append(NSAttributedString(string: " "))
+        attributedString.append(makeRoomAliasMention(alias: "#element:matrix.org", displayName: "Element"))
+        attributedString.append(NSAttributedString(string: " "))
+        attributedString.append(makeRoomIDMention(roomID: "!room:matrix.org"))
+        attributedString.append(NSAttributedString(string: " "))
+        attributedString.append(makeEventOnRoomAliasMention(alias: "#foundation:matrix.org"))
+        attributedString.append(NSAttributedString(string: " "))
+        attributedString.append(makeEventOnRoomIDMention(roomID: "!event-room:matrix.org"))
+
+        let result = try transformed(attributedString,
+                                     roomNameForID: { $0 == "!room:matrix.org" ? "Matrix HQ" : nil },
+                                     roomNameForAlias: { $0 == "#foundation:matrix.org" ? "Foundation" : nil })
+
+        #expect(result.string == "@Alice @bob:matrix.org @room #Element #Matrix HQ 💬 > #Foundation 💬 > !event-room:matrix.org")
+        #expect(!result.string.contains("\u{fffc}"))
+        result.enumerateAttributes(in: NSRange(location: 0, length: result.length)) { attributes, _, _ in
+            #expect(!(attributes[.attachment] is PillTextAttachment))
+            #expect(attributes[.link] == nil)
+        }
+    }
+
+    @Test
+    func preservesUnicodeAndNoninteractiveFormatting() throws {
+        let originalString = "Family: 👨‍👩‍👧‍👦 — مرحبا بالعالم"
+        let attributedString = NSMutableAttributedString(string: originalString)
+        let range = NSRange(location: 0, length: attributedString.length)
+        let font = UIFont.preferredFont(forTextStyle: .body)
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.alignment = .natural
+        attributedString.addAttributes([.font: font,
+                                        .paragraphStyle: paragraphStyle,
+                                        .MatrixBlockquote: true,
+                                        .link: URL(string: "https://matrix.org")!],
+                                       range: range)
+
+        let result = try transformed(attributedString)
+
+        #expect(result.string == originalString)
+        #expect(result.attribute(.font, at: 0, effectiveRange: nil) as? UIFont == font)
+        #expect((result.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle)?.alignment == .natural)
+        #expect(result.attribute(.MatrixBlockquote, at: 0, effectiveRange: nil) as? Bool == true)
+        #expect(result.attribute(.link, at: 0, effectiveRange: nil) == nil)
+    }
+
+    private func makeUserMention(userID: String, displayName: String?) -> NSAttributedString {
+        makeMention("user") { attributedString, range in
+            MentionBuilder().handleUserMention(for: attributedString,
+                                               in: range,
+                                               url: URL(string: "https://matrix.org")!,
+                                               userID: userID,
+                                               userDisplayName: displayName)
+        }
+    }
+
+    private func makeAllUsersMention() -> NSAttributedString {
+        makeMention("@room") { attributedString, range in
+            MentionBuilder().handleAllUsersMention(for: attributedString, in: range)
+        }
+    }
+
+    private func makeRoomAliasMention(alias: String, displayName: String?) -> NSAttributedString {
+        makeMention("room") { attributedString, range in
+            MentionBuilder().handleRoomAliasMention(for: attributedString,
+                                                    in: range,
+                                                    url: URL(string: "https://matrix.org")!,
+                                                    roomAlias: alias,
+                                                    roomDisplayName: displayName)
+        }
+    }
+
+    private func makeRoomIDMention(roomID: String) -> NSAttributedString {
+        makeMention("room") { attributedString, range in
+            MentionBuilder().handleRoomIDMention(for: attributedString,
+                                                 in: range,
+                                                 url: URL(string: "https://matrix.org")!,
+                                                 roomID: roomID)
+        }
+    }
+
+    private func makeEventOnRoomAliasMention(alias: String) -> NSAttributedString {
+        makeMention("event") { attributedString, range in
+            MentionBuilder().handleEventOnRoomAliasMention(for: attributedString,
+                                                           in: range,
+                                                           url: URL(string: "https://matrix.org")!,
+                                                           eventID: "$event",
+                                                           roomAlias: alias)
+        }
+    }
+
+    private func makeEventOnRoomIDMention(roomID: String) -> NSAttributedString {
+        makeMention("event") { attributedString, range in
+            MentionBuilder().handleEventOnRoomIDMention(for: attributedString,
+                                                        in: range,
+                                                        url: URL(string: "https://matrix.org")!,
+                                                        eventID: "$event",
+                                                        roomID: roomID)
+        }
+    }
+
+    private func makeMention(_ string: String,
+                             configure: (NSMutableAttributedString, NSRange) -> Void) -> NSAttributedString {
+        let attributedString = NSMutableAttributedString(string: string,
+                                                         attributes: [.font: UIFont.preferredFont(forTextStyle: .body),
+                                                                      .foregroundColor: UIColor.label])
+        configure(attributedString, NSRange(location: 0, length: attributedString.length))
+        return attributedString
+    }
+
+    private func transformed(_ attributedString: NSAttributedString,
+                             userDisplayNameForID: (String) -> String? = { _ in nil },
+                             roomNameForID: (String) -> String? = { _ in nil },
+                             roomNameForAlias: (String) -> String? = { _ in nil }) throws -> NSAttributedString {
+        let source = try AttributedString(attributedString, including: \.elementX)
+        let result = MatrixPillTextTransformer.transform(source,
+                                                         userDisplayNameForID: userDisplayNameForID,
+                                                         roomNameForID: roomNameForID,
+                                                         roomNameForAlias: roomNameForAlias)
+        return try NSAttributedString(result, including: \.elementX)
+    }
+}


### PR DESCRIPTION
Add a dedicated text-selection sheet for timeline messages.

Long agent and human messages often contain a command, quote, identifier, or paragraph that needs to be copied exactly. The existing Copy action only copies the whole message, while inline UITextView selection was previously removed because it conflicts with timeline scrolling, links, and swipe-to-reply gestures.

This change follows element-hq/element-x-ios#5451:

- adds Select text beside the existing whole-message Copy action;
- presents the complete text or media caption in an isolated selection sheet;
- enables native substring selection only inside that sheet;
- keeps normal timeline gesture safeguards unchanged;
- supports formatted bodies, captions, mentions, links, blockquotes, code blocks, RTL text, and Dynamic Type through the existing attributed-text renderer;
- adds focused action-provider and selectable-content tests plus a testable preview.

Verification on the Linux implementation host:

- exact 13-file staged set verified;
- `git diff --cached --check` passed before commit;
- `git show --check` passes on the pushed commit;
- local and remote commit SHAs match;
- working tree is clean.

Xcode compilation, unit tests, previews, accessibility snapshots, and interactive selection behavior still require macOS CI/device verification. This PR remains draft until those checks pass.

Upstream issue: element-hq/element-x-ios#5451
