### PR TITLE
Add an `oAuthClientURIPath` option to AppSettings.

### DIFF
--- a/ElementX/Sources/Application/Settings/AppSettings.swift
+++ b/ElementX/Sources/Application/Settings/AppSettings.swift
@@ -80,6 +80,7 @@ final nonisolated class AppSettings: @unchecked Sendable {
                   hideBrandChrome: Bool,
                   pushGatewayBaseURL: URL,
                   oAuthRedirectURL: URL,
+                  oAuthClientURIPath: String?,
                   websiteURL: URL,
                   logoURL: URL,
                   copyrightURL: URL,
@@ -100,6 +101,7 @@ final nonisolated class AppSettings: @unchecked Sendable {
         self.hideBrandChrome = hideBrandChrome
         self.pushGatewayBaseURL = pushGatewayBaseURL
         self.oAuthRedirectURL = oAuthRedirectURL
+        self.oAuthClientURIPath = oAuthClientURIPath
         self.websiteURL = websiteURL
         self.logoURL = logoURL
         self.copyrightURL = copyrightURL
@@ -198,11 +200,15 @@ final nonisolated class AppSettings: @unchecked Sendable {
     /// The redirect URL used for OAuth. For the normal case we don't actually need the bundle ID as the web authentication session handles the redirect internally.
     /// However in the case where MAS sends the user to an external app, we need to make sure that the system will open the correct variant of the app (e.g. Nightly).
     private(set) nonisolated(unsafe) var oAuthRedirectURL: URL! = URL(string: "https://element.io/oauth/ios/\(InfoPlistReader.main.bundleIdentifier)")
+    /// A path that is appended to `websiteURL` to form the OAuth `clientURI`. MAS uses `clientURI` as the identifier for a specific app, allowing us to
+    /// distinguish the various clients we have for Android, iOS and Web from each other.
+    /// Intentionally a distinct property so it can be easily overridden without having to manipulate the website URL.
+    private(set) var oAuthClientURIPath: String? // = "app/ios"
     
     var oAuthConfiguration: OAuthConfiguration {
         OAuthConfiguration(clientName: InfoPlistReader.main.bundleDisplayName,
                            redirectURI: oAuthRedirectURL,
-                           clientURI: websiteURL,
+                           clientURI: oAuthClientURIPath.map { websiteURL.appending(path: $0) } ?? websiteURL,
                            logoURI: logoURL,
                            tosURI: acceptableUseURL,
                            policyURI: privacyURL,

--- a/ElementX/Sources/UITests/UITestsAppCoordinator.swift
+++ b/ElementX/Sources/UITests/UITestsAppCoordinator.swift
@@ -155,6 +155,7 @@ class MockScreen: Identifiable {
                                      hideBrandChrome: false,
                                      pushGatewayBaseURL: appSettings.pushGatewayBaseURL,
                                      oAuthRedirectURL: appSettings.oAuthRedirectURL,
+                                     oAuthClientURIPath: appSettings.oAuthClientURIPath,
                                      websiteURL: appSettings.websiteURL,
                                      logoURL: appSettings.logoURL,
                                      copyrightURL: appSettings.copyrightURL,

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/pkl-swift",
       "state" : {
-        "revision" : "40e5decb9481c8c5d8c64389255166023c936900",
-        "version" : "0.8.2"
+        "revision" : "00f4b15c0941e137bf90de712b6fb643c9f0880a",
+        "version" : "0.10.0"
       }
     },
     {

--- a/UnitTests/Sources/AuthenticationStartScreenViewModelTests.swift
+++ b/UnitTests/Sources/AuthenticationStartScreenViewModelTests.swift
@@ -336,6 +336,7 @@ final class AuthenticationStartScreenViewModelTests {
                              hideBrandChrome: false,
                              pushGatewayBaseURL: appSettings.pushGatewayBaseURL,
                              oAuthRedirectURL: appSettings.oAuthRedirectURL,
+                             oAuthClientURIPath: appSettings.oAuthClientURIPath,
                              websiteURL: appSettings.websiteURL,
                              logoURL: appSettings.logoURL,
                              copyrightURL: appSettings.copyrightURL,

--- a/UnitTests/Sources/ServerConfirmationScreenViewModelTests.swift
+++ b/UnitTests/Sources/ServerConfirmationScreenViewModelTests.swift
@@ -325,6 +325,7 @@ final class ServerConfirmationScreenViewModelTests {
                                  hideBrandChrome: false,
                                  pushGatewayBaseURL: appSettings.pushGatewayBaseURL,
                                  oAuthRedirectURL: appSettings.oAuthRedirectURL,
+                                 oAuthClientURIPath: appSettings.oAuthClientURIPath,
                                  websiteURL: appSettings.websiteURL,
                                  logoURL: appSettings.logoURL,
                                  copyrightURL: appSettings.copyrightURL,


### PR DESCRIPTION
This allows us to use unique client URIs for OAuth which MAS can use to distinguish Element on iOS from Web & Android. It is optional as forks would not necessarily need this. The value is `nil` for now until we have confirmation of the URL we can use on element.io