### PR TITLE
Escape search queries and keep results aligned with the SDK's diff stream

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -231,6 +231,7 @@
 		2435DCCBD4513B9FD053CAC9 /* target.yml in Resources */ = {isa = PBXBuildFile; fileRef = DD3C65634A34467CB407A061 /* target.yml */; };
 		244407B18B2F2D6466BA5961 /* RoomChangeRolesScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82DFA1B7B088D033E0794B82 /* RoomChangeRolesScreenCoordinator.swift */; };
 		2447FADEF13225BB6227B977 /* VerificationBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D97BAF04AA150C0EF03021 /* VerificationBadge.swift */; };
+		249D15AAF13C7ED37BC504E0 /* TantivyEscapingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F62FB4D78056B2BB3AFA79 /* TantivyEscapingTests.swift */; };
 		24A1BBADAC43DC3F3A7347DA /* AnalyticsPromptScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = E53BFB7E4F329621C844E8C3 /* AnalyticsPromptScreen.swift */; };
 		24A75F72EEB7561B82D726FD /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2141693488CE5446BB391964 /* Date.swift */; };
 		24B7CD41342C143117ADA768 /* Comparable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2B1CC9AA154F4D5435BF60A /* Comparable.swift */; };
@@ -1177,6 +1178,7 @@
 		BED59052E5C5163D2B065CA6 /* EventTimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A81FD0C60175FA081EB19AD /* EventTimelineItem.swift */; };
 		BF523D9E12E3C4AABBA2F6CB /* SpaceHeaderTopicSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9F2E1FC5A0139571211CE8 /* SpaceHeaderTopicSheetView.swift */; };
 		BFEB24336DFD5F196E6F3456 /* IntentionalMentions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DF5CBAF69BDF5DF31C661E1 /* IntentionalMentions.swift */; };
+		BFFC5974061B4A9CAE32EB80 /* SearchServiceProxyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0174C7E1B30E2AB729FF840 /* SearchServiceProxyTests.swift */; };
 		C0090506A52A1991BAF4BA68 /* NotificationSettingsChatType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07579F9C29001E40715F3014 /* NotificationSettingsChatType.swift */; };
 		C022284E2774A5E1EF683B4D /* FileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04DF593C3F7AF4B2FBAEB05D /* FileManager.swift */; };
 		C02DE5F62C81FB9E173C3D2F /* TimelineMediaPreviewDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED0AD0C652385F69FA90FAF5 /* TimelineMediaPreviewDataSourceTests.swift */; };
@@ -1258,6 +1260,7 @@
 		CB99B0FA38A4AC596F38CC13 /* KeychainControllerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E94DCFEE803E5ABAE8ACCE /* KeychainControllerProtocol.swift */; };
 		CB9FB2BEF313072C705AC9B5 /* SecurityAndPrivacyScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0315C328FF40F84276364E66 /* SecurityAndPrivacyScreenViewModelTests.swift */; };
 		CBBBE597BE74A2DF68DE2209 /* NotificationItemProxyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DDB7A9BB466C56614BB589D /* NotificationItemProxyProtocol.swift */; };
+		CBD2834EEF5F16BB4A73AEC7 /* String+TantivyEscaping.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7DFD5E5CA1F081B59DDCA11 /* String+TantivyEscaping.swift */; };
 		CBD2ABE4C1A47ECD99E1488E /* NotificationSettingsScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 421FA93BCC2840E66E4F306F /* NotificationSettingsScreenViewModelProtocol.swift */; };
 		CBEE2AA8B0C9BDDB3FDD4C81 /* DeferredFulfillment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91AD590B0B40718A0AA0C61 /* DeferredFulfillment.swift */; };
 		CC0D088F505F33A20DC5590F /* RoomStateEventStringBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEAFB646E583655652C3D04 /* RoomStateEventStringBuilderTests.swift */; };
@@ -2586,6 +2589,7 @@
 		A0013D4F8EA288D589CFBF37 /* ContentScannerProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentScannerProxy.swift; sourceTree = "<group>"; };
 		A00C7A331B72C0F05C00392F /* RoomScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		A010B8EAD1A9F6B4686DF2F4 /* BlockedUsersScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedUsersScreenViewModel.swift; sourceTree = "<group>"; };
+		A0174C7E1B30E2AB729FF840 /* SearchServiceProxyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchServiceProxyTests.swift; sourceTree = "<group>"; };
 		A019A12C866D64CF072024B9 /* AppLockSetupPINScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockSetupPINScreenViewModel.swift; sourceTree = "<group>"; };
 		A02D1A490944BF01A37586E1 /* sk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sk; path = sk.lproj/SAS.strings; sourceTree = "<group>"; };
 		A04EFA0E3139C01E1CFDC93B /* GalleryRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryRoomTimelineView.swift; sourceTree = "<group>"; };
@@ -2828,6 +2832,7 @@
 		C75FE3F524B575D53787868C /* TimelineMediaPreviewRedactConfirmationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineMediaPreviewRedactConfirmationView.swift; sourceTree = "<group>"; };
 		C7661EFFCAA307A97D71132A /* HomeScreenRoomList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenRoomList.swift; sourceTree = "<group>"; };
 		C79C2C6E7F66646D1D254927 /* RoomLiveLocationServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomLiveLocationServiceMock.swift; sourceTree = "<group>"; };
+		C7F62FB4D78056B2BB3AFA79 /* TantivyEscapingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TantivyEscapingTests.swift; sourceTree = "<group>"; };
 		C830A64609CBD152F06E0457 /* NotificationConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationConstants.swift; sourceTree = "<group>"; };
 		C8794B3D86D7D444B9B6FF7B /* ContentScanningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentScanningView.swift; sourceTree = "<group>"; };
 		C90514BE9B8ACCBCF0AD2489 /* ComposerToolbarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerToolbarViewModel.swift; sourceTree = "<group>"; };
@@ -2916,6 +2921,7 @@
 		D79BB714D28C9F588DD69353 /* SecureBackupScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureBackupScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		D7B18089ED50324583BB2FB7 /* EditRoomAddressScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditRoomAddressScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		D7BB243B26D54EF1A0C422C0 /* NotificationContentBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationContentBuilder.swift; sourceTree = "<group>"; };
+		D7DFD5E5CA1F081B59DDCA11 /* String+TantivyEscaping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+TantivyEscaping.swift"; sourceTree = "<group>"; };
 		D80807B554CF9C524F98674F /* ManageRoomMemberSheetViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageRoomMemberSheetViewModelTests.swift; sourceTree = "<group>"; };
 		D8320AB70CEFCDC0EC6E72B6 /* ur */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ur; path = ur.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		D879DC5515B1D42577F96C94 /* RoomSelectionScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomSelectionScreen.swift; sourceTree = "<group>"; };
@@ -5125,6 +5131,7 @@
 				046C0D3F53B0B5EF0A1F5BEA /* RoomSummaryTests.swift */,
 				B7728AA8046D460145EAC740 /* RoomTests.swift */,
 				5413213B56FB76C1071E2BFB /* SearchScreenViewModelTests.swift */,
