### PR TITLE
Allow tapping the avatar in the room member bottom sheet to view it fullscreen

### DIFF
--- a/ElementX/Sources/Screens/FilePreviewScreen/InteractiveQuickLook.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/InteractiveQuickLook.swift
@@ -163,6 +163,16 @@ class MediaPreviewItem: NSObject, QLPreviewItem {
         self.file = file
         previewItemTitle = title
     }
+    
+    /// Loads the media at the given URL, guessing at a JPEG for callers such as avatars that don't know the real mime type.
+    static func load(from url: URL, title: String?, mimeType: String = "image/jpeg", using mediaProvider: MediaProviderProtocol) async -> MediaPreviewItem? {
+        guard let mediaSource = try? MediaSourceProxy(url: url, mimeType: mimeType),
+              case let .success(file) = await mediaProvider.loadFileFromSource(mediaSource) else {
+            return nil
+        }
+        
+        return MediaPreviewItem(file: file, title: title)
+    }
 }
 
 // MARK: - Previews

--- a/ElementX/Sources/Screens/FilePreviewScreen/InteractiveQuickLook.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/InteractiveQuickLook.swift
@@ -83,6 +83,8 @@ private struct MediaPreviewViewController: UIViewControllerRepresentable {
             dismissalObserver = dismissalPublisher.sink { [weak self] _ in
                 // Dispatching on main.async with weak self we avoid doing an extra dismiss if the view is presented on top of another modal
                 DispatchQueue.main.async { [weak self] in
+                    // Only dismiss a preview we still have up, UIKit forwards dismiss() to an ancestor otherwise.
+                    guard self?.presentedViewController != nil else { return }
                     self?.dismiss(animated: true)
                 }
             }

--- a/ElementX/Sources/Screens/ManageRoomMemberSheet/ManageRoomMemberSheetModels.swift
+++ b/ElementX/Sources/Screens/ManageRoomMemberSheet/ManageRoomMemberSheetModels.swift
@@ -6,6 +6,8 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+import Foundation
+
 enum ManageRoomMemberSheetViewModelAction: Equatable {
     case dismiss(shouldShowDetails: Bool)
 }
@@ -46,6 +48,7 @@ struct ManageRoomMemberSheetViewState: BindableState {
 
 struct ManageRoomMemberSheetViewStateBindings {
     var alertInfo: AlertInfo<ManageRoomMemberSheetViewAlertType>?
+    var mediaPreviewItem: MediaPreviewItem?
 }
 
 enum ManageRoomMemberSheetViewAlertType {
@@ -59,6 +62,7 @@ enum ManageRoomMemberSheetViewAction {
     case ban
     case unban
     case displayDetails
+    case displayAvatar(URL)
 }
 
 enum ManageRoomMemberDetails {

--- a/ElementX/Sources/Screens/ManageRoomMemberSheet/ManageRoomMemberSheetViewModel.swift
+++ b/ElementX/Sources/Screens/ManageRoomMemberSheet/ManageRoomMemberSheetViewModel.swift
@@ -16,6 +16,7 @@ class ManageRoomMemberSheetViewModel: ManageRoomMemberSheetViewModelType, Manage
     private let roomProxy: JoinedRoomProxyProtocol
     private let userIndicatorController: UserIndicatorControllerProtocol
     private let analyticsService: AnalyticsServiceProtocol
+    private let mediaProvider: MediaProviderProtocol
     
     private var actionsSubject: PassthroughSubject<ManageRoomMemberSheetViewModelAction, Never> = .init()
     
@@ -32,6 +33,7 @@ class ManageRoomMemberSheetViewModel: ManageRoomMemberSheetViewModelType, Manage
         self.userIndicatorController = userIndicatorController
         self.roomProxy = roomProxy
         self.analyticsService = analyticsService
+        self.mediaProvider = mediaProvider
         super.init(initialViewState: .init(memberDetails: memberDetails, permissions: permissions), mediaProvider: mediaProvider)
     }
     
@@ -45,6 +47,8 @@ class ManageRoomMemberSheetViewModel: ManageRoomMemberSheetViewModelType, Manage
             actionsSubject.send(.dismiss(shouldShowDetails: true))
         case .unban:
             displayAlert(.unban)
+        case .displayAvatar(let url):
+            Task { await displayFullScreenAvatar(url) }
         }
     }
     
@@ -125,6 +129,14 @@ class ManageRoomMemberSheetViewModel: ManageRoomMemberSheetViewModelType, Manage
         case .failure:
             showManageMemberFailure(title: indicatorTitle)
         }
