### PR TITLE
Increase the multi-file upload limit to 25

### DIFF
--- a/ElementX/Sources/Screens/MediaPickerScreen/DocumentPicker.swift
+++ b/ElementX/Sources/Screens/MediaPickerScreen/DocumentPicker.swift
@@ -79,7 +79,7 @@ struct DocumentPicker: UIViewControllerRepresentable {
             }
             
             var selectedURLs = [URL]()
-            for url in urls.prefix(10) {
+            for url in urls.prefix(25) {
                 do {
                     _ = url.startAccessingSecurityScopedResource()
                     let newURL = try FileManager.default.copyFileToTemporaryDirectory(file: url)

--- a/ElementX/Sources/Screens/MediaPickerScreen/PhotoLibraryPicker.swift
+++ b/ElementX/Sources/Screens/MediaPickerScreen/PhotoLibraryPicker.swift
@@ -40,7 +40,7 @@ struct PhotoLibraryPicker: UIViewControllerRepresentable {
         case .single:
             1
         case .multiple:
-            10
+            25
         }
         
         let pickerViewController = PHPickerViewController(configuration: configuration)

--- a/ShareExtension/SupportingFiles/Info.plist
+++ b/ShareExtension/SupportingFiles/Info.plist
@@ -31,15 +31,15 @@
 			<key>NSExtensionActivationRule</key>
 			<dict>
 				<key>NSExtensionActivationSupportsFileWithMaxCount</key>
-				<integer>10</integer>
+				<integer>25</integer>
 				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
-				<integer>10</integer>
+				<integer>25</integer>
 				<key>NSExtensionActivationSupportsMovieWithMaxCount</key>
-				<integer>10</integer>
+				<integer>25</integer>
 				<key>NSExtensionActivationSupportsText</key>
 				<true/>
 				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
-				<integer>10</integer>
+				<integer>25</integer>
 			</dict>
 		</dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/ShareExtension/SupportingFiles/target.yml
+++ b/ShareExtension/SupportingFiles/target.yml
@@ -56,11 +56,11 @@ targets:
           NSExtensionAttributes:
             IntentsSupported: [INSendMessageIntent]
             NSExtensionActivationRule:
-              NSExtensionActivationSupportsFileWithMaxCount: 10
-              NSExtensionActivationSupportsImageWithMaxCount: 10
-              NSExtensionActivationSupportsMovieWithMaxCount: 10
+              NSExtensionActivationSupportsFileWithMaxCount: 25
+              NSExtensionActivationSupportsImageWithMaxCount: 25
+              NSExtensionActivationSupportsMovieWithMaxCount: 25
               NSExtensionActivationSupportsText: true
-              NSExtensionActivationSupportsWebURLWithMaxCount: 10
+              NSExtensionActivationSupportsWebURLWithMaxCount: 25
 
     entitlements:
       path: ShareExtension.entitlements


### PR DESCRIPTION
**What changed**

This PR increases the maximum number of files that can be selected or shared at once from 10 to 25.

**Why**

The original limit of 10 was chosen mainly because inline media galleries were not supported at the time (https://github.com/element-hq/element-x-ios/pull/4358). Sending a larger number of attachments would therefore have resulted in many individual timeline entries and could easily spam the room.

Now that media galleries are available, multiple attachments are displayed in a much more compact and user-friendly way. This removes the main reason for keeping the limit low.

Increasing the limit to 25 better supports common use cases such as sharing a larger set of photos, while still keeping a reasonable upper bound on the number of files processed in a single upload.