### PR TITLE
Add hooks for the RoomDetails, RoomMemberDetails and UserProfile screens.

### DIFF
--- a/BuildExtensions/Sources/Macros/AppHook.swift
+++ b/BuildExtensions/Sources/Macros/AppHook.swift
@@ -1,0 +1,16 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+/// Exposes a `Mutex`-backed hook as a read-only computed property, alongside a `register<Name>`
+/// peer that swaps in a replacement hook.
+///
+/// The `default` argument provides the hook used until (and unless) a replacement is registered.
+/// The enclosing type must have `Synchronization` in scope for the generated `Mutex` storage.
+@attached(accessor)
+@attached(peer, names: arbitrary)
+public macro AppHook<Value>(default: Value) =
+    #externalMacro(module: "MacrosImplementation", type: "AppHookMacro")

--- a/BuildExtensions/Sources/MacrosImplementation/AppHookMacro.swift
+++ b/BuildExtensions/Sources/MacrosImplementation/AppHookMacro.swift
@@ -1,0 +1,98 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// Implements `@AppHook`. The generated property reads through a `Mutex`-backed store, and a
+/// generated `register<Name>` method swaps in a replacement hook.
+enum AppHookMacro {
+    enum DiagnosticError: Error, CustomStringConvertible {
+        case notAStoredProperty
+        case missingTypeAnnotation
+        case missingDefault
+        
+        var description: String {
+            switch self {
+            case .notAStoredProperty:
+                "@AppHook can only be applied to a stored property."
+            case .missingTypeAnnotation:
+                "@AppHook requires an explicit type annotation."
+            case .missingDefault:
+                "@AppHook requires a default value."
+            }
+        }
+    }
+    
+    private struct AppHook {
+        let name: String
+        let type: TypeSyntax
+        let defaultValue: ExprSyntax
+        
+        var storageName: TokenSyntax {
+            "_\(raw: name)"
+        }
+        
+        var registerMethodName: TokenSyntax {
+            "register\(raw: name.prefix(1).uppercased() + name.dropFirst())"
+        }
+    }
+    
+    private static func appHook(for declaration: some DeclSyntaxProtocol, node: AttributeSyntax) throws -> AppHook {
+        guard let variable = declaration.as(VariableDeclSyntax.self),
+              let binding = variable.bindings.first,
+              let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier else {
+            throw DiagnosticError.notAStoredProperty
+        }
+        guard let type = binding.typeAnnotation?.type.trimmed else {
+            throw DiagnosticError.missingTypeAnnotation
+        }
+        
+        var defaultValue: ExprSyntax?
+        if let list = node.arguments?.as(LabeledExprListSyntax.self) {
+            for argument in list where argument.label?.text == "default" {
+                defaultValue = argument.expression
+            }
+        }
+        guard let defaultValue else {
+            throw DiagnosticError.missingDefault
+        }
+        
+        return AppHook(name: identifier.text, type: type, defaultValue: defaultValue)
+    }
+}
+
+extension AppHookMacro: AccessorMacro {
+    static func expansion(of node: AttributeSyntax,
+                          providingAccessorsOf declaration: some DeclSyntaxProtocol,
+                          in context: some MacroExpansionContext) throws -> [AccessorDeclSyntax] {
+        let appHook = try appHook(for: declaration, node: node)
+        return [
+            """
+            get {
+                \(appHook.storageName).withLock { $0 }
+            }
+            """
+        ]
+    }
+}
+
+extension AppHookMacro: PeerMacro {
+    static func expansion(of node: AttributeSyntax,
+                          providingPeersOf declaration: some DeclSyntaxProtocol,
+                          in context: some MacroExpansionContext) throws -> [DeclSyntax] {
+        let appHook = try appHook(for: declaration, node: node)
+        return [
+            "private let \(appHook.storageName) = Mutex<\(appHook.type)>(\(appHook.defaultValue))",
+            """
+            func \(appHook.registerMethodName)(_ hook: \(appHook.type)) {
+                \(appHook.storageName).withLock { $0 = hook }
+            }
+            """
+        ]
+    }
+}

--- a/BuildExtensions/Sources/MacrosImplementation/Plugin.swift
+++ b/BuildExtensions/Sources/MacrosImplementation/Plugin.swift
@@ -10,5 +10,5 @@ import SwiftSyntaxMacros
 
 @main
 struct BuildExtensionsPlugin: CompilerPlugin {
-    let providingMacros: [Macro.Type] = [UserPreferenceMacro.self]
+    let providingMacros: [Macro.Type] = [UserPreferenceMacro.self, AppHookMacro.self]
 }

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -230,6 +230,7 @@
 		241CDEFE23819867D9B39066 /* RoomChangePermissionsScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AE75941583A033A9EDC9FE0 /* RoomChangePermissionsScreenViewModel.swift */; };
 		2435DCCBD4513B9FD053CAC9 /* target.yml in Resources */ = {isa = PBXBuildFile; fileRef = DD3C65634A34467CB407A061 /* target.yml */; };
 		244407B18B2F2D6466BA5961 /* RoomChangeRolesScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82DFA1B7B088D033E0794B82 /* RoomChangeRolesScreenCoordinator.swift */; };
+		244718EA54B798DF6CE57F9C /* UserProfileScreenHook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B35734F3743563566413C9A /* UserProfileScreenHook.swift */; };
 		2447FADEF13225BB6227B977 /* VerificationBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D97BAF04AA150C0EF03021 /* VerificationBadge.swift */; };
 		24A1BBADAC43DC3F3A7347DA /* AnalyticsPromptScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = E53BFB7E4F329621C844E8C3 /* AnalyticsPromptScreen.swift */; };
 		24A75F72EEB7561B82D726FD /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2141693488CE5446BB391964 /* Date.swift */; };
@@ -237,6 +238,7 @@
 		24BDDD09A90B8BFE3793F3AA /* ClientProxyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6033779EB37259F27F938937 /* ClientProxyProtocol.swift */; };
 		24C32D7EF94ECF9081638DF6 /* RemotePreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69A05E85E4872C3221C5C287 /* RemotePreference.swift */; };
 		250D2E8309C8CC48796D41D1 /* SpaceScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11397904D19CFF0E3689F0E /* SpaceScreenModels.swift */; };
+		25115EDCFF365397F7C4604A /* RoomMemberDetailsScreenHook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99EB08B2C8B01F3BFE4B0CEC /* RoomMemberDetailsScreenHook.swift */; };
 		2538350683F421AB620AA950 /* AccessibleLongPress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 307C3E5B9B189497D3250E23 /* AccessibleLongPress.swift */; };
 		25618589E0DE0F1E95FC7B5C /* EmojiProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 099F2D36C141D845A445B1E6 /* EmojiProviderTests.swift */; };
 		256D76972BA3254F7CB7F88B /* LocationAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD8234D0E9C9B12BF9F240B /* LocationAnnotation.swift */; };
@@ -1094,6 +1096,7 @@
 		AF33B9044498211C3D82F1E1 /* UNTextInputNotificationResponse+Creator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 130ED565A078F7E0B59D9D25 /* UNTextInputNotificationResponse+Creator.swift */; };
 		AF8BFA37791E1756EE243E08 /* SettingsScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B8F0ED874DF8C9A51B0AB6F /* SettingsScreenCoordinator.swift */; };
 		AFE2AB612A1460E49578D746 /* JoinRoomScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BDCCD2F6B405C14B9BCE94E /* JoinRoomScreenCoordinator.swift */; };
+		B004A08BE32F06832BF41CFC /* RoomDetailsScreenHook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3674212CAB6C5143DD437AC4 /* RoomDetailsScreenHook.swift */; };
 		B04E9EB589CE99C3929E817A /* HomeScreenRecoveryKeyConfirmationBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05512FB13987D221B7205DE0 /* HomeScreenRecoveryKeyConfirmationBanner.swift */; };
 		B0CB16349B96262AA65A04AF /* PostHog in Frameworks */ = {isa = PBXBuildFile; productRef = 4278261E147DB2DE5CFB7FC5 /* PostHog */; };
 		B1088417801A962BA861C13F /* RoomPowerLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7E247E29C7A0E421DB839D7 /* RoomPowerLevel.swift */; };
