### PR TITLE
Tweak the stalebot configuration

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,15 +15,19 @@ jobs:
     steps:
       - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11
         with:
-          only-labels: "X-Needs-Info"
+          labels-to-remove-when-unstale: "X-Needs-Info"
+
+          # Issues
+          only-issue-labels: "X-Needs-Info"
           days-before-issue-stale: 30
           days-before-issue-close: 7
-          days-before-pr-stale: 30
-          days-before-pr-close: 7
-          stale-pr-label: "stale"
-          stale-pr-message: "This pull request has seen no activity for the past 30 days and will now be marked as stale. Please update it or leave a comment within the next 7 days to keep it open."
-          close-pr-message: "This pull request is being closed due to inactivity."
-          stale-issue-label: "stale"
-          labels-to-remove-when-unstale: "X-Needs-Info"
+          stale-issue-label: "Stale"
           stale-issue-message: "This issue has been awaiting further information for the past 30 days so will now be marked as stale. Please provide the requested information within the next 7 days to keep it open."
           close-issue-message: "This issue is being closed due to inactivity after further information was requested."
+
+          # Pull requests
+          days-before-pr-stale: 30
+          days-before-pr-close: 7
+          stale-pr-label: "Stale"
+          stale-pr-message: "This pull request has seen no activity for the past 30 days and will now be marked as stale. Please update it or leave a comment within the next 7 days to keep it open."
+          close-pr-message: "This pull request is being closed due to inactivity."


### PR DESCRIPTION
So that it:
* checks PRs without needing a needs info label
* capitalize the Stale label
* groups the issues and PRs configurations separately