+    }
+    
+    private func displayFullScreenAvatar(_ url: URL) async {
+        let loadingIndicatorIdentifier = "manageRoomMemberAvatarLoadingIndicator"
+        userIndicatorController.submitIndicator(UserIndicator(id: loadingIndicatorIdentifier, type: .modal, title: L10n.commonLoading, persistent: true))
+        defer { userIndicatorController.retractIndicatorWithId(loadingIndicatorIdentifier) }
+        
+        state.bindings.mediaPreviewItem = await MediaPreviewItem.load(from: url, title: state.memberDetails.name, using: mediaProvider)
     }
     
     private func showManageMemberIndicator(title: String) {

--- a/ElementX/Sources/Screens/ManageRoomMemberSheet/View/ManageRoomMemberSheetView.swift
+++ b/ElementX/Sources/Screens/ManageRoomMemberSheet/View/ManageRoomMemberSheetView.swift
@@ -18,15 +18,19 @@ struct ManageRoomMemberSheetView: View {
             case .memberDetails(let member):
                 AvatarHeaderView(member: member,
                                  avatarSize: .user(on: .memberDetails),
-                                 mediaProvider: context.mediaProvider,
-                                 onAvatarTap: { context.send(viewAction: .displayAvatar($0)) },
-                                 footer: { EmptyView() })
+                                 mediaProvider: context.mediaProvider) { url in
+                    context.send(viewAction: .displayAvatar(url))
+                } footer: {
+                    EmptyView()
+                }
             case .loadingMemberDetails(let sender):
                 AvatarHeaderView(sender: sender,
                                  avatarSize: .user(on: .memberDetails),
-                                 mediaProvider: context.mediaProvider,
-                                 onAvatarTap: { context.send(viewAction: .displayAvatar($0)) },
-                                 footer: { EmptyView() })
+                                 mediaProvider: context.mediaProvider) { url in
+                    context.send(viewAction: .displayAvatar(url))
+                } footer: {
+                    EmptyView()
+                }
             }
             
             Section {

--- a/ElementX/Sources/Screens/ManageRoomMemberSheet/View/ManageRoomMemberSheetView.swift
+++ b/ElementX/Sources/Screens/ManageRoomMemberSheet/View/ManageRoomMemberSheetView.swift
@@ -18,15 +18,15 @@ struct ManageRoomMemberSheetView: View {
             case .memberDetails(let member):
                 AvatarHeaderView(member: member,
                                  avatarSize: .user(on: .memberDetails),
-                                 mediaProvider: context.mediaProvider) {
-                    EmptyView()
-                }
+                                 mediaProvider: context.mediaProvider,
+                                 onAvatarTap: { context.send(viewAction: .displayAvatar($0)) },
+                                 footer: { EmptyView() })
             case .loadingMemberDetails(let sender):
                 AvatarHeaderView(sender: sender,
                                  avatarSize: .user(on: .memberDetails),
-                                 mediaProvider: context.mediaProvider) {
-                    EmptyView()
-                }
+                                 mediaProvider: context.mediaProvider,
+                                 onAvatarTap: { context.send(viewAction: .displayAvatar($0)) },
+                                 footer: { EmptyView() })
             }
             
             Section {
@@ -76,6 +76,7 @@ struct ManageRoomMemberSheetView: View {
         .presentationDragIndicator(.visible)
         .presentationDetents([.large, .fraction(0.67)]) // Maybe find a way to use the ideal height somehow?
         .alert(item: $context.alertInfo)
+        .interactiveQuickLook(item: $context.mediaPreviewItem, allowEditing: false)
     }
 }
 

--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
@@ -484,11 +484,7 @@ class RoomDetailsScreenViewModel: RoomDetailsScreenViewModelType, RoomDetailsScr
                 userIndicatorController.retractIndicatorWithId(loadingIndicatorIdentifier)
             }
             
-            // We don't actually know the mime type here, assume it's an image.
-            if let mediaSource = try? MediaSourceProxy(url: url, mimeType: "image/jpeg"),
-               case let .success(file) = await userSession.mediaProvider.loadFileFromSource(mediaSource) {
-                state.bindings.mediaPreviewItem = MediaPreviewItem(file: file, title: roomProxy.infoPublisher.value.displayName)
-            }
+            state.bindings.mediaPreviewItem = await MediaPreviewItem.load(from: url, title: roomProxy.infoPublisher.value.displayName, using: userSession.mediaProvider)
         }
     }
     

--- a/ElementX/Sources/Screens/RoomMemberDetailsScreen/RoomMemberDetailsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomMemberDetailsScreen/RoomMemberDetailsScreenViewModel.swift
@@ -174,11 +174,7 @@ class RoomMemberDetailsScreenViewModel: RoomMemberDetailsScreenViewModelType, Ro
         userIndicatorController.submitIndicator(UserIndicator(id: loadingIndicatorIdentifier, type: .modal, title: L10n.commonLoading, persistent: true))
         defer { userIndicatorController.retractIndicatorWithId(loadingIndicatorIdentifier) }
         
-        // We don't actually know the mime type here, assume it's an image.
-        if let mediaSource = try? MediaSourceProxy(url: url, mimeType: "image/jpeg"),
-           case let .success(file) = await userSession.mediaProvider.loadFileFromSource(mediaSource) {
-            state.bindings.mediaPreviewItem = MediaPreviewItem(file: file, title: roomMemberProxy.displayName)
-        }
+        state.bindings.mediaPreviewItem = await MediaPreviewItem.load(from: url, title: roomMemberProxy.displayName, using: userSession.mediaProvider)
     }
     
     private func openDirectChat() {

--- a/ElementX/Sources/Screens/UserProfileScreen/UserProfileScreenViewModel.swift
+++ b/ElementX/Sources/Screens/UserProfileScreen/UserProfileScreenViewModel.swift
@@ -117,11 +117,7 @@ class UserProfileScreenViewModel: UserProfileScreenViewModelType, UserProfileScr
         showLoadingIndicator(allowsInteraction: false)
         defer { hideLoadingIndicator() }
         
-        // We don't actually know the mime type here, assume it's an image.
-        if let mediaSource = try? MediaSourceProxy(url: url, mimeType: "image/jpeg"),
-           case let .success(file) = await userSession.mediaProvider.loadFileFromSource(mediaSource) {
-            state.bindings.mediaPreviewItem = MediaPreviewItem(file: file, title: userProfile.displayName)
-        }
+        state.bindings.mediaPreviewItem = await MediaPreviewItem.load(from: url, title: userProfile.displayName, using: userSession.mediaProvider)
     }
     
     private func openDirectChat() {

--- a/UnitTests/Sources/ManageRoomMemberSheetViewModelTests.swift
+++ b/UnitTests/Sources/ManageRoomMemberSheetViewModelTests.swift
@@ -97,4 +97,22 @@ struct ManageRoomMemberSheetViewModelTests {
         try await deferredAction.fulfill()
         #expect(context.alertInfo == nil)
     }
+    
+    @Test
+    mutating func displayAvatar() async throws {
+        let member = RoomMemberDetails(withProxy: RoomMemberProxyMock.mockDan)
+        viewModel = ManageRoomMemberSheetViewModel(memberDetails: .memberDetails(roomMember: member),
+                                                   permissions: .init(canKick: true, canBan: true, ownPowerLevel: RoomMemberProxyMock.mockAdmin.powerLevel),
+                                                   roomProxy: JoinedRoomProxyMock(.init()),
+                                                   userIndicatorController: UserIndicatorControllerMock(),
+                                                   analyticsService: AnalyticsServiceMock(.init()),
+                                                   mediaProvider: MediaProviderMock(.init()))
+        
+        let avatarURL = try #require(member.avatarURL)
+        let deferred = deferFulfillment(context.observe(\.viewState.bindings.mediaPreviewItem)) { $0 != nil }
+        context.send(viewAction: .displayAvatar(avatarURL))
+        try await deferred.fulfill()
+        
+        #expect(context.mediaPreviewItem?.previewItemTitle == member.name)
+    }
 }


### PR DESCRIPTION
Issue: #4827

Three commits:

1. A refactor: Extracted a shared helper for loading a media preview, moves duplicated load-and-wrap logic out of 4 screens
2. A fix: closing the full screen avatar was dismissing the member details sheet
3. The feature: Allow tapping the avatar in the room member bottom sheet to view it fullscreen, plus a unit test

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [x] iPhone and iPad simulators in portrait and landscape orientations.
- [x] Dark mode enabled and disabled.
- [x] Various sizes of dynamic type.
- [ ] Voiceover enabled.

