### PR TITLE
Offer Retry and Remove actions with a reason when tapping a failed message

### DIFF
--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "515d7858f8d13128cb330ef4e14c9bb41516cd04a0280a625a852155c53a610e",
+  "originHash" : "fbe2663429af94e60cfa70345bffe72998cbc19f6f659bd6f3c1a0ddc50b941d",
   "pins" : [
     {
       "identity" : "compound-design-tokens",
@@ -194,8 +194,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/PostHog/posthog-ios",
       "state" : {
-        "revision" : "9b12d093e774883c40ee456e34b74b45cee03d46",
-        "version" : "3.69.5"
+        "revision" : "c0218386c49115cce6b05a50b41f4f60bc995acb",
+        "version" : "3.69.6"
       }
     },
     {

--- a/ElementX/Sources/Other/AccessibilityIdentifiers.swift
+++ b/ElementX/Sources/Other/AccessibilityIdentifiers.swift
@@ -165,6 +165,7 @@ enum A11yIdentifiers {
         
         let messageComposer = "room-message_composer"
         let sendButton = "room-send_button"
+        let sendInfo = "room-send_info"
         
         let composerToolbar = ComposerToolbar()
         

--- a/ElementX/Sources/Screens/Timeline/TimelineModels.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineModels.swift
@@ -222,7 +222,7 @@ struct ReadReceiptSummaryInfo: Identifiable {
 enum TimelineAlertInfoType: Hashable {
     case audioRecodingPermissionError
     case pollEndConfirmation(String)
-    case sendingFailed(reason: String?, itemID: TimelineItemIdentifier)
+    case sendingFailed(reason: String?, sendHandle: SendHandleProxy)
     case encryptionAuthenticity(String)
     case encryptionForwarder(String)
     case inviteAgain

--- a/ElementX/Sources/Screens/Timeline/TimelineModels.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineModels.swift
@@ -222,7 +222,7 @@ struct ReadReceiptSummaryInfo: Identifiable {
 enum TimelineAlertInfoType: Hashable {
     case audioRecodingPermissionError
     case pollEndConfirmation(String)
-    case sendingFailed(reason: String?, sendHandle: SendHandleProxy)
+    case sendingFailed(reason: String?, sendHandle: SendHandleProxy?)
     case encryptionAuthenticity(String)
     case encryptionForwarder(String)
     case inviteAgain

--- a/ElementX/Sources/Screens/Timeline/TimelineModels.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineModels.swift
@@ -222,7 +222,7 @@ struct ReadReceiptSummaryInfo: Identifiable {
 enum TimelineAlertInfoType: Hashable {
     case audioRecodingPermissionError
     case pollEndConfirmation(String)
-    case sendingFailed
+    case sendingFailed(reason: String?, itemID: TimelineItemIdentifier)
     case encryptionAuthenticity(String)
     case encryptionForwarder(String)
     case inviteAgain

--- a/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
@@ -761,7 +761,7 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
         Task {
             if case .failure(let error) = await sendHandle.resend() {
                 MXLog.error("Failed retrying to send \(sendHandle.itemID): \(error)")
-                userIndicatorController.submitIndicator(.init(title: L10n.errorUnknown))
+                displayErrorToast(L10n.errorUnknown)
             }
         }
     }

--- a/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
@@ -739,7 +739,12 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
         }
         
         if case let .sendingFailed(.unknown(reason)) = eventTimelineItem.properties.deliveryStatus {
-            displayAlert(.sendingFailed(reason: reason, itemID: itemID))
+            guard let sendHandle = timelineController.sendHandle(for: itemID) else {
+                MXLog.error("Cannot find send handle for \(itemID).")
+                return
+            }
+            
+            displayAlert(.sendingFailed(reason: reason, sendHandle: sendHandle))
         } else if case let .sendingFailed(.verifiedUser(failure)) = eventTimelineItem.properties.deliveryStatus {
             guard let sendHandle = timelineController.sendHandle(for: itemID) else {
                 MXLog.error("Cannot find send handle for \(itemID).")
@@ -755,26 +760,14 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
             displayAlert(.encryptionAuthenticity(authenticityMessage))
         }
     }
-
-    private func retrySending(itemID: TimelineItemIdentifier) {
-        guard let sendHandle = timelineController.sendHandle(for: itemID) else {
-            MXLog.error("Cannot find send handle for \(itemID).")
-            return
-        }
-
+    
+    private func retrySending(_ sendHandle: SendHandleProxy) {
         Task {
             if case .failure(let error) = await sendHandle.resend() {
-                MXLog.error("Failed retrying to send \(itemID): \(error)")
+                MXLog.error("Failed retrying to send \(sendHandle.itemID): \(error)")
+                userIndicatorController.submitIndicator(.init(title: L10n.errorUnknown))
             }
         }
-    }
-
-    private func removeFailedMessage(itemID: TimelineItemIdentifier) {
-        guard case let .event(_, eventOrTransactionID) = itemID else {
-            fatalError("Only events can fail to send.")
-        }
-
-        Task { await timelineController.redact(eventOrTransactionID) }
     }
     
     private func slashCommand(message: String) -> SlashCommand? {
@@ -1124,13 +1117,15 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
                                              message: L10n.commonPollEndConfirmation,
                                              primaryButton: .init(title: L10n.actionCancel, role: .cancel, action: nil),
                                              secondaryButton: .init(title: L10n.actionOk) { self.timelineInteractionHandler.endPoll(pollStartID: pollStartID) })
-        case .sendingFailed(let reason, let itemID):
+        case .sendingFailed(let reason, let sendHandle):
             state.bindings.alertInfo = .init(id: type,
                                              title: L10n.commonSendingFailed,
                                              message: reason,
                                              primaryButton: .init(title: L10n.actionCancel, role: .cancel, action: nil),
-                                             verticalButtons: [.init(title: L10n.actionRetry) { [weak self] in self?.retrySending(itemID: itemID) },
-                                                               .init(title: L10n.actionRemoveMessage, role: .destructive) { [weak self] in self?.removeFailedMessage(itemID: itemID) }])
+                                             verticalButtons: [.init(title: L10n.actionRetry) { [weak self] in self?.retrySending(sendHandle) },
+                                                               .init(title: L10n.actionRemoveMessage, role: .destructive) { [weak self] in
+                                                                   self?.timelineInteractionHandler.handleTimelineItemMenuAction(.redact(isMedia: false), itemID: sendHandle.itemID)
+                                                               }])
         case .encryptionAuthenticity(let message):
             state.bindings.alertInfo = .init(id: type,
                                              title: message,

--- a/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
@@ -738,8 +738,8 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
             fatalError("Only events can have send info.")
         }
         
-        if case .sendingFailed(.unknown) = eventTimelineItem.properties.deliveryStatus {
-            displayAlert(.sendingFailed)
+        if case let .sendingFailed(.unknown(reason)) = eventTimelineItem.properties.deliveryStatus {
+            displayAlert(.sendingFailed(reason: reason, itemID: itemID))
         } else if case let .sendingFailed(.verifiedUser(failure)) = eventTimelineItem.properties.deliveryStatus {
             guard let sendHandle = timelineController.sendHandle(for: itemID) else {
                 MXLog.error("Cannot find send handle for \(itemID).")
@@ -754,6 +754,27 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
         } else if let authenticityMessage = eventTimelineItem.properties.encryptionAuthenticity?.message {
             displayAlert(.encryptionAuthenticity(authenticityMessage))
         }
+    }
+
+    private func retrySending(itemID: TimelineItemIdentifier) {
+        guard let sendHandle = timelineController.sendHandle(for: itemID) else {
+            MXLog.error("Cannot find send handle for \(itemID).")
+            return
+        }
+
+        Task {
+            if case .failure(let error) = await sendHandle.resend() {
+                MXLog.error("Failed retrying to send \(itemID): \(error)")
+            }
+        }
+    }
+
+    private func removeFailedMessage(itemID: TimelineItemIdentifier) {
+        guard case let .event(_, eventOrTransactionID) = itemID else {
+            fatalError("Only events can fail to send.")
+        }
+
+        Task { await timelineController.redact(eventOrTransactionID) }
     }
     
     private func slashCommand(message: String) -> SlashCommand? {
@@ -1103,10 +1124,13 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
                                              message: L10n.commonPollEndConfirmation,
                                              primaryButton: .init(title: L10n.actionCancel, role: .cancel, action: nil),
                                              secondaryButton: .init(title: L10n.actionOk) { self.timelineInteractionHandler.endPoll(pollStartID: pollStartID) })
-        case .sendingFailed:
+        case .sendingFailed(let reason, let itemID):
             state.bindings.alertInfo = .init(id: type,
                                              title: L10n.commonSendingFailed,
-                                             primaryButton: .init(title: L10n.actionOk, action: nil))
+                                             message: reason,
+                                             primaryButton: .init(title: L10n.actionCancel, role: .cancel, action: nil),
+                                             verticalButtons: [.init(title: L10n.actionRetry) { [weak self] in self?.retrySending(itemID: itemID) },
+                                                               .init(title: L10n.actionRemoveMessage, role: .destructive) { [weak self] in self?.removeFailedMessage(itemID: itemID) }])
         case .encryptionAuthenticity(let message):
             state.bindings.alertInfo = .init(id: type,
                                              title: message,

--- a/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineViewModel.swift
@@ -739,12 +739,8 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
         }
         
         if case let .sendingFailed(.unknown(reason)) = eventTimelineItem.properties.deliveryStatus {
-            guard let sendHandle = timelineController.sendHandle(for: itemID) else {
-                MXLog.error("Cannot find send handle for \(itemID).")
-                return
-            }
-            
-            displayAlert(.sendingFailed(reason: reason, sendHandle: sendHandle))
+            // A missing send handle only costs the retry/remove actions, the reason is still worth showing.
+            displayAlert(.sendingFailed(reason: reason, sendHandle: timelineController.sendHandle(for: itemID)))
         } else if case let .sendingFailed(.verifiedUser(failure)) = eventTimelineItem.properties.deliveryStatus {
             guard let sendHandle = timelineController.sendHandle(for: itemID) else {
                 MXLog.error("Cannot find send handle for \(itemID).")
@@ -1121,11 +1117,13 @@ class TimelineViewModel: TimelineViewModelType, TimelineViewModelProtocol {
             state.bindings.alertInfo = .init(id: type,
                                              title: L10n.commonSendingFailed,
                                              message: reason,
-                                             primaryButton: .init(title: L10n.actionCancel, role: .cancel, action: nil),
-                                             verticalButtons: [.init(title: L10n.actionRetry) { [weak self] in self?.retrySending(sendHandle) },
-                                                               .init(title: L10n.actionRemoveMessage, role: .destructive) { [weak self] in
-                                                                   self?.timelineInteractionHandler.handleTimelineItemMenuAction(.redact(isMedia: false), itemID: sendHandle.itemID)
-                                                               }])
+                                             primaryButton: .init(title: sendHandle == nil ? L10n.actionOk : L10n.actionCancel, role: .cancel, action: nil),
+                                             verticalButtons: sendHandle.map { sendHandle in
+                                                 [.init(title: L10n.actionRetry) { [weak self] in self?.retrySending(sendHandle) },
+                                                  .init(title: L10n.actionRemoveMessage, role: .destructive) { [weak self] in
+                                                      self?.timelineInteractionHandler.handleTimelineItemMenuAction(.redact(isMedia: false), itemID: sendHandle.itemID)
+                                                  }]
+                                             })
         case .encryptionAuthenticity(let message):
             state.bindings.alertInfo = .init(id: type,
                                              title: message,

--- a/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenu.swift
+++ b/ElementX/Sources/Screens/Timeline/View/ItemMenu/TimelineItemMenu.swift
@@ -262,7 +262,7 @@ struct TimelineItemMenu_Previews: PreviewProvider, TestablePreview {
     static let (backupItem, _) = makeActions(authenticity: .notGuaranteed(color: .gray))
     static let (unsignedItem, _) = makeActions(authenticity: .unsignedDevice(color: .red))
     static let (unencryptedItem, _) = makeActions(authenticity: .sentInClear(color: .red))
-    static let (unknownFailureItem, _) = makeActions(deliveryStatus: .sendingFailed(.unknown))
+    static let (unknownFailureItem, _) = makeActions(deliveryStatus: .sendingFailed(.unknown(reason: nil)))
     static let (identityChangedItem, _) = makeActions(deliveryStatus: .sendingFailed(.verifiedUser(.changedIdentity(users: [
         "@alice:matrix.org"
     ]))))

--- a/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemSendInfoLabel.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemSendInfoLabel.swift
@@ -48,8 +48,7 @@ private struct TimelineItemSendInfoModifier: ViewModifier {
             TimelineItemSendInfoLabel(sendInfo: sendInfo)
                 .accessibilityHidden(isAccessibilityHidden)
                 .contentShape(.rect)
-                // Only the labels with a tappable status get the identifier, so that
-                // plain timestamps don't produce ambiguous matches in UI tests.
+                // Only tappable labels get the identifier, plain timestamps would be ambiguous matches.
                 .accessibilityIdentifier(sendInfo.status != nil ? A11yIdentifiers.roomScreen.sendInfo : "")
                 // Tap gesture to avoid the message being detected as a button by VoiceOver
                 // (and the action shows a description that is already read to the user).

--- a/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemSendInfoLabel.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemSendInfoLabel.swift
@@ -48,6 +48,7 @@ private struct TimelineItemSendInfoModifier: ViewModifier {
             TimelineItemSendInfoLabel(sendInfo: sendInfo)
                 .accessibilityHidden(isAccessibilityHidden)
                 .contentShape(.rect)
+                .accessibilityIdentifier(A11yIdentifiers.roomScreen.sendInfo)
                 // Tap gesture to avoid the message being detected as a button by VoiceOver
                 // (and the action shows a description that is already read to the user).
                 .onTapGesture {

--- a/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemSendInfoLabel.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Style/TimelineItemSendInfoLabel.swift
@@ -48,7 +48,9 @@ private struct TimelineItemSendInfoModifier: ViewModifier {
             TimelineItemSendInfoLabel(sendInfo: sendInfo)
                 .accessibilityHidden(isAccessibilityHidden)
                 .contentShape(.rect)
-                .accessibilityIdentifier(A11yIdentifiers.roomScreen.sendInfo)
+                // Only the labels with a tappable status get the identifier, so that
+                // plain timestamps don't produce ambiguous matches in UI tests.
+                .accessibilityIdentifier(sendInfo.status != nil ? A11yIdentifiers.roomScreen.sendInfo : "")
                 // Tap gesture to avoid the message being detected as a button by VoiceOver
                 // (and the action shows a description that is already read to the user).
                 .onTapGesture {

--- a/ElementX/Sources/Screens/Timeline/View/Style/TimelineStyler.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Style/TimelineStyler.swift
@@ -92,7 +92,7 @@ struct TimelineItemStyler_Previews: PreviewProvider, TestablePreview {
     
     static let failed: TextRoomTimelineItem = {
         var result = base
-        result.properties.deliveryStatus = .sendingFailed(.unknown)
+        result.properties.deliveryStatus = .sendingFailed(.unknown(reason: nil))
         return result
     }()
     

--- a/ElementX/Sources/Services/Timeline/TimelineItemProxy.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItemProxy.swift
@@ -65,7 +65,7 @@ nonisolated enum TimelineItemSendFailure: Hashable {
     }
     
     case verifiedUser(VerifiedUser)
-    case unknown
+    case unknown(reason: String?)
 }
 
 /// A light wrapper around event timeline items returned from Rust.
@@ -95,8 +95,10 @@ final nonisolated class EventTimelineItemProxy: Sendable {
                 return .sendingFailed(.verifiedUser(.changedIdentity(users: users)))
             case .insecureDevices(let userDeviceMap):
                 return .sendingFailed(.verifiedUser(.hasUnsignedDevice(devices: userDeviceMap)))
+            case .genericApiError(let message):
+                return .sendingFailed(.unknown(reason: message))
             default:
-                return .sendingFailed(.unknown)
+                return .sendingFailed(.unknown(reason: nil))
             }
         case .notSentYet:
             return .sending

--- a/UnitTests/Sources/TimelineViewModelTests.swift
+++ b/UnitTests/Sources/TimelineViewModelTests.swift
@@ -565,6 +565,35 @@ final class TimelineViewModelTests {
         #expect(viewModel.state.bindings.alertInfo?.title == "alice (@alice:matrix.org) shared this message since you were not in the room when it was sent.")
     }
     
+    @Test
+    func tapSendInfoSendingFailedDisplaysAlertWithActions() {
+        // Given a room with a message that failed to send for a known reason
+        let items = [TextRoomTimelineItem(eventID: "t1", sendFailure: .unknown(reason: "M_TOO_LARGE"))]
+        let timelineController = TimelineControllerMock(.init(timelineItems: items))
+        timelineController.sendHandleForReturnValue = .mock
+        let viewModel = makeViewModel(timelineController: timelineController)
+        
+        viewModel.process(viewAction: .itemSendInfoTapped(itemID: items[0].id))
+        
+        // Then the reason and both recovery actions are offered
+        #expect(viewModel.state.bindings.alertInfo?.message == "M_TOO_LARGE")
+        #expect(viewModel.state.bindings.alertInfo?.verticalButtons?.count == 2)
+    }
+    
+    @Test
+    func tapSendInfoSendingFailedWithoutSendHandleStillDisplaysAlert() {
+        // Given a failed message whose send handle can no longer be found
+        let items = [TextRoomTimelineItem(eventID: "t1", sendFailure: .unknown(reason: "M_TOO_LARGE"))]
+        let timelineController = TimelineControllerMock(.init(timelineItems: items))
+        let viewModel = makeViewModel(timelineController: timelineController)
+        
+        viewModel.process(viewAction: .itemSendInfoTapped(itemID: items[0].id))
+        
+        // Then the reason is still shown, without any actions to recover with
+        #expect(viewModel.state.bindings.alertInfo?.message == "M_TOO_LARGE")
+        #expect(viewModel.state.bindings.alertInfo?.verticalButtons == nil)
+    }
+    
     // MARK: - Helpers
     
     private func makeViewModel(roomProxy: JoinedRoomProxyProtocol? = nil,
@@ -642,6 +671,19 @@ private extension TextRoomTimelineItem {
                   sender: .init(id: ""),
                   content: .init(body: "Hello, World!"),
                   properties: RoomTimelineItemProperties(encryptionAuthenticity: encryptionAuthenticity))
+    }
+}
+
+private extension TextRoomTimelineItem {
+    init(eventID: String, sendFailure: TimelineItemSendFailure) {
+        self.init(id: .event(uniqueID: .init(UUID().uuidString), eventOrTransactionID: .eventID(eventID)),
+                  timestamp: .mock,
+                  isOutgoing: true,
+                  isEditable: false,
+                  canBeRepliedTo: true,
+                  sender: .init(id: ""),
+                  content: .init(body: "Hello, World!"),
+                  properties: RoomTimelineItemProperties(deliveryStatus: .sendingFailed(sendFailure)))
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-x-ios/issues/4050

Tapping the red (!) on a message that failed to send used to show a bare "Sending failed" alert with only an OK button - it told the user nothing and offered nothing. Now the alert includes the failure reason reported by the SDK (e.g. the HTTP error that caused it) and offers **Retry**, **Remove message** and **Cancel**, wired to the send handle's resend and to redacting the local echo:

<img src="https://raw.githubusercontent.com/element-hq/element-x-ios/refs/heads/matthew/send-failure-dialog-assets/send-failure-dialog.png" width="360" alt="Sending failed dialog showing the M_TOO_LARGE reason with Retry, Remove message and Cancel buttons, with a second message queued behind the failed one" />

Any comparisons to Abort / Retry / Ignore are entirely coincidental.

This pairs with matrix-org/matrix-rust-sdk#6843, which makes a permanently-failed message block the messages queued behind it (instead of silently sending them past it, out of order).

Once the queue blocks on a wedged message, the (!) is the user's only way to unblock it, so it must surface the two meaningful actions - retry (unwedge) and remove (cancel the local echo) - rather than a dead-end OK. Showing the SDK's failure reason costs nothing and turns "it didn't work" into something actionable/reportable (in the screenshot: a 413 M_TOO_LARGE; in the incident that motivated this, a Cloudflare 520 during a server blip). The dialog keeps the existing tap-the-send-info gesture; the verified-user failure flows are untouched.

Also adds an accessibility identifier to the send-info label so UI tests (and accessibility tooling) can target it - used by the end-to-end validation below.

Validated end-to-end against a real synapse with an XCUITest flow: an M_TOO_LARGE-wedged message visibly blocks a second queued message, Retry re-attempts the send, and Remove message unblocks the queue so the second message delivers.

We haven't done a matching Element X Android PR yet - we'd like feedback on this approach first, then port it to EXA.

*This code was drafted by Claude (Claude Code), reviewed and directed by @ara4n.*

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations. *(tested on iPhone simulator, portrait, light mode - the dialog is a stock SwiftUI alert)*
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1H1UimuVrfVkU9Wf1phsd
