### PR TITLE
Allow previews in the timeline to include filtered galleries

### DIFF
--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -11491,7 +11491,7 @@ nonisolated class TimelineControllerMock: TimelineControllerProtocol, @unchecked
         set(value) { underlyingTimelineKind = value }
     }
     nonisolated(unsafe) var underlyingTimelineKind: TimelineKind!
-    nonisolated(unsafe) var galleryFilters: [GalleryFilter]?
+    nonisolated(unsafe) var allowedGalleryItemTypes: [TimelineAllowedGalleryItemType]?
     nonisolated(unsafe) var timelineItems: [RoomTimelineItemProtocol] = []
     var paginationState: TimelinePaginationState {
         get { return underlyingPaginationState }

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -11491,6 +11491,7 @@ nonisolated class TimelineControllerMock: TimelineControllerProtocol, @unchecked
         set(value) { underlyingTimelineKind = value }
     }
     nonisolated(unsafe) var underlyingTimelineKind: TimelineKind!
+    nonisolated(unsafe) var galleryFilters: [GalleryFilter]?
     nonisolated(unsafe) var timelineItems: [RoomTimelineItemProtocol] = []
     var paginationState: TimelinePaginationState {
         get { return underlyingPaginationState }

--- a/ElementX/Sources/Mocks/TimelineControllerMock.swift
+++ b/ElementX/Sources/Mocks/TimelineControllerMock.swift
@@ -18,7 +18,7 @@ struct TimelineControllerMockConfiguration {
     var timelineProxy: TimelineProxyProtocol?
     var timelineItemsTimestamps: [TimelineItemIdentifier: Date] = [:]
     var paginationState: TimelinePaginationState = .initial
-    var galleryFilters: [GalleryFilter]?
+    var allowedGalleryItemTypes: [TimelineAllowedGalleryItemType]?
 }
 
 @MainActor extension TimelineControllerMock {
@@ -45,7 +45,7 @@ struct TimelineControllerMockConfiguration {
         
         callbacks = PassthroughSubject()
         timelineKind = configuration.timelineKind
-        galleryFilters = configuration.galleryFilters
+        allowedGalleryItemTypes = configuration.allowedGalleryItemTypes
         paginationState = configuration.paginationState
         timelineItems = configuration.timelineItems
         

--- a/ElementX/Sources/Mocks/TimelineControllerMock.swift
+++ b/ElementX/Sources/Mocks/TimelineControllerMock.swift
@@ -18,6 +18,7 @@ struct TimelineControllerMockConfiguration {
     var timelineProxy: TimelineProxyProtocol?
     var timelineItemsTimestamps: [TimelineItemIdentifier: Date] = [:]
     var paginationState: TimelinePaginationState = .initial
+    var galleryFilters: [GalleryFilter]?
 }
 
 @MainActor extension TimelineControllerMock {
@@ -44,6 +45,7 @@ struct TimelineControllerMockConfiguration {
         
         callbacks = PassthroughSubject()
         timelineKind = configuration.timelineKind
+        galleryFilters = configuration.galleryFilters
         paginationState = configuration.paginationState
         timelineItems = configuration.timelineItems
         

--- a/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewDataSource.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewDataSource.swift
@@ -36,7 +36,7 @@ class TimelineMediaPreviewDataSource: NSObject, QLPreviewControllerDataSource {
     var paginationState: TimelinePaginationState
     
     /// The gallery attachments to include, so that a gallery only contributes the media being browsed.
-    private let galleryFilters: [GalleryFilter]?
+    private let allowedGalleryItemTypes: [TimelineAllowedGalleryItemType]?
     
     /// Builds a data source spanning every previewable attachment in the timeline, paginating
     /// as the user swipes past the loaded range. Used when tapping a standalone media message.
@@ -44,10 +44,10 @@ class TimelineMediaPreviewDataSource: NSObject, QLPreviewControllerDataSource {
          initialItem: EventBasedMessageTimelineItemProtocol,
          initialPadding: Int = 100,
          paginationState: TimelinePaginationState,
-         galleryFilters: [GalleryFilter]? = nil) {
-        self.galleryFilters = galleryFilters
+         allowedGalleryItemTypes: [TimelineAllowedGalleryItemType]? = nil) {
+        self.allowedGalleryItemTypes = allowedGalleryItemTypes
         
-        previewItems = itemViewStates.flatMap { TimelineMediaPreviewItem.Media.items(from: $0, galleryFilters: galleryFilters) }
+        previewItems = itemViewStates.flatMap { $0.previewableMedia(allowedGalleryItemTypes: allowedGalleryItemTypes) }
         
         let initialPreviewID = TimelineMediaPreviewItem.Media(timelineItem: initialItem).id
         if let initialItemArrayIndex = previewItems.firstIndex(where: { $0.id == initialPreviewID }) {
@@ -72,7 +72,7 @@ class TimelineMediaPreviewDataSource: NSObject, QLPreviewControllerDataSource {
     /// gallery and there's no timeline pagination to drive.
     init(galleryItem: GalleryRoomTimelineItem,
          initialIndex: Int) {
-        galleryFilters = nil // All of the gallery's attachments are shown.
+        allowedGalleryItemTypes = nil // All of the gallery's attachments are shown.
         
         let media = galleryItem.content.items.map { item in
             TimelineMediaPreviewItem.Media(galleryParent: galleryItem, item: item)
@@ -102,7 +102,7 @@ class TimelineMediaPreviewDataSource: NSObject, QLPreviewControllerDataSource {
     
     func updatePreviewItems(itemViewStates: [RoomTimelineItemViewState]) {
         let newItems: [TimelineMediaPreviewItem.Media] = itemViewStates
-            .flatMap { TimelineMediaPreviewItem.Media.items(from: $0, galleryFilters: galleryFilters) }
+            .flatMap { $0.previewableMedia(allowedGalleryItemTypes: allowedGalleryItemTypes) }
             .map { newItem in
                 // If an item already exists use that instead to preserve the file handle, download error etc.
                 if let oldItem = previewItems.first(where: { $0.id == newItem.id }) {
@@ -255,24 +255,6 @@ enum TimelineMediaPreviewItem: Equatable {
             }
             content = .timelineItem(timelineItem)
             id = MediaPreviewItemID(timelineItem: timelineItem)
-        }
-        
-        /// The previewable media of a timeline item, flattening a gallery message into its individual
-        /// attachments so that they can be browsed alongside the timeline's other media.
-        /// - Parameter galleryFilters: Restricts a gallery's attachments to the media being browsed, as
-        ///   the SDK can only filter the gallery event as a whole.
-        static func items(from itemViewState: RoomTimelineItemViewState, galleryFilters: [GalleryFilter]?) -> [Media] {
-            guard case .gallery(let galleryItem) = itemViewState.type else {
-                return [Media(roomTimelineItemViewState: itemViewState)].compactMap { $0 }
-            }
-            
-            return galleryItem.content.items.filter { item in
-                guard let filter = item.filter else {
-                    return false // Nothing to preview, and unlike a tile there's no index to line up with.
-                }
-                
-                return galleryFilters?.contains(filter) ?? true
-            }.map { Media(galleryParent: galleryItem, item: $0) }
         }
         
         /// Wraps a single attachment of a gallery message. `.other` items have no media source,
@@ -454,5 +436,25 @@ enum TimelineMediaPreviewItem: Equatable {
         init(state: State) {
             self.state = state
         }
+    }
+}
+
+private extension RoomTimelineItemViewState {
+    /// The media of this item that can be previewed, flattening a gallery message into its individual
+    /// attachments so that they can be browsed alongside the timeline's other media.
+    /// - Parameter allowedGalleryItemTypes: Restricts a gallery's attachments to the media being
+    ///   browsed, as the SDK can only filter the gallery event as a whole.
+    func previewableMedia(allowedGalleryItemTypes: [TimelineAllowedGalleryItemType]?) -> [TimelineMediaPreviewItem.Media] {
+        guard case .gallery(let galleryItem) = type else {
+            return [TimelineMediaPreviewItem.Media(roomTimelineItemViewState: self)].compactMap { $0 }
+        }
+        
+        return galleryItem.content.items.filter { item in
+            guard let allowedItemType = item.allowedItemType else {
+                return false // Nothing to preview, and unlike a tile there's no index to line up with.
+            }
+            
+            return allowedGalleryItemTypes?.contains(allowedItemType) ?? true
+        }.map { TimelineMediaPreviewItem.Media(galleryParent: galleryItem, item: $0) }
     }
 }

--- a/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewDataSource.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewDataSource.swift
@@ -35,13 +35,19 @@ class TimelineMediaPreviewDataSource: NSObject, QLPreviewControllerDataSource {
     
     var paginationState: TimelinePaginationState
     
+    /// The gallery attachments to include, so that a gallery only contributes the media being browsed.
+    private let galleryFilters: [GalleryFilter]?
+    
     /// Builds a data source spanning every previewable attachment in the timeline, paginating
     /// as the user swipes past the loaded range. Used when tapping a standalone media message.
     init(itemViewStates: [RoomTimelineItemViewState],
          initialItem: EventBasedMessageTimelineItemProtocol,
          initialPadding: Int = 100,
-         paginationState: TimelinePaginationState) {
-        previewItems = itemViewStates.compactMap(TimelineMediaPreviewItem.Media.init)
+         paginationState: TimelinePaginationState,
+         galleryFilters: [GalleryFilter]? = nil) {
+        self.galleryFilters = galleryFilters
+        
+        previewItems = itemViewStates.flatMap { TimelineMediaPreviewItem.Media.items(from: $0, galleryFilters: galleryFilters) }
         
         let initialPreviewID = TimelineMediaPreviewItem.Media(timelineItem: initialItem).id
         if let initialItemArrayIndex = previewItems.firstIndex(where: { $0.id == initialPreviewID }) {
@@ -66,6 +72,8 @@ class TimelineMediaPreviewDataSource: NSObject, QLPreviewControllerDataSource {
     /// gallery and there's no timeline pagination to drive.
     init(galleryItem: GalleryRoomTimelineItem,
          initialIndex: Int) {
+        galleryFilters = nil // All of the gallery's attachments are shown.
+        
         let media = galleryItem.content.items.map { item in
             TimelineMediaPreviewItem.Media(galleryParent: galleryItem, item: item)
         }
@@ -93,17 +101,17 @@ class TimelineMediaPreviewDataSource: NSObject, QLPreviewControllerDataSource {
     }
     
     func updatePreviewItems(itemViewStates: [RoomTimelineItemViewState]) {
-        let newItems: [TimelineMediaPreviewItem.Media] = itemViewStates.compactMap { itemViewState in
-            guard let newItem = TimelineMediaPreviewItem.Media(roomTimelineItemViewState: itemViewState) else { return nil }
-            
-            // If an item already exists use that instead to preserve the file handle, download error etc.
-            if let oldItem = previewItems.first(where: { $0.id == newItem.id }) {
-                oldItem.content = newItem.content
-                return oldItem
+        let newItems: [TimelineMediaPreviewItem.Media] = itemViewStates
+            .flatMap { TimelineMediaPreviewItem.Media.items(from: $0, galleryFilters: galleryFilters) }
+            .map { newItem in
+                // If an item already exists use that instead to preserve the file handle, download error etc.
+                if let oldItem = previewItems.first(where: { $0.id == newItem.id }) {
+                    oldItem.content = newItem.content
+                    return oldItem
+                }
+                
+                return newItem
             }
-            
-            return newItem
-        }
         
         var hasPaginated = false
         if let range = newItems.map(\.id).firstRange(of: previewItems.map(\.id)) {
@@ -247,6 +255,24 @@ enum TimelineMediaPreviewItem: Equatable {
             }
             content = .timelineItem(timelineItem)
             id = MediaPreviewItemID(timelineItem: timelineItem)
+        }
+        
+        /// The previewable media of a timeline item, flattening a gallery message into its individual
+        /// attachments so that they can be browsed alongside the timeline's other media.
+        /// - Parameter galleryFilters: Restricts a gallery's attachments to the media being browsed, as
+        ///   the SDK can only filter the gallery event as a whole.
+        static func items(from itemViewState: RoomTimelineItemViewState, galleryFilters: [GalleryFilter]?) -> [Media] {
+            guard case .gallery(let galleryItem) = itemViewState.type else {
+                return [Media(roomTimelineItemViewState: itemViewState)].compactMap { $0 }
+            }
+            
+            return galleryItem.content.items.filter { item in
+                guard let filter = item.filter else {
+                    return false // Nothing to preview, and unlike a tile there's no index to line up with.
+                }
+                
+                return galleryFilters?.contains(filter) ?? true
+            }.map { Media(galleryParent: galleryItem, item: $0) }
         }
         
         /// Wraps a single attachment of a gallery message. `.other` items have no media source,

--- a/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewViewModel.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewViewModel.swift
@@ -49,7 +49,7 @@ class TimelineMediaPreviewViewModel: TimelineMediaPreviewViewModelType {
         super.init(initialViewState: TimelineMediaPreviewViewState(dataSource: .init(itemViewStates: timelineState.itemViewStates,
                                                                                      initialItem: initialItem,
                                                                                      paginationState: timelineState.paginationState,
-                                                                                     galleryFilters: timelineViewModel.context.viewState.galleryFilters)),
+                                                                                     allowedGalleryItemTypes: timelineViewModel.context.viewState.allowedGalleryItemTypes)),
                    mediaProvider: mediaProvider)
         
         rebuildCurrentItemActions()

--- a/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewViewModel.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewViewModel.swift
@@ -48,7 +48,8 @@ class TimelineMediaPreviewViewModel: TimelineMediaPreviewViewModelType {
         
         super.init(initialViewState: TimelineMediaPreviewViewState(dataSource: .init(itemViewStates: timelineState.itemViewStates,
                                                                                      initialItem: initialItem,
-                                                                                     paginationState: timelineState.paginationState)),
+                                                                                     paginationState: timelineState.paginationState,
+                                                                                     galleryFilters: timelineViewModel.context.viewState.galleryFilters)),
                    mediaProvider: mediaProvider)
         
         rebuildCurrentItemActions()

--- a/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewViewModel.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewViewModel.swift
@@ -22,10 +22,6 @@ class TimelineMediaPreviewViewModel: TimelineMediaPreviewViewModelType {
     private let userIndicatorController: UserIndicatorControllerProtocol
     private let appMediator: AppMediatorProtocol
     
-    /// Overrides the timeline kind used to build the context menu. Gallery previews use `.media` so the
-    /// standard download/forward/delete actions appear, since their underlying room timeline is `.live`.
-    private let menuTimelineKind: TimelineKind?
-    
     private var contentScannerService: ContentScannerServiceProtocol? {
         timelineViewModel.context.contentScannerService
     }
@@ -47,7 +43,6 @@ class TimelineMediaPreviewViewModel: TimelineMediaPreviewViewModelType {
         self.photoLibraryManager = photoLibraryManager
         self.userIndicatorController = userIndicatorController
         self.appMediator = appMediator
-        menuTimelineKind = nil
         
         let timelineState = timelineViewModel.context.viewState.timelineState
         
@@ -99,7 +94,6 @@ class TimelineMediaPreviewViewModel: TimelineMediaPreviewViewModelType {
         self.photoLibraryManager = photoLibraryManager
         self.userIndicatorController = userIndicatorController
         self.appMediator = appMediator
-        menuTimelineKind = .media(.roomScreenLive)
         
         super.init(initialViewState: TimelineMediaPreviewViewState(dataSource: .init(galleryItem: galleryItem,
                                                                                      initialIndex: initialIndex)),
@@ -236,7 +230,7 @@ class TimelineMediaPreviewViewModel: TimelineMediaPreviewViewModelType {
                                            pinnedEventIDs: timelineContext.viewState.pinnedEventIDs,
                                            isViewSourceEnabled: timelineContext.viewState.isViewSourceEnabled,
                                            areThreadsEnabled: timelineContext.viewState.areThreadsEnabled,
-                                           timelineKind: menuTimelineKind ?? timelineContext.viewState.timelineKind,
+                                           timelineKind: timelineContext.viewState.timelineKind,
                                            emojiProvider: timelineContext.viewState.emojiProvider)
                 .makeActions()
         }

--- a/ElementX/Sources/Screens/Timeline/TimelineInteractionHandler.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineInteractionHandler.swift
@@ -560,14 +560,15 @@ class TimelineInteractionHandler {
                                                              timestamp: item.timestamp,
                                                              timeoutDate: item.content.timeoutDate)
             return .displayLiveLocation(sender: item.sender, initialLiveLocationShare: initialLiveLocationShare)
+        // Galleries are included so that their attachments can be browsed as individual media.
         case let item as ImageRoomTimelineItem:
-            return await mediaPreviewAction(for: item, messageTypes: [.image, .video])
+            return await mediaPreviewAction(for: item, messageTypes: [.image, .video, .gallery])
         case let item as VideoRoomTimelineItem:
-            return await mediaPreviewAction(for: item, messageTypes: [.image, .video])
+            return await mediaPreviewAction(for: item, messageTypes: [.image, .video, .gallery])
         case let item as AudioRoomTimelineItem:
-            return await mediaPreviewAction(for: item, messageTypes: [.audio, .file])
+            return await mediaPreviewAction(for: item, messageTypes: [.audio, .file, .gallery])
         case let item as FileRoomTimelineItem:
-            return await mediaPreviewAction(for: item, messageTypes: [.audio, .file])
+            return await mediaPreviewAction(for: item, messageTypes: [.audio, .file, .gallery])
         case let item as GalleryRoomTimelineItem:
             // Only galleries are needed as the preview is scoped to the attachments of the tapped one.
             return await mediaPreviewAction(for: item, messageTypes: [.gallery])

--- a/ElementX/Sources/Screens/Timeline/TimelineInteractionHandler.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineInteractionHandler.swift
@@ -107,6 +107,14 @@ class TimelineInteractionHandler {
     
     // swiftlint:disable:next cyclomatic_complexity
     func handleTimelineItemMenuAction(_ action: TimelineItemMenuAction, itemID: TimelineItemIdentifier) {
+        // Redacting needs the event alone, so it works even when the item isn't part of this timeline,
+        // such as one held by a media preview that was built from a different one.
+        if case .redact = action {
+            guard case let .event(_, eventOrTransactionID) = itemID else { fatalError() }
+            Task { await timelineController.redact(eventOrTransactionID) }
+            return
+        }
+        
         guard let timelineItem = timelineController.timelineItems.firstUsingStableID(itemID),
               let eventTimelineItem = timelineItem as? EventBasedTimelineItemProtocol else {
             return
@@ -156,8 +164,7 @@ class TimelineInteractionHandler {
                 UIPasteboard.general.url = permalinkURL
             }
         case .redact:
-            guard case let .event(_, eventOrTransactionID) = itemID else { fatalError() }
-            Task { await timelineController.redact(eventOrTransactionID) }
+            break // Handled above, before the timeline item is looked up.
         case .reply:
             guard let eventID = eventTimelineItem.id.eventID else { return }
             
@@ -607,7 +614,10 @@ class TimelineInteractionHandler {
         case .pinned:
             newTimelineFocus = .pinned
             newTimelinePresentation = .pinnedEventsScreen
-        case .media, .thread:
+        case .thread(let rootEventID):
+            newTimelineFocus = .thread(eventID: rootEventID)
+            newTimelinePresentation = .roomScreenThread
+        case .media:
             break // We don't need to create a new timeline as it is already filtered.
         }
         

--- a/ElementX/Sources/Screens/Timeline/TimelineInteractionHandler.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineInteractionHandler.swift
@@ -568,19 +568,12 @@ class TimelineInteractionHandler {
             return await mediaPreviewAction(for: item, messageTypes: [.audio, .file])
         case let item as FileRoomTimelineItem:
             return await mediaPreviewAction(for: item, messageTypes: [.audio, .file])
+        case let item as GalleryRoomTimelineItem:
+            // Only galleries are needed as the preview is scoped to the attachments of the tapped one.
+            return await mediaPreviewAction(for: item, messageTypes: [.gallery])
         default:
             return .none
         }
-    }
-    
-    /// Opens a media preview scoped to a single gallery's attachments. The preview pages
-    /// only between the items of that one gallery — siblings in the wider timeline aren't
-    /// reachable from this entry point (use the regular media tap for that).
-    func processGalleryItemTap(itemID: TimelineItemIdentifier, index: Int) -> TimelineControllerAction {
-        guard let galleryItem = timelineController.timelineItems.firstUsingStableID(itemID) as? GalleryRoomTimelineItem else {
-            return .none
-        }
-        return .displayGalleryPreview(galleryItem: galleryItem, initialIndex: index)
     }
     
     // MARK: - Private
@@ -644,10 +637,20 @@ class TimelineInteractionHandler {
                                                       linkMetadataProvider: linkMetadataProvider,
                                                       timelineControllerFactory: timelineControllerFactory)
             
-            return .displayMediaPreview(item: item, timelineViewModel: .new(timelineViewModel))
+            return previewAction(for: item, timelineViewModel: .new(timelineViewModel))
         } else {
-            return .displayMediaPreview(item: item, timelineViewModel: .active)
+            return previewAction(for: item, timelineViewModel: .active)
         }
+    }
+    
+    /// A gallery is previewed scoped to its own attachments rather than the wider timeline's media.
+    private func previewAction(for item: EventBasedMessageTimelineItemProtocol,
+                               timelineViewModel: TimelineControllerAction.TimelineViewModelKind) -> TimelineControllerAction {
+        guard let galleryItem = item as? GalleryRoomTimelineItem else {
+            return .displayMediaPreview(item: item, timelineViewModel: timelineViewModel)
+        }
+        
+        return .displayGalleryPreview(galleryItem: galleryItem, timelineViewModel: timelineViewModel)
     }
 }
 

--- a/ElementX/Sources/Screens/Timeline/TimelineModels.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineModels.swift
@@ -104,6 +104,8 @@ enum TimelineComposerAction {
 
 struct TimelineViewState: BindableState {
     let timelineKind: TimelineKind
+    /// The gallery attachments the timeline includes, or `nil` when it isn't filtered.
+    let galleryFilters: [GalleryFilter]?
     var roomID: String
     var members: [String: RoomMemberState] = [:]
     var typingMembers: [String] = []

--- a/ElementX/Sources/Screens/Timeline/TimelineModels.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineModels.swift
@@ -105,7 +105,7 @@ enum TimelineComposerAction {
 struct TimelineViewState: BindableState {
     let timelineKind: TimelineKind
     /// The gallery attachments the timeline includes, or `nil` when it isn't filtered.
-    let galleryFilters: [GalleryFilter]?
+    let allowedGalleryItemTypes: [TimelineAllowedGalleryItemType]?
     var roomID: String
     var members: [String: RoomMemberState] = [:]
     var typingMembers: [String] = []

--- a/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
@@ -92,7 +92,7 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
             true
         }
         super.init(initialViewState: TimelineViewState(timelineKind: timelineController.timelineKind,
-                                                       galleryFilters: timelineController.galleryFilters,
+                                                       allowedGalleryItemTypes: timelineController.allowedGalleryItemTypes,
                                                        roomID: roomProxy.id,
                                                        isDM: roomProxy.infoPublisher.value.isDM,
                                                        timelineState: TimelineState(focussedEvent: focussedEventID.map { .init(eventID: $0, appearance: .immediate) }),

--- a/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
@@ -160,7 +160,7 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
         case .mediaTapped(let id):
             Task { await handleMediaTapped(with: id) }
         case .galleryItemTapped(let id, let index):
-            handleGalleryItemTapped(itemID: id, index: index)
+            Task { await handleMediaTapped(with: id, galleryIndex: index) }
         case .itemSendInfoTapped(let itemID):
             handleItemSendInfoTapped(itemID: itemID)
         case .toggleReaction(let emoji, let itemID):
@@ -700,7 +700,7 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
         await timelineController.sendReadReceipt(for: lastVisibleItemID)
     }
     
-    private func handleMediaTapped(with itemID: TimelineItemIdentifier) async {
+    private func handleMediaTapped(with itemID: TimelineItemIdentifier, galleryIndex: Int? = nil) async {
         state.showLoading = true
         let action = await timelineInteractionHandler.processItemTap(itemID)
         
@@ -710,8 +710,13 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
             
             let mediaPreviewViewModel = makeMediaPreviewViewModel(item: item, timelineViewModelKind: timelineViewModelKind)
             actionsSubject.send(.displayMediaPreview(mediaPreviewViewModel))
-        case .displayGalleryPreview:
-            fatalError("Galleries open through the dedicated galleryItemTapped path, which carries the tapped index.")
+        case .displayGalleryPreview(let galleryItem, let timelineViewModelKind):
+            actionsSubject.send(.composer(action: .removeFocus))
+            
+            let mediaPreviewViewModel = makeGalleryPreviewViewModel(galleryItem: galleryItem,
+                                                                    timelineViewModelKind: timelineViewModelKind,
+                                                                    initialIndex: galleryIndex ?? 0)
+            actionsSubject.send(.displayMediaPreview(mediaPreviewViewModel))
         case .displayLocation(let location):
             actionsSubject.send(.displayLocation(location))
         case .displayLiveLocation(let sender, let initialLiveLocationShare):
@@ -720,18 +725,6 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
             break
         }
         state.showLoading = false
-    }
-    
-    private func handleGalleryItemTapped(itemID: TimelineItemIdentifier, index: Int) {
-        if case let .displayGalleryPreview(galleryItem, initialIndex) = timelineInteractionHandler.processGalleryItemTap(itemID: itemID, index: index) {
-            displayGalleryPreview(galleryItem: galleryItem, initialIndex: initialIndex)
-        }
-    }
-    
-    private func displayGalleryPreview(galleryItem: GalleryRoomTimelineItem, initialIndex: Int) {
-        actionsSubject.send(.composer(action: .removeFocus))
-        let mediaPreviewViewModel = makeGalleryPreviewViewModel(galleryItem: galleryItem, initialIndex: initialIndex)
-        actionsSubject.send(.displayMediaPreview(mediaPreviewViewModel))
     }
     
     private func handleItemSendInfoTapped(itemID: TimelineItemIdentifier) {
@@ -836,28 +829,31 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
     
     private func makeMediaPreviewViewModel(item: EventBasedMessageTimelineItemProtocol,
                                            timelineViewModelKind: TimelineControllerAction.TimelineViewModelKind) -> TimelineMediaPreviewViewModel {
-        let timelineViewModel = switch timelineViewModelKind {
-        case .active: self
-        case .new(let newViewModel): newViewModel
-        }
-        
-        return TimelineMediaPreviewViewModel(initialItem: item,
-                                             timelineViewModel: timelineViewModel,
-                                             mediaProvider: userSession.mediaProvider,
-                                             photoLibraryManager: PhotoLibraryManager(),
-                                             userIndicatorController: userIndicatorController,
-                                             appMediator: appMediator)
-    }
-    
-    private func makeGalleryPreviewViewModel(galleryItem: GalleryRoomTimelineItem,
-                                             initialIndex: Int) -> TimelineMediaPreviewViewModel {
-        TimelineMediaPreviewViewModel(galleryItem: galleryItem,
-                                      initialIndex: initialIndex,
-                                      timelineViewModel: self,
+        TimelineMediaPreviewViewModel(initialItem: item,
+                                      timelineViewModel: timelineViewModel(for: timelineViewModelKind),
                                       mediaProvider: userSession.mediaProvider,
                                       photoLibraryManager: PhotoLibraryManager(),
                                       userIndicatorController: userIndicatorController,
                                       appMediator: appMediator)
+    }
+    
+    private func makeGalleryPreviewViewModel(galleryItem: GalleryRoomTimelineItem,
+                                             timelineViewModelKind: TimelineControllerAction.TimelineViewModelKind,
+                                             initialIndex: Int) -> TimelineMediaPreviewViewModel {
+        TimelineMediaPreviewViewModel(galleryItem: galleryItem,
+                                      initialIndex: initialIndex,
+                                      timelineViewModel: timelineViewModel(for: timelineViewModelKind),
+                                      mediaProvider: userSession.mediaProvider,
+                                      photoLibraryManager: PhotoLibraryManager(),
+                                      userIndicatorController: userIndicatorController,
+                                      appMediator: appMediator)
+    }
+    
+    private func timelineViewModel(for kind: TimelineControllerAction.TimelineViewModelKind) -> TimelineViewModel {
+        switch kind {
+        case .active: self
+        case .new(let newViewModel): newViewModel
+        }
     }
     
     // MARK: - Timeline Item Building

--- a/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
@@ -92,6 +92,7 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
             true
         }
         super.init(initialViewState: TimelineViewState(timelineKind: timelineController.timelineKind,
+                                                       galleryFilters: timelineController.galleryFilters,
                                                        roomID: roomProxy.id,
                                                        isDM: roomProxy.infoPublisher.value.isDM,
                                                        timelineState: TimelineState(focussedEvent: focussedEventID.map { .init(eventID: $0, appearance: .immediate) }),

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/GalleryItemTileView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/GalleryItemTileView.swift
@@ -52,7 +52,7 @@ struct GalleryItemTileView: View {
     private var content: some View {
         if let source = item.thumbnailSource ?? item.mediaSource {
             LoadableImage(mediaSource: source,
-                          mediaType: .timelineItem(uniqueID: item.id.timelineItemUniqueID),
+                          mediaType: .timelineItem(uniqueID: item.id.timelineItemID.uniqueID),
                           blurhash: item.blurhash,
                           size: item.size,
                           mediaProvider: mediaProvider) { imageView in

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/GalleryListView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/GalleryListView.swift
@@ -110,7 +110,7 @@ private struct GalleryListRow: View {
     private var icon: some View {
         if item.hasThumbnail, let source = item.thumbnailSource ?? item.mediaSource {
             LoadableImage(mediaSource: source,
-                          mediaType: .timelineItem(uniqueID: item.id.timelineItemUniqueID),
+                          mediaType: .timelineItem(uniqueID: item.id.timelineItemID.uniqueID),
                           blurhash: item.blurhash,
                           size: item.size,
                           mediaProvider: mediaProvider) { imageView in

--- a/ElementX/Sources/Services/Timeline/TimelineController/TimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/TimelineController.swift
@@ -44,12 +44,16 @@ class TimelineController: TimelineControllerProtocol {
         activeTimelineItemProvider.kind
     }
     
+    let galleryFilters: [GalleryFilter]?
+    
     init(roomProxy: JoinedRoomProxyProtocol,
          timelineProxy: TimelineProxyProtocol,
          initialFocussedEventID: String?,
          timelineItemFactory: RoomTimelineItemFactoryProtocol,
          mediaProvider: MediaProviderProtocol,
-         appSettings: AppSettings) {
+         appSettings: AppSettings,
+         galleryFilters: [GalleryFilter]? = nil) {
+        self.galleryFilters = galleryFilters
         self.roomProxy = roomProxy
         liveTimelineItemProvider = timelineProxy.timelineItemProvider
         self.timelineItemFactory = timelineItemFactory

--- a/ElementX/Sources/Services/Timeline/TimelineController/TimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/TimelineController.swift
@@ -44,7 +44,7 @@ class TimelineController: TimelineControllerProtocol {
         activeTimelineItemProvider.kind
     }
     
-    let galleryFilters: [GalleryFilter]?
+    let allowedGalleryItemTypes: [TimelineAllowedGalleryItemType]?
     
     init(roomProxy: JoinedRoomProxyProtocol,
          timelineProxy: TimelineProxyProtocol,
@@ -52,8 +52,8 @@ class TimelineController: TimelineControllerProtocol {
          timelineItemFactory: RoomTimelineItemFactoryProtocol,
          mediaProvider: MediaProviderProtocol,
          appSettings: AppSettings,
-         galleryFilters: [GalleryFilter]? = nil) {
-        self.galleryFilters = galleryFilters
+         allowedGalleryItemTypes: [TimelineAllowedGalleryItemType]? = nil) {
+        self.allowedGalleryItemTypes = allowedGalleryItemTypes
         self.roomProxy = roomProxy
         liveTimelineItemProvider = timelineProxy.timelineItemProvider
         self.timelineItemFactory = timelineItemFactory

--- a/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerFactory.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerFactory.swift
@@ -71,7 +71,8 @@ struct TimelineControllerFactory: TimelineControllerFactoryProtocol {
                                                initialFocussedEventID: nil,
                                                timelineItemFactory: timelineItemFactory,
                                                mediaProvider: mediaProvider,
-                                               appSettings: appSettings))
+                                               appSettings: appSettings,
+                                               galleryFilters: allowedMessageTypes.galleryFilters))
         case .failure(let error):
             return .failure(.roomProxyError(error))
         }

--- a/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerFactory.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerFactory.swift
@@ -72,7 +72,7 @@ struct TimelineControllerFactory: TimelineControllerFactoryProtocol {
                                                timelineItemFactory: timelineItemFactory,
                                                mediaProvider: mediaProvider,
                                                appSettings: appSettings,
-                                               galleryFilters: allowedMessageTypes.galleryFilters))
+                                               allowedGalleryItemTypes: allowedMessageTypes.allowedGalleryItemTypes))
         case .failure(let error):
             return .failure(.roomProxyError(error))
         }

--- a/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerProtocol.swift
@@ -26,7 +26,7 @@ enum TimelineControllerAction {
     }
     
     case displayMediaPreview(item: EventBasedMessageTimelineItemProtocol, timelineViewModel: TimelineViewModelKind)
-    case displayGalleryPreview(galleryItem: GalleryRoomTimelineItem, initialIndex: Int)
+    case displayGalleryPreview(galleryItem: GalleryRoomTimelineItem, timelineViewModel: TimelineViewModelKind)
     case displayLocation(StaticLocationData)
     case displayLiveLocation(sender: TimelineItemSender, initialLiveLocationShare: LiveLocationShare)
     case none

--- a/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerProtocol.swift
@@ -47,6 +47,9 @@ enum TimelineControllerError: Error {
 protocol TimelineControllerProtocol: Sendable {
     var timelineKind: TimelineKind { get }
     
+    /// The gallery attachments this timeline includes, or `nil` when it isn't filtered.
+    var galleryFilters: [GalleryFilter]? { get }
+    
     /// The currently known items, use only for setting up the intial state.
     var timelineItems: [RoomTimelineItemProtocol] { get }
     

--- a/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/TimelineControllerProtocol.swift
@@ -48,7 +48,7 @@ protocol TimelineControllerProtocol: Sendable {
     var timelineKind: TimelineKind { get }
     
     /// The gallery attachments this timeline includes, or `nil` when it isn't filtered.
-    var galleryFilters: [GalleryFilter]? { get }
+    var allowedGalleryItemTypes: [TimelineAllowedGalleryItemType]? { get }
     
     /// The currently known items, use only for setting up the intial state.
     var timelineItems: [RoomTimelineItemProtocol] { get }

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/GalleryRoomTimelineItemContent.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/GalleryRoomTimelineItemContent.swift
@@ -26,16 +26,6 @@ nonisolated struct GalleryItemID: Hashable {
     let mediaIndex: Int
 }
 
-/// The kinds of gallery attachment that a screen includes, mirroring the message types its timeline is
-/// filtered to. The SDK can only filter whole events, so a gallery's attachments are filtered by these
-/// client side. Unlike a message type there's no gallery case, as a gallery can't contain another one.
-nonisolated enum GalleryFilter {
-    case image
-    case video
-    case audio
-    case file
-}
-
 /// A single attachment of a gallery message. The SDK hands back the same content types it uses for
 /// individual messages, so we reuse them here rather than duplicating their fields.
 nonisolated enum GalleryItem: Hashable, Identifiable {
@@ -164,8 +154,8 @@ nonisolated enum GalleryItem: Hashable, Identifiable {
         isImage || thumbnailSource != nil
     }
     
-    /// The filter this attachment is matched by, or `nil` when its type is unknown.
-    var filter: GalleryFilter? {
+    /// The type this attachment is allowed by, or `nil` when its type is unknown.
+    var allowedItemType: TimelineAllowedGalleryItemType? {
         switch self {
         case .image: .image
         case .video: .video
@@ -180,7 +170,7 @@ nonisolated enum GalleryItem: Hashable, Identifiable {
 
 nonisolated extension GalleryItemID {
     static func mock(_ index: Int) -> GalleryItemID {
-        .init(timelineItemID: .virtual(uniqueID: .init("gallery-mock")), mediaIndex: index)
+        .init(timelineItemID: .randomEvent, mediaIndex: index)
     }
 }
 

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/GalleryRoomTimelineItemContent.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/GalleryRoomTimelineItemContent.swift
@@ -25,6 +25,16 @@ nonisolated struct GalleryItemID: Hashable {
     let mediaIndex: Int
 }
 
+/// The kinds of gallery attachment that a screen includes, mirroring the message types its timeline is
+/// filtered to. The SDK can only filter whole events, so a gallery's attachments are filtered by these
+/// client side. Unlike a message type there's no gallery case, as a gallery can't contain another one.
+nonisolated enum GalleryFilter {
+    case image
+    case video
+    case audio
+    case file
+}
+
 /// A single attachment of a gallery message. The SDK hands back the same content types it uses for
 /// individual messages, so we reuse them here rather than duplicating their fields.
 nonisolated enum GalleryItem: Hashable, Identifiable {
@@ -151,6 +161,17 @@ nonisolated enum GalleryItem: Hashable, Identifiable {
     /// IS the image); for everything else we need an explicit thumbnail source.
     var hasThumbnail: Bool {
         isImage || thumbnailSource != nil
+    }
+    
+    /// The filter this attachment is matched by, or `nil` when its type is unknown.
+    var filter: GalleryFilter? {
+        switch self {
+        case .image: .image
+        case .video: .video
+        case .audio: .audio
+        case .file: .file
+        case .other: nil
+        }
     }
 }
 

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/GalleryRoomTimelineItemContent.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/GalleryRoomTimelineItemContent.swift
@@ -19,8 +19,9 @@ nonisolated struct GalleryRoomTimelineItemContent: Hashable {
 
 /// Identifies a single attachment within a gallery message.
 nonisolated struct GalleryItemID: Hashable {
-    /// The unique ID of the parent gallery timeline item.
-    let timelineItemUniqueID: TimelineItemIdentifier.UniqueID
+    /// The identifier of the parent gallery timeline item. The whole identifier is used so that an
+    /// attachment remains identifiable across timelines, where the unique ID alone wouldn't be.
+    let timelineItemID: TimelineItemIdentifier
     /// The item's position within the gallery.
     let mediaIndex: Int
 }
@@ -179,7 +180,7 @@ nonisolated enum GalleryItem: Hashable, Identifiable {
 
 nonisolated extension GalleryItemID {
     static func mock(_ index: Int) -> GalleryItemID {
-        .init(timelineItemUniqueID: .init("gallery-mock"), mediaIndex: index)
+        .init(timelineItemID: .virtual(uniqueID: .init("gallery-mock")), mediaIndex: index)
     }
 }
 

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
@@ -149,7 +149,7 @@ nonisolated struct RoomTimelineItemFactory: RoomTimelineItemFactoryProtocol {
         case .location(let content):
             .location(buildLocationTimelineItemContent(content))
         case .gallery(let content):
-            .gallery(buildGalleryTimelineItemContent(content, timelineItemID: .virtual(uniqueID: .init(senderID))))
+            .gallery(buildGalleryTimelineItemContent(content, timelineItemID: .randomEvent))
         case .other(_, let body):
             .text(.init(body: body))
         case .none:

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
@@ -149,7 +149,7 @@ nonisolated struct RoomTimelineItemFactory: RoomTimelineItemFactoryProtocol {
         case .location(let content):
             .location(buildLocationTimelineItemContent(content))
         case .gallery(let content):
-            .gallery(buildGalleryTimelineItemContent(content, uniqueID: .init(senderID)))
+            .gallery(buildGalleryTimelineItemContent(content, timelineItemID: .virtual(uniqueID: .init(senderID))))
         case .other(_, let body):
             .text(.init(body: body))
         case .none:
@@ -417,7 +417,7 @@ nonisolated struct RoomTimelineItemFactory: RoomTimelineItemFactoryProtocol {
                                 canBeRepliedTo: eventItemProxy.canBeRepliedTo,
                                 shouldBoost: eventItemProxy.shouldBoost,
                                 sender: eventItemProxy.sender,
-                                content: buildGalleryTimelineItemContent(galleryMessageContent, uniqueID: eventItemProxy.id.uniqueID),
+                                content: buildGalleryTimelineItemContent(galleryMessageContent, timelineItemID: eventItemProxy.id),
                                 properties: .init(replyDetails: buildTimelineItemReplyDetails(messageLikeContent.inReplyTo),
                                                   isThreaded: messageLikeContent.threadRoot != nil,
                                                   threadSummary: buildTimelineItemThreadSummary(messageLikeContent.threadSummary),
@@ -429,13 +429,13 @@ nonisolated struct RoomTimelineItemFactory: RoomTimelineItemFactoryProtocol {
                                                   encryptionForwarder: eventItemProxy.forwarder))
     }
     
-    private func buildGalleryTimelineItemContent(_ messageContent: GalleryMessageContent, uniqueID: TimelineItemIdentifier.UniqueID) -> GalleryRoomTimelineItemContent {
+    private func buildGalleryTimelineItemContent(_ messageContent: GalleryMessageContent, timelineItemID: TimelineItemIdentifier) -> GalleryRoomTimelineItemContent {
         let htmlCaption = messageContent.formatted?.format == .html ? messageContent.formatted?.body : nil
         let plainCaption = messageContent.formatted?.format != .html ? messageContent.formatted?.body : nil
         let formattedCaption = htmlCaption != nil ? attributedStringBuilder.fromHTML(htmlCaption) : (plainCaption.flatMap(attributedStringBuilder.fromPlain))
         
         let items = messageContent.itemtypes.enumerated().map { index, itemType in
-            buildGalleryItem(itemType, id: GalleryItemID(timelineItemUniqueID: uniqueID, mediaIndex: index))
+            buildGalleryItem(itemType, id: GalleryItemID(timelineItemID: timelineItemID, mediaIndex: index))
         }
         
         return GalleryRoomTimelineItemContent(body: messageContent.body,

--- a/ElementX/Sources/Services/Timeline/TimelineProxy.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineProxy.swift
@@ -94,7 +94,7 @@ final class TimelineProxy: TimelineProxyProtocol {
     }
     
     func messageEventContent(for timelineItemID: TimelineItemIdentifier) async -> RoomMessageEventContentWithoutRelation? {
-        guard let content = timelineItemProvider.itemProxies.firstEventTimelineItemUsingStableID(timelineItemID)?.content,
+        guard let content = timelineItemProvider.itemProxies.firstEventTimelineItem(matching: timelineItemID)?.content,
               case let .msgLike(messageLikeContent) = content,
               case let .message(messageContent) = messageLikeContent.kind else {
             return nil
@@ -663,15 +663,19 @@ private extension MatrixRustSDK.PollKind {
 }
 
 extension Array where Element == TimelineItemProxy {
-    func firstEventTimelineItemUsingStableID(_ id: TimelineItemIdentifier) -> EventTimelineItem? {
-        for item in self {
-            if case let .event(eventTimelineItem) = item {
-                if eventTimelineItem.id.uniqueID == id.uniqueID {
-                    return eventTimelineItem.item
-                }
-            }
+    /// The event matching the given identifier, found by the event itself as that is the only part of
+    /// the identifier that can be compared across timelines. Identifiers that don't represent an event
+    /// fall back to the unique ID.
+    func firstEventTimelineItem(matching id: TimelineItemIdentifier) -> EventTimelineItem? {
+        let eventTimelineItems = compactMap { item -> EventTimelineItemProxy? in
+            guard case let .event(eventTimelineItem) = item else { return nil }
+            return eventTimelineItem
         }
         
-        return nil
+        guard let eventOrTransactionID = id.eventOrTransactionID else {
+            return eventTimelineItems.first { $0.id.uniqueID == id.uniqueID }?.item
+        }
+        
+        return eventTimelineItems.first { $0.id.eventOrTransactionID == eventOrTransactionID }?.item
     }
 }

--- a/ElementX/Sources/Services/Timeline/TimelineProxyProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineProxyProtocol.swift
@@ -16,7 +16,7 @@ enum TimelineKind: Equatable {
     case pinned
     case thread(rootEventID: String)
     
-    enum MediaPresentation { case roomScreenLive, roomScreenDetached, pinnedEventsScreen, mediaFilesScreen }
+    enum MediaPresentation { case roomScreenLive, roomScreenDetached, roomScreenThread, pinnedEventsScreen, mediaFilesScreen }
     case media(MediaPresentation)
     
     var isThread: Bool {

--- a/ElementX/Sources/Services/Timeline/TimelineProxyProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineProxyProtocol.swift
@@ -42,6 +42,27 @@ enum TimelineFocus {
 
 enum TimelineAllowedMessageType {
     case audio, file, image, video, gallery
+    
+    /// The gallery attachments this type allows, so that a gallery event's attachments can be
+    /// filtered client side to match. A gallery can't contain another gallery, hence the `nil`.
+    var galleryFilter: GalleryFilter? {
+        switch self {
+        case .audio: .audio
+        case .file: .file
+        case .image: .image
+        case .video: .video
+        case .gallery: nil
+        }
+    }
+}
+
+extension [TimelineAllowedMessageType] {
+    /// The gallery attachments these types allow, or `nil` when they place no restriction on them,
+    /// which is the case for a timeline made up of galleries alone.
+    var galleryFilters: [GalleryFilter]? {
+        let filters = compactMap(\.galleryFilter)
+        return filters.isEmpty ? nil : filters
+    }
 }
 
 enum TimelineProxyError: Error {

--- a/ElementX/Sources/Services/Timeline/TimelineProxyProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineProxyProtocol.swift
@@ -45,7 +45,7 @@ enum TimelineAllowedMessageType {
     
     /// The gallery attachments this type allows, so that a gallery event's attachments can be
     /// filtered client side to match. A gallery can't contain another gallery, hence the `nil`.
-    var galleryFilter: GalleryFilter? {
+    var allowedGalleryItemType: TimelineAllowedGalleryItemType? {
         switch self {
         case .audio: .audio
         case .file: .file
@@ -56,12 +56,19 @@ enum TimelineAllowedMessageType {
     }
 }
 
+/// The gallery attachments a timeline allows, mirroring the message types it is filtered to. The SDK can
+/// only filter whole events, so a gallery's attachments are filtered by these client side. Unlike a
+/// message type there's no gallery case, as a gallery can't contain another one.
+enum TimelineAllowedGalleryItemType {
+    case audio, file, image, video
+}
+
 extension [TimelineAllowedMessageType] {
     /// The gallery attachments these types allow, or `nil` when they place no restriction on them,
     /// which is the case for a timeline made up of galleries alone.
-    var galleryFilters: [GalleryFilter]? {
-        let filters = compactMap(\.galleryFilter)
-        return filters.isEmpty ? nil : filters
+    var allowedGalleryItemTypes: [TimelineAllowedGalleryItemType]? {
+        let types = compactMap(\.allowedGalleryItemType)
+        return types.isEmpty ? nil : types
     }
 }
 

--- a/UnitTests/Sources/TimelineMediaPreviewDataSourceTests.swift
+++ b/UnitTests/Sources/TimelineMediaPreviewDataSourceTests.swift
@@ -51,7 +51,7 @@ struct TimelineMediaPreviewDataSourceTests {
         let dataSource = TimelineMediaPreviewDataSource(itemViewStates: itemViewStates,
                                                         initialItem: image,
                                                         paginationState: .initial,
-                                                        galleryFilters: [.image, .video])
+                                                        allowedGalleryItemTypes: [.image, .video])
         
         // Then the galleries' visual attachments are browsable as though they were individual messages,
         // whilst the file is left to the timeline that shows those.

--- a/UnitTests/Sources/TimelineMediaPreviewDataSourceTests.swift
+++ b/UnitTests/Sources/TimelineMediaPreviewDataSourceTests.swift
@@ -30,26 +30,57 @@ struct TimelineMediaPreviewDataSourceTests {
     }
     
     @Test
+    func timelinePreviewFlattensGalleries() throws {
+        // Given a timeline containing an image, a gallery of 2 attachments and a gallery of 3, one of
+        // which is a file that belongs in the other timeline.
+        let image = ImageRoomTimelineItem(id: .randomEvent,
+                                          timestamp: .mock,
+                                          isOutgoing: false,
+                                          isEditable: false,
+                                          canBeRepliedTo: true,
+                                          sender: .init(id: "Bob"),
+                                          content: .init(filename: "image.jpg", imageInfo: .mockImage, thumbnailInfo: nil, blurhash: nil))
+        let firstGalleryItems: [GalleryItem] = [.mockImage(index: 0), .mockVideo(index: 1)]
+        let secondGalleryItems: [GalleryItem] = [.mockImage(index: 0), .mockFile(index: 1), .mockImage(index: 2)]
+        let timelineItems: [RoomTimelineItemProtocol] = [image,
+                                                         makeGallery(items: firstGalleryItems),
+                                                         makeGallery(items: secondGalleryItems)]
+        let itemViewStates = timelineItems.map { RoomTimelineItemViewState(item: $0, groupStyle: .single) }
+        
+        // When opening the preview from the image, which isn't part of a gallery.
+        let dataSource = TimelineMediaPreviewDataSource(itemViewStates: itemViewStates,
+                                                        initialItem: image,
+                                                        paginationState: .initial,
+                                                        galleryFilters: [.image, .video])
+        
+        // Then the galleries' visual attachments are browsable as though they were individual messages,
+        // whilst the file is left to the timeline that shows those.
+        let imageID = try #require(image.id.eventOrTransactionID)
+        let expectedIDs: [MediaPreviewItemID] = [.timelineItem(imageID),
+                                                 .galleryItem(firstGalleryItems[0].id),
+                                                 .galleryItem(firstGalleryItems[1].id),
+                                                 .galleryItem(secondGalleryItems[0].id),
+                                                 .galleryItem(secondGalleryItems[2].id)]
+        #expect(dataSource.previewItems.map(\.id) == expectedIDs)
+        
+        // …starting from the tapped image.
+        #expect(dataSource.currentMediaItemID == .timelineItem(imageID))
+    }
+    
+    @Test
     func galleryPreview() throws {
-        // Given a gallery message with three previewable attachments.
-        let items = (0..<3).map { index in
-            GalleryItem.mockImage(index: index, filename: "image-\(index).jpg")
-        }
-        let gallery = GalleryRoomTimelineItem(id: .randomEvent,
-                                              timestamp: .mock,
-                                              isOutgoing: false,
-                                              isEditable: false,
-                                              canBeRepliedTo: true,
-                                              sender: .init(id: "Bob"),
-                                              content: .init(body: "Gallery", caption: nil, items: items),
-                                              properties: .init())
+        // Given a gallery message whose attachments are a mix of media types.
+        let items: [GalleryItem] = [.mockImage(index: 0), .mockFile(index: 1), .mockVideo(index: 2), .mockAudio(index: 3)]
+        let gallery = makeGallery(items: items)
         
         // When opening the preview scoped to that gallery on the second attachment.
         let dataSource = TimelineMediaPreviewDataSource(galleryItem: gallery, initialIndex: 1)
         
-        // Then it contains exactly the gallery's attachments with no surrounding pagination…
-        #expect(dataSource.previewItems.count == 3)
-        #expect(dataSource.numberOfPreviewItems(in: previewController) == 3)
+        // Then it is self contained, holding every one of the attachments without filtering any of
+        // them out and with no surrounding pagination…
+        let expectedIDs: [MediaPreviewItemID] = items.map { .galleryItem($0.id) }
+        #expect(dataSource.previewItems.map(\.id) == expectedIDs)
+        #expect(dataSource.numberOfPreviewItems(in: previewController) == items.count)
         #expect(dataSource.initialItemIndex == 1)
         
         // …and the initial item is the tapped attachment.
@@ -293,6 +324,17 @@ struct TimelineMediaPreviewDataSourceTests {
     }
     
     // MARK: Helpers
+    
+    private func makeGallery(items: [GalleryItem]) -> GalleryRoomTimelineItem {
+        .init(id: .randomEvent,
+              timestamp: .mock,
+              isOutgoing: false,
+              isEditable: false,
+              canBeRepliedTo: true,
+              sender: .init(id: "Bob"),
+              content: .init(body: "Gallery", caption: nil, items: items),
+              properties: .init())
+    }
     
     func newChunk() -> [EventBasedMessageTimelineItemProtocol] {
         TimelineFixtures.mediaChunk


### PR DESCRIPTION
When a gallery is opened directly from the timeline, the preview should be self contained to the gallery.
However when the preview is opened outside the gallery, galleries should be included too when swiping between media, and the gallery should also be filtered following the same pattern used for the opening media (images and videos, or files and audios), essentially flattening the gallery and considering each single media element as a timeline item.