### PR TITLE
Manually publish room list range updates when the content isn't scrollable

### DIFF
--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreenContent.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreenContent.swift
@@ -146,6 +146,8 @@ struct HomeScreenContent: View {
         }
         
         guard scrollView.contentSize.height > scrollView.bounds.height else {
+            // This list never scrolls, publish the range manually.
+            context.send(viewAction: .updateVisibleItemRange(0..<context.viewState.visibleRooms.count))
             return
         }
         


### PR DESCRIPTION
Which would make small accounts not correctly register for sliding sync room subscriptions