### PR TITLE
Fix Pro Max In Call Rotation Bug

### DIFF
--- a/ElementX/Sources/Screens/CallScreen/CallScreenModels.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenModels.swift
@@ -21,6 +21,8 @@ struct CallScreenViewState: BindableState {
     var url: URL?
     
     var bindings = Bindings()
+    
+    var swiftUICallViewCoordinator: CallView.Coordinator?
 }
 
 struct Bindings {

--- a/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
+++ b/ElementX/Sources/Screens/CallScreen/CallScreenViewModel.swift
@@ -52,6 +52,8 @@ class CallScreenViewModel: CallScreenViewModelType, CallScreenViewModelProtocol 
         
         super.init(initialViewState: CallScreenViewState(script: CallScreenJavaScriptMessageName.allCasesInjectionScript))
         
+        state.swiftUICallViewCoordinator = .init(viewModelContext: context)
+        
         elementCallService.actions
             .receive(on: DispatchQueue.main)
             .sink { [weak self] action in

--- a/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
+++ b/ElementX/Sources/Screens/CallScreen/View/CallScreen.swift
@@ -53,7 +53,7 @@ struct CallScreen: View {
     }
 }
 
-private struct CallView: UIViewRepresentable {
+struct CallView: UIViewRepresentable {
     /// The top-level view this representable displays. It wraps the web view when picture in picture isn't running.
     typealias WebViewWrapper = UIView
     
@@ -65,7 +65,13 @@ private struct CallView: UIViewRepresentable {
     }
     
     func makeCoordinator() -> Coordinator {
-        Coordinator(viewModelContext: viewModelContext)
+        if let existing = viewModelContext.viewState.swiftUICallViewCoordinator {
+            return existing
+        }
+        // When the screen is rotated, the pro max models regenerate the swiftui view tree, destroying and
+        // rebuilding this view. For that reason, we need to create and store the coordinator in the view model
+        // (and by extension the UIView) to persist between rotations to retain state
+        fatalError("CallView.Coordinator must be initialized in the context view state")
     }
     
     func updateUIView(_ callWebView: WebViewWrapper, context: Context) {
@@ -151,6 +157,7 @@ private struct CallView: UIViewRepresentable {
         }
         
         func load(_ url: URL) {
+            guard self.url != url else { return }
             self.url = url
             // The only file URL we allow is the one coming from our own local ElementCall bundle, so it's okay to allow read permission only to our local EC bundle
             if url.isFileURL {


### PR DESCRIPTION
When the screen is rotated, the pro max models regenerate the swiftui view tree for some reason. I would hypothesize it's related to the horizontal size class changing from `.compact` to `.regular`, but I believe the precise reason is buried in apple's source code. Anyway, when that happens, it regenerates the web view from scratch, which not only loses its loaded content, it disconnects from the call.

This solution is definitely a hack - I don't think it's kosher to generate the coordinator in the way that it does or to persist a UIView to be shared by the lifecycle of two swiftui views, but the old swiftui view is discarded in the process of this graph regeneration, so I don't think it'll actually cause any problems. I also don't see any other clean way to keep the view identity intact and prevent the graph rebuild. (I tried `.id()` in a couple places and it had no effect)

Anyway, since the view object persists through the swiftui graph regeneration now, it doesn't get reloaded, nor does it drop the call.

Fixes #4330

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [x] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