@@ -1989,6 +1992,7 @@
 		35A057BA9BE0F079784CD061 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		35A5AB4E2E5CA98F99BFC552 /* GalleryRoomTimelineItemContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryRoomTimelineItemContent.swift; sourceTree = "<group>"; };
 		35AFCF4C05DEED04E3DB1A16 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
+		3674212CAB6C5143DD437AC4 /* RoomDetailsScreenHook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomDetailsScreenHook.swift; sourceTree = "<group>"; };
 		36DA824791172B9821EACBED /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		36FD673E24FBFCFDF398716A /* RoomMemberProxyMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomMemberProxyMock.swift; sourceTree = "<group>"; };
 		3747C96188856006F784BF49 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ko; path = ko.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
@@ -2474,6 +2478,7 @@
 		8AE0C9653870803E4F91F474 /* RoomListFiltersStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomListFiltersStateTests.swift; sourceTree = "<group>"; };
 		8AE78FA0011E07920AE83135 /* PlainMentionBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlainMentionBuilder.swift; sourceTree = "<group>"; };
 		8AFCE895ECFFA53FEE64D62B /* MediaLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaLoader.swift; sourceTree = "<group>"; };
+		8B35734F3743563566413C9A /* UserProfileScreenHook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileScreenHook.swift; sourceTree = "<group>"; };
 		8B89D6C760E8CAE29CA28FB1 /* CompoundHook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompoundHook.swift; sourceTree = "<group>"; };
 		8BCCE3D12B0A9C6E559B5B5A /* EmojiProviderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiProviderProtocol.swift; sourceTree = "<group>"; };
 		8BD9C9A31D9AB3B6D8128E69 /* KnockRequestsListScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnockRequestsListScreenModels.swift; sourceTree = "<group>"; };
@@ -2551,6 +2556,7 @@
 		98C6A082F2B2A15E1B9BE280 /* TimelineItemThreadSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineItemThreadSummary.swift; sourceTree = "<group>"; };
 		98F4DFFFC62187D9A4D2030D /* ClassicAppAccountManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClassicAppAccountManager.swift; sourceTree = "<group>"; };
 		997BF045585AF6DB2EBC5755 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		99EB08B2C8B01F3BFE4B0CEC /* RoomMemberDetailsScreenHook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomMemberDetailsScreenHook.swift; sourceTree = "<group>"; };
 		9A008E57D52B07B78DFAD1BB /* RoomFlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomFlowCoordinator.swift; sourceTree = "<group>"; };
 		9A028783CFFF861C5E44FFB1 /* BadgeLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeLabel.swift; sourceTree = "<group>"; };
 		9A1C33355FFB0F0953C35036 /* ClientBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientBuilder.swift; sourceTree = "<group>"; };
@@ -3823,8 +3829,11 @@
 				04CAC77224E949D8E758E2E3 /* OAuthPresenterHook.swift */,
 				7AE97AD18893E2D8120F559D /* RecoveryKeyScreenHook.swift */,
 				D5D186A6DB8FAC5C9D0E4D61 /* RemoteSettingsHook.swift */,
+				3674212CAB6C5143DD437AC4 /* RoomDetailsScreenHook.swift */,
+				99EB08B2C8B01F3BFE4B0CEC /* RoomMemberDetailsScreenHook.swift */,
 				B343C5255FB408DDE853CFDF /* RoomScreenHook.swift */,
 				2A95C9B8299A36A6495DECA6 /* TracingHook.swift */,
+				8B35734F3743563566413C9A /* UserProfileScreenHook.swift */,
 			);
 			path = Hooks;
 			sourceTree = "<group>";
@@ -8933,6 +8942,7 @@
 				C49FCC766673006B6D299F1C /* RoomDetailsEditScreenViewModelProtocol.swift in Sources */,
 				126EE01D8BEAEF26105D83C5 /* RoomDetailsScreen.swift in Sources */,
 				FA5A7E32B1920FCB4EEDC1BA /* RoomDetailsScreenCoordinator.swift in Sources */,
+				B004A08BE32F06832BF41CFC /* RoomDetailsScreenHook.swift in Sources */,
 				DB079D1929B5A5F52D207C83 /* RoomDetailsScreenModels.swift in Sources */,
 				A5D551E5691749066E0E0C44 /* RoomDetailsScreenViewModel.swift in Sources */,
 				E9560744F7B0292E20ECE5F2 /* RoomDetailsScreenViewModelProtocol.swift in Sources */,
@@ -8964,6 +8974,7 @@
 				8DC176CC5ABA24138EB443DD /* RoomMemberDetails.swift in Sources */,
 				19FE025AE9BA2959B6589B0D /* RoomMemberDetailsScreen.swift in Sources */,
 				899793EFC63DF93C3E0141E7 /* RoomMemberDetailsScreenCoordinator.swift in Sources */,
+				25115EDCFF365397F7C4604A /* RoomMemberDetailsScreenHook.swift in Sources */,
 				A816F7087C495D85048AC50E /* RoomMemberDetailsScreenModels.swift in Sources */,
 				EAF2B3E6C6AEC4AD3A8BD454 /* RoomMemberDetailsScreenViewModel.swift in Sources */,
 				5B6E5AD224509E6C0B520D6E /* RoomMemberDetailsScreenViewModelProtocol.swift in Sources */,
@@ -9318,6 +9329,7 @@
 				ED90A59F068FD0CA27E602ED /* UserProfileListRow.swift in Sources */,
 				1A3B073568D1DC8F76F1F3A0 /* UserProfileScreen.swift in Sources */,
 				6AEB650311F694A5702255C9 /* UserProfileScreenCoordinator.swift in Sources */,
+				244718EA54B798DF6CE57F9C /* UserProfileScreenHook.swift in Sources */,
 				D4CB979EB4FE26AAD9F9A72B /* UserProfileScreenModels.swift in Sources */,
 				AC1DB27A4134470846BE49F6 /* UserProfileScreenViewModel.swift in Sources */,
 				46A183C6125A669AEB005699 /* UserProfileScreenViewModelProtocol.swift in Sources */,

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -908,6 +908,7 @@
 		914BDF61447C723F104BCE33 /* SessionDirectories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C2067FF58B4996323EB40C /* SessionDirectories.swift */; };
 		915B4CDAF220D9AEB4047D45 /* PollInteractionHandlerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259E5B05BDE6E20C26CF11B4 /* PollInteractionHandlerProtocol.swift */; };
 		91ABC91758A6E4A5FAA2E9C4 /* ReadReceipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314F1C79850BE46E8ABEAFCB /* ReadReceipt.swift */; };
+		91C590378C591DCA3E40416A /* UserSessionHook.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9773983346838AABFAA914D /* UserSessionHook.swift */; };
 		91C6AC0E9D2B9C0C76CC6AD4 /* RoomDirectorySearchScreenScreenModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3984C93B8E9B10C92DADF9EE /* RoomDirectorySearchScreenScreenModelProtocol.swift */; };
 		91D1A46A733EC24C081DD353 /* SessionVerificationRequestDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1265FAF2C0AF1C30605BE7 /* SessionVerificationRequestDetailsView.swift */; };
 		92012C96039BC8C2CAEBA9E2 /* AuthenticationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 671C338B7259DC5774816885 /* AuthenticationServiceTests.swift */; };
@@ -3015,6 +3016,7 @@
 		E8A1F98AE670377B20679FF5 /* MediaPlayerProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPlayerProvider.swift; sourceTree = "<group>"; };
 		E8AE4B3273BA189FDCD4055C /* UserIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserIndicator.swift; sourceTree = "<group>"; };
 		E944F717FC10A428D027074D /* RoomPowerLevelsProxyMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomPowerLevelsProxyMock.swift; sourceTree = "<group>"; };
+		E9773983346838AABFAA914D /* UserSessionHook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSessionHook.swift; sourceTree = "<group>"; };
 		E992D7B8BE54B2AB454613AF /* XCUIElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCUIElement.swift; sourceTree = "<group>"; };
 		E994322F10D20ECE68683683 /* GalleryRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryRoomTimelineItem.swift; sourceTree = "<group>"; };
 		E9A3D3CFA199FA7897364547 /* CallInviteRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallInviteRoomTimelineItem.swift; sourceTree = "<group>"; };
@@ -3834,6 +3836,7 @@
 				B343C5255FB408DDE853CFDF /* RoomScreenHook.swift */,
 				2A95C9B8299A36A6495DECA6 /* TracingHook.swift */,
 				8B35734F3743563566413C9A /* UserProfileScreenHook.swift */,
+				E9773983346838AABFAA914D /* UserSessionHook.swift */,
 			);
 			path = Hooks;
 			sourceTree = "<group>";
@@ -9336,6 +9339,7 @@
 				69A9B430397C15075D86193F /* UserPropertiesExt.swift in Sources */,
 				8AB8ED1051216546CB35FA0E /* UserSession.swift in Sources */,
 				4A618590DEB72C4F186BFED4 /* UserSessionFlowCoordinator.swift in Sources */,
+				91C590378C591DCA3E40416A /* UserSessionHook.swift in Sources */,
 				6586E1F1D5F0651D0638FFAF /* UserSessionMock.swift in Sources */,
 				978BB24F2A5D31EE59EEC249 /* UserSessionProtocol.swift in Sources */,
 				7E91BAC17963ED41208F489B /* UserSessionStore.swift in Sources */,

