### PR TITLE
Set the finalised OAuth Client URI path to match the new EXI page.

### DIFF
--- a/ElementX/Sources/Application/Settings/AppSettings.swift
+++ b/ElementX/Sources/Application/Settings/AppSettings.swift
@@ -204,7 +204,7 @@ final nonisolated class AppSettings: @unchecked Sendable {
     /// A path that is appended to `websiteURL` to form the OAuth `clientURI`. MAS uses `clientURI` as the identifier for a specific app, allowing us to
     /// distinguish the various clients we have for Android, iOS and Web from each other.
     /// Intentionally a distinct property so it can be easily overridden without having to manipulate the website URL.
-    private(set) var oAuthClientURIPath: String? // = "app/ios"
+    private(set) var oAuthClientURIPath: String? = "apps/ios"
     
     var oAuthConfiguration: OAuthConfiguration {
         OAuthConfiguration(clientName: InfoPlistReader.main.bundleDisplayName,


### PR DESCRIPTION
The page is live at https://element.io/apps/ios so we can now set this value to point at it.