+				A0174C7E1B30E2AB729FF840 /* SearchServiceProxyTests.swift */,
 				848F69921527D31CAACB93AF /* SecureBackupLogoutConfirmationScreenViewModelTests.swift */,
 				0315C328FF40F84276364E66 /* SecurityAndPrivacyScreenViewModelTests.swift */,
 				277C20CDD5B64510401B6D0D /* ServerConfigurationScreenViewStateTests.swift */,
@@ -5140,6 +5147,7 @@
 				18B223FA339BF53085328DEE /* SpaceScreenViewModelTests.swift */,
 				6DF438EAFC732D2D95D34BF6 /* StartChatViewModelTests.swift */,
 				2CEBCB9676FCD1D0F13188DD /* StringTests.swift */,
+				C7F62FB4D78056B2BB3AFA79 /* TantivyEscapingTests.swift */,
 				9AA3AF94A06D319BB37E52DA /* TimelineItemFactoryTests.swift */,
 				ED0AD0C652385F69FA90FAF5 /* TimelineMediaPreviewDataSourceTests.swift */,
 				5C1F000589F2CEE6B03ECFAB /* TimelineMediaPreviewViewModelTests.swift */,
@@ -6384,6 +6392,7 @@
 			children = (
 				7AD6FFE581238BD30B53BA0A /* SearchServiceProxy.swift */,
 				9F3E4640982CE98C6ADD7896 /* SearchServiceProxyProtocol.swift */,
+				D7DFD5E5CA1F081B59DDCA11 /* String+TantivyEscaping.swift */,
 			);
 			path = Search;
 			sourceTree = "<group>";
@@ -8140,6 +8149,7 @@
 				15913A5B07118C1268A840E4 /* RoomSummaryTests.swift in Sources */,
 				62811275F1ED9EA55638838E /* RoomTests.swift in Sources */,
 				D69CCEC785E6C819551B402F /* SearchScreenViewModelTests.swift in Sources */,
+				BFFC5974061B4A9CAE32EB80 /* SearchServiceProxyTests.swift in Sources */,
 				EB87DF90CF6F8D5D12404C6E /* SecureBackupLogoutConfirmationScreenViewModelTests.swift in Sources */,
 				CB9FB2BEF313072C705AC9B5 /* SecurityAndPrivacyScreenViewModelTests.swift in Sources */,
 				53A55748D5F587C9061F98BF /* ServerConfigurationScreenViewStateTests.swift in Sources */,
@@ -8155,6 +8165,7 @@
 				72D2298DE695A6797CDA1A2A /* SpaceScreenViewModelTests.swift in Sources */,
 				6189B4ABD535CE526FA1107B /* StartChatViewModelTests.swift in Sources */,
 				1FEC0A4EC6E6DF693C16B32A /* StringTests.swift in Sources */,
+				249D15AAF13C7ED37BC504E0 /* TantivyEscapingTests.swift in Sources */,
 				E75CE800B3E64D0F7F8E228D /* TemplateScreenViewModelTests.swift in Sources */,
 				0D4EB2ABAA5FE8CB10FDBCB8 /* TimelineItemFactoryTests.swift in Sources */,
 				C02DE5F62C81FB9E173C3D2F /* TimelineMediaPreviewDataSourceTests.swift in Sources */,
@@ -9186,6 +9197,7 @@
 				C58E305C380D3ADDF7912180 /* StickerRoomTimelineItem.swift in Sources */,
 				197441F1EF23A5DABACCA79F /* StickerRoomTimelineView.swift in Sources */,
 				715FB2D768E8919979EACD71 /* StopButton.swift in Sources */,
+				CBD2834EEF5F16BB4A73AEC7 /* String+TantivyEscaping.swift in Sources */,
 				2F94054F50E312AF30BE07F3 /* String.swift in Sources */,
 				7640A4B412CACF15D143CCD4 /* Strings+SAS.swift in Sources */,
 				A7D48E44D485B143AADDB77D /* Strings+Untranslated.swift in Sources */,

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -2357,6 +2357,48 @@ nonisolated class ClientProxyMock: ClientProxyProtocol, @unchecked Sendable {
     }
     nonisolated(unsafe) var underlyingLiveLocationOwnInfoUpdatesPublisher: AnyPublisher<LiveLocationOwnInfoUpdate, Never>!
 
+    //MARK: - makeSearchService
+
+    private let makeSearchServiceRoomIDCallsCountLock = NSLock()
+    private nonisolated(unsafe) var makeSearchServiceRoomIDUnderlyingCallsCount = 0
+    var makeSearchServiceRoomIDCallsCount: Int {
+        get { makeSearchServiceRoomIDCallsCountLock.withLock { makeSearchServiceRoomIDUnderlyingCallsCount } }
+        set { makeSearchServiceRoomIDCallsCountLock.withLock { makeSearchServiceRoomIDUnderlyingCallsCount = newValue } }
+    }
+    var makeSearchServiceRoomIDCalled: Bool {
+        return makeSearchServiceRoomIDCallsCount > 0
+    }
+    private let makeSearchServiceRoomIDReceivedRoomIDLock = NSLock()
+    private nonisolated(unsafe) var makeSearchServiceRoomIDUnderlyingReceivedRoomID: String?
+    var makeSearchServiceRoomIDReceivedRoomID: String? {
+        get { makeSearchServiceRoomIDReceivedRoomIDLock.withLock { makeSearchServiceRoomIDUnderlyingReceivedRoomID } }
+        set { makeSearchServiceRoomIDReceivedRoomIDLock.withLock { makeSearchServiceRoomIDUnderlyingReceivedRoomID = newValue } }
+    }
+    private let makeSearchServiceRoomIDReceivedInvocationsLock = NSLock()
+    private nonisolated(unsafe) var makeSearchServiceRoomIDUnderlyingReceivedInvocations: [String?] = []
+    var makeSearchServiceRoomIDReceivedInvocations: [String?] {
+        get { makeSearchServiceRoomIDReceivedInvocationsLock.withLock { makeSearchServiceRoomIDUnderlyingReceivedInvocations } }
+        set { makeSearchServiceRoomIDReceivedInvocationsLock.withLock { makeSearchServiceRoomIDUnderlyingReceivedInvocations = newValue } }
+    }
+
+    private let makeSearchServiceRoomIDReturnValueLock = NSLock()
+    private nonisolated(unsafe) var makeSearchServiceRoomIDUnderlyingReturnValue: SearchServiceProxyProtocol!
+    var makeSearchServiceRoomIDReturnValue: SearchServiceProxyProtocol! {
+        get { makeSearchServiceRoomIDReturnValueLock.withLock { makeSearchServiceRoomIDUnderlyingReturnValue } }
+        set { makeSearchServiceRoomIDReturnValueLock.withLock { makeSearchServiceRoomIDUnderlyingReturnValue = newValue } }
+    }
+    nonisolated(unsafe) var makeSearchServiceRoomIDClosure: ((String?) -> SearchServiceProxyProtocol)?
+
+    func makeSearchService(roomID: String?) -> SearchServiceProxyProtocol {
+        makeSearchServiceRoomIDCallsCountLock.withLock { makeSearchServiceRoomIDUnderlyingCallsCount += 1 }
+        makeSearchServiceRoomIDReceivedRoomID = roomID
+        makeSearchServiceRoomIDReceivedInvocationsLock.withLock { makeSearchServiceRoomIDUnderlyingReceivedInvocations.append(roomID) }
+        if let makeSearchServiceRoomIDClosure = makeSearchServiceRoomIDClosure {
+            return makeSearchServiceRoomIDClosure(roomID)
+        } else {
+            return makeSearchServiceRoomIDReturnValue
+        }
+    }
     //MARK: - isOnlyDeviceLeft
 
     private let isOnlyDeviceLeftCallsCountLock = NSLock()
@@ -10458,11 +10500,23 @@ nonisolated class SearchServiceProxyMock: SearchServiceProxyProtocol, @unchecked
     var paginateCalled: Bool {
         return paginateCallsCount > 0
     }
-    nonisolated(unsafe) var paginateClosure: (() async -> Void)?
 
-    @concurrent func paginate() async {
+    private let paginateReturnValueLock = NSLock()
+    private nonisolated(unsafe) var paginateUnderlyingReturnValue: Result<Void, SearchServiceProxyError>!
+    var paginateReturnValue: Result<Void, SearchServiceProxyError>! {
+        get { paginateReturnValueLock.withLock { paginateUnderlyingReturnValue } }
+        set { paginateReturnValueLock.withLock { paginateUnderlyingReturnValue = newValue } }
+    }
+    nonisolated(unsafe) var paginateClosure: (() async -> Result<Void, SearchServiceProxyError>)?
+
+    @discardableResult
+    @concurrent func paginate() async -> Result<Void, SearchServiceProxyError> {
         paginateCallsCountLock.withLock { paginateUnderlyingCallsCount += 1 }
-        await paginateClosure?()
+        if let paginateClosure = paginateClosure {
+            return await paginateClosure()
+        } else {
+            return paginateReturnValue
+        }
     }
 }
 nonisolated class SecureBackupControllerMock: SecureBackupControllerProtocol, @unchecked Sendable {

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -238,11 +238,7 @@ class ClientProxy: ClientProxyProtocol {
         spaceService = await SpaceServiceProxy(spaceService: client.spaceService())
         
         let searchUserID = try client.userId()
-        searchService = SearchServiceProxy(searchService: client.searchService(),
-                                           timelineItemFactory: RoomTimelineItemFactory(userID: searchUserID,
-                                                                                        attributedStringBuilder: AttributedStringBuilder(cacheKey: "search",
-                                                                                                                                         mentionBuilder: PlainMentionBuilder()),
-                                                                                        stateEventStringBuilder: RoomStateEventStringBuilder(userID: searchUserID)))
+        searchService = Self.makeSearchService(client: client, userID: searchUserID, roomID: nil)
         
         capabilities = HomeserverCapabilitiesProxy(underlyingCapabilities: client.homeserverCapabilities())
         
@@ -311,6 +307,19 @@ class ClientProxy: ClientProxyProtocol {
         }
         
         liveLocationOwnInfoUpdatesListenerTaskHandle = createLiveLocationOwnInfoUpdatesObserver()
+    }
+    
+    func makeSearchService(roomID: String?) -> SearchServiceProxyProtocol {
+        Self.makeSearchService(client: client, userID: userID, roomID: roomID)
+    }
+    
+    private static func makeSearchService(client: ClientProtocol, userID: String, roomID: String?) -> SearchServiceProxy {
+        SearchServiceProxy(searchService: client.searchService(),
+                           timelineItemFactory: RoomTimelineItemFactory(userID: userID,
+                                                                        attributedStringBuilder: AttributedStringBuilder(cacheKey: "search",
+                                                                                                                         mentionBuilder: PlainMentionBuilder()),
+                                                                        stateEventStringBuilder: RoomStateEventStringBuilder(userID: userID)),
+                           roomID: roomID)
     }
     
     var userID: String {

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -162,6 +162,10 @@ protocol ClientProxyProtocol: AnyObject {
     
     var searchService: SearchServiceProxyProtocol { get }
     
+    /// Creates an independent search cursor. The underlying SDK service is stateful, running one
+    /// query at a time, so create one per screen. Pass a `roomID` to scope the results to a room.
+    func makeSearchService(roomID: String?) -> SearchServiceProxyProtocol
+    
     var capabilities: HomeserverCapabilitiesProxyProtocol { get }
     
     var isReportRoomSupported: Bool { get async }

--- a/ElementX/Sources/Services/Search/SearchServiceProxy.swift
+++ b/ElementX/Sources/Services/Search/SearchServiceProxy.swift
@@ -11,8 +11,12 @@ import MatrixRustSDK
 class SearchServiceProxy: SearchServiceProxyProtocol {
     private let searchService: SearchServiceProtocol
     private let timelineItemFactory: RoomTimelineItemFactoryProtocol
+    private let roomID: String?
     
     private var resultsHandle: TaskHandle?
+    
+    /// Index-parallel with the SDK's list — positional diffs land here. Never filter this.
+    private var innerResults: [SearchServiceResult] = []
     
     private let resultsSubject = CurrentValueSubject<[SearchServiceResult], Never>([])
     var resultsPublisher: CurrentValuePublisher<[SearchServiceResult], Never> {
@@ -27,9 +31,12 @@ class SearchServiceProxy: SearchServiceProxyProtocol {
         paginationStateSubject.asCurrentValuePublisher()
     }
     
-    init(searchService: SearchServiceProtocol, timelineItemFactory: RoomTimelineItemFactoryProtocol) {
+    init(searchService: SearchServiceProtocol,
+         timelineItemFactory: RoomTimelineItemFactoryProtocol,
+         roomID: String? = nil) {
         self.searchService = searchService
         self.timelineItemFactory = timelineItemFactory
+        self.roomID = roomID
         
         paginationStateSubject = CurrentValueSubject(.init(sdkState: searchService.paginationState()))
         
@@ -45,8 +52,15 @@ class SearchServiceProxy: SearchServiceProxyProtocol {
             })
         }
         
+        // Whatever endReached we are holding describes the PREVIOUS query — or, on the very first
+        // search, a cursor that was never queried at all and reports endReached = true. Carrying
+        // it over makes a search look finished before it has started. We are about to load the
+        // first page, so publish .loading rather than an .idle that would momentarily clear the
+        // view's loading state and flash the empty view before any result arrives.
+        paginationStateSubject.send(.loading)
+        
         do {
-            try await searchService.setQuery(query: query)
+            try await searchService.setQuery(query: query.escapedForTantivy)
             return .success(())
         } catch {
             MXLog.error("Failed to set search query: \(error)")
@@ -54,58 +68,74 @@ class SearchServiceProxy: SearchServiceProxyProtocol {
         }
     }
     
-    func paginate() async {
+    @discardableResult
+    func paginate() async -> Result<Void, SearchServiceProxyError> {
         do {
             try await searchService.paginate()
+            return .success(())
         } catch {
             MXLog.error("Failed to paginate search results: \(error)")
+            return .failure(.sdkError(error))
         }
     }
     
     // MARK: - Private
     
     private func handleResultUpdates(_ updates: [SearchServiceResultsUpdate]) {
-        var results = resultsSubject.value
+        // This list MUST stay index-parallel with the SDK's: the updates below carry the SDK's
+        // indices. Dropping or filtering entries here mis-addresses every later positional
+        // update — do any filtering at the exposure boundary instead.
+        var results = innerResults
         
         for update in updates {
             switch update {
             case .append(let values):
-                results.append(contentsOf: values.compactMap(makeResult))
+                results.append(contentsOf: values.map(makeResult))
             case .clear:
                 results.removeAll()
             case .pushFront(let value):
-                if let result = makeResult(value) {
-                    results.insert(result, at: 0)
-                }
+                results.insert(makeResult(value), at: 0)
             case .pushBack(let value):
-                if let result = makeResult(value) {
-                    results.append(result)
-                }
+                results.append(makeResult(value))
             case .popFront:
-                results.removeFirst()
+                if !results.isEmpty {
+                    results.removeFirst()
+                }
             case .popBack:
-                results.removeLast()
+                if !results.isEmpty {
+                    results.removeLast()
+                }
             case .insert(let index, let value):
-                if let result = makeResult(value) {
-                    results.insert(result, at: Int(index))
-                }
+                results.insert(makeResult(value), at: Int(index))
             case .set(let index, let value):
-                if let result = makeResult(value) {
-                    results[Int(index)] = result
-                }
+                results[Int(index)] = makeResult(value)
             case .remove(let index):
                 results.remove(at: Int(index))
             case .truncate(let length):
                 results.removeSubrange(Int(length)..<results.count)
             case .reset(let values):
-                results = values.compactMap(makeResult)
+                results = values.map(makeResult)
             }
         }
         
-        resultsSubject.send(results)
+        innerResults = results
+        publishResults()
     }
     
-    private func makeResult(_ searchResult: MatrixRustSDK.SearchServiceResult) -> SearchServiceResult? {
+    private func publishResults() {
+        guard let roomID else {
+            resultsSubject.send(innerResults)
+            return
+        }
+        
+        // Room scoping is a client-side filter over a globally ranked set — the FFI has no
+        // per-room search. Applied here, at the exposure boundary, and nowhere earlier.
+        resultsSubject.send(innerResults.filter { $0.roomID == roomID })
+    }
+    
+    /// Maps every SDK result — never drops one. Content the app has no rendering for becomes a
+    /// placeholder so the list stays index-parallel with the SDK's.
+    private func makeResult(_ searchResult: MatrixRustSDK.SearchServiceResult) -> SearchServiceResult {
         switch searchResult {
         case .message(let roomID, let result):
             let sender = TimelineItemSender(senderID: result.sender, senderProfile: result.senderProfile)
@@ -127,10 +157,10 @@ class SearchServiceProxy: SearchServiceProxyProtocol {
                 case .liveLocation:
                     content = .liveLocation
                 default:
-                    return nil
+                    content = .message(.text(.init(body: L10n.commonUnsupportedEvent)))
                 }
             default:
-                return nil
+                content = .message(.text(.init(body: L10n.commonUnsupportedEvent)))
             }
             
             return SearchServiceResult(roomID: roomID,

--- a/ElementX/Sources/Services/Search/SearchServiceProxyProtocol.swift
+++ b/ElementX/Sources/Services/Search/SearchServiceProxyProtocol.swift
@@ -21,7 +21,8 @@ protocol SearchServiceProxyProtocol {
     func setQuery(_ query: String) async -> Result<Void, SearchServiceProxyError>
     
     /// Loads the next page of results. No-ops if a page is already loading or the end has been reached.
-    func paginate() async
+    @discardableResult
+    func paginate() async -> Result<Void, SearchServiceProxyError>
 }
 
 struct SearchServiceResult {

--- a/ElementX/Sources/Services/Search/String+TantivyEscaping.swift
+++ b/ElementX/Sources/Services/Search/String+TantivyEscaping.swift
@@ -1,0 +1,64 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Foundation
+
+private nonisolated let escapedAnywhere: Set<Unicode.Scalar> = ["\\", "^", "`", ":", "{", "}", "\"", "'", "[", "]", "(", ")", "*"]
+private nonisolated let escapedWhenLeading: Set<Unicode.Scalar> = ["-", "+", "/", ">", "<", "!", "~"]
+private nonisolated let operatorWords: Set = ["AND", "OR", "NOT", "IN", "TO"]
+
+nonisolated extension String {
+    /// Escapes tantivy query syntax so what the user typed is searched as literal text, and
+    /// prefixes every token containing a letter or digit with `+` (Must) so all words are
+    /// required — the SDK's parser is OR-by-default and `set_conjunction_by_default` is not
+    /// reachable over the FFI.
+    ///
+    /// Port of `TantivyQueryEscaper.kt` (element-x-android); pinned to the tantivy grammar
+    /// shipped in matrix-rust-components-swift 26.07.15. The query is never logged.
+    var escapedForTantivy: String {
+        split(whereSeparator: \.isWhitespace)
+            .map { token in
+                let escaped = String(token).tantivyEscapedToken
+                // tantivy's default tokenizer splits on non-alphanumerics, so a token like `:)`
+                // indexes no terms at all. Required, such a token could only ever subtract.
+                // Kotlin parity: `isLetterOrDigit` means letter or DECIMAL digit — Swift's
+                // `Character.isNumber` is broader (fractions, Roman numerals) and would wrongly
+                // promote such tokens to Must clauses.
+                let hasLetterOrDigit = token.contains { character in
+                    character.isLetter || character.unicodeScalars.contains { $0.properties.numericType == .decimal }
+                }
+                return hasLetterOrDigit ? "+\(escaped)" : escaped
+            }
+            .joined(separator: " ")
+    }
+    
+    private var tantivyEscapedToken: String {
+        var result = ""
+        result.reserveCapacity(count + 8)
+        
+        if operatorWords.contains(self) {
+            result.append("\\")
+        }
+        
+        // One forward pass: chained replacingOccurrences calls would re-escape the backslashes
+        // they just added. The `+` Must prefix is applied by the caller *after* escaping —
+        // prefixing first would emit a literal `\+` that parses cleanly and silently restores
+        // OR semantics.
+        //
+        // Escape at scalar granularity: tantivy's grammar is defined over scalars, so a special
+        // character carrying a combining mark (one Swift Character, two scalars) is still that
+        // special character to the parser and must still be escaped.
+        for (index, scalar) in unicodeScalars.enumerated() {
+            if escapedAnywhere.contains(scalar) || (index == 0 && escapedWhenLeading.contains(scalar)) {
+                result.unicodeScalars.append("\\")
+            }
+            result.unicodeScalars.append(scalar)
+        }
+        
+        return result
+    }
+}

--- a/UnitTests/Sources/SearchServiceProxyTests.swift
+++ b/UnitTests/Sources/SearchServiceProxyTests.swift
@@ -1,0 +1,185 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+@testable import ElementX
+import MatrixRustSDK
+import MatrixRustSDKMocks
+import Testing
+
+@MainActor
+struct SearchServiceProxyTests {
+    let searchService = SearchServiceSDKMock()
+    
+    private func makeProxy(roomID: String? = nil) async -> SearchServiceProxy {
+        searchService.paginationStateReturnValue = .idle(endReached: true)
+        searchService.subscribeToPaginationStateUpdatesListenerReturnValue = TaskHandleSDKMock()
+        searchService.subscribeToResultsListenerReturnValue = TaskHandleSDKMock()
+        
+        let proxy = SearchServiceProxy(searchService: searchService,
+                                       timelineItemFactory: RoomTimelineItemFactory(userID: "@me:hs.tld",
+                                                                                    attributedStringBuilder: AttributedStringBuilder(cacheKey: "tests",
+                                                                                                                                     mentionBuilder: PlainMentionBuilder()),
+                                                                                    stateEventStringBuilder: RoomStateEventStringBuilder(userID: "@me:hs.tld")),
+                                       roomID: roomID)
+        // The results subscription is lazy — set a query so the listener exists.
+        _ = await proxy.setQuery("query")
+        return proxy
+    }
+    
+    private var resultsListener: SearchServiceResultsListener {
+        searchService.subscribeToResultsListenerReceivedListener!
+    }
+    
+    /// Content the proxy renders. Hits the `.message` branch of `makeResult`.
+    private static let supportedContent = TimelineItemContent.msgLike(content: .init(kind: .message(content: .init(msgType: .text(content: .init(body: "hello", formatted: nil)),
+                                                                                                                   body: "hello",
+                                                                                                                   isEdited: false,
+                                                                                                                   mentions: nil)),
+                                                                                     reactions: [],
+                                                                                     inReplyTo: nil,
+                                                                                     threadRoot: nil,
+                                                                                     threadSummary: nil))
+    
+    /// Content the proxy has no rendering for — this used to be dropped, desyncing the list.
+    private static let unsupportedContent = TimelineItemContent.callInvite
+    
+    private func sdkResult(eventID: String, roomID: String = "!room:hs.tld", supported: Bool = true) -> MatrixRustSDK.SearchServiceResult {
+        .message(roomId: roomID, result: .init(eventId: eventID,
+                                               sender: "@sender:hs.tld",
+                                               senderProfile: .pending,
+                                               content: supported ? Self.supportedContent : Self.unsupportedContent,
+                                               timestamp: 1_721_500_000_000))
+    }
+    
+    @Test func positionalUpdatesStayAlignedWhenContentIsUnsupported() async throws {
+        let proxy = await makeProxy()
+        
+        // Listener delivery hops through an AsyncStream onto the main actor, so always await the
+        // published value rather than reading `resultsPublisher.value` straight after `onUpdate`.
+        var deferred = deferFulfillment(proxy.resultsPublisher) { $0.count == 3 }
+        resultsListener.onUpdate(updates: [.append(values: [sdkResult(eventID: "$1"),
+                                                            sdkResult(eventID: "$2", supported: false),
+                                                            sdkResult(eventID: "$3")])])
+        try await deferred.fulfill()
+        
+        // The SDK removes ITS index 1 ($2). A compactMap-filtered local list would drop $3 here.
+        deferred = deferFulfillment(proxy.resultsPublisher) { $0.count == 2 }
+        resultsListener.onUpdate(updates: [.remove(index: 1)])
+        try await deferred.fulfill()
+        
+        #expect(proxy.resultsPublisher.value.map(\.eventID) == ["$1", "$3"])
+    }
+    
+    @Test func unsupportedContentIsRenderedAsPlaceholderNotDropped() async throws {
+        let proxy = await makeProxy()
+        
+        let deferred = deferFulfillment(proxy.resultsPublisher) { $0.count == 1 }
+        resultsListener.onUpdate(updates: [.append(values: [sdkResult(eventID: "$1", supported: false)])])
+        try await deferred.fulfill()
+        
+        #expect(proxy.resultsPublisher.value.first?.eventID == "$1")
+    }
+    
+    @Test func truncateDoesNotTrapWhenUnsupportedContentWasDropped() async throws {
+        let proxy = await makeProxy()
+        
+        let deferred = deferFulfillment(proxy.resultsPublisher) { $0.count == 3 }
+        resultsListener.onUpdate(updates: [.append(values: [sdkResult(eventID: "$1", supported: false),
+                                                            sdkResult(eventID: "$2", supported: false),
+                                                            sdkResult(eventID: "$3")])])
+        try await deferred.fulfill()
+        
+        // The SDK truncates ITS list to 2. Against a filtered list of 1 this is an invalid range
+        // (2..<1) and traps.
+        let truncated = deferFulfillment(proxy.resultsPublisher) { $0.count == 2 }
+        resultsListener.onUpdate(updates: [.truncate(length: 2)])
+        try await truncated.fulfill()
+        
+        #expect(proxy.resultsPublisher.value.map(\.eventID) == ["$1", "$2"])
+    }
+    
+    @Test func resetAndClearReplaceTheWholeList() async throws {
+        let proxy = await makeProxy()
+        
+        var deferred = deferFulfillment(proxy.resultsPublisher) { $0.map(\.eventID) == ["$1", "$2"] }
+        resultsListener.onUpdate(updates: [.append(values: [sdkResult(eventID: "$1"),
+                                                            sdkResult(eventID: "$2", supported: false)])])
+        try await deferred.fulfill()
+        
+        // `.reset` maps the replacement set totally too — an unsupported result in it must still
+        // occupy its slot, or the very next positional update is misaddressed.
+        deferred = deferFulfillment(proxy.resultsPublisher) { $0.map(\.eventID) == ["$3", "$4", "$5"] }
+        resultsListener.onUpdate(updates: [.reset(values: [sdkResult(eventID: "$3", supported: false),
+                                                           sdkResult(eventID: "$4"),
+                                                           sdkResult(eventID: "$5", supported: false)])])
+        try await deferred.fulfill()
+        
+        deferred = deferFulfillment(proxy.resultsPublisher) { $0.isEmpty }
+        resultsListener.onUpdate(updates: [.clear])
+        try await deferred.fulfill()
+    }
+    
+    @Test func setQueryResetsPaginationStateBeforeResultsArrive() async {
+        // makeProxy seeds the SDK's state as .idle(endReached: true) — what a cursor that has
+        // never run a query reports, and what the previous query would have left behind. Setting a
+        // query clears that stale "finished" state; it publishes .loading, since a page is about
+        // to be fetched.
+        let proxy = await makeProxy()
+        
+        #expect(proxy.paginationStatePublisher.value == .loading)
+    }
+    
+    @Test func queriesAreEscapedBeforeReachingTheSDK() async {
+        let proxy = await makeProxy()
+        
+        _ = await proxy.setQuery("cats AND dogs")
+        
+        #expect(searchService.setQueryQueryReceivedInvocations.last == "+cats +\\AND +dogs")
+    }
+    
+    @Test func paginateFailuresAreSurfaced() async {
+        enum TestError: Error { case dummy }
+        
+        let proxy = await makeProxy()
+        searchService.paginateThrowableError = TestError.dummy
+        
+        guard case .failure = await proxy.paginate() else {
+            Issue.record("A throwing SDK paginate must surface as .failure")
+            return
+        }
+    }
+    
+    @Test func roomFilterDoesNotBreakIndexParallelism() async throws {
+        let proxy = await makeProxy(roomID: "!r1:hs.tld")
+        
+        var deferred = deferFulfillment(proxy.resultsPublisher) { $0.map(\.eventID) == ["$1", "$3"] }
+        resultsListener.onUpdate(updates: [.append(values: [sdkResult(eventID: "$1", roomID: "!r1:hs.tld"),
+                                                            sdkResult(eventID: "$2", roomID: "!r2:hs.tld"),
+                                                            sdkResult(eventID: "$3", roomID: "!r1:hs.tld"),
+                                                            sdkResult(eventID: "$4", roomID: "!r2:hs.tld")])])
+        try await deferred.fulfill()
+        
+        // SDK index 2 addresses $3 in the UNFILTERED list. Had the filter been applied to the list
+        // the diffs land in, index 2 would address the wrong row.
+        deferred = deferFulfillment(proxy.resultsPublisher) { $0.map(\.eventID) == ["$1", "$3b"] }
+        resultsListener.onUpdate(updates: [.set(index: 2, value: sdkResult(eventID: "$3b", roomID: "!r1:hs.tld"))])
+        try await deferred.fulfill()
+    }
+    
+    @Test func popsDoNotTrapOnADrainedList() async throws {
+        let proxy = await makeProxy()
+        
+        let deferred = deferFulfillment(proxy.resultsPublisher) { $0.count == 1 }
+        resultsListener.onUpdate(updates: [.append(values: [sdkResult(eventID: "$1", supported: false)])])
+        try await deferred.fulfill()
+        
+        // Against a list drained by filtering, these used to crash outright.
+        let popped = deferFulfillment(proxy.resultsPublisher) { $0.isEmpty }
+        resultsListener.onUpdate(updates: [.popFront])
+        try await popped.fulfill()
+    }
+}

--- a/UnitTests/Sources/TantivyEscapingTests.swift
+++ b/UnitTests/Sources/TantivyEscapingTests.swift
@@ -1,0 +1,79 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+@testable import ElementX
+import Testing
+
+struct TantivyEscapingTests {
+    @Test func everyWordBecomesAMustClause() {
+        #expect("hello world".escapedForTantivy == "+hello +world")
+    }
+    
+    @Test func operatorWordsAreNeutralised() {
+        #expect("cats AND dogs".escapedForTantivy == "+cats +\\AND +dogs")
+        #expect("TO".escapedForTantivy == "+\\TO")
+        // Lowercase operators are not operators.
+        #expect("and".escapedForTantivy == "+and")
+    }
+    
+    @Test func charactersEscapedAnywhere() {
+        #expect("a:b".escapedForTantivy == "+a\\:b")
+        #expect("foo*".escapedForTantivy == "+foo\\*")
+        #expect("(a)".escapedForTantivy == "+\\(a\\)")
+        #expect("say \"hi\"".escapedForTantivy == "+say +\\\"hi\\\"")
+    }
+    
+    @Test func charactersEscapedOnlyWhenLeading() {
+        #expect("-exclude".escapedForTantivy == "+\\-exclude")
+        #expect("~fuzzy".escapedForTantivy == "+\\~fuzzy")
+        // Mid-word occurrences survive untouched: real-world tokens must not be mangled.
+        #expect("C++".escapedForTantivy == "+C++")
+        #expect("1/2/2024".escapedForTantivy == "+1/2/2024")
+    }
+    
+    @Test func typedBackslashesAreDoubled() {
+        // A backslash the user typed cannot be allowed to escape one of ours. This is NOT
+        // idempotence: the single forward pass only guarantees our own added backslashes are
+        // never revisited — user-typed backslashes are always doubled.
+        #expect("a\\b".escapedForTantivy == "+a\\\\b")
+    }
+    
+    @Test func symbolOnlyTokensGetNoMustPrefix() {
+        // The default tokenizer indexes no terms for `:)`; as a Must clause it could only
+        // subtract, so it stays optional.
+        #expect(":)".escapedForTantivy == "\\:\\)")
+    }
+    
+    @Test func matrixIdentifiersSurvive() {
+        #expect("@alice:example.org".escapedForTantivy == "+@alice\\:example.org")
+    }
+    
+    @Test func specialCharactersCarryingCombiningMarksAreStillEscaped() {
+        // A special character followed by a combining mark is one Swift Character but still that
+        // special character to tantivy's scalar-level grammar. Escaping must reach it.
+        #expect("\u{22}\u{0301}hi".escapedForTantivy == "+\\\u{22}\u{0301}hi") // combined " must escape
+        #expect("a:\u{0301}b".escapedForTantivy == "+a\\:\u{0301}b") // combined : must escape
+    }
+    
+    @Test func whitespaceCollapses() {
+        #expect("  a \n b  ".escapedForTantivy == "+a +b")
+        #expect("".escapedForTantivy == "")
+        #expect("   ".escapedForTantivy == "")
+    }
+    
+    @Test func remainingAndroidSuiteCases() {
+        // The groups above compress the Android suite; these are the cases they miss. Keep this
+        // file 1:1 with TantivyQueryEscaperTest.kt (21 cases) — cross-check when porting.
+        #expect("body : hello".escapedForTantivy == "+body \\: +hello") // spaced field colon
+        #expect(">quote".escapedForTantivy == "+\\>quote") // leading elastic-range operator
+        #expect("\"unclosed".escapedForTantivy == "+\\\"unclosed") // unclosed quote
+        #expect("🙂".escapedForTantivy == "🙂") // emoji: indexes no terms, stays optional
+        #expect("...".escapedForTantivy == "...") // punctuation-only token, nothing to escape
+        #expect("*".escapedForTantivy == "\\*") // lone wildcard, escaped and unprefixed
+        #expect("héllo wörld".escapedForTantivy == "+héllo +wörld") // non-ASCII words are words
+    }
+}


### PR DESCRIPTION

### Problem

Three bugs in `SearchServiceProxy`, all reachable today through the Messages tab behind the
`globalSearchEnabled` developer flag:

- `handleResultUpdates` applies the SDK's positional diffs to a local list that `makeResult` has
  already filtered, since it returns `nil` for content it cannot render. From the first dropped
  result onward every index addresses the wrong row, and `popFront`, `popBack` and an over-long
  `truncate` do not merely misbehave — they trap.
- `setQuery` never resets pagination state, so the previous query's `endReached` survives into the
  new one. A cursor that has never run a query reports `endReached = true`.
- The raw query reaches tantivy's parser: `"unclosed` or `(` fails the whole search, `AND`/`OR`/`TO`
  are read as operators, and the parser being OR-by-default, a multi-word query matches documents
  containing *any* word rather than all of them.

### Fix

- Map every result instead of dropping some — content with no view renders as the existing
  unsupported-event placeholder — and move filtering to the exposure boundary, so the local list
  stays index-parallel with the SDK's.
- Reset pagination state in `setQuery`, and return a `Result` from `paginate()` so a caller can
  tell a finished list from a failed page. It is `@discardableResult`; the existing call site is
  unchanged.
- Escape tantivy syntax in a single forward pass, marking every token containing a letter or digit
  as required (`+`). Tokens that index no terms at all, such as `:)`, stay optional.

Two additions a room-scoped surface will need, both inert for the shipped tab: an optional `roomID`
on `SearchServiceProxy`, applied only at the exposure boundary, and
`ClientProxy.makeSearchService(roomID:)`.

**This changes what the Messages tab returns**, deliberately: multi-word queries are now AND rather
than OR, and unrenderable results appear as a placeholder row instead of vanishing — which is what
desynced the list.

### Tests

19 Swift Testing cases. `TantivyEscapingTests` pins the escaper against the tantivy grammar in the
SDK we ship (`26.07.28`). `SearchServiceProxyTests` adds one regression per bug: a positional
update following an unsupported result, the `truncate` and `popFront` traps, the pagination reset,
escaping at the boundary, `paginate` failure propagation, and a room-filter case proving the filter
leaves index parallelism intact.

### Notes for reviewers

138 lines of non-generated, non-test source; the rest is tests and regenerated mocks. The
behaviour changes are described above.

No file overlap with #5910, which now has a `Result` from `paginate()` to surface as well.

Could a maintainer add the `pr-bugfix` label when you get a chance? Danger fails without one and
I cannot set it from a fork.

Relates to element-hq/element-x-ios#3766 — the canonical iOS tracker.
Relates to element-hq/element-x-ios#5829 — added the Messages mode and the index this hardens.
Relates to element-hq/element-x-ios#5910 — the set-query error indicator.
Relates to matrix-org/matrix-rust-sdk#5350 — the SDK-side full-text search work.

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.