--- a/ElementX/Sources/AppHooks/AppHooks.swift
+++ b/ElementX/Sources/AppHooks/AppHooks.swift
@@ -13,10 +13,7 @@ import Synchronization
 final nonisolated class AppHooks: AppHooksProtocol {
     #if IS_MAIN_APP
     func configure(with userSession: UserSessionProtocol?) async {
-        await roomScreenHook.configure(with: userSession)
-        await roomDetailsScreenHook.configure(with: userSession)
-        await roomMemberDetailsScreenHook.configure(with: userSession)
-        await userProfileScreenHook.configure(with: userSession)
+        await userSessionHook.configure(with: userSession)
     }
     
     @AppHook(default: DefaultAppSettingsHook())
@@ -30,6 +27,9 @@ final nonisolated class AppHooks: AppHooksProtocol {
     
     @AppHook(default: DefaultOAuthPresenterHook())
     var oAuthPresenterHook: OAuthPresenterHookProtocol
+    
+    @AppHook(default: DefaultUserSessionHook())
+    var userSessionHook: UserSessionHookProtocol
     
     @AppHook(default: DefaultRoomScreenHook())
     var roomScreenHook: RoomScreenHookProtocol

--- a/ElementX/Sources/AppHooks/AppHooks.swift
+++ b/ElementX/Sources/AppHooks/AppHooks.swift
@@ -13,6 +13,9 @@ final nonisolated class AppHooks: AppHooksProtocol {
     #if IS_MAIN_APP
     func configure(with userSession: UserSessionProtocol?) async {
         await roomScreenHook.configure(with: userSession)
+        await roomDetailsScreenHook.configure(with: userSession)
+        await roomMemberDetailsScreenHook.configure(with: userSession)
+        await userProfileScreenHook.configure(with: userSession)
     }
     
     private let _appSettingsHook: Mutex<AppSettingsHookProtocol> = Mutex(DefaultAppSettingsHook())
@@ -58,6 +61,33 @@ final nonisolated class AppHooks: AppHooksProtocol {
     
     func registerRoomScreenHook(_ hook: RoomScreenHookProtocol) {
         _roomScreenHook.withLock { $0 = hook }
+    }
+    
+    private let _roomDetailsScreenHook: Mutex<RoomDetailsScreenHookProtocol> = Mutex(DefaultRoomDetailsScreenHook())
+    var roomDetailsScreenHook: RoomDetailsScreenHookProtocol {
+        _roomDetailsScreenHook.withLock { $0 }
+    }
+    
+    func registerRoomDetailsScreenHook(_ hook: RoomDetailsScreenHookProtocol) {
+        _roomDetailsScreenHook.withLock { $0 = hook }
+    }
+    
+    private let _roomMemberDetailsScreenHook: Mutex<RoomMemberDetailsScreenHookProtocol> = Mutex(DefaultRoomMemberDetailsScreenHook())
+    var roomMemberDetailsScreenHook: RoomMemberDetailsScreenHookProtocol {
+        _roomMemberDetailsScreenHook.withLock { $0 }
+    }
+    
+    func registerRoomMemberDetailsScreenHook(_ hook: RoomMemberDetailsScreenHookProtocol) {
+        _roomMemberDetailsScreenHook.withLock { $0 = hook }
+    }
+    
+    private let _userProfileScreenHook: Mutex<UserProfileScreenHookProtocol> = Mutex(DefaultUserProfileScreenHook())
+    var userProfileScreenHook: UserProfileScreenHookProtocol {
+        _userProfileScreenHook.withLock { $0 }
+    }
+    
+    func registerUserProfileScreenHook(_ hook: UserProfileScreenHookProtocol) {
+        _userProfileScreenHook.withLock { $0 = hook }
     }
     
     private let _developerOptionsScreenHook: Mutex<DeveloperOptionsScreenHookProtocol> = Mutex(DefaultDeveloperOptionsScreenHook())

--- a/ElementX/Sources/AppHooks/AppHooks.swift
+++ b/ElementX/Sources/AppHooks/AppHooks.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import Macros
 import Synchronization
 
 final nonisolated class AppHooks: AppHooksProtocol {
@@ -18,124 +19,45 @@ final nonisolated class AppHooks: AppHooksProtocol {
         await userProfileScreenHook.configure(with: userSession)
     }
     
-    private let _appSettingsHook: Mutex<AppSettingsHookProtocol> = Mutex(DefaultAppSettingsHook())
-    var appSettingsHook: AppSettingsHookProtocol {
-        _appSettingsHook.withLock { $0 }
-    }
+    @AppHook(default: DefaultAppSettingsHook())
+    var appSettingsHook: AppSettingsHookProtocol
     
-    func registerAppSettingsHook(_ hook: AppSettingsHookProtocol) {
-        _appSettingsHook.withLock { $0 = hook }
-    }
+    @AppHook(default: DefaultCompoundHook())
+    var compoundHook: CompoundHookProtocol
     
-    private let _compoundHook: Mutex<CompoundHookProtocol> = Mutex(DefaultCompoundHook())
-    var compoundHook: CompoundHookProtocol {
-        _compoundHook.withLock { $0 }
-    }
+    @AppHook(default: DefaultBugReportHook())
+    var bugReportHook: BugReportHookProtocol
     
-    func registerCompoundHook(_ hook: CompoundHookProtocol) {
-        _compoundHook.withLock { $0 = hook }
-    }
+    @AppHook(default: DefaultOAuthPresenterHook())
+    var oAuthPresenterHook: OAuthPresenterHookProtocol
     
-    private let _bugReportHook: Mutex<BugReportHookProtocol> = Mutex(DefaultBugReportHook())
-    var bugReportHook: BugReportHookProtocol {
-        _bugReportHook.withLock { $0 }
-    }
+    @AppHook(default: DefaultRoomScreenHook())
+    var roomScreenHook: RoomScreenHookProtocol
     
-    func registerBugReportHook(_ hook: BugReportHookProtocol) {
-        _bugReportHook.withLock { $0 = hook }
-    }
+    @AppHook(default: DefaultRoomDetailsScreenHook())
+    var roomDetailsScreenHook: RoomDetailsScreenHookProtocol
     
-    private let _oAuthPresenterHook: Mutex<OAuthPresenterHookProtocol> = Mutex(DefaultOAuthPresenterHook())
-    var oAuthPresenterHook: OAuthPresenterHookProtocol {
-        _oAuthPresenterHook.withLock { $0 }
-    }
+    @AppHook(default: DefaultRoomMemberDetailsScreenHook())
+    var roomMemberDetailsScreenHook: RoomMemberDetailsScreenHookProtocol
     
-    func registerOAuthPresenterHook(_ hook: OAuthPresenterHookProtocol) {
-        _oAuthPresenterHook.withLock { $0 = hook }
-    }
+    @AppHook(default: DefaultUserProfileScreenHook())
+    var userProfileScreenHook: UserProfileScreenHookProtocol
     
-    private let _roomScreenHook: Mutex<RoomScreenHookProtocol> = Mutex(DefaultRoomScreenHook())
-    var roomScreenHook: RoomScreenHookProtocol {
-        _roomScreenHook.withLock { $0 }
-    }
+    @AppHook(default: DefaultDeveloperOptionsScreenHook())
+    var developerOptionsScreenHook: DeveloperOptionsScreenHookProtocol
     
-    func registerRoomScreenHook(_ hook: RoomScreenHookProtocol) {
-        _roomScreenHook.withLock { $0 = hook }
-    }
-    
-    private let _roomDetailsScreenHook: Mutex<RoomDetailsScreenHookProtocol> = Mutex(DefaultRoomDetailsScreenHook())
-    var roomDetailsScreenHook: RoomDetailsScreenHookProtocol {
-        _roomDetailsScreenHook.withLock { $0 }
-    }
-    
-    func registerRoomDetailsScreenHook(_ hook: RoomDetailsScreenHookProtocol) {
-        _roomDetailsScreenHook.withLock { $0 = hook }
-    }
-    
-    private let _roomMemberDetailsScreenHook: Mutex<RoomMemberDetailsScreenHookProtocol> = Mutex(DefaultRoomMemberDetailsScreenHook())
-    var roomMemberDetailsScreenHook: RoomMemberDetailsScreenHookProtocol {
-        _roomMemberDetailsScreenHook.withLock { $0 }
-    }
-    
-    func registerRoomMemberDetailsScreenHook(_ hook: RoomMemberDetailsScreenHookProtocol) {
-        _roomMemberDetailsScreenHook.withLock { $0 = hook }
-    }
-    
-    private let _userProfileScreenHook: Mutex<UserProfileScreenHookProtocol> = Mutex(DefaultUserProfileScreenHook())
-    var userProfileScreenHook: UserProfileScreenHookProtocol {
-        _userProfileScreenHook.withLock { $0 }
-    }
-    
-    func registerUserProfileScreenHook(_ hook: UserProfileScreenHookProtocol) {
-        _userProfileScreenHook.withLock { $0 = hook }
-    }
-    
-    private let _developerOptionsScreenHook: Mutex<DeveloperOptionsScreenHookProtocol> = Mutex(DefaultDeveloperOptionsScreenHook())
-    var developerOptionsScreenHook: DeveloperOptionsScreenHookProtocol {
-        _developerOptionsScreenHook.withLock { $0 }
-    }
-    
-    func registerDeveloperOptionsScreenHook(_ hook: DeveloperOptionsScreenHookProtocol) {
-        _developerOptionsScreenHook.withLock { $0 = hook }
-    }
-    
-    private let _recoveryKeyScreenHook: Mutex<RecoveryKeyScreenHookProtocol> = Mutex(DefaultRecoveryKeyScreenHook())
-    var recoveryKeyScreenHook: RecoveryKeyScreenHookProtocol {
-        _recoveryKeyScreenHook.withLock { $0 }
-    }
-    
-    func registerRecoveryKeyScreenHook(_ hook: RecoveryKeyScreenHookProtocol) {
-        _recoveryKeyScreenHook.withLock { $0 = hook }
-    }
+    @AppHook(default: DefaultRecoveryKeyScreenHook())
+    var recoveryKeyScreenHook: RecoveryKeyScreenHookProtocol
     #endif
     
-    private let _tracingHook: Mutex<TracingHookProtocol> = Mutex(DefaultTracingHook())
-    var tracingHook: TracingHookProtocol {
-        _tracingHook.withLock { $0 }
-    }
+    @AppHook(default: DefaultTracingHook())
+    var tracingHook: TracingHookProtocol
     
-    func registerTracingHook(_ hook: TracingHookProtocol) {
-        _tracingHook.withLock { $0 = hook }
-    }
+    @AppHook(default: DefaultClientBuilderHook())
+    var clientBuilderHook: ClientBuilderHookProtocol
     
-    private let _clientBuilderHook: Mutex<ClientBuilderHookProtocol> = Mutex(DefaultClientBuilderHook())
-    var clientBuilderHook: ClientBuilderHookProtocol {
-        _clientBuilderHook.withLock { $0 }
-    }
-    
-    // periphery:ignore - might be useful to have
-    func registerClientBuilderHook(_ hook: ClientBuilderHookProtocol) {
-        _clientBuilderHook.withLock { $0 = hook }
-    }
-    
-    private let _remoteSettingsHook: Mutex<RemoteSettingsHookProtocol> = Mutex(DefaultRemoteSettingsHook())
-    var remoteSettingsHook: RemoteSettingsHookProtocol {
-        _remoteSettingsHook.withLock { $0 }
-    }
-    
-    func registerRemoteSettingsHook(_ hook: RemoteSettingsHookProtocol) {
-        _remoteSettingsHook.withLock { $0 = hook }
-    }
+    @AppHook(default: DefaultRemoteSettingsHook())
+    var remoteSettingsHook: RemoteSettingsHookProtocol
 }
 
 nonisolated protocol AppHooksProtocol: Sendable {

--- a/ElementX/Sources/AppHooks/Hooks/RoomDetailsScreenHook.swift
+++ b/ElementX/Sources/AppHooks/Hooks/RoomDetailsScreenHook.swift
@@ -8,12 +8,10 @@
 import Foundation
 
 nonisolated protocol RoomDetailsScreenHookProtocol: Sendable {
-    @MainActor func configure(with userSession: UserSessionProtocol?) async
     @MainActor func update(_ viewState: RoomDetailsScreenViewState) -> RoomDetailsScreenViewState
 }
 
 struct DefaultRoomDetailsScreenHook: RoomDetailsScreenHookProtocol {
-    func configure(with userSession: UserSessionProtocol?) async { }
     func update(_ viewState: RoomDetailsScreenViewState) -> RoomDetailsScreenViewState {
         viewState
     }

--- a/ElementX/Sources/AppHooks/Hooks/RoomDetailsScreenHook.swift
+++ b/ElementX/Sources/AppHooks/Hooks/RoomDetailsScreenHook.swift
@@ -1,0 +1,20 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Foundation
+
+nonisolated protocol RoomDetailsScreenHookProtocol: Sendable {
+    @MainActor func configure(with userSession: UserSessionProtocol?) async
+    @MainActor func update(_ viewState: RoomDetailsScreenViewState) -> RoomDetailsScreenViewState
+}
+
+struct DefaultRoomDetailsScreenHook: RoomDetailsScreenHookProtocol {
+    func configure(with userSession: UserSessionProtocol?) async { }
+    func update(_ viewState: RoomDetailsScreenViewState) -> RoomDetailsScreenViewState {
+        viewState
+    }
+}

--- a/ElementX/Sources/AppHooks/Hooks/RoomMemberDetailsScreenHook.swift
+++ b/ElementX/Sources/AppHooks/Hooks/RoomMemberDetailsScreenHook.swift
@@ -8,12 +8,10 @@
 import Foundation
 
 nonisolated protocol RoomMemberDetailsScreenHookProtocol: Sendable {
-    @MainActor func configure(with userSession: UserSessionProtocol?) async
     @MainActor func update(_ viewState: RoomMemberDetailsScreenViewState) -> RoomMemberDetailsScreenViewState
 }
 
 struct DefaultRoomMemberDetailsScreenHook: RoomMemberDetailsScreenHookProtocol {
-    func configure(with userSession: UserSessionProtocol?) async { }
     func update(_ viewState: RoomMemberDetailsScreenViewState) -> RoomMemberDetailsScreenViewState {
         viewState
     }

--- a/ElementX/Sources/AppHooks/Hooks/RoomMemberDetailsScreenHook.swift
+++ b/ElementX/Sources/AppHooks/Hooks/RoomMemberDetailsScreenHook.swift
@@ -1,0 +1,20 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Foundation
+
+nonisolated protocol RoomMemberDetailsScreenHookProtocol: Sendable {
+    @MainActor func configure(with userSession: UserSessionProtocol?) async
+    @MainActor func update(_ viewState: RoomMemberDetailsScreenViewState) -> RoomMemberDetailsScreenViewState
+}
+
+struct DefaultRoomMemberDetailsScreenHook: RoomMemberDetailsScreenHookProtocol {
+    func configure(with userSession: UserSessionProtocol?) async { }
+    func update(_ viewState: RoomMemberDetailsScreenViewState) -> RoomMemberDetailsScreenViewState {
+        viewState
+    }
+}

--- a/ElementX/Sources/AppHooks/Hooks/RoomScreenHook.swift
+++ b/ElementX/Sources/AppHooks/Hooks/RoomScreenHook.swift
@@ -9,12 +9,10 @@
 import Foundation
 
 nonisolated protocol RoomScreenHookProtocol: Sendable {
-    @MainActor func configure(with userSession: UserSessionProtocol?) async
     @MainActor func update(_ viewState: RoomScreenViewState) -> RoomScreenViewState
 }
 
 struct DefaultRoomScreenHook: RoomScreenHookProtocol {
-    func configure(with userSession: UserSessionProtocol?) async { }
     func update(_ viewState: RoomScreenViewState) -> RoomScreenViewState {
         viewState
     }

--- a/ElementX/Sources/AppHooks/Hooks/UserProfileScreenHook.swift
+++ b/ElementX/Sources/AppHooks/Hooks/UserProfileScreenHook.swift
@@ -1,0 +1,20 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Foundation
+
+nonisolated protocol UserProfileScreenHookProtocol: Sendable {
+    @MainActor func configure(with userSession: UserSessionProtocol?) async
+    @MainActor func update(_ viewState: UserProfileScreenViewState) -> UserProfileScreenViewState
+}
+
+struct DefaultUserProfileScreenHook: UserProfileScreenHookProtocol {
+    func configure(with userSession: UserSessionProtocol?) async { }
+    func update(_ viewState: UserProfileScreenViewState) -> UserProfileScreenViewState {
+        viewState
+    }
+}

--- a/ElementX/Sources/AppHooks/Hooks/UserProfileScreenHook.swift
+++ b/ElementX/Sources/AppHooks/Hooks/UserProfileScreenHook.swift
@@ -8,12 +8,10 @@
 import Foundation
 
 nonisolated protocol UserProfileScreenHookProtocol: Sendable {
-    @MainActor func configure(with userSession: UserSessionProtocol?) async
     @MainActor func update(_ viewState: UserProfileScreenViewState) -> UserProfileScreenViewState
 }
 
 struct DefaultUserProfileScreenHook: UserProfileScreenHookProtocol {
-    func configure(with userSession: UserSessionProtocol?) async { }
     func update(_ viewState: UserProfileScreenViewState) -> UserProfileScreenViewState {
         viewState
     }

--- a/ElementX/Sources/AppHooks/Hooks/UserSessionHook.swift
+++ b/ElementX/Sources/AppHooks/Hooks/UserSessionHook.swift
@@ -1,0 +1,16 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import MatrixRustSDK
+
+nonisolated protocol UserSessionHookProtocol: Sendable {
+    func configure(with userSession: UserSessionProtocol?) async
+}
+
+nonisolated struct DefaultUserSessionHook: UserSessionHookProtocol {
+    func configure(with userSession: UserSessionProtocol?) async { }
+}

--- a/ElementX/Sources/FlowCoordinators/ChatsTabFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/ChatsTabFlowCoordinator.swift
@@ -750,8 +750,9 @@ class ChatsTabFlowCoordinator: FlowCoordinatorProtocol {
         let parameters = UserProfileScreenCoordinatorParameters(userID: userID,
                                                                 isPresentedModally: true,
                                                                 userSession: userSession,
-                                                                userIndicatorController: flowParameters.userIndicatorController,
-                                                                analytics: flowParameters.analytics)
+                                                                appHooks: flowParameters.appHooks,
+                                                                analytics: flowParameters.analytics,
+                                                                userIndicatorController: flowParameters.userIndicatorController)
         let coordinator = UserProfileScreenCoordinator(parameters: parameters)
         coordinator.actionsPublisher.sink { [weak self] action in
             guard let self else { return }

--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -940,6 +940,7 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
     private func presentRoomDetails(isRoot: Bool, animated: Bool) async {
         let params = RoomDetailsScreenCoordinatorParameters(roomProxy: roomProxy,
                                                             userSession: userSession,
+                                                            appHooks: flowParameters.appHooks,
                                                             analyticsService: flowParameters.analytics,
                                                             userIndicatorController: flowParameters.userIndicatorController,
                                                             notificationSettings: userSession.clientProxy.notificationSettings,

--- a/ElementX/Sources/FlowCoordinators/RoomMembersFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomMembersFlowCoordinator.swift
@@ -231,8 +231,9 @@ final class RoomMembersFlowCoordinator: FlowCoordinatorProtocol {
         let params = RoomMemberDetailsScreenCoordinatorParameters(userID: userID,
                                                                   roomProxy: roomProxy,
                                                                   userSession: flowParameters.userSession,
-                                                                  userIndicatorController: flowParameters.userIndicatorController,
-                                                                  analytics: flowParameters.analytics)
+                                                                  appHooks: flowParameters.appHooks,
+                                                                  analytics: flowParameters.analytics,
+                                                                  userIndicatorController: flowParameters.userIndicatorController)
         let coordinator = RoomMemberDetailsScreenCoordinator(parameters: params)
         
         coordinator.actions.sink { [weak self] action in
@@ -287,8 +288,9 @@ final class RoomMembersFlowCoordinator: FlowCoordinatorProtocol {
         let parameters = UserProfileScreenCoordinatorParameters(userID: userID,
                                                                 isPresentedModally: false,
                                                                 userSession: flowParameters.userSession,
-                                                                userIndicatorController: flowParameters.userIndicatorController,
-                                                                analytics: flowParameters.analytics)
+                                                                appHooks: flowParameters.appHooks,
+                                                                analytics: flowParameters.analytics,
+                                                                userIndicatorController: flowParameters.userIndicatorController)
         let coordinator = UserProfileScreenCoordinator(parameters: parameters)
         coordinator.actionsPublisher.sink { [weak self] action in
             guard let self else { return }

--- a/ElementX/Sources/FlowCoordinators/SpaceSettingsFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/SpaceSettingsFlowCoordinator.swift
@@ -211,6 +211,7 @@ final class SpaceSettingsFlowCoordinator: FlowCoordinatorProtocol {
     private func presentSpaceSettings(animated: Bool) {
         let coordinator = RoomDetailsScreenCoordinator(parameters: .init(roomProxy: roomProxy,
                                                                          userSession: flowParameters.userSession,
+                                                                         appHooks: flowParameters.appHooks,
                                                                          analyticsService: flowParameters.analytics,
                                                                          userIndicatorController: flowParameters.userIndicatorController,
                                                                          notificationSettings: flowParameters.userSession.clientProxy.notificationSettings,

--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenCoordinator.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct RoomDetailsScreenCoordinatorParameters {
     let roomProxy: JoinedRoomProxyProtocol
     let userSession: UserSessionProtocol
+    let appHooks: AppHooks
     let analyticsService: AnalyticsServiceProtocol
     let userIndicatorController: UserIndicatorControllerProtocol
     let notificationSettings: NotificationSettingsProxyProtocol
@@ -52,6 +53,7 @@ final class RoomDetailsScreenCoordinator: CoordinatorProtocol {
         isSpace = parameters.roomProxy.infoPublisher.value.isSpace
         viewModel = RoomDetailsScreenViewModel(roomProxy: parameters.roomProxy,
                                                userSession: parameters.userSession,
+                                               appHooks: parameters.appHooks,
                                                analyticsService: parameters.analyticsService,
                                                userIndicatorController: parameters.userIndicatorController,
                                                notificationSettingsProxy: parameters.notificationSettings,

--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenModels.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenModels.swift
@@ -62,6 +62,7 @@ struct RoomDetailsScreenViewState: BindableState {
     var canKickUsers = false
     var canBanUsers = false
     var notificationSettingsState: RoomDetailsNotificationSettingsState = .loading
+    var isCallingEnabled = true
     var canJoinCall = false
     var pinnedEventsActionState = RoomDetailsScreenPinnedEventsActionState.loading
     
@@ -93,7 +94,7 @@ struct RoomDetailsScreenViewState: BindableState {
     
     var shortcuts: [RoomDetailsScreenViewShortcut] {
         var shortcuts: [RoomDetailsScreenViewShortcut] = [.mute]
-        if !ProcessInfo.processInfo.isiOSAppOnMac, canJoinCall {
+        if !ProcessInfo.processInfo.isiOSAppOnMac, isCallingEnabled, canJoinCall {
             if isDirect {
                 shortcuts.append(.voiceCall)
             }

--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
@@ -45,6 +45,7 @@ class RoomDetailsScreenViewModel: RoomDetailsScreenViewModelType, RoomDetailsScr
     
     init(roomProxy: JoinedRoomProxyProtocol,
          userSession: UserSessionProtocol,
+         appHooks: AppHooks,
          analyticsService: AnalyticsServiceProtocol,
          userIndicatorController: UserIndicatorControllerProtocol,
          notificationSettingsProxy: NotificationSettingsProxyProtocol,
@@ -58,14 +59,15 @@ class RoomDetailsScreenViewModel: RoomDetailsScreenViewModelType, RoomDetailsScr
         
         let topic = attributedStringBuilder.fromPlain(roomProxy.infoPublisher.value.topic)
         
-        super.init(initialViewState: .init(details: roomProxy.details,
-                                           isEncrypted: roomProxy.infoPublisher.value.isEncrypted,
-                                           isDirect: roomProxy.infoPublisher.value.isDirect,
-                                           topic: topic,
-                                           topicSummary: topic?.unattributedStringByReplacingNewlinesWithSpaces(),
-                                           joinedMembersCount: roomProxy.infoPublisher.value.joinedMembersCount,
-                                           notificationSettingsState: .loading,
-                                           bindings: .init()),
+        let viewState = RoomDetailsScreenViewState(details: roomProxy.details,
+                                                   isEncrypted: roomProxy.infoPublisher.value.isEncrypted,
+                                                   isDirect: roomProxy.infoPublisher.value.isDirect,
+                                                   topic: topic,
+                                                   topicSummary: topic?.unattributedStringByReplacingNewlinesWithSpaces(),
+                                                   joinedMembersCount: roomProxy.infoPublisher.value.joinedMembersCount,
+                                                   notificationSettingsState: .loading,
+                                                   bindings: .init())
+        super.init(initialViewState: appHooks.roomDetailsScreenHook.update(viewState),
                    mediaProvider: userSession.mediaProvider)
         
         Task {

--- a/ElementX/Sources/Screens/RoomDetailsScreen/View/RoomDetailsScreen.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/View/RoomDetailsScreen.swift
@@ -441,6 +441,7 @@ struct RoomDetailsScreen_Previews: PreviewProvider, TestablePreview {
         
         return .init(roomProxy: roomProxy,
                      userSession: UserSessionMock(.init()),
+                     appHooks: AppHooks(),
                      analyticsService: AnalyticsServiceMock(.init()),
                      userIndicatorController: UserIndicatorControllerMock(),
                      notificationSettingsProxy: notificationSettingsProxy,
@@ -468,6 +469,7 @@ struct RoomDetailsScreen_Previews: PreviewProvider, TestablePreview {
         
         return .init(roomProxy: roomProxy,
                      userSession: UserSessionMock(.init()),
+                     appHooks: AppHooks(),
                      analyticsService: AnalyticsServiceMock(.init()),
                      userIndicatorController: UserIndicatorControllerMock(),
                      notificationSettingsProxy: notificationSettingsProxy,
@@ -505,6 +507,7 @@ struct RoomDetailsScreen_Previews: PreviewProvider, TestablePreview {
         
         return .init(roomProxy: roomProxy,
                      userSession: UserSessionMock(.init(clientProxy: clientProxyMock)),
+                     appHooks: AppHooks(),
                      analyticsService: AnalyticsServiceMock(.init()),
                      userIndicatorController: UserIndicatorControllerMock(),
                      notificationSettingsProxy: notificationSettingsProxy,

--- a/ElementX/Sources/Screens/RoomMemberDetailsScreen/RoomMemberDetailsScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/RoomMemberDetailsScreen/RoomMemberDetailsScreenCoordinator.swift
@@ -13,8 +13,9 @@ struct RoomMemberDetailsScreenCoordinatorParameters {
     let userID: String
     let roomProxy: JoinedRoomProxyProtocol
     let userSession: UserSessionProtocol
-    let userIndicatorController: UserIndicatorControllerProtocol
+    let appHooks: AppHooks
     let analytics: AnalyticsServiceProtocol
+    let userIndicatorController: UserIndicatorControllerProtocol
 }
 
 enum RoomMemberDetailsScreenCoordinatorAction {
@@ -38,8 +39,9 @@ final class RoomMemberDetailsScreenCoordinator: CoordinatorProtocol {
         viewModel = RoomMemberDetailsScreenViewModel(userID: parameters.userID,
                                                      roomProxy: parameters.roomProxy,
                                                      userSession: parameters.userSession,
-                                                     userIndicatorController: parameters.userIndicatorController,
-                                                     analytics: parameters.analytics)
+                                                     appHooks: parameters.appHooks,
+                                                     analytics: parameters.analytics,
+                                                     userIndicatorController: parameters.userIndicatorController)
     }
     
     func start() {

--- a/ElementX/Sources/Screens/RoomMemberDetailsScreen/RoomMemberDetailsScreenModels.swift
+++ b/ElementX/Sources/Screens/RoomMemberDetailsScreen/RoomMemberDetailsScreenModels.swift
@@ -22,6 +22,7 @@ struct RoomMemberDetailsScreenViewState: BindableState {
     var isOwnMemberDetails = false
     var isProcessingIgnoreRequest = false
     var dmRoomID: String?
+    var isCallingEnabled = true
     
     var bindings: RoomMemberDetailsScreenViewStateBindings
     

--- a/ElementX/Sources/Screens/RoomMemberDetailsScreen/RoomMemberDetailsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomMemberDetailsScreen/RoomMemberDetailsScreenViewModel.swift
@@ -14,8 +14,8 @@ typealias RoomMemberDetailsScreenViewModelType = StateStoreViewModel<RoomMemberD
 class RoomMemberDetailsScreenViewModel: RoomMemberDetailsScreenViewModelType, RoomMemberDetailsScreenViewModelProtocol {
     private let roomProxy: JoinedRoomProxyProtocol
     private let userSession: UserSessionProtocol
-    private let userIndicatorController: UserIndicatorControllerProtocol
     private let analytics: AnalyticsServiceProtocol
+    private let userIndicatorController: UserIndicatorControllerProtocol
     
     private var actionsSubject: PassthroughSubject<RoomMemberDetailsScreenViewModelAction, Never> = .init()
     
@@ -28,8 +28,9 @@ class RoomMemberDetailsScreenViewModel: RoomMemberDetailsScreenViewModelType, Ro
     init(userID: String,
          roomProxy: JoinedRoomProxyProtocol,
          userSession: UserSessionProtocol,
-         userIndicatorController: UserIndicatorControllerProtocol,
-         analytics: AnalyticsServiceProtocol) {
+         appHooks: AppHooks,
+         analytics: AnalyticsServiceProtocol,
+         userIndicatorController: UserIndicatorControllerProtocol) {
         self.roomProxy = roomProxy
         self.userSession = userSession
         self.userIndicatorController = userIndicatorController
@@ -37,7 +38,8 @@ class RoomMemberDetailsScreenViewModel: RoomMemberDetailsScreenViewModelType, Ro
         
         let initialViewState = RoomMemberDetailsScreenViewState(userID: userID, bindings: .init())
         
-        super.init(initialViewState: initialViewState, mediaProvider: userSession.mediaProvider)
+        super.init(initialViewState: appHooks.roomMemberDetailsScreenHook.update(initialViewState),
+                   mediaProvider: userSession.mediaProvider)
         
         showMemberLoadingIndicator()
         

--- a/ElementX/Sources/Screens/RoomMemberDetailsScreen/View/RoomMemberDetailsScreen.swift
+++ b/ElementX/Sources/Screens/RoomMemberDetailsScreen/View/RoomMemberDetailsScreen.swift
@@ -101,7 +101,7 @@ struct RoomMemberDetailsScreen: View {
                 .accessibilityIdentifier(A11yIdentifiers.roomMemberDetailsScreen.directChat)
             }
             
-            if let roomID = context.viewState.dmRoomID {
+            if let roomID = context.viewState.dmRoomID, context.viewState.isCallingEnabled {
                 Button {
                     context.send(viewAction: .startCall(roomID: roomID, isVoiceCall: true))
                 } label: {
@@ -239,7 +239,8 @@ struct RoomMemberDetailsScreen_Previews: PreviewProvider, TestablePreview {
         return RoomMemberDetailsScreenViewModel(userID: member.userID,
                                                 roomProxy: roomProxyMock,
                                                 userSession: UserSessionMock(.init(clientProxy: clientProxyMock)),
-                                                userIndicatorController: UserIndicatorControllerMock(),
-                                                analytics: AnalyticsServiceMock(.init()))
+                                                appHooks: AppHooks(),
+                                                analytics: AnalyticsServiceMock(.init()),
+                                                userIndicatorController: UserIndicatorControllerMock())
     }
 }

--- a/ElementX/Sources/Screens/Spaces/SpaceSettingsScreen/View/SpaceSettingsScreen.swift
+++ b/ElementX/Sources/Screens/Spaces/SpaceSettingsScreen/View/SpaceSettingsScreen.swift
@@ -132,6 +132,7 @@ struct SpaceSettingsScreen_Previews: PreviewProvider, TestablePreview {
                                                                         canonicalAlias: "#space:matrix.org",
                                                                         members: members)),
                                    userSession: UserSessionMock(.init()),
+                                   appHooks: AppHooks(),
                                    analyticsService: AnalyticsServiceMock(.init()),
                                    userIndicatorController: UserIndicatorControllerMock(),
                                    notificationSettingsProxy: NotificationSettingsProxyMock(with: NotificationSettingsProxyMockConfiguration()),

--- a/ElementX/Sources/Screens/UserProfileScreen/UserProfileScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/UserProfileScreen/UserProfileScreenCoordinator.swift
@@ -13,8 +13,9 @@ struct UserProfileScreenCoordinatorParameters {
     let userID: String
     let isPresentedModally: Bool
     let userSession: UserSessionProtocol
-    let userIndicatorController: UserIndicatorControllerProtocol
+    let appHooks: AppHooks
     let analytics: AnalyticsServiceProtocol
+    let userIndicatorController: UserIndicatorControllerProtocol
 }
 
 enum UserProfileScreenCoordinatorAction {
@@ -37,8 +38,9 @@ final class UserProfileScreenCoordinator: CoordinatorProtocol {
         viewModel = UserProfileScreenViewModel(userID: parameters.userID,
                                                isPresentedModally: parameters.isPresentedModally,
                                                userSession: parameters.userSession,
-                                               userIndicatorController: parameters.userIndicatorController,
-                                               analytics: parameters.analytics)
+                                               appHooks: parameters.appHooks,
+                                               analytics: parameters.analytics,
+                                               userIndicatorController: parameters.userIndicatorController)
     }
     
     func start() {

--- a/ElementX/Sources/Screens/UserProfileScreen/UserProfileScreenModels.swift
+++ b/ElementX/Sources/Screens/UserProfileScreen/UserProfileScreenModels.swift
@@ -24,6 +24,7 @@ struct UserProfileScreenViewState: BindableState {
     var isVerified: Bool?
     var permalink: URL?
     var dmRoomID: String?
+    var isCallingEnabled = true
     
     var bindings: UserProfileScreenViewStateBindings
     

--- a/ElementX/Sources/Screens/UserProfileScreen/UserProfileScreenViewModel.swift
+++ b/ElementX/Sources/Screens/UserProfileScreen/UserProfileScreenViewModel.swift
@@ -14,8 +14,8 @@ typealias UserProfileScreenViewModelType = StateStoreViewModelV2<UserProfileScre
 
 class UserProfileScreenViewModel: UserProfileScreenViewModelType, UserProfileScreenViewModelProtocol {
     private let userSession: UserSessionProtocol
-    private let userIndicatorController: UserIndicatorControllerProtocol
     private let analytics: AnalyticsServiceProtocol
+    private let userIndicatorController: UserIndicatorControllerProtocol
     
     private var actionsSubject: PassthroughSubject<UserProfileScreenViewModelAction, Never> = .init()
     var actionsPublisher: AnyPublisher<UserProfileScreenViewModelAction, Never> {
@@ -25,18 +25,20 @@ class UserProfileScreenViewModel: UserProfileScreenViewModelType, UserProfileScr
     init(userID: String,
          isPresentedModally: Bool,
          userSession: UserSessionProtocol,
-         userIndicatorController: UserIndicatorControllerProtocol,
-         analytics: AnalyticsServiceProtocol) {
+         appHooks: AppHooks,
+         analytics: AnalyticsServiceProtocol,
+         userIndicatorController: UserIndicatorControllerProtocol) {
         self.userSession = userSession
-        self.userIndicatorController = userIndicatorController
         self.analytics = analytics
+        self.userIndicatorController = userIndicatorController
         
         let initialViewState = UserProfileScreenViewState(userID: userID,
                                                           isOwnUser: userID == userSession.clientProxy.userID,
                                                           isPresentedModally: isPresentedModally,
                                                           bindings: .init())
         
-        super.init(initialViewState: initialViewState, mediaProvider: userSession.mediaProvider)
+        super.init(initialViewState: appHooks.userProfileScreenHook.update(initialViewState),
+                   mediaProvider: userSession.mediaProvider)
         
         showLoadingIndicator(allowsInteraction: true)
         Task {

--- a/ElementX/Sources/Screens/UserProfileScreen/View/UserProfileScreen.swift
+++ b/ElementX/Sources/Screens/UserProfileScreen/View/UserProfileScreen.swift
@@ -65,7 +65,7 @@ struct UserProfileScreen: View {
                 .accessibilityIdentifier(A11yIdentifiers.roomMemberDetailsScreen.directChat)
             }
             
-            if let roomID = context.viewState.dmRoomID {
+            if let roomID = context.viewState.dmRoomID, context.viewState.isCallingEnabled {
                 Button {
                     context.send(viewAction: .startCall(roomID: roomID, isVoiceCall: true))
                 } label: {
@@ -147,7 +147,8 @@ struct UserProfileScreen_Previews: PreviewProvider, TestablePreview {
         return UserProfileScreenViewModel(userID: userID,
                                           isPresentedModally: false,
                                           userSession: UserSessionMock(.init(clientProxy: clientProxyMock)),
-                                          userIndicatorController: UserIndicatorControllerMock(),
-                                          analytics: AnalyticsServiceMock(.init()))
+                                          appHooks: AppHooks(),
+                                          analytics: AnalyticsServiceMock(.init()),
+                                          userIndicatorController: UserIndicatorControllerMock())
     }
 }

--- a/UnitTests/Sources/RoomDetailsScreenViewModelTests.swift
+++ b/UnitTests/Sources/RoomDetailsScreenViewModelTests.swift
@@ -30,6 +30,7 @@ struct RoomDetailsScreenViewModelTests {
         notificationSettingsProxyMock = NotificationSettingsProxyMock(with: NotificationSettingsProxyMockConfiguration())
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                userSession: UserSessionMock(.init()),
+                                               appHooks: AppHooks(),
                                                analyticsService: AnalyticsServiceMock(.init()),
                                                userIndicatorController: UserIndicatorControllerMock(),
                                                notificationSettingsProxy: notificationSettingsProxyMock,
@@ -42,6 +43,7 @@ struct RoomDetailsScreenViewModelTests {
         roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", members: mockedMembers, joinRule: .public))
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                userSession: UserSessionMock(.init()),
+                                               appHooks: AppHooks(),
                                                analyticsService: AnalyticsServiceMock(.init()),
                                                userIndicatorController: UserIndicatorControllerMock(),
                                                notificationSettingsProxy: NotificationSettingsProxyMock(with: NotificationSettingsProxyMockConfiguration()),
@@ -61,6 +63,7 @@ struct RoomDetailsScreenViewModelTests {
         roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", members: mockedMembers))
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                userSession: UserSessionMock(.init()),
+                                               appHooks: AppHooks(),
                                                analyticsService: AnalyticsServiceMock(.init()),
                                                userIndicatorController: UserIndicatorControllerMock(),
                                                notificationSettingsProxy: NotificationSettingsProxyMock(with: NotificationSettingsProxyMockConfiguration()),
@@ -81,6 +84,7 @@ struct RoomDetailsScreenViewModelTests {
         roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", members: mockedMembers))
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                userSession: UserSessionMock(.init()),
+                                               appHooks: AppHooks(),
                                                analyticsService: AnalyticsServiceMock(.init()),
                                                userIndicatorController: UserIndicatorControllerMock(),
                                                notificationSettingsProxy: NotificationSettingsProxyMock(with: NotificationSettingsProxyMockConfiguration()),
@@ -138,6 +142,7 @@ struct RoomDetailsScreenViewModelTests {
         roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", isDirect: true, isEncrypted: true, members: mockedMembers))
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                userSession: UserSessionMock(.init()),
+                                               appHooks: AppHooks(),
                                                analyticsService: AnalyticsServiceMock(.init()),
                                                userIndicatorController: UserIndicatorControllerMock(),
                                                notificationSettingsProxy: NotificationSettingsProxyMock(with: NotificationSettingsProxyMockConfiguration()),
@@ -158,6 +163,7 @@ struct RoomDetailsScreenViewModelTests {
         roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", isDirect: true, isEncrypted: true, members: mockedMembers))
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                userSession: UserSessionMock(.init()),
+                                               appHooks: AppHooks(),
                                                analyticsService: AnalyticsServiceMock(.init()),
                                                userIndicatorController: UserIndicatorControllerMock(),
                                                notificationSettingsProxy: NotificationSettingsProxyMock(with: NotificationSettingsProxyMockConfiguration()),
@@ -189,6 +195,7 @@ struct RoomDetailsScreenViewModelTests {
         roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", isDirect: true, isEncrypted: true, members: mockedMembers))
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                userSession: UserSessionMock(.init(clientProxy: clientProxy)),
+                                               appHooks: AppHooks(),
                                                analyticsService: AnalyticsServiceMock(.init()),
                                                userIndicatorController: UserIndicatorControllerMock(),
                                                notificationSettingsProxy: NotificationSettingsProxyMock(with: NotificationSettingsProxyMockConfiguration()),
@@ -219,6 +226,7 @@ struct RoomDetailsScreenViewModelTests {
         roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", isDirect: true, isEncrypted: true, members: mockedMembers))
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                userSession: UserSessionMock(.init()),
+                                               appHooks: AppHooks(),
                                                analyticsService: AnalyticsServiceMock(.init()),
                                                userIndicatorController: UserIndicatorControllerMock(),
                                                notificationSettingsProxy: NotificationSettingsProxyMock(with: NotificationSettingsProxyMockConfiguration()),
@@ -250,6 +258,7 @@ struct RoomDetailsScreenViewModelTests {
         roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", isDirect: true, isEncrypted: true, members: mockedMembers))
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                userSession: UserSessionMock(.init(clientProxy: clientProxy)),
+                                               appHooks: AppHooks(),
                                                analyticsService: AnalyticsServiceMock(.init()),
                                                userIndicatorController: UserIndicatorControllerMock(),
                                                notificationSettingsProxy: NotificationSettingsProxyMock(with: NotificationSettingsProxyMockConfiguration()),
@@ -282,6 +291,7 @@ struct RoomDetailsScreenViewModelTests {
                                                   powerLevelsConfiguration: .init(canUserInvite: false)))
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                userSession: UserSessionMock(.init()),
+                                               appHooks: AppHooks(),
                                                analyticsService: AnalyticsServiceMock(.init()),
                                                userIndicatorController: UserIndicatorControllerMock(),
                                                notificationSettingsProxy: NotificationSettingsProxyMock(with: NotificationSettingsProxyMockConfiguration()),
@@ -298,6 +308,7 @@ struct RoomDetailsScreenViewModelTests {
         roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", members: mockedMembers, joinRule: .public))
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                userSession: UserSessionMock(.init()),
+                                               appHooks: AppHooks(),
                                                analyticsService: AnalyticsServiceMock(.init()),
                                                userIndicatorController: UserIndicatorControllerMock(),
                                                notificationSettingsProxy: NotificationSettingsProxyMock(with: NotificationSettingsProxyMockConfiguration()),
@@ -345,6 +356,7 @@ struct RoomDetailsScreenViewModelTests {
         
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                userSession: UserSessionMock(.init()),
+                                               appHooks: AppHooks(),
                                                analyticsService: AnalyticsServiceMock(.init()),
                                                userIndicatorController: UserIndicatorControllerMock(),
                                                notificationSettingsProxy: NotificationSettingsProxyMock(with: NotificationSettingsProxyMockConfiguration()),
@@ -379,6 +391,7 @@ struct RoomDetailsScreenViewModelTests {
         
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                userSession: UserSessionMock(.init()),
+                                               appHooks: AppHooks(),
                                                analyticsService: AnalyticsServiceMock(.init()),
                                                userIndicatorController: UserIndicatorControllerMock(),
                                                notificationSettingsProxy: NotificationSettingsProxyMock(with: NotificationSettingsProxyMockConfiguration()),
@@ -413,6 +426,7 @@ struct RoomDetailsScreenViewModelTests {
         
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                userSession: UserSessionMock(.init()),
+                                               appHooks: AppHooks(),
                                                analyticsService: AnalyticsServiceMock(.init()),
                                                userIndicatorController: UserIndicatorControllerMock(),
                                                notificationSettingsProxy: NotificationSettingsProxyMock(with: NotificationSettingsProxyMockConfiguration()),
@@ -432,6 +446,7 @@ struct RoomDetailsScreenViewModelTests {
         roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", isDirect: false, members: mockedMembers))
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                userSession: UserSessionMock(.init()),
+                                               appHooks: AppHooks(),
                                                analyticsService: AnalyticsServiceMock(.init()),
                                                userIndicatorController: UserIndicatorControllerMock(),
                                                notificationSettingsProxy: NotificationSettingsProxyMock(with: NotificationSettingsProxyMockConfiguration()),
@@ -451,6 +466,7 @@ struct RoomDetailsScreenViewModelTests {
         roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", isDirect: true, members: mockedMembers))
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                userSession: UserSessionMock(.init()),
+                                               appHooks: AppHooks(),
                                                analyticsService: AnalyticsServiceMock(.init()),
                                                userIndicatorController: UserIndicatorControllerMock(),
                                                notificationSettingsProxy: NotificationSettingsProxyMock(with: NotificationSettingsProxyMockConfiguration()),
@@ -468,6 +484,7 @@ struct RoomDetailsScreenViewModelTests {
         notificationSettingsProxyMock.getNotificationSettingsRoomIdIsEncryptedIsOneToOneThrowableError = NotificationSettingsError.Generic(msg: "error")
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                userSession: UserSessionMock(.init()),
+                                               appHooks: AppHooks(),
                                                analyticsService: AnalyticsServiceMock(.init()),
                                                userIndicatorController: UserIndicatorControllerMock(),
                                                notificationSettingsProxy: notificationSettingsProxyMock,
@@ -675,6 +692,7 @@ struct RoomDetailsScreenViewModelTests {
         roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", isDirect: false, knockRequestsState: .loaded(mockedRequests), joinRule: .knock))
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                userSession: UserSessionMock(.init()),
+                                               appHooks: AppHooks(),
                                                analyticsService: AnalyticsServiceMock(.init()),
                                                userIndicatorController: UserIndicatorControllerMock(),
                                                notificationSettingsProxy: notificationSettingsProxyMock,
@@ -695,6 +713,7 @@ struct RoomDetailsScreenViewModelTests {
         roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", isDirect: false, knockRequestsState: .loading, joinRule: .knock))
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                userSession: UserSessionMock(.init()),
+                                               appHooks: AppHooks(),
                                                analyticsService: AnalyticsServiceMock(.init()),
                                                userIndicatorController: UserIndicatorControllerMock(),
                                                notificationSettingsProxy: notificationSettingsProxyMock,
@@ -717,6 +736,7 @@ struct RoomDetailsScreenViewModelTests {
                                                   powerLevelsConfiguration: .init(canUserInvite: false)))
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                userSession: UserSessionMock(.init()),
+                                               appHooks: AppHooks(),
                                                analyticsService: AnalyticsServiceMock(.init()),
                                                userIndicatorController: UserIndicatorControllerMock(),
                                                notificationSettingsProxy: notificationSettingsProxyMock,
@@ -739,6 +759,7 @@ struct RoomDetailsScreenViewModelTests {
         roomProxyMock = JoinedRoomProxyMock(.init(name: "Test", isDirect: true, members: mockedMembers, knockRequestsState: .loaded(mockedRequests), joinRule: .knock))
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                userSession: UserSessionMock(.init()),
+                                               appHooks: AppHooks(),
                                                analyticsService: AnalyticsServiceMock(.init()),
                                                userIndicatorController: UserIndicatorControllerMock(),
                                                notificationSettingsProxy: notificationSettingsProxyMock,
@@ -765,6 +786,7 @@ struct RoomDetailsScreenViewModelTests {
         
         viewModel = RoomDetailsScreenViewModel(roomProxy: roomProxyMock,
                                                userSession: UserSessionMock(.init()),
+                                               appHooks: AppHooks(),
                                                analyticsService: AnalyticsServiceMock(.init()),
                                                userIndicatorController: UserIndicatorControllerMock(),
                                                notificationSettingsProxy: notificationSettingsProxyMock,

--- a/UnitTests/Sources/RoomMemberDetailsViewModelTests.swift
+++ b/UnitTests/Sources/RoomMemberDetailsViewModelTests.swift
@@ -210,7 +210,8 @@ struct RoomMemberDetailsViewModelTests {
         viewModel = RoomMemberDetailsScreenViewModel(userID: roomMemberProxyMock.userID,
                                                      roomProxy: roomProxyMock,
                                                      userSession: userSession,
-                                                     userIndicatorController: UserIndicatorControllerMock(),
-                                                     analytics: AnalyticsServiceMock(.init()))
+                                                     appHooks: AppHooks(),
+                                                     analytics: AnalyticsServiceMock(.init()),
+                                                     userIndicatorController: UserIndicatorControllerMock())
     }
 }

--- a/UnitTests/Sources/UserProfileScreenViewModelTests.swift
+++ b/UnitTests/Sources/UserProfileScreenViewModelTests.swift
@@ -22,8 +22,9 @@ struct UserProfileScreenViewModelTests {
         let viewModel = UserProfileScreenViewModel(userID: profile.id,
                                                    isPresentedModally: false,
                                                    userSession: UserSessionMock(.init(clientProxy: clientProxy)),
-                                                   userIndicatorController: userIndicatorController,
-                                                   analytics: AnalyticsServiceMock(.init()))
+                                                   appHooks: AppHooks(),
+                                                   analytics: AnalyticsServiceMock(.init()),
+                                                   userIndicatorController: userIndicatorController)
         let context = viewModel.context
         
         let waitForMemberToLoad = deferFulfillment(context.observe(\.viewState.userProfile)) { $0 != nil }
@@ -45,8 +46,9 @@ struct UserProfileScreenViewModelTests {
         let viewModel = UserProfileScreenViewModel(userID: profile.id,
                                                    isPresentedModally: false,
                                                    userSession: UserSessionMock(.init(clientProxy: clientProxy)),
-                                                   userIndicatorController: userIndicatorController,
-                                                   analytics: AnalyticsServiceMock(.init()))
+                                                   appHooks: AppHooks(),
+                                                   analytics: AnalyticsServiceMock(.init()),
+                                                   userIndicatorController: userIndicatorController)
         let context = viewModel.context
         
         let waitForMemberToLoad = deferFulfillment(context.observe(\.viewState.userProfile)) { $0 != nil }
@@ -70,8 +72,9 @@ struct UserProfileScreenViewModelTests {
         let viewModel = UserProfileScreenViewModel(userID: profile.id,
                                                    isPresentedModally: false,
                                                    userSession: UserSessionMock(.init(clientProxy: clientProxy)),
-                                                   userIndicatorController: userIndicatorController,
-                                                   analytics: AnalyticsServiceMock(.init()))
+                                                   appHooks: AppHooks(),
+                                                   analytics: AnalyticsServiceMock(.init()),
+                                                   userIndicatorController: userIndicatorController)
         
         let context = viewModel.context
         


### PR DESCRIPTION
Also tidies up the `AppHooks` file with a new `@AppHook` macro to remove the repetitive boilerplate. The history should make sense to review commit-by-commit if wanted (but not really necessary).