### PR TITLE
Add timeouts after verifying the device owner when linking a new device.

### DIFF
--- a/ElementX/Sources/FlowCoordinators/LinkNewDeviceFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/LinkNewDeviceFlowCoordinator.swift
@@ -57,7 +57,7 @@ class LinkNewDeviceFlowCoordinator: FlowCoordinatorProtocol {
                 
                 switch action {
                 case .linkMobileDevice(let progressPublisher):
-                    presentQRCodeScreen(mode: .linkMobile(progressPublisher, flowParameters.userSession.clientProxy))
+                    presentQRCodeScreen(mode: .linkMobile(progressPublisher))
                 case .linkDesktopComputer:
                     presentQRCodeScreen(mode: .linkDesktop(flowParameters.userSession.clientProxy.linkNewDeviceService()))
                 case .verifyWithAppLockPIN(let continuation):

--- a/ElementX/Sources/Screens/QRCodeLoginScreen/QRCodeLoginScreenModels.swift
+++ b/ElementX/Sources/Screens/QRCodeLoginScreen/QRCodeLoginScreenModels.swift
@@ -39,7 +39,7 @@ enum QRCodeLoginScreenMode {
     /// Configures the screen to link another device by scanning a QR code.
     case linkDesktop(LinkNewDeviceServiceProtocol)
     /// Configures the screen to link another device by showing it a QR code.
-    case linkMobile(LinkNewDeviceService.LinkMobileProgressPublisher, ClientProxyProtocol)
+    case linkMobile(LinkNewDeviceService.LinkMobileProgressPublisher)
 }
 
 struct QRCodeLoginScreenViewState: BindableState {
@@ -107,7 +107,7 @@ nonisolated enum QRCodeLoginState: Equatable {
     case displayCode(DisplayCodeState)
     
     /// Initial state where the user can link another device using the shown QR code.
-    case displayQR(DisplayQRState)
+    case displayQR(UIImage)
     /// The user needs to enter the two digit code to confirm the channel is secure
     case confirmCode(CheckCodeState)
     
@@ -169,13 +169,6 @@ nonisolated enum QRCodeLoginState: Equatable {
                 }
             }
         }
-    }
-    
-    nonisolated enum DisplayQRState: Equatable {
-        /// The QR code is available and is being shown.
-        case active(UIImage)
-        /// The QR code being shown has expired. We will need to generate a new one.
-        case expired
     }
     
     nonisolated enum DisplayCodeState: Equatable {

--- a/ElementX/Sources/Screens/QRCodeLoginScreen/QRCodeLoginScreenViewModel.swift
+++ b/ElementX/Sources/Screens/QRCodeLoginScreen/QRCodeLoginScreenViewModel.swift
@@ -262,12 +262,13 @@ class QRCodeLoginScreenViewModel: QRCodeLoginScreenViewModelType, QRCodeLoginScr
     private func handleExpiration() {
         // Don't override an error that's already being shown.
         if case .error = state.state {
+            currentTask = nil // Cancel the scan (just in case).
             return
         }
         
         MXLog.info("Timed out establishing a secure channel, expiring.")
         currentTask = nil // Cancel the scan.
-        state.state = .error(.expired)
+        handleError(.expired)
     }
     
     private func sendCheckCode() async {
@@ -290,10 +291,8 @@ class QRCodeLoginScreenViewModel: QRCodeLoginScreenViewModelType, QRCodeLoginScr
     }
     
     private func requestOAuthAuthorization(url: URL, continuationSender: ContinuationMessageSenderProxy) {
-        // We're meant to use the continuationSender to confirm when the URL has been opened or if the user decided
-        // against it (by cancelling the system's WAS prompt). Unfortunately the WAS only gives us a signal for
-        // success or failure (and we don't get success as there isn't a redirect at the end of the flow).
-        // Failure could be the user cancelling the prompt or closing the web view when they're done.
+        // There's no OAuth redirect, so the WAS always returns a cancellation failure (both for a declined system prompt and
+        // when closing after successful authorisation). We can't use the continuation as intended, so confirm it and continue.
         Task { await continuationSender.confirm() }
         
         let (stream, continuation) = AsyncStream<Result<Void, OAuthError>>.makeStream()

--- a/ElementX/Sources/Screens/QRCodeLoginScreen/QRCodeLoginScreenViewModel.swift
+++ b/ElementX/Sources/Screens/QRCodeLoginScreen/QRCodeLoginScreenViewModel.swift
@@ -13,6 +13,11 @@ typealias QRCodeLoginScreenViewModelType = StateStoreViewModel<QRCodeLoginScreen
 
 class QRCodeLoginScreenViewModel: QRCodeLoginScreenViewModelType, QRCodeLoginScreenViewModelProtocol {
     private let appMediator: AppMediatorProtocol
+    /// The time allowed between verifying the device's owner (on the previous screen), to having
+    /// scanned a QR code and established a secure channel for the `linkDesktopComputer` flow.
+    ///
+    /// The generated QR code handles this automatically when linking a mobile device and QR login doesn't need it.
+    private let linkDesktopTimeout: Duration
     
     private let actionsSubject: PassthroughSubject<QRCodeLoginScreenViewModelAction, Never> = .init()
     var actionsPublisher: AnyPublisher<QRCodeLoginScreenViewModelAction, Never> {
@@ -21,11 +26,14 @@ class QRCodeLoginScreenViewModel: QRCodeLoginScreenViewModelType, QRCodeLoginScr
     
     private var currentTask: AnyCancellable?
     private var oAuthResultTask: AnyCancellable?
+    private var expirationTask: AnyCancellable?
     
     init(mode: QRCodeLoginScreenMode,
          canSignInManually: Bool,
-         appMediator: AppMediatorProtocol) {
+         appMediator: AppMediatorProtocol,
+         linkDesktopTimeout: Duration = .seconds(120)) {
         self.appMediator = appMediator
+        self.linkDesktopTimeout = linkDesktopTimeout
         
         let initialViewState: QRCodeLoginState = switch mode {
         case .login: .loginInstructions
@@ -40,8 +48,13 @@ class QRCodeLoginScreenViewModel: QRCodeLoginScreenViewModelType, QRCodeLoginScr
         super.init(initialViewState: .init(state: initialViewState, mode: mode, canSignInManually: canSignInManually))
         setupSubscriptions()
         
-        if case .linkMobile(let progressPublisher) = mode {
+        switch mode {
+        case .linkDesktop:
+            scheduleLinkDesktopExpiration()
+        case .linkMobile(let progressPublisher):
             listenToDisplayQRProgress(progressPublisher: progressPublisher)
+        case .login:
+            break
         }
     }
     
@@ -180,6 +193,7 @@ class QRCodeLoginScreenViewModel: QRCodeLoginScreenViewModelType, QRCodeLoginScr
                 case .starting:
                     break // Nothing to do, the state was set above.
                 case .establishingSecureChannel(let checkCodeString):
+                    expirationTask?.cancel()
                     state.state = .displayCode(.deviceCode(checkCodeString))
                 case .waitingForAuthorisation(let verificationURL, let continuationSender):
                     requestOAuthAuthorization(url: verificationURL, continuationSender: continuationSender)
@@ -230,6 +244,30 @@ class QRCodeLoginScreenViewModel: QRCodeLoginScreenViewModelType, QRCodeLoginScr
                     actionsSubject.send(.linkedDevice)
                 }
             }
+    }
+    
+    /// Starts the timeout for scanning a desktop's QR code. The flow will expire (cancelling the scan)
+    /// if the secure channel isn't established within the timeout period.
+    private func scheduleLinkDesktopExpiration() {
+        guard case .linkDesktop = state.mode else { fatalError("Expiration requested on an unexpected flow") }
+        
+        expirationTask = Task { [weak self, linkDesktopTimeout] in
+            try? await Task.sleep(for: linkDesktopTimeout, tolerance: .zero)
+            guard !Task.isCancelled else { return }
+            self?.handleExpiration()
+        }
+        .asCancellable()
+    }
+    
+    private func handleExpiration() {
+        // Don't override an error that's already being shown.
+        if case .error = state.state {
+            return
+        }
+        
+        MXLog.info("Timed out establishing a secure channel, expiring.")
+        currentTask = nil // Cancel the scan.
+        state.state = .error(.expired)
     }
     
     private func sendCheckCode() async {
@@ -311,6 +349,7 @@ class QRCodeLoginScreenViewModel: QRCodeLoginScreenViewModelType, QRCodeLoginScr
     /// Only for mocking initial states
     fileprivate init(state: QRCodeLoginState, mode: QRCodeLoginScreenMode, canSignInManually: Bool, checkCodeInput: String) {
         appMediator = AppMediatorMock(.init())
+        linkDesktopTimeout = .seconds(3600)
         super.init(initialViewState: .init(state: state,
                                            mode: mode,
                                            canSignInManually: canSignInManually,

--- a/ElementX/Sources/Screens/QRCodeLoginScreen/QRCodeLoginScreenViewModel.swift
+++ b/ElementX/Sources/Screens/QRCodeLoginScreen/QRCodeLoginScreenViewModel.swift
@@ -181,8 +181,8 @@ class QRCodeLoginScreenViewModel: QRCodeLoginScreenViewModelType, QRCodeLoginScr
                     break // Nothing to do, the state was set above.
                 case .establishingSecureChannel(let checkCodeString):
                     state.state = .displayCode(.deviceCode(checkCodeString))
-                case .waitingForAuthorisation(let url):
-                    requestOAuthAuthorization(url: url)
+                case .waitingForAuthorisation(let verificationURL, let continuationSender):
+                    requestOAuthAuthorization(url: verificationURL, continuationSender: continuationSender)
                 case .syncingSecrets:
                     break // Nothing to do.
                 case .done:
@@ -221,8 +221,8 @@ class QRCodeLoginScreenViewModel: QRCodeLoginScreenViewModelType, QRCodeLoginScr
                     break // Nothing to do, we are already showing the code by the time this method is called.
                 case .qrScanned(let checkCodeSender):
                     state.state = .confirmCode(.inputCode(checkCodeSender))
-                case .waitingForAuthorisation(let url):
-                    requestOAuthAuthorization(url: url)
+                case .waitingForAuthorisation(let url, let continuationSender):
+                    requestOAuthAuthorization(url: url, continuationSender: continuationSender)
                 case .syncingSecrets:
                     break // Nothing to do.
                 case .done:
@@ -284,7 +284,13 @@ class QRCodeLoginScreenViewModel: QRCodeLoginScreenViewModelType, QRCodeLoginScr
         }
     }
     
-    private func requestOAuthAuthorization(url: URL) {
+    private func requestOAuthAuthorization(url: URL, continuationSender: ContinuationMessageSenderProxy) {
+        // We're meant to use the continuationSender to confirm when the URL has been opened or if the user decided
+        // against it (by cancelling the system's WAS prompt). Unfortunately the WAS only gives us a signal for
+        // success or failure (and we don't get success as there isn't a redirect at the end of the flow).
+        // Failure could be the user cancelling the prompt or closing the web view when they're done.
+        Task { await continuationSender.confirm() }
+        
         let (stream, continuation) = AsyncStream<Result<Void, OAuthError>>.makeStream()
         actionsSubject.send(.requestOAuthAuthorisation(url, continuation))
         

--- a/ElementX/Sources/Screens/QRCodeLoginScreen/QRCodeLoginScreenViewModel.swift
+++ b/ElementX/Sources/Screens/QRCodeLoginScreen/QRCodeLoginScreenViewModel.swift
@@ -30,9 +30,9 @@ class QRCodeLoginScreenViewModel: QRCodeLoginScreenViewModelType, QRCodeLoginScr
         let initialViewState: QRCodeLoginState = switch mode {
         case .login: .loginInstructions
         case .linkDesktop: .linkDesktopInstructions
-        case .linkMobile(let progressPublisher, _):
+        case .linkMobile(let progressPublisher):
             switch progressPublisher.value {
-            case .qrReady(let image): .displayQR(.active(image))
+            case .qrReady(let image): .displayQR(image)
             default: .error(.unknown)
             }
         }
@@ -40,7 +40,7 @@ class QRCodeLoginScreenViewModel: QRCodeLoginScreenViewModelType, QRCodeLoginScr
         super.init(initialViewState: .init(state: initialViewState, mode: mode, canSignInManually: canSignInManually))
         setupSubscriptions()
         
-        if case .linkMobile(let progressPublisher, _) = mode {
+        if case .linkMobile(let progressPublisher) = mode {
             listenToDisplayQRProgress(progressPublisher: progressPublisher)
         }
     }
@@ -232,39 +232,6 @@ class QRCodeLoginScreenViewModel: QRCodeLoginScreenViewModelType, QRCodeLoginScr
             }
     }
     
-    private func regenerateQRCode() async {
-        guard case .linkMobile(_, let clientProxy) = state.mode else {
-            fatalError("Cannot display a QR code in this mode.")
-        }
-        
-        let linkNewDeviceService = clientProxy.linkNewDeviceService()
-        let progressPublisher = linkNewDeviceService.linkMobileDevice()
-        
-        do {
-            async let minimumDelay = Task.sleep(for: .seconds(1)) // To show the spinner for long enough so there isn't a flicker.
-            async let qrReadyProgress = progressPublisher.values
-                .first { progress in
-                    switch progress {
-                    case .qrReady: true
-                    default: false
-                    }
-                }
-            
-            guard case .qrReady(let image) = try await (qrReadyProgress, minimumDelay).0 else {
-                state.state = .error(.unknown)
-                return
-            }
-            
-            state.state = .displayQR(.active(image))
-        } catch let error as QRCodeLoginError {
-            handleError(error)
-        } catch {
-            handleError(.unknown)
-        }
-        
-        listenToDisplayQRProgress(progressPublisher: progressPublisher)
-    }
-    
     private func sendCheckCode() async {
         guard case let .confirmCode(.inputCode(checkCodeSender)) = state.state else {
             fatalError("Attempting to check code from the wrong state.")
@@ -330,9 +297,6 @@ class QRCodeLoginScreenViewModel: QRCodeLoginScreenViewModelType, QRCodeLoginScr
             state.state = .error(.declined)
         case .linkingNotSupported:
             state.state = .error(.linkingNotSupported)
-        case .expired where state.state.isDisplayQR:
-            state.state = .displayQR(.expired)
-            Task { await regenerateQRCode() }
         case .expired:
             state.state = .error(.expired)
         case .slidingSyncNotAvailable:

--- a/ElementX/Sources/Screens/QRCodeLoginScreen/View/QRCodeLoginScreen.swift
+++ b/ElementX/Sources/Screens/QRCodeLoginScreen/View/QRCodeLoginScreen.swift
@@ -214,26 +214,19 @@ struct QRCodeLoginScreen: View {
     
     @ViewBuilder
     private var displayQRContent: some View {
-        if case let .displayQR(qrState) = context.viewState.state {
+        if case let .displayQR(image) = context.viewState.state {
             FullscreenDialog(topPadding: 24, horizontalPadding: 24) {
                 VStack(spacing: 32) {
                     TitleAndIcon(title: L10n.screenLinkNewDeviceMobileTitle(InfoPlistReader.main.productionAppName),
                                  icon: \.takePhotoSolid,
                                  iconStyle: .default)
                     
-                    switch qrState {
-                    case .active(let image):
-                        Image(uiImage: image)
-                            .interpolation(.none) // to stop it getting blurred
-                            .resizable()
-                            .scaledToFit()
-                            .frame(width: 200, height: 200)
-                            .accessibilityLabel(L10n.a11yQrCode)
-                    case .expired:
-                        ProgressView()
-                            .controlSize(.large)
-                            .frame(width: 200, height: 200)
-                    }
+                    Image(uiImage: image)
+                        .interpolation(.none) // to stop it getting blurred
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 200, height: 200)
+                        .accessibilityLabel(L10n.a11yQrCode)
                     
                     SFNumberedListView(items: context.viewState.instructions.linkMobileItems)
                 }
@@ -351,8 +344,7 @@ struct QRCodeLoginScreen_Previews: PreviewProvider, TestablePreview {
     static let deviceNotSignedInStateViewModel = QRCodeLoginScreenViewModel.mock(state: .scan(.scanFailed(.deviceNotSignedIn)))
     
     /// Showing
-    static let showingStateViewModel = QRCodeLoginScreenViewModel.mock(state: .displayQR(.active(LinkNewDeviceServiceMock.mockQRCodeImage)))
-    static let showingExpiredStateViewModel = QRCodeLoginScreenViewModel.mock(state: .displayQR(.expired))
+    static let showingStateViewModel = QRCodeLoginScreenViewModel.mock(state: .displayQR(LinkNewDeviceServiceMock.mockQRCodeImage))
     
     // Displaying codes
     static let deviceCodeStateViewModel = QRCodeLoginScreenViewModel.mock(state: .displayCode(.deviceCode("12")))
@@ -384,8 +376,6 @@ struct QRCodeLoginScreen_Previews: PreviewProvider, TestablePreview {
         
         ElementNavigationStack { QRCodeLoginScreen(context: showingStateViewModel.context) }
             .previewDisplayName("Showing")
-        ElementNavigationStack { QRCodeLoginScreen(context: showingExpiredStateViewModel.context) }
-            .previewDisplayName("Showing expired")
         
         ElementNavigationStack { QRCodeLoginScreen(context: deviceCodeStateViewModel.context) }
             .previewDisplayName("Device code")

--- a/ElementX/Sources/Services/Authentication/AuthenticationService.swift
+++ b/ElementX/Sources/Services/Authentication/AuthenticationService.swift
@@ -378,7 +378,7 @@ private extension HumanQrLoginError {
             .qrCodeError(.deviceNotSignedIn)
         case .UnsupportedQrCodeType:
             .qrCodeError(.invalidQRCode)
-        case .Unknown, .OAuthMetadataInvalid, .CheckCodeAlreadySent, .CheckCodeCannotBeSent, .ContinuationCannotBeSent, .ContinuationAlreadySent:
+        case .Unknown, .OAuthMetadataInvalid, .CheckCodeAlreadySent, .CheckCodeCannotBeSent, .ContinuationAlreadySent, .ContinuationCannotBeSent:
             .qrCodeError(.unknown)
         }
     }

--- a/ElementX/Sources/Services/Authentication/LinkNewDeviceService.swift
+++ b/ElementX/Sources/Services/Authentication/LinkNewDeviceService.swift
@@ -240,8 +240,9 @@ private extension QRCodeLoginError {
     }
 }
 
-nonisolated class CheckCodeSenderProxy: Equatable {
+final nonisolated class CheckCodeSenderProxy: Equatable, Sendable {
     static func == (lhs: CheckCodeSenderProxy, rhs: CheckCodeSenderProxy) -> Bool {
+        // Not ideal but good enough as the equality check is purely for removing duplicates from the progress stream.
         lhs.underlyingSender === rhs.underlyingSender
     }
     
@@ -256,8 +257,9 @@ nonisolated class CheckCodeSenderProxy: Equatable {
     }
 }
 
-class ContinuationMessageSenderProxy: Equatable {
+final nonisolated class ContinuationMessageSenderProxy: Equatable, Sendable {
     static func == (lhs: ContinuationMessageSenderProxy, rhs: ContinuationMessageSenderProxy) -> Bool {
+        // Not ideal but good enough as the equality check is purely for removing duplicates from the progress stream.
         lhs.underlyingSender === rhs.underlyingSender
     }
     

--- a/ElementX/Sources/Services/Authentication/LinkNewDeviceService.swift
+++ b/ElementX/Sources/Services/Authentication/LinkNewDeviceService.swift
@@ -29,7 +29,7 @@ class LinkNewDeviceService: LinkNewDeviceServiceProtocol {
         case starting
         case qrReady(UIImage)
         case qrScanned(CheckCodeSenderProxy)
-        case waitingForAuthorisation(verificationURL: URL)
+        case waitingForAuthorisation(verificationURL: URL, continuationSender: ContinuationMessageSenderProxy)
         case syncingSecrets
         case done
     }
@@ -38,7 +38,7 @@ class LinkNewDeviceService: LinkNewDeviceServiceProtocol {
     enum LinkDesktopProgress: Equatable {
         case starting
         case establishingSecureChannel(checkCodeString: String)
-        case waitingForAuthorisation(verificationURL: URL)
+        case waitingForAuthorisation(verificationURL: URL, continuationSender: ContinuationMessageSenderProxy)
         case syncingSecrets
         case done
     }
@@ -163,10 +163,10 @@ extension LinkNewDeviceService.LinkMobileProgress: CustomStringConvertible {
                 throw Error.invalidQRCodeData
             }
         case .qrScanned(let checkCodeSender): .qrScanned(.init(underlyingSender: checkCodeSender))
-        case .waitingForAuth(let verificationURI, _):
+        case .waitingForAuth(let verificationURI, let continuationSender):
             // verificationURI is a String; ASWebAuthenticationSession requires a URL.
             if let url = URL(string: verificationURI) {
-                .waitingForAuthorisation(verificationURL: url)
+                .waitingForAuthorisation(verificationURL: url, continuationSender: .init(underlyingSender: continuationSender))
             } else {
                 throw Error.invalidVerificationURI(verificationURI)
             }
@@ -194,10 +194,10 @@ extension LinkNewDeviceService.LinkDesktopProgress: CustomStringConvertible {
         self = switch rustProgress {
         case .starting: .starting
         case .establishingSecureChannel(_, let checkCodeString): .establishingSecureChannel(checkCodeString: checkCodeString)
-        case .waitingForAuth(let verificationURI, _):
+        case .waitingForAuth(let verificationURI, let continuationSender):
             // verificationURI is a String; ASWebAuthenticationSession requires a URL.
             if let url = URL(string: verificationURI) {
-                .waitingForAuthorisation(verificationURL: url)
+                .waitingForAuthorisation(verificationURL: url, continuationSender: .init(underlyingSender: continuationSender))
             } else {
                 throw Error.invalidVerificationURI(verificationURI)
             }
@@ -253,6 +253,34 @@ nonisolated class CheckCodeSenderProxy: Equatable {
     
     func send(code: UInt8) async throws {
         try await underlyingSender.send(code: code)
+    }
+}
+
+class ContinuationMessageSenderProxy: Equatable {
+    static func == (lhs: ContinuationMessageSenderProxy, rhs: ContinuationMessageSenderProxy) -> Bool {
+        lhs.underlyingSender === rhs.underlyingSender
+    }
+    
+    let underlyingSender: ContinuationMessageSenderProtocol
+    
+    init(underlyingSender: ContinuationMessageSenderProtocol) {
+        self.underlyingSender = underlyingSender
+    }
+    
+    func confirm() async {
+        do {
+            try await underlyingSender.confirm()
+        } catch {
+            MXLog.error("Failed to confirm the continuation of the login grant: \(error)")
+        }
+    }
+    
+    func cancel() async {
+        do {
+            try await underlyingSender.cancel()
+        } catch {
+            MXLog.error("Failed to cancel the login grant: \(error)")
+        }
     }
 }
 

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/qRCodeLoginScreen.Showing-expired-iPad-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/qRCodeLoginScreen.Showing-expired-iPad-en-GB.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:35b2338f432dd2d65581f94680382a33af87881bfd36e2a426a96f879ed1d93f
-size 119474

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/qRCodeLoginScreen.Showing-expired-iPad-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/qRCodeLoginScreen.Showing-expired-iPad-pseudo.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f34b4d5fb95d223b8b1cf850fe74fc75d031da0a7f0a359b5a4c3e29fa83669
-size 142744

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/qRCodeLoginScreen.Showing-expired-iPhone-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/qRCodeLoginScreen.Showing-expired-iPhone-en-GB.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c86cc8592649e4d3e65a6632fd02756455ffd48bbdc35b12d7db5a8ba147c988
-size 70650

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/qRCodeLoginScreen.Showing-expired-iPhone-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/qRCodeLoginScreen.Showing-expired-iPhone-pseudo.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2bbc55c8ae626a1e652864927dfa2eab2860c85dca9372cca73e0af982d7ca41
-size 96693

--- a/SDKMocks/Sources/Generated/SDKGeneratedMocks.swift
+++ b/SDKMocks/Sources/Generated/SDKGeneratedMocks.swift
@@ -5556,6 +5556,65 @@ open class ContentScannerSDKMock: MatrixRustSDK.ContentScanner, @unchecked Senda
         }
     }
 }
+open class ContinuationMessageSenderSDKMock: MatrixRustSDK.ContinuationMessageSender, @unchecked Sendable {
+    public init() {
+        super.init(noHandle: .init())
+    }
+
+    public required init(unsafeFromHandle handle: UInt64) {
+        fatalError("init(unsafeFromHandle:) has not been implemented")
+    }
+
+    fileprivate var handle: UInt64 {
+        get { return underlyingHandle }
+        set(value) { underlyingHandle = value }
+    }
+    fileprivate var underlyingHandle: UInt64!
+
+    //MARK: - cancel
+
+    open var cancelThrowableError: Error?
+    private let cancelCallsCountLock = NSLock()
+    private var cancelUnderlyingCallsCount = 0
+    open var cancelCallsCount: Int {
+        get { cancelCallsCountLock.withLock { cancelUnderlyingCallsCount } }
+        set { cancelCallsCountLock.withLock { cancelUnderlyingCallsCount = newValue } }
+    }
+    open var cancelCalled: Bool {
+        return cancelCallsCount > 0
+    }
+    open var cancelClosure: (() async throws -> Void)?
+
+    open override func cancel() async throws {
+        if let error = cancelThrowableError {
+            throw error
+        }
+        cancelCallsCountLock.withLock { cancelUnderlyingCallsCount += 1 }
+        try await cancelClosure?()
+    }
+
+    //MARK: - confirm
+
+    open var confirmThrowableError: Error?
+    private let confirmCallsCountLock = NSLock()
+    private var confirmUnderlyingCallsCount = 0
+    open var confirmCallsCount: Int {
+        get { confirmCallsCountLock.withLock { confirmUnderlyingCallsCount } }
+        set { confirmCallsCountLock.withLock { confirmUnderlyingCallsCount = newValue } }
+    }
+    open var confirmCalled: Bool {
+        return confirmCallsCount > 0
+    }
+    open var confirmClosure: (() async throws -> Void)?
+
+    open override func confirm() async throws {
+        if let error = confirmThrowableError {
+            throw error
+        }
+        confirmCallsCountLock.withLock { confirmUnderlyingCallsCount += 1 }
+        try await confirmClosure?()
+    }
+}
 open class CrossSigningSecretsSDKMock: MatrixRustSDK.CrossSigningSecrets, @unchecked Sendable {
     public init() {
         super.init(noHandle: .init())
@@ -10332,6 +10391,53 @@ open class RoomSDKMock: MatrixRustSDK.Room, @unchecked Sendable {
             return try await loadOrFetchEventEventIdClosure(eventId)
         } else {
             return loadOrFetchEventEventIdReturnValue
+        }
+    }
+
+    //MARK: - loadUserReceipt
+
+    open var loadUserReceiptReceiptTypeThreadUserIdThrowableError: Error?
+    private let loadUserReceiptReceiptTypeThreadUserIdCallsCountLock = NSLock()
+    private var loadUserReceiptReceiptTypeThreadUserIdUnderlyingCallsCount = 0
+    open var loadUserReceiptReceiptTypeThreadUserIdCallsCount: Int {
+        get { loadUserReceiptReceiptTypeThreadUserIdCallsCountLock.withLock { loadUserReceiptReceiptTypeThreadUserIdUnderlyingCallsCount } }
+        set { loadUserReceiptReceiptTypeThreadUserIdCallsCountLock.withLock { loadUserReceiptReceiptTypeThreadUserIdUnderlyingCallsCount = newValue } }
+    }
+    open var loadUserReceiptReceiptTypeThreadUserIdCalled: Bool {
+        return loadUserReceiptReceiptTypeThreadUserIdCallsCount > 0
+    }
+    private let loadUserReceiptReceiptTypeThreadUserIdReceivedArgumentsLock = NSLock()
+    private var loadUserReceiptReceiptTypeThreadUserIdUnderlyingReceivedArguments: (receiptType: ReceiptType, thread: ReceiptThread, userId: String)?
+    open var loadUserReceiptReceiptTypeThreadUserIdReceivedArguments: (receiptType: ReceiptType, thread: ReceiptThread, userId: String)? {
+        get { loadUserReceiptReceiptTypeThreadUserIdReceivedArgumentsLock.withLock { loadUserReceiptReceiptTypeThreadUserIdUnderlyingReceivedArguments } }
+        set { loadUserReceiptReceiptTypeThreadUserIdReceivedArgumentsLock.withLock { loadUserReceiptReceiptTypeThreadUserIdUnderlyingReceivedArguments = newValue } }
+    }
+    private let loadUserReceiptReceiptTypeThreadUserIdReceivedInvocationsLock = NSLock()
+    private var loadUserReceiptReceiptTypeThreadUserIdUnderlyingReceivedInvocations: [(receiptType: ReceiptType, thread: ReceiptThread, userId: String)] = []
+    open var loadUserReceiptReceiptTypeThreadUserIdReceivedInvocations: [(receiptType: ReceiptType, thread: ReceiptThread, userId: String)] {
+        get { loadUserReceiptReceiptTypeThreadUserIdReceivedInvocationsLock.withLock { loadUserReceiptReceiptTypeThreadUserIdUnderlyingReceivedInvocations } }
+        set { loadUserReceiptReceiptTypeThreadUserIdReceivedInvocationsLock.withLock { loadUserReceiptReceiptTypeThreadUserIdUnderlyingReceivedInvocations = newValue } }
+    }
+
+    private let loadUserReceiptReceiptTypeThreadUserIdReturnValueLock = NSLock()
+    open var loadUserReceiptReceiptTypeThreadUserIdUnderlyingReturnValue: UserReceipt?
+    open var loadUserReceiptReceiptTypeThreadUserIdReturnValue: UserReceipt? {
+        get { loadUserReceiptReceiptTypeThreadUserIdReturnValueLock.withLock { loadUserReceiptReceiptTypeThreadUserIdUnderlyingReturnValue } }
+        set { loadUserReceiptReceiptTypeThreadUserIdReturnValueLock.withLock { loadUserReceiptReceiptTypeThreadUserIdUnderlyingReturnValue = newValue } }
+    }
+    open var loadUserReceiptReceiptTypeThreadUserIdClosure: ((ReceiptType, ReceiptThread, String) async throws -> UserReceipt?)?
+
+    open override func loadUserReceipt(receiptType: ReceiptType, thread: ReceiptThread, userId: String) async throws -> UserReceipt? {
+        if let error = loadUserReceiptReceiptTypeThreadUserIdThrowableError {
+            throw error
+        }
+        loadUserReceiptReceiptTypeThreadUserIdCallsCountLock.withLock { loadUserReceiptReceiptTypeThreadUserIdUnderlyingCallsCount += 1 }
+        loadUserReceiptReceiptTypeThreadUserIdReceivedArguments = (receiptType: receiptType, thread: thread, userId: userId)
+        loadUserReceiptReceiptTypeThreadUserIdReceivedInvocationsLock.withLock { loadUserReceiptReceiptTypeThreadUserIdUnderlyingReceivedInvocations.append((receiptType: receiptType, thread: thread, userId: userId)) }
+        if let loadUserReceiptReceiptTypeThreadUserIdClosure = loadUserReceiptReceiptTypeThreadUserIdClosure {
+            return try await loadUserReceiptReceiptTypeThreadUserIdClosure(receiptType, thread, userId)
+        } else {
+            return loadUserReceiptReceiptTypeThreadUserIdReturnValue
         }
     }
 

--- a/UnitTests/Sources/QRCodeLoginScreenViewModelTests.swift
+++ b/UnitTests/Sources/QRCodeLoginScreenViewModelTests.swift
@@ -168,6 +168,25 @@ struct QRCodeLoginScreenViewModelTests {
     }
     
     @Test
+    mutating func linkDesktopExpiresWithoutSecureChannel() async throws {
+        setup(mode: .linkDesktop, linkDesktopTimeout: .zero)
+        #expect(context.viewState.state == .linkDesktopInstructions)
+        
+        // The timeout begins as soon as the screen appears, so the flow expires before a channel is established.
+        let deferred = deferFulfillment(context.$viewState) { $0.state == .error(.expired) }
+        try await deferred.fulfill()
+    }
+    
+    @Test
+    mutating func loginDoesNotExpire() async throws {
+        setup(mode: .login, linkDesktopTimeout: .zero)
+        
+        // The timeout only applies when linking a desktop, so signing in must never expire.
+        let deferredFailure = deferFailure(context.$viewState, timeout: .seconds(1)) { $0.state == .error(.expired) }
+        try await deferredFailure.fulfill()
+    }
+    
+    @Test
     mutating func linkMobileDevice() async throws {
         setup(mode: .linkMobile)
         #expect(context.viewState.state.isDisplayQR)
@@ -206,7 +225,7 @@ struct QRCodeLoginScreenViewModelTests {
     
     // MARK: - Helpers
     
-    private mutating func setup(mode: Mode) {
+    private mutating func setup(mode: Mode, linkDesktopTimeout: Duration = .seconds(120)) {
         qrLoginProgressSubject = .init(.starting)
         qrCodeLoginService = QRCodeLoginServiceMock()
         qrCodeLoginService.loginWithQRCodeDataReturnValue = qrLoginProgressSubject.asCurrentValuePublisher()
@@ -229,6 +248,7 @@ struct QRCodeLoginScreenViewModelTests {
         appMediator = AppMediatorMock(.init())
         viewModel = QRCodeLoginScreenViewModel(mode: screenMode,
                                                canSignInManually: true,
-                                               appMediator: appMediator)
+                                               appMediator: appMediator,
+                                               linkDesktopTimeout: linkDesktopTimeout)
     }
 }

--- a/UnitTests/Sources/QRCodeLoginScreenViewModelTests.swift
+++ b/UnitTests/Sources/QRCodeLoginScreenViewModelTests.swift
@@ -152,7 +152,8 @@ struct QRCodeLoginScreenViewModelTests {
             guard case .requestOAuthAuthorisation = action else { return false }
             return true
         }
-        linkDesktopProgressSubject.send(.waitingForAuthorisation(verificationURL: .homeDirectory))
+        linkDesktopProgressSubject.send(.waitingForAuthorisation(verificationURL: .homeDirectory,
+                                                                 continuationSender: .init(underlyingSender: ContinuationMessageSenderSDKMock())))
         try await deferredAction.fulfill()
         
         let currentState = context.viewState.state
@@ -188,7 +189,8 @@ struct QRCodeLoginScreenViewModelTests {
             guard case .requestOAuthAuthorisation = action else { return false }
             return true
         }
-        linkMobileProgressSubject.send(.waitingForAuthorisation(verificationURL: .homeDirectory))
+        linkMobileProgressSubject.send(.waitingForAuthorisation(verificationURL: .homeDirectory,
+                                                                continuationSender: .init(underlyingSender: ContinuationMessageSenderSDKMock())))
         try await deferredAction.fulfill()
         
         let currentState = context.viewState.state

--- a/UnitTests/Sources/QRCodeLoginScreenViewModelTests.swift
+++ b/UnitTests/Sources/QRCodeLoginScreenViewModelTests.swift
@@ -9,7 +9,6 @@
 import Combine
 @testable import ElementX
 import MatrixRustSDKMocks
-import SwiftUI
 import Testing
 
 @MainActor
@@ -19,7 +18,6 @@ struct QRCodeLoginScreenViewModelTests {
     var qrLoginProgressSubject: CurrentValueSubject<QRLoginProgress, AuthenticationServiceError>!
     var qrCodeLoginService: QRCodeLoginServiceMock!
     
-    var regeneratedQRCodeImage: UIImage!
     var linkMobileProgressSubject: CurrentValueSubject<LinkNewDeviceService.LinkMobileProgress, QRCodeLoginError>!
     var linkDesktopProgressSubject: CurrentValueSubject<LinkNewDeviceService.LinkDesktopProgress, QRCodeLoginError>!
     var linkNewDeviceService: LinkNewDeviceServiceMock!
@@ -206,17 +204,6 @@ struct QRCodeLoginScreenViewModelTests {
         try await deferredAction.fulfill()
     }
     
-    @Test
-    mutating func linkMobileDeviceQRCodeExpiry() async throws {
-        setup(mode: .linkMobile)
-        #expect(context.viewState.state.isDisplayQR)
-        
-        let deferred = deferFulfillment(context.$viewState, keyPath: \.state, transitionValues: [.displayQR(.expired),
-                                                                                                 .displayQR(.active(regeneratedQRCodeImage))])
-        linkMobileProgressSubject.send(completion: .failure(.expired))
-        try await deferred.fulfill()
-    }
-    
     // MARK: - Helpers
     
     private mutating func setup(mode: Mode) {
@@ -229,11 +216,6 @@ struct QRCodeLoginScreenViewModelTests {
         linkNewDeviceService = LinkNewDeviceServiceMock(.init(linkMobileProgressPublisher: linkMobileProgressSubject.asCurrentValuePublisher(),
                                                               linkDesktopProgressPublisher: linkDesktopProgressSubject.asCurrentValuePublisher()))
         
-        regeneratedQRCodeImage = LinkNewDeviceServiceMock.mockQRCodeImage
-        let clientProxy = ClientProxyMock(.init())
-        clientProxy.linkNewDeviceServiceReturnValue = LinkNewDeviceServiceMock(.init(linkMobileProgressPublisher: .init(.qrReady(regeneratedQRCodeImage)),
-                                                                                     linkDesktopProgressPublisher: .init(.starting)))
-        
         let screenMode: QRCodeLoginScreenMode
         switch mode {
         case .login:
@@ -241,7 +223,7 @@ struct QRCodeLoginScreenViewModelTests {
         case .linkDesktop:
             screenMode = .linkDesktop(linkNewDeviceService)
         case .linkMobile:
-            screenMode = .linkMobile(linkNewDeviceService.linkMobileDevice(), clientProxy)
+            screenMode = .linkMobile(linkNewDeviceService.linkMobileDevice())
         }
         
         appMediator = AppMediatorMock(.init())


### PR DESCRIPTION
- Linking a new mobile device uses the timeout already emitted by the SDK (by removing the automatic regeneration of the QR code). This is currently 1-minute but will be extended to 2-minutes when the newer QR code MSC is available.
- Linking a new desktop computer schedules an expiration date on the `QRCodeLoginScreen` (shown immediately after verifying).

Also includes #5927 now that we have SDK support.

Easiest to review commit-by-commit. Closes #5954.
