### PR TITLE
Fix tracing span panic when accessed from multiple threads

### DIFF
--- a/ElementX/Sources/Other/Extensions/URL.swift
+++ b/ElementX/Sources/Other/Extensions/URL.swift
@@ -94,12 +94,6 @@ nonisolated extension URL {
     }
     
     var globalProxy: String? {
-        let span = MXLog.createSpan("Global proxy")
-        span.enter()
-        defer {
-            span.exit()
-        }
-        
         guard let proxySettings = CFNetworkCopySystemProxySettings()?.takeRetainedValue() else {
             MXLog.error("Failed retrieving proxy settings")
             return nil

--- a/ElementX/Sources/Other/Logging/MXLog.swift
+++ b/ElementX/Sources/Other/Logging/MXLog.swift
@@ -23,14 +23,6 @@ nonisolated enum MXLog {
         rootSpan.enter()
     }
     
-    static func createSpan(_ name: String,
-                           file: String = #file,
-                           function: String = #function,
-                           line: Int = #line,
-                           column: Int = #column) -> Span {
-        createSpan(name, level: .info, file: file, function: function, line: line, column: column)
-    }
-    
     static func verbose(_ message: Any,
                         file: String = #file,
                         function: String = #function,
@@ -111,20 +103,6 @@ nonisolated enum MXLog {
     #endif
     
     // MARK: - Private
-    
-    // periphery:ignore:parameters function,column
-    private static func createSpan(_ name: String,
-                                   level: LogLevel,
-                                   file: String = #file,
-                                   function: String = #function,
-                                   line: Int = #line,
-                                   column: Int = #column) -> Span {
-        if Span.current().isNone() {
-            rootSpan.enter()
-        }
-        
-        return Span(file: file, line: UInt32(line), level: level.rustLogLevel, target: currentTarget, name: name, bridgeTraceId: nil)
-    }
     
     // periphery:ignore:parameters function,column
     private static func log(_ message: Any,

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
@@ -251,15 +251,6 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
             return currentItems
         }
         
-        // The span guard is thread local, so it must not straddle a suspension
-        // point, otherwise the task could resume on a different thread and
-        // unbalance it, causing a panic and subsequent (intentional) crash.
-        let span = MXLog.createSpan("\(name).apply_room_list_diff")
-        span.enter()
-        defer {
-            span.exit()
-        }
-        
         guard let updatedItems = currentItems.applying(collectionDiff) else {
             MXLog.error("\(name): Failed applying diff: \(collectionDiff)")
             return currentItems

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
@@ -238,12 +238,6 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
                                      on currentRooms: [RoomSummary],
                                      eventStringBuilder: RoomEventStringBuilder,
                                      name: String) async -> [RoomSummary] {
-        let span = MXLog.createSpan("\(name).process_room_list_diffs")
-        span.enter()
-        defer {
-            span.exit()
-        }
-        
         var updatedRooms = currentRooms
         for diff in diffs {
             updatedRooms = await processDiff(diff, on: updatedRooms, eventStringBuilder: eventStringBuilder, name: name)
@@ -255,6 +249,15 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
         guard let collectionDiff = await buildDiff(from: diff, on: currentItems, eventStringBuilder: eventStringBuilder) else {
             MXLog.error("\(name): Failed building CollectionDifference from \(diff)")
             return currentItems
+        }
+        
+        // The span guard is thread local, so it must not straddle a suspension
+        // point, otherwise the task could resume on a different thread and
+        // unbalance it, causing a panic and subsequent (intentional) crash.
+        let span = MXLog.createSpan("\(name).apply_room_list_diff")
+        span.enter()
+        defer {
+            span.exit()
         }
         
         guard let updatedItems = currentItems.applying(collectionDiff) else {
@@ -447,19 +450,13 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
     private func rebuildRoomSummaries() async {
         MXLog.info("\(name): Rebuilding room summaries for \(rooms.count) rooms")
         
-        rooms = await Self.rebuiltRoomSummaries(from: rooms, eventStringBuilder: eventStringBuilder, name: name)
+        rooms = await Self.rebuiltRoomSummaries(from: rooms, eventStringBuilder: eventStringBuilder)
         
         MXLog.info("\(name): Finished rebuilding room summaries (\(rooms.count) rooms)")
     }
     
     @concurrent
-    private static func rebuiltRoomSummaries(from rooms: [RoomSummary], eventStringBuilder: RoomEventStringBuilder, name: String) async -> [RoomSummary] {
-        let span = MXLog.createSpan("\(name).rebuild_room_summaries")
-        span.enter()
-        defer {
-            span.exit()
-        }
-        
+    private static func rebuiltRoomSummaries(from rooms: [RoomSummary], eventStringBuilder: RoomEventStringBuilder) async -> [RoomSummary] {
         var rebuiltRooms = [RoomSummary]()
         rebuiltRooms.reserveCapacity(rooms.count)
         for room in rooms {

--- a/ElementX/Sources/Services/Timeline/TimelineItemProvider.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItemProvider.swift
@@ -99,12 +99,6 @@ class TimelineItemProvider: TimelineItemProviderProtocol {
     private static func processDiffs(_ diffs: [TimelineDiff],
                                      on currentItems: [TimelineItemProxy],
                                      spanName: String) async -> (itemProxies: [TimelineItemProxy], hasMembershipChange: Bool) {
-        let span = MXLog.createSpan(spanName)
-        span.enter()
-        defer {
-            span.exit()
-        }
-        
         var hasMembershipChange = false
         
         let itemProxies = diffs.reduce(currentItems) { currentItems, diff in


### PR DESCRIPTION
L.E. Decided to remove the whole thing in the end because it's easier to live without it instead of dealing with the with the API redesign and/or misuse.

---

Brings it in sync with the TimelineItemProvider as it happens.

Fixes https://sentry.tools.element.io/organizations/element/issues/11257907/?project=63&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream

> assertion `left != right` failed: tried to clone a span (Id(790382009481428994)) that already closed