### PR TITLE
Update the Enterprise submodule.

### DIFF
--- a/ElementX/Sources/Services/Client/Client.swift
+++ b/ElementX/Sources/Services/Client/Client.swift
@@ -9,7 +9,7 @@
 import Foundation
 import MatrixRustSDK
 
-extension ClientProtocol {
+nonisolated extension ClientProtocol {
     func elementWellKnown() async -> Result<Data, ClientProxyError> {
         let serverNameURLString = if let userIDServerName = try? userIdServerName() {
             "https://\(userIDServerName)"

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -41,6 +41,7 @@ enum ClientProxyError: Error {
     
     case invalidMedia
     case invalidServerName
+    case invalidHomeserverURL
     case failedUploadingMedia(ErrorKind)
     case roomPreviewIsPrivate
     case failedRetrievingUserIdentity


### PR DESCRIPTION
Also adds a new `ClientProxyError` case and makes our `ClientProtocol` extension `nonisolated` (which whilst not strictly necessary is a nice to have on this type).