### PR TITLE
Fix tab rail background in dark mode

### DIFF
--- a/ElementX/Sources/Application/Navigation/NavigationTabCoordinator.swift
+++ b/ElementX/Sources/Application/Navigation/NavigationTabCoordinator.swift
@@ -369,6 +369,7 @@ private struct NavigationTabCoordinatorView<Tag: Hashable>: View {
                     .id(module.id)
             }
         }
+        .background(Color.compound.bgCanvasDefault.ignoresSafeArea())
         .introspect(.window, on: .supportedVersions) { window in
             guard self.window !== window else { return }
             


### PR DESCRIPTION
## Description

Fixes the tab rail background rendering in dark mode.

In dark mode, the tab rail was rendered with an unaligned black background, creating a visible difference between the tab rail and the surrounding application background.

This change applies the same canvas background color to the tab rail and extends it into the safe area, making the background consistent with the rest of the UI.

## Changes

- Applied `Color.compound.bgCanvasDefault` as the tab rail background.
- Used `ignoresSafeArea()` so the background covers the appropriate safe-area region.
- No changes were made to the tab navigation behavior or layout.

## Testing

Tested the change on an iPad simulator with:

- Dark mode enabled
- Light mode enabled
- Tab rail visible in the main navigation

### Before

The tab rail displayed an unaligned black background in dark mode.

### After

The tab rail background now matches the surrounding dark-mode background without the visible black bar.

## Issue

Closes #5979

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**

- [x] iPhone and iPad simulators in portrait and landscape orientations.
- [x] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.