### PR TITLE
Drop the `addressSanitizer` and `undefinedBehaviorSanitizer` from the Accessibility and UI tests

### DIFF
--- a/AccessibilityTests/SupportingFiles/AccessibilityTests.xctestplan
+++ b/AccessibilityTests/SupportingFiles/AccessibilityTests.xctestplan
@@ -9,9 +9,6 @@
     }
   ],
   "defaultOptions" : {
-    "addressSanitizer" : {
-      "enabled" : true
-    },
     "codeCoverage" : {
       "targets" : [
         {
@@ -36,8 +33,7 @@
       "identifier" : "C0C687DE1D270F9895FEE186",
       "name" : "AccessibilityTests"
     },
-    "testTimeoutsEnabled" : true,
-    "undefinedBehaviorSanitizerEnabled" : true
+    "testTimeoutsEnabled" : true
   },
   "testTargets" : [
     {

--- a/UITests/SupportingFiles/UITests.xctestplan
+++ b/UITests/SupportingFiles/UITests.xctestplan
@@ -10,9 +10,6 @@
     }
   ],
   "defaultOptions" : {
-    "addressSanitizer" : {
-      "enabled" : true
-    },
     "codeCoverage" : {
       "targets" : [
         {
@@ -43,8 +40,7 @@
       "identifier" : "0E28CD62691FDBC63147D5E3",
       "name" : "UITests"
     },
-    "testTimeoutsEnabled" : true,
-    "undefinedBehaviorSanitizerEnabled" : true
+    "testTimeoutsEnabled" : true
   },
   "testTargets" : [
     {


### PR DESCRIPTION
They cost a lot of extra memory to enable and cause problems on constrained CIs