### PR TITLE
Improve the room member part of the UI test user session flows

### DIFF
--- a/ElementX/Sources/Other/AccessibilityIdentifiers.swift
+++ b/ElementX/Sources/Other/AccessibilityIdentifiers.swift
@@ -325,6 +325,11 @@ enum A11yIdentifiers {
     
     struct RoomMembersListScreen {
         let invite = "room_members_list_screen-invite"
+        
+        let roomMemberPrefix = "room_members_list_screen-member"
+        func member(_ userID: String) -> String {
+            "\(roomMemberPrefix):\(userID)"
+        }
     }
     
     struct ManageRoomMemberSheet {

--- a/ElementX/Sources/Screens/RoomMemberListScreen/View/RoomMembersListScreenMemberCell.swift
+++ b/ElementX/Sources/Screens/RoomMemberListScreen/View/RoomMembersListScreenMemberCell.swift
@@ -74,6 +74,7 @@ struct RoomMembersListScreenMemberCell: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .accessibilityElement(children: .combine)
         }
+        .accessibilityIdentifier(A11yIdentifiers.roomMembersListScreen.member(listEntry.member.id))
     }
     
     var role: String? {

--- a/UITests/Sources/UserSessionScreenTests.swift
+++ b/UITests/Sources/UserSessionScreenTests.swift
@@ -126,10 +126,10 @@ class UserSessionScreenTests: XCTestCase {
         // Open the room members list.
         app.buttons[A11yIdentifiers.roomDetailsScreen.people].tap()
         
-        // Open the first member's details. Loading members for big rooms can take a while.
-        let firstRoomMember = app.scrollViews.buttons.firstMatch
-        XCTAssertTrue(firstRoomMember.waitForExistence(timeout: 1000.0))
-        firstRoomMember.tap(.center)
+        // Open a member's details.
+        let roomMember = app.buttons[A11yIdentifiers.roomMembersListScreen.member("@alice:matrix.org")]
+        XCTAssertTrue(roomMember.waitForExistence(timeout: 10.0))
+        roomMember.tap(.center)
         
         // Open the profile from the bottom sheet
         let viewProfileButton = app.buttons[A11yIdentifiers.manageRoomMemberSheet.viewProfile]


### PR DESCRIPTION
Assign proper accessibility identifiers to the room members list and use them accordingly in the UI tests