### PR TITLE
Fix for pagination getting stuck loading when swiping media previews in the timeline

### DIFF
--- a/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewDataSource.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/TimelineMediaPreviewDataSource.swift
@@ -33,7 +33,14 @@ class TimelineMediaPreviewDataSource: NSObject, QLPreviewControllerDataSource {
     private var backwardPadding: Int
     private var forwardPadding: Int
     
-    var paginationState: TimelinePaginationState
+    /// Reaching the end of the timeline changes which placeholder an index shows, so a change
+    /// needs to be published too, not only the arrival of new items.
+    var paginationState: TimelinePaginationState {
+        didSet {
+            guard paginationState != oldValue else { return }
+            previewItemsPaginationPublisher.send()
+        }
+    }
     
     /// The gallery attachments to include, so that a gallery only contributes the media being browsed.
     private let allowedGalleryItemTypes: [TimelineAllowedGalleryItemType]?

--- a/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewController.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewController.swift
@@ -243,11 +243,13 @@ class TimelineMediaPreviewController: QLPreviewController {
     }
     
     private func handleUpdatedItems() {
-        if currentPreviewItem is TimelineMediaPreviewItem.Loading {
-            let dataSource = context.viewState.dataSource
-            if dataSource.previewController(self, previewItemAt: currentPreviewItemIndex) is TimelineMediaPreviewItem.Media {
-                refreshCurrentPreviewItem() // This will trigger loadCurrentItem automatically.
-            }
+        guard let displayedItem = currentPreviewItem as? TimelineMediaPreviewItem.Loading else { return }
+        
+        // The index may now hold a media, or a different placeholder having reached the end of
+        // the timeline, in which case what's on display is stale.
+        let dataSource = context.viewState.dataSource
+        if dataSource.previewController(self, previewItemAt: currentPreviewItemIndex) as AnyObject !== displayedItem {
+            refreshCurrentPreviewItem() // This will trigger loadCurrentItem automatically.
         }
     }
     


### PR DESCRIPTION
When a pagination finished without adding any media, nothing re-evaluated the placeholder: `previewItemsPaginationPublisher` only fired when items were added, and the controller only refreshed on placeholder→media, never when one placeholder replaced another. So the spinner stayed even though the data source would now return the start of the timeline for that index. `paginationState` now publishes when it changes, and the controller refreshes whenever the item at the current index differs from the one on display.