### PR TITLE
Fix rageshake upload progress bar

### DIFF
--- a/ElementX/Sources/Services/BugReport/BugReportService.swift
+++ b/ElementX/Sources/Services/BugReport/BugReportService.swift
@@ -296,7 +296,7 @@ nonisolated extension BugReportService: URLSessionTaskDelegate {
     /// where the service lives.
     func urlSession(_ session: URLSession, didCreateTask task: URLSessionTask) {
         Task { @MainActor [weak self] in
-            for await value in task.progress.publisher(for: \.fractionCompleted).values {
+            for await value in task.progress.publisher(for: \.fractionCompleted).buffer(size: 1, prefetch: .byRequest, whenFull: .dropOldest).values {
                 self?.progressSubject.send(value)
             }
         }


### PR DESCRIPTION
The bug report upload progress bar has been stuck at 0% since the Swift 6 migration. Closes #5807

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
