### PR TITLE
Load MapLibre lazily instead of at every app launch

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -737,6 +737,7 @@
 		767D366C40F1311CFA333763 /* PillContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86376BEE425704AEE197CA54 /* PillContext.swift */; };
 		76B6046788017DEF088FBF87 /* RoomThreadListScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3534D37BFC074DD26F2FFE /* RoomThreadListScreenModels.swift */; };
 		76C874243A8C440D6CF7B344 /* ProcessInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077B01C13BBA2996272C5FB5 /* ProcessInfo.swift */; };
+		76D4D5312ED8E42B35C29FA3 /* MapLibreInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 842F63AA68E8EB410B1BA29F /* MapLibreInterface.framework */; };
 		7708976CEE6AFB5CFAEFBA68 /* PillTextAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF1EE0AA78470C674554262 /* PillTextAttachment.swift */; };
 		77574A519A4E484880053EAD /* IdentityConfirmationScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FDF541AE914059942B575B4 /* IdentityConfirmationScreenModels.swift */; };
 		77693820498ABF3508814D49 /* AppLockServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD97F9661ABF08CE002054A2 /* AppLockServiceTests.swift */; };
@@ -838,6 +839,7 @@
 		86DFA58FBBEB0AF671D2A1E1 /* HomeScreenKnockedCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A103580EBA06155B1343EF16 /* HomeScreenKnockedCell.swift */; };
 		86F9D3028A1F4AE819D75560 /* RoomChangePermissionsScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D879FC4E881E748BB9B34DC /* RoomChangePermissionsScreenCoordinator.swift */; };
 		872A6457DF573AF8CEAE927A /* LoginHomeserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9349F590E35CE514A71E6764 /* LoginHomeserver.swift */; };
+		874704A177B0A6D78E037908 /* MapLibreInterface.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 842F63AA68E8EB410B1BA29F /* MapLibreInterface.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		877D3CE8680536DB430DE6A2 /* TimelineItemIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48C91C8BE55CAE1A3DBC3BC /* TimelineItemIdentifier.swift */; };
 		878070573C7BF19E735707B4 /* RoomTimelineItemProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DE8D25D6A91030175D52A20 /* RoomTimelineItemProperties.swift */; };
 		87CEA3E07B602705BC2D2A20 /* ClientBuilderHook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AC0CD1CAFD3F8B057F9AEA5 /* ClientBuilderHook.swift */; };
@@ -999,6 +1001,7 @@
 		9FC79DA30AE0E1502DAEBD51 /* StartChatFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477A8C656B7B26E99C35927F /* StartChatFlowCoordinator.swift */; };
 		A009BDFB0A6816D4C392ADCB /* SettingsScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF715D4FD4710EBB637D661 /* SettingsScreenViewModelProtocol.swift */; };
 		A021827B528F1EDC9101CA58 /* AppCoordinatorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBC776F301D374A3298C69DA /* AppCoordinatorProtocol.swift */; };
+		A05D6ACD38082D3E0A14D63E /* MapModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33FF3E6EED8FC58755AF3A42 /* MapModels.swift */; };
 		A0601810597769B81C2358AF /* EncryptionResetPasswordScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2B5274C1D3D2999D643786 /* EncryptionResetPasswordScreenViewModelProtocol.swift */; };
 		A0646F23876D6326AD27FF52 /* LiveLocationSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2FEFA393FC7D2870263012 /* LiveLocationSession.swift */; };
 		A07178337F3C0B208B5A77A8 /* NotificationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6ED50FE104992419310EEB /* NotificationHandler.swift */; };
@@ -1614,6 +1617,13 @@
 			remoteGlobalIDString = C0FAEB81CFD9776CD78CE489;
 			remoteInfo = ElementX;
 		};
+		815AF2253661A93303B8E9C4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = AC22997D58D612146053154D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 96435A765678A64A956EE59C;
+			remoteInfo = MapLibreInterface;
+		};
 		889C131F86E6415074D382B9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = AC22997D58D612146053154D /* Project object */;
@@ -1650,6 +1660,7 @@
 			dstSubfolderSpec = 10;
 			files = (
 				C9C562D85999E436C7265AF1 /* MatrixRustSDK in Embed Frameworks */,
+				874704A177B0A6D78E037908 /* MapLibreInterface.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1971,6 +1982,7 @@
 		337AD37403015231CAE3E80B /* SentryEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryEvent.swift; sourceTree = "<group>"; };
 		33AE897D86784CCA5E4E9227 /* ElementCallService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementCallService.swift; sourceTree = "<group>"; };
 		33E49C5C6F802B4D94CA78D1 /* ro */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ro; path = ro.lproj/Localizable.strings; sourceTree = "<group>"; };
+		33FF3E6EED8FC58755AF3A42 /* MapModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapModels.swift; sourceTree = "<group>"; };
 		3423C39324CF851A72EC9976 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/SAS.strings; sourceTree = "<group>"; };
 		342BEBC3C5FC3F9943C41C4C /* TemplateScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		345172AD4377E83A44BD864F /* MessageComposerTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageComposerTextField.swift; sourceTree = "<group>"; };
@@ -2422,6 +2434,7 @@
 		83B574805B9812C111D6215D /* Tracing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tracing.swift; sourceTree = "<group>"; };
 		83E2B20431F890ED64255CA1 /* AdvancedSettingsScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		840182D7A61402D5947DE094 /* NotificationItemProxyMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationItemProxyMock.swift; sourceTree = "<group>"; };
+		842F63AA68E8EB410B1BA29F /* MapLibreInterface.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MapLibreInterface.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		84311D707B09854D67F78BBF /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		845DDBDE5A0887E73D38B826 /* InviteUsersViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteUsersViewModelTests.swift; sourceTree = "<group>"; };
 		847C893CF354BCBDF1351C13 /* ChatsSpaceFilterCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatsSpaceFilterCell.swift; sourceTree = "<group>"; };
@@ -3254,6 +3267,7 @@
 				8F2FAA98457750D9D664136F /* LoremSwiftum in Frameworks */,
 				FC10228E73323BDC09526F97 /* LRUCache in Frameworks */,
 				EAC6FE2CD4F50A43068ADCD8 /* Mantis in Frameworks */,
+				76D4D5312ED8E42B35C29FA3 /* MapLibreInterface.framework in Frameworks */,
 				754602A7B2AAD443C4228ED4 /* MapLibre in Frameworks */,
 				B0CB16349B96262AA65A04AF /* PostHog in Frameworks */,
 				36AD4DD4C798E22584ED3200 /* SwiftState in Frameworks */,
@@ -3728,6 +3742,14 @@
 			path = Resources;
 			sourceTree = "<group>";
 		};
+		29CB9F2D011BB5649B3E86BE /* MapLibre */ = {
+			isa = PBXGroup;
+			children = (
+				2F311A9BA03995E736E065DE /* MapLibreInterface */,
+			);
+			path = MapLibre;
+			sourceTree = "<group>";
+		};
 		2AC6FD695C6F79F67C056463 /* AppLockSetupSettingsScreen */ = {
 			isa = PBXGroup;
 			children = (
@@ -3832,6 +3854,14 @@
 				B6C585CE1F721A2770C70D47 /* TimelineControllerProtocol.swift */,
 			);
 			path = TimelineController;
+			sourceTree = "<group>";
+		};
+		2F311A9BA03995E736E065DE /* MapLibreInterface */ = {
+			isa = PBXGroup;
+			children = (
+				A7793413E64FE8831FE95F57 /* Sources */,
+			);
+			path = MapLibreInterface;
 			sourceTree = "<group>";
 		};
 		2F72FD053616BA8A5D565323 /* View */ = {
@@ -4895,6 +4925,7 @@
 				4CD6AC7546E8D7E5C73CEA48 /* ElementX.app */,
 				9C7F7DE62D33C6A26CBFCD72 /* IntegrationTests.xctest */,
 				73F3153AB9D628110878E24F /* libMatrixRustSDKMocks.a */,
+				842F63AA68E8EB410B1BA29F /* MapLibreInterface.framework */,
 				0D8F620C8B314840D8602E3F /* NSE.appex */,
 				D95E8C0EFEC0C6F96EDAA71A /* PreviewTests.xctest */,
 				3D8BEEFCA07BEA43F4F4BF77 /* ShareExtension.appex */,
@@ -5844,6 +5875,7 @@
 				E68740F873AB18A5C26844EA /* Sources */,
 				2774D635E78D8B98390EA694 /* Resources */,
 				0B7746360C4753B5A014838F /* SupportingFiles */,
+				29CB9F2D011BB5649B3E86BE /* MapLibre */,
 			);
 			path = ElementX;
 			sourceTree = "<group>";
@@ -6053,6 +6085,14 @@
 				C3141EE5B2CBEC45270E01EB /* CreateRoomSpaceSelectionSheet.swift */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		A7793413E64FE8831FE95F57 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				33FF3E6EED8FC58755AF3A42 /* MapModels.swift */,
+			);
+			path = Sources;
 			sourceTree = "<group>";
 		};
 		A78C2592419CA4C76FBA8FD2 /* Application */ = {
@@ -7366,6 +7406,23 @@
 			productReference = D95E8C0EFEC0C6F96EDAA71A /* PreviewTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		96435A765678A64A956EE59C /* MapLibreInterface */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 012B545B5F54127704478A55 /* Build configuration list for PBXNativeTarget "MapLibreInterface" */;
+			buildPhases = (
+				294638399D803C4F2154D2B7 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MapLibreInterface;
+			packageProductDependencies = (
+			);
+			productName = MapLibreInterface;
+			productReference = 842F63AA68E8EB410B1BA29F /* MapLibreInterface.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		C0C687DE1D270F9895FEE186 /* AccessibilityTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8FFA8C81E8F740B7AC0183EC /* Build configuration list for PBXNativeTarget "AccessibilityTests" */;
@@ -7409,6 +7466,7 @@
 				2C29670603B37E38705D5FF1 /* PBXTargetDependency */,
 				58C473A5DEA945AACFEA8E9F /* PBXTargetDependency */,
 				2E32BC489F482046B8B1460F /* PBXTargetDependency */,
+				0C42CEF186BBA0F3DBC17B85 /* PBXTargetDependency */,
 			);
 			name = ElementX;
 			packageProductDependencies = (
@@ -7528,6 +7586,9 @@
 					7A17BE29BAC81ADBAC6349D9 = {
 						DevelopmentTeam = 7J4U792NQT;
 					};
+					96435A765678A64A956EE59C = {
+						DevelopmentTeam = 7J4U792NQT;
+					};
 					C0C687DE1D270F9895FEE186 = {
 						DevelopmentTeam = 7J4U792NQT;
 						TestTargetID = C0FAEB81CFD9776CD78CE489;
@@ -7632,6 +7693,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				96435A765678A64A956EE59C /* MapLibreInterface */,
 				C0FAEB81CFD9776CD78CE489 /* ElementX */,
 				FEB53A5BC378C913769656D8 /* NSE */,
 				19F0C845D67E9BEA4BE7133E /* ShareExtension */,
@@ -8165,6 +8227,14 @@
 				0AB4FF7645175FF1F6E942CC /* DeferredFulfillment.swift in Sources */,
 				038AB2E86960FD240231D4C2 /* GeneratedPreviewTests.swift in Sources */,
 				ED635D7F00FA07E94D3CE1E8 /* PreviewTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		294638399D803C4F2154D2B7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A05D6ACD38082D3E0A14D63E /* MapModels.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -9394,6 +9464,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		0C42CEF186BBA0F3DBC17B85 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 96435A765678A64A956EE59C /* MapLibreInterface */;
+			targetProxy = 815AF2253661A93303B8E9C4 /* PBXContainerItemProxy */;
+		};
 		0EEC1557A40FBA6DF49D83A2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = C0FAEB81CFD9776CD78CE489 /* ElementX */;
@@ -9629,6 +9704,32 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		23463D98F3F6627A6721C4BF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "$(BASE_BUNDLE_IDENTIFIER).maplibre-interface";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_VERSION = 6.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
 		2DFF6BC8513E455947420CEA /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -10075,6 +10176,32 @@
 			};
 			name = Debug;
 		};
+		9BF0A7B1A7C478C41B1FFE56 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "$(BASE_BUNDLE_IDENTIFIER).maplibre-interface";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_VERSION = 6.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
 		A1ACA222659F60BAAFB9976B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -10219,6 +10346,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		012B545B5F54127704478A55 /* Build configuration list for PBXNativeTarget "MapLibreInterface" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9BF0A7B1A7C478C41B1FFE56 /* Debug */,
+				23463D98F3F6627A6721C4BF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
 		4272AFBE93EEF7B03D9B9ECD /* Build configuration list for PBXNativeTarget "MatrixRustSDKMocks" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -312,6 +312,7 @@
 		30CC1DB7CE357659C82AA115 /* MediaProviderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EB16E7FE59A947CA441531 /* MediaProviderProtocol.swift */; };
 		30DA1A668482E5B95E8F1F2B /* GalleryRoomTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04EFA0E3139C01E1CFDC93B /* GalleryRoomTimelineView.swift */; };
 		30E5628F74AD3C27A061BF25 /* QRCodeLoginScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC1B7CB061C9865B2B91B56 /* QRCodeLoginScreenViewModel.swift */; };
+		310E1D9D246277A4FFA66162 /* MapLibreMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3989F50ECBC5AEE2E5A062DA /* MapLibreMapView.swift */; };
 		311868F5E65BA61AFA6CCC2C /* CompoundHook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B89D6C760E8CAE29CA28FB1 /* CompoundHook.swift */; };
 		3118D9ABFD4BE5A3492FF88A /* ElementCallConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC437C491EA6996513B1CEAB /* ElementCallConfiguration.swift */; };
 		31CCF3159E5CE1C05AE5781B /* HTMLFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A5FBB74981BF8EFFDAE90D /* HTMLFixtures.swift */; };
@@ -555,6 +556,7 @@
 		5AA81A4E2D40A32A9E7F71F2 /* ShareExtensionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C3ADF21BE301D0DA48F2A7E /* ShareExtensionView.swift */; };
 		5AC5CD6D893073EE4D9A277E /* ShareExtensionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D27299A36536DBF91AE8FA6 /* ShareExtensionViewController.swift */; };
 		5AE6404C4FD4848ACCFF9EDC /* SecureBackupLogoutConfirmationScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1573D28C8A9FB6399D0EEFB /* SecureBackupLogoutConfirmationScreenCoordinator.swift */; };
+		5B2CE8FE14CB16F2FCAFC4B2 /* MapLibreShim.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 44E8BAA982EC260E74CCCB22 /* MapLibreShim.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5B6E5AD224509E6C0B520D6E /* RoomMemberDetailsScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DDF49CEBC0DFC59C308335F /* RoomMemberDetailsScreenViewModelProtocol.swift */; };
 		5BC6C4ADFE7F2A795ECDE130 /* SecureBackupKeyBackupScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2D4EEBE8C098BBADD10939 /* SecureBackupKeyBackupScreenCoordinator.swift */; };
 		5C02841B2A86327B2C377682 /* NotificationConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C830A64609CBD152F06E0457 /* NotificationConstants.swift */; };
@@ -566,6 +568,7 @@
 		5D52925FEB1B780C65B0529F /* PinnedEventsTimelineScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA4F6D7000EDCD187E0989E7 /* PinnedEventsTimelineScreen.swift */; };
 		5D53AE9342A4C06B704247ED /* MediaLoaderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A02406480C351B8C6E0682C /* MediaLoaderProtocol.swift */; };
 		5D56CE09743C6B90C21B04C2 /* RoomMembersListScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E9E0929CEFA356090BE5FB8 /* RoomMembersListScreenViewModelTests.swift */; };
+		5D586C5CED7B7B086C61B84A /* MapLibre in Frameworks */ = {isa = PBXBuildFile; productRef = 7E8600FD98955C620F83BFBA /* MapLibre */; };
 		5D99F63CC88BB29383019FC6 /* ShareExtensionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCAC01A97A43BE07B9E94E43 /* ShareExtensionModels.swift */; };
 		5DB4334CBBA142376FF5FFEC /* preview_image.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 200626E8353AB2729444F991 /* preview_image.jpg */; };
 		5DD85A0FE3D85AEC3C7EFE36 /* DeveloperOptionsScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C7C7CFA6B2A62A685FF6CE3 /* DeveloperOptionsScreenCoordinator.swift */; };
@@ -660,11 +663,13 @@
 		6AEB650311F694A5702255C9 /* UserProfileScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B4932E4EFBC8FAC10972CD /* UserProfileScreenCoordinator.swift */; };
 		6B31508C6334C617360C2EAB /* RoomMemberDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC589E641AE46EFB2962534D /* RoomMemberDetailsViewModelTests.swift */; };
 		6B3AB95A6993646A5081BFF9 /* TestablePreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43F773904F87FF5ADFE4DD1 /* TestablePreview.swift */; };
+		6B47F2C6B11A1EDF0480DA71 /* CoordinateAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10A8171DA78BA39F07D669B1 /* CoordinateAnimator.swift */; };
 		6B61F5B27412ED4BC2F9769C /* test_audio.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 66B96842BF5F8ACA1AC84C55 /* test_audio.mp3 */; };
 		6B80C24A52411EAF10E06E96 /* SecurityAndPrivacyScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBADF8010C813D905C172CE /* SecurityAndPrivacyScreenModels.swift */; };
 		6B8F03A85E83755D98DF0443 /* SearchScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C4724D5CB16CFA5853EF8F9 /* SearchScreenViewModel.swift */; };
 		6BA9214F31A24C7A84287A56 /* SentryEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 337AD37403015231CAE3E80B /* SentryEvent.swift */; };
 		6BAE34CFA9821709CFE61E50 /* DeveloperOptionsScreenHook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F60FDB3AEFC60830BD289FE /* DeveloperOptionsScreenHook.swift */; };
+		6BD28DF22B18AA9269BD97D4 /* MapLibreAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C086BE461902C44B608393 /* MapLibreAnnotation.swift */; };
 		6BEB10499149444909EBE42F /* TrackedUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D751743B20B314D84D79FE /* TrackedUserDefaults.swift */; };
 		6C34237AFB808E38FC8776B9 /* RoomStateEventStringBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D55702474F279D910D2D162 /* RoomStateEventStringBuilder.swift */; };
 		6C8BAF1E91618D69E7D652B2 /* NotificationServiceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A1AD6389A4659AF0CEAE62 /* NotificationServiceExtension.swift */; };
@@ -708,7 +713,6 @@
 		72D2298DE695A6797CDA1A2A /* SpaceScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18B223FA339BF53085328DEE /* SpaceScreenViewModelTests.swift */; };
 		733E2B19AB1FDA3B93293A28 /* AppLockSetupPINScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F275432954C8C6B1B7D966 /* AppLockSetupPINScreen.swift */; };
 		738288EAEE235CAC0893AB9E /* ThreadTimelineScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C9ACDD96F36510C1FC0836B /* ThreadTimelineScreenViewModel.swift */; };
-		73DBE886625AF56FF08D7F76 /* CoordinateAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA74F57B0DA3B9A9DD51F691 /* CoordinateAnimator.swift */; };
 		73F33E9776B7A50B65A031D2 /* AppLockSettingsScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0BA67B3E4EF9D29D14A78CE /* AppLockSettingsScreenViewModelTests.swift */; };
 		73F547BEB41D3DAFAAF6E0AF /* UserProfileScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71E2E5103702D13361D09100 /* UserProfileScreenViewModelTests.swift */; };
 		7405B4824D45BA7C3D943E76 /* Application.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0CBC76C80E04345E11F2DB /* Application.swift */; };
@@ -806,6 +810,7 @@
 		82434593648CB74121F1A821 /* RowDivider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C513A6CD99E6C3C163DA1E /* RowDivider.swift */; };
 		8285FF4B2C2331758C437FF7 /* ReportContentScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 713B48DBF65DE4B0DD445D66 /* ReportContentScreenViewModelProtocol.swift */; };
 		828EA5009557C2B9DCD4CA0F /* UserDiscoverySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D071F86CD47582B9196C9D16 /* UserDiscoverySection.swift */; };
+		82A33B40198D4EDD9F90493A /* MapViewConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8686F7CDEFAE2CBB3B9117 /* MapViewConfiguration.swift */; };
 		82D1368B43020B55347E1743 /* GalleryGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE0273EC14A781BBF715E37 /* GalleryGridView.swift */; };
 		832A4EA1094B8FE423A08700 /* RoomChangeRolesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B2A421198FD20AAAED20004 /* RoomChangeRolesScreen.swift */; };
 		8358D145F9BF94F412BEDCA8 /* RoomRolesAndPermissionsScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE7969EBCAF078813E18EA1 /* RoomRolesAndPermissionsScreenModels.swift */; };
@@ -1055,6 +1060,7 @@
 		A6FFC4C5154C446BAD6B40D8 /* TimelineItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8520AFD6680CBAD388F6D927 /* TimelineItemProvider.swift */; };
 		A722F426FD81FC67706BB1E0 /* CustomLayoutLabelStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42236480CF0431535EBE8387 /* CustomLayoutLabelStyle.swift */; };
 		A74438ED16F8683A4B793E6A /* AnalyticsSettingsScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BCE3FAF40932AC7C7639AC4 /* AnalyticsSettingsScreenViewModel.swift */; };
+		A79634DCE52B5021F549E0E9 /* MapLibreShim.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E8BAA982EC260E74CCCB22 /* MapLibreShim.framework */; };
 		A7D48E44D485B143AADDB77D /* Strings+Untranslated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A18F6CE4D694D21E4EA9B25 /* Strings+Untranslated.swift */; };
 		A7DB75E090542331F6668A23 /* CreateRoomScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF19027E7FFA5E63D148873A /* CreateRoomScreenViewModel.swift */; };
 		A808DC3F72D15C6C5A52317E /* TimelineItemDebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCDA016D05107DED3B9495CB /* TimelineItemDebugView.swift */; };
@@ -1336,12 +1342,14 @@
 		D8459AAD6969B1431ECBE990 /* UnsupportedRoomTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E535B3388755B65C34CD10 /* UnsupportedRoomTimelineView.swift */; };
 		D8517B8EED58D24396FB71E7 /* DeactivateAccountScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BAE25A0E9E9F2F1BBA8930 /* DeactivateAccountScreenViewModel.swift */; };
 		D885B783B95AD7832D4EF5DD /* CharacterSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8C01DEEA83903D45069BBD /* CharacterSet.swift */; };
+		D89E46C3AAD462407D332046 /* MapLibreShimProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 726D7EB0E16F7E4F6DD95395 /* MapLibreShimProtocol.swift */; };
 		D8CFA0EE46376F9FF04EEE45 /* TextRoomTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4853C923A1AF43711D025EAF /* TextRoomTimelineView.swift */; };
 		D8F1462EA00AFC939FF9ACCA /* target.yml in Resources */ = {isa = PBXBuildFile; fileRef = 203D1ACC20287F8986C959D3 /* target.yml */; };
 		D97C782FE0005995C36FA04A /* portrait_test_video.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = E5E7D4EE7CA295E5039FDA21 /* portrait_test_video.mp4 */; };
 		D98B5EE8C4F5A2CE84687AE8 /* UTType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 897DF5E9A70CE05A632FC8AF /* UTType.swift */; };
 		D9F80CE61BF8FF627FDB0543 /* LoadableImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C352359663A0E52BA20761EE /* LoadableImage.swift */; };
 		DA10C99BA43A0F1E732F6274 /* LogLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2711E5996016ABD6EAAEB58A /* LogLevel.swift */; };
+		DA4ABC37ED49F6617091F142 /* MapLibreInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 842F63AA68E8EB410B1BA29F /* MapLibreInterface.framework */; };
 		DA7E867F5EAFF8E20B2EE3B6 /* SecureBackupScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3D16709ADD4F4BCC710B1E /* SecureBackupScreenModels.swift */; };
 		DA8AE352C8FFCD47327811CA /* LeaveSpaceModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822B5573BDF52CF220BF9A17 /* LeaveSpaceModels.swift */; };
 		DAF63A9CF9932CA8F6830F11 /* ShareExtensionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCAC01A97A43BE07B9E94E43 /* ShareExtensionModels.swift */; };
@@ -1352,6 +1360,7 @@
 		DBC3FDE1540B39702A117D8E /* RoomRolesAndPermissionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44DDC82DB6A84E700CD5DEC0 /* RoomRolesAndPermissionsTests.swift */; };
 		DBC8D1DBFE9F9CA7662BC8AA /* RoomPermissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 974AEAF3FE0C577A6C04AD6E /* RoomPermissions.swift */; };
 		DC08ADC41E792086A340A8B3 /* AccessibilityIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BB8DDE245ED86C489BA983 /* AccessibilityIdentifiers.swift */; };
+		DC1321AC05EE491E5D5A9A50 /* MapLibreShim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89ABAF691BA268B93C06142A /* MapLibreShim.swift */; };
 		DC68E866D6E664B0D2B06E74 /* MockImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC1DA29A5A041CC0BACA7CB0 /* MockImageCache.swift */; };
 		DC77E9DB2CFBE84A2BDF20C5 /* RoomRolesAndPermissionsFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0833F51229E166BCA141D004 /* RoomRolesAndPermissionsFlowCoordinator.swift */; };
 		DCFE7CB3B9A104330BBB96AD /* AnalyticsPromptScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B67DF223EEB8DCAF178A1D4 /* AnalyticsPromptScreenCoordinator.swift */; };
@@ -1610,6 +1619,13 @@
 			remoteGlobalIDString = 19F0C845D67E9BEA4BE7133E;
 			remoteInfo = ShareExtension;
 		};
+		5F1D4E7C20485C444FA1D42F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = AC22997D58D612146053154D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 392E7AA23D7BA2CEEB25CF73;
+			remoteInfo = MapLibreShim;
+		};
 		6848AF4480814C5F810FB7EB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = AC22997D58D612146053154D /* Project object */;
@@ -1638,6 +1654,13 @@
 			remoteGlobalIDString = FEB53A5BC378C913769656D8;
 			remoteInfo = NSE;
 		};
+		D96A382EE558F49A8070D92A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = AC22997D58D612146053154D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 96435A765678A64A956EE59C;
+			remoteInfo = MapLibreInterface;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -1661,6 +1684,7 @@
 			files = (
 				C9C562D85999E436C7265AF1 /* MatrixRustSDK in Embed Frameworks */,
 				874704A177B0A6D78E037908 /* MapLibreInterface.framework in Embed Frameworks */,
+				5B2CE8FE14CB16F2FCAFC4B2 /* MapLibreShim.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1772,6 +1796,7 @@
 		105429F29096729EDD3152CF /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/SAS.strings; sourceTree = "<group>"; };
 		1059E2AE7878CF7820592637 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		105B2A8426404EF66F00CFDB /* RoomTimelineItemFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomTimelineItemFactory.swift; sourceTree = "<group>"; };
+		10A8171DA78BA39F07D669B1 /* CoordinateAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinateAnimator.swift; sourceTree = "<group>"; };
 		10CC626F97AD70FF0420C115 /* RoomSummaryProviderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomSummaryProviderProtocol.swift; sourceTree = "<group>"; };
 		10D751743B20B314D84D79FE /* TrackedUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackedUserDefaults.swift; sourceTree = "<group>"; };
 		10F130DF775CE6BC51A4E392 /* AppLockSetupBiometricsScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockSetupBiometricsScreenModels.swift; sourceTree = "<group>"; };
@@ -2009,6 +2034,7 @@
 		38E521D6C2BF8DF0DFB35146 /* DeveloperOptionsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperOptionsScreen.swift; sourceTree = "<group>"; };
 		3984C93B8E9B10C92DADF9EE /* RoomDirectorySearchScreenScreenModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomDirectorySearchScreenScreenModelProtocol.swift; sourceTree = "<group>"; };
 		398817652FA8ABAE0A31AC6D /* ReadableFrameModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadableFrameModifier.swift; sourceTree = "<group>"; };
+		3989F50ECBC5AEE2E5A062DA /* MapLibreMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapLibreMapView.swift; sourceTree = "<group>"; };
 		39C0D861FC397AC34BCF089E /* KeychainControllerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainControllerMock.swift; sourceTree = "<group>"; };
 		39C78D5FF15343724902EB20 /* ClassicAppManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClassicAppManager.swift; sourceTree = "<group>"; };
 		3A12D3D8138F1B71AFA7C858 /* CompletionSuggestionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionSuggestionService.swift; sourceTree = "<group>"; };
@@ -2080,6 +2106,7 @@
 		44C314C00533E2C297796B60 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		44C70BD39FC34A9FD2467540 /* SearchScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		44DDC82DB6A84E700CD5DEC0 /* RoomRolesAndPermissionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomRolesAndPermissionsTests.swift; sourceTree = "<group>"; };
+		44E8BAA982EC260E74CCCB22 /* MapLibreShim.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MapLibreShim.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		44ECC9D66400727DFFEE12E8 /* TimelineStartRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineStartRoomTimelineView.swift; sourceTree = "<group>"; };
 		450E04B2A976CC4C8CC1807C /* EmoteRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmoteRoomTimelineItem.swift; sourceTree = "<group>"; };
 		4525E8C0FBDD27D1ACE90952 /* SecureBackupKeyBackupScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureBackupKeyBackupScreenViewModelProtocol.swift; sourceTree = "<group>"; };
@@ -2326,6 +2353,7 @@
 		722013E20EEED73553EC6F8D /* RoomHistorySharingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomHistorySharingState.swift; sourceTree = "<group>"; };
 		723B055A57857BFF0F18D9CB /* test_rotated_image.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = test_rotated_image.jpg; sourceTree = "<group>"; };
 		72614BFF35B8394C6E13F55A /* TimelineItemStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineItemStatusView.swift; sourceTree = "<group>"; };
+		726D7EB0E16F7E4F6DD95395 /* MapLibreShimProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapLibreShimProtocol.swift; sourceTree = "<group>"; };
 		726E901DF76393E335FD7E8E /* ManageAuthorizedSpacesScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageAuthorizedSpacesScreenViewModel.swift; sourceTree = "<group>"; };
 		72C4A2D279386A811BDC6DAE /* LinkNewDeviceScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkNewDeviceScreen.swift; sourceTree = "<group>"; };
 		72D03D36422177EF01905D20 /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -2476,6 +2504,7 @@
 		8977176AB534AA41630395BC /* LegalInformationScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegalInformationScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		897DF5E9A70CE05A632FC8AF /* UTType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTType.swift; sourceTree = "<group>"; };
 		89AAEA70CFF3284920811941 /* RoomChangePermissionsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomChangePermissionsScreen.swift; sourceTree = "<group>"; };
+		89ABAF691BA268B93C06142A /* MapLibreShim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapLibreShim.swift; sourceTree = "<group>"; };
 		89BB11A792EF6F70B95B467E /* EncryptionResetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptionResetTests.swift; sourceTree = "<group>"; };
 		89D7846847BA9D2C5346ED9C /* EditAvatarButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAvatarButtonStyle.swift; sourceTree = "<group>"; };
 		89FBFC09F9DAFF1E4BA97849 /* FormButtonStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormButtonStyles.swift; sourceTree = "<group>"; };
@@ -2656,6 +2685,7 @@
 		A9FC06B3414D3BBD709E72E4 /* CLLocationCoordinate2D.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLLocationCoordinate2D.swift; sourceTree = "<group>"; };
 		AA12A7F5EF5C6D0B992869ED /* LiveLocationShareProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveLocationShareProxy.swift; sourceTree = "<group>"; };
 		AA19C32BD97F45847724E09A /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Untranslated.strings; sourceTree = "<group>"; };
+		AA8686F7CDEFAE2CBB3B9117 /* MapViewConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewConfiguration.swift; sourceTree = "<group>"; };
 		AAC9344689121887B74877AF /* UnitTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = UnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AACE9B8E1A4AE79A7E2914F6 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = es; path = es.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		AAD01F7FC2BBAC7351948595 /* UserProfile+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserProfile+Mock.swift"; sourceTree = "<group>"; };
@@ -2971,6 +3001,7 @@
 		DF3D25B3EDB283B5807EADCF /* ReadMarkerRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadMarkerRoomTimelineItem.swift; sourceTree = "<group>"; };
 		DFFB0E7C6D8E190AFA0176DC /* uz */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = uz; path = uz.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		E06AAD6D9D3F5833E7A5A2F9 /* RoomListFilterModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomListFilterModels.swift; sourceTree = "<group>"; };
+		E0C086BE461902C44B608393 /* MapLibreAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapLibreAnnotation.swift; sourceTree = "<group>"; };
 		E0FCA0957FAA0E15A9F5579D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Untranslated.stringsdict; sourceTree = "<group>"; };
 		E0FF9CB3EFA753277291F609 /* EncryptionResetScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptionResetScreenCoordinator.swift; sourceTree = "<group>"; };
 		E10DA51DBC8C7E1460DBCCBD /* UserProfileListRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileListRow.swift; sourceTree = "<group>"; };
@@ -3127,7 +3158,6 @@
 		FA393404F96DFB505B86E913 /* CurrentValuePublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentValuePublisherTests.swift; sourceTree = "<group>"; };
 		FA3EB5B1848CF4F64E63C6B7 /* PermalinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermalinkTests.swift; sourceTree = "<group>"; };
 		FA723686F23EF45E2B398FBC /* TestablePreviewsDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestablePreviewsDictionary.swift; sourceTree = "<group>"; };
-		FA74F57B0DA3B9A9DD51F691 /* CoordinateAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinateAnimator.swift; sourceTree = "<group>"; };
 		FA7BB497B2F539C17E88F6B7 /* NotificationSettingsEditScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsEditScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		FABAC5C4373B0EC24D399663 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/SAS.strings"; sourceTree = "<group>"; };
 		FB7BAD55A4E2B8E5828CD64C /* SoftLogoutScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoftLogoutScreenViewModel.swift; sourceTree = "<group>"; };
@@ -3190,6 +3220,15 @@
 				B5C40DCFFDFBA0F86E228602 /* Clocks in Frameworks */,
 				D75C591C44C2510FDFA9C3D8 /* Dynamic in Frameworks */,
 				71AF9345A1202DB9B5DCD9AE /* Macros in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B2E8191126927DDE67256B6E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DA4ABC37ED49F6617091F142 /* MapLibreInterface.framework in Frameworks */,
+				5D586C5CED7B7B086C61B84A /* MapLibre in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3268,6 +3307,7 @@
 				FC10228E73323BDC09526F97 /* LRUCache in Frameworks */,
 				EAC6FE2CD4F50A43068ADCD8 /* Mantis in Frameworks */,
 				76D4D5312ED8E42B35C29FA3 /* MapLibreInterface.framework in Frameworks */,
+				A79634DCE52B5021F549E0E9 /* MapLibreShim.framework in Frameworks */,
 				754602A7B2AAD443C4228ED4 /* MapLibre in Frameworks */,
 				B0CB16349B96262AA65A04AF /* PostHog in Frameworks */,
 				36AD4DD4C798E22584ED3200 /* SwiftState in Frameworks */,
@@ -3651,6 +3691,14 @@
 			path = MediaUploadPreviewScreen;
 			sourceTree = "<group>";
 		};
+		2368DD797236140F1D21429C /* MapLibreShim */ = {
+			isa = PBXGroup;
+			children = (
+				57A8D2B00E79926C6E5E6F49 /* Sources */,
+			);
+			path = MapLibreShim;
+			sourceTree = "<group>";
+		};
 		24FBB8F76D6435033CD07747 /* ManageAuthorizedSpacesScreen */ = {
 			isa = PBXGroup;
 			children = (
@@ -3746,6 +3794,7 @@
 			isa = PBXGroup;
 			children = (
 				2F311A9BA03995E736E065DE /* MapLibreInterface */,
+				2368DD797236140F1D21429C /* MapLibreShim */,
 			);
 			path = MapLibre;
 			sourceTree = "<group>";
@@ -4700,6 +4749,17 @@
 			path = AppLockSetupPINScreen;
 			sourceTree = "<group>";
 		};
+		57A8D2B00E79926C6E5E6F49 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				10A8171DA78BA39F07D669B1 /* CoordinateAnimator.swift */,
+				E0C086BE461902C44B608393 /* MapLibreAnnotation.swift */,
+				3989F50ECBC5AEE2E5A062DA /* MapLibreMapView.swift */,
+				89ABAF691BA268B93C06142A /* MapLibreShim.swift */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
 		593C7129C5927E25AD8B688F /* FlowCoordinators */ = {
 			isa = PBXGroup;
 			children = (
@@ -4926,6 +4986,7 @@
 				9C7F7DE62D33C6A26CBFCD72 /* IntegrationTests.xctest */,
 				73F3153AB9D628110878E24F /* libMatrixRustSDKMocks.a */,
 				842F63AA68E8EB410B1BA29F /* MapLibreInterface.framework */,
+				44E8BAA982EC260E74CCCB22 /* MapLibreShim.framework */,
 				0D8F620C8B314840D8602E3F /* NSE.appex */,
 				D95E8C0EFEC0C6F96EDAA71A /* PreviewTests.xctest */,
 				3D8BEEFCA07BEA43F4F4BF77 /* ShareExtension.appex */,
@@ -6090,7 +6151,9 @@
 		A7793413E64FE8831FE95F57 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				726D7EB0E16F7E4F6DD95395 /* MapLibreShimProtocol.swift */,
 				33FF3E6EED8FC58755AF3A42 /* MapModels.swift */,
+				AA8686F7CDEFAE2CBB3B9117 /* MapViewConfiguration.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -6468,7 +6531,6 @@
 		C17C3586C93F3A314C1CC318 /* MapLibre */ = {
 			isa = PBXGroup;
 			children = (
-				FA74F57B0DA3B9A9DD51F691 /* CoordinateAnimator.swift */,
 				AAD8234D0E9C9B12BF9F240B /* LocationAnnotation.swift */,
 				622D09D4ECE759189009AEAF /* MapLibreMapView.swift */,
 				B81B6170DB690013CEB646F4 /* MapLibreModels.swift */,
@@ -7364,6 +7426,26 @@
 			productReference = AAC9344689121887B74877AF /* UnitTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		392E7AA23D7BA2CEEB25CF73 /* MapLibreShim */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4986BC84F7961B6E169BC9A2 /* Build configuration list for PBXNativeTarget "MapLibreShim" */;
+			buildPhases = (
+				2258F3E0D784959ADD4FCE50 /* Sources */,
+				B2E8191126927DDE67256B6E /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				233E31868DA9FF26EAB3044D /* PBXTargetDependency */,
+			);
+			name = MapLibreShim;
+			packageProductDependencies = (
+				7E8600FD98955C620F83BFBA /* MapLibre */,
+			);
+			productName = MapLibreShim;
+			productReference = 44E8BAA982EC260E74CCCB22 /* MapLibreShim.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		676A87694F0F247B2AF1A142 /* MatrixRustSDKMocks */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 4272AFBE93EEF7B03D9B9ECD /* Build configuration list for PBXNativeTarget "MatrixRustSDKMocks" */;
@@ -7467,6 +7549,7 @@
 				58C473A5DEA945AACFEA8E9F /* PBXTargetDependency */,
 				2E32BC489F482046B8B1460F /* PBXTargetDependency */,
 				0C42CEF186BBA0F3DBC17B85 /* PBXTargetDependency */,
+				36A05892F02FA9721A47871F /* PBXTargetDependency */,
 			);
 			name = ElementX;
 			packageProductDependencies = (
@@ -7578,6 +7661,9 @@
 						DevelopmentTeam = "$(DEVELOPMENT_TEAM)";
 					};
 					32C23C8D224D46EFE62AFAD0 = {
+						DevelopmentTeam = 7J4U792NQT;
+					};
+					392E7AA23D7BA2CEEB25CF73 = {
 						DevelopmentTeam = 7J4U792NQT;
 					};
 					676A87694F0F247B2AF1A142 = {
@@ -7694,6 +7780,7 @@
 			projectRoot = "";
 			targets = (
 				96435A765678A64A956EE59C /* MapLibreInterface */,
+				392E7AA23D7BA2CEEB25CF73 /* MapLibreShim */,
 				C0FAEB81CFD9776CD78CE489 /* ElementX */,
 				FEB53A5BC378C913769656D8 /* NSE */,
 				19F0C845D67E9BEA4BE7133E /* ShareExtension */,
@@ -8230,11 +8317,24 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		2258F3E0D784959ADD4FCE50 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6B47F2C6B11A1EDF0480DA71 /* CoordinateAnimator.swift in Sources */,
+				6BD28DF22B18AA9269BD97D4 /* MapLibreAnnotation.swift in Sources */,
+				310E1D9D246277A4FFA66162 /* MapLibreMapView.swift in Sources */,
+				DC1321AC05EE491E5D5A9A50 /* MapLibreShim.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		294638399D803C4F2154D2B7 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D89E46C3AAD462407D332046 /* MapLibreShimProtocol.swift in Sources */,
 				A05D6ACD38082D3E0A14D63E /* MapModels.swift in Sources */,
+				82A33B40198D4EDD9F90493A /* MapViewConfiguration.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8510,7 +8610,6 @@
 				E8F88136C8E69D9E69621E19 /* ContentScannerServiceProtocol.swift in Sources */,
 				9DD0DFFEFCA51AE241B637D1 /* ContentScanningFailureView.swift in Sources */,
 				681FA9A37E82A14EDFB22D56 /* ContentScanningView.swift in Sources */,
-				73DBE886625AF56FF08D7F76 /* CoordinateAnimator.swift in Sources */,
 				C3522917C0C367C403429EEC /* CoordinatorProtocol.swift in Sources */,
 				633501761094E09DFBEBFFAD /* CopyTextButton.swift in Sources */,
 				CE8296D4AD30DDC6D0C67A74 /* CreateRoomScreen.swift in Sources */,
@@ -9474,6 +9573,11 @@
 			target = C0FAEB81CFD9776CD78CE489 /* ElementX */;
 			targetProxy = 4D8DD8FE84794CA168A8499A /* PBXContainerItemProxy */;
 		};
+		233E31868DA9FF26EAB3044D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 96435A765678A64A956EE59C /* MapLibreInterface */;
+			targetProxy = D96A382EE558F49A8070D92A /* PBXContainerItemProxy */;
+		};
 		2C29670603B37E38705D5FF1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = FEB53A5BC378C913769656D8 /* NSE */;
@@ -9483,6 +9587,11 @@
 			isa = PBXTargetDependency;
 			target = 676A87694F0F247B2AF1A142 /* MatrixRustSDKMocks */;
 			targetProxy = 2324965D972BC4812FE0F380 /* PBXContainerItemProxy */;
+		};
+		36A05892F02FA9721A47871F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 392E7AA23D7BA2CEEB25CF73 /* MapLibreShim */;
+			targetProxy = 5F1D4E7C20485C444FA1D42F /* PBXContainerItemProxy */;
 		};
 		421359F1BC0A1816DD34A2BB /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -9929,6 +10038,32 @@
 			};
 			name = Debug;
 		};
+		68ED112958B6D89CEFACC03F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "$(BASE_BUNDLE_IDENTIFIER).maplibre-shim";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_VERSION = 6.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
 		6EE786F14472D5CCF8DD0980 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -10252,6 +10387,32 @@
 			};
 			name = Debug;
 		};
+		A84BC5F889292CF399F36B08 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "$(BASE_BUNDLE_IDENTIFIER).maplibre-shim";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_VERSION = 6.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
 		AAE81BF8DCDB30B237B10C3E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -10360,6 +10521,15 @@
 			buildConfigurations = (
 				53B6D5892165E771A8489F9D /* Debug */,
 				2DFF6BC8513E455947420CEA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		4986BC84F7961B6E169BC9A2 /* Build configuration list for PBXNativeTarget "MapLibreShim" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				68ED112958B6D89CEFACC03F /* Debug */,
+				A84BC5F889292CF399F36B08 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -10875,6 +11045,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E9C4F3A12AA1F65C13A8C8EB /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */;
 			productName = SnapshotTesting;
+		};
+		7E8600FD98955C620F83BFBA /* MapLibre */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0CBF57301AA172C21F76CE86 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */;
+			productName = MapLibre;
 		};
 		800631D7250B7F93195035F1 /* KeychainAccess */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 		149D1942DC005D0485FB8D93 /* LoggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC1943ADE6A62ED5129D7C8 /* LoggingTests.swift */; };
 		14E99D27628B1A6F0CB46FEA /* SeparatorRoomTimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6A9F49B3EE59147AF2F70BB /* SeparatorRoomTimelineItem.swift */; };
 		151D2477F75782C8702F2873 /* PollInteractionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC528B3764E3CF7FCFEF40E7 /* PollInteractionHandler.swift */; };
+		1524AAAE9BCAA32D65E97866 /* MapLibreInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 842F63AA68E8EB410B1BA29F /* MapLibreInterface.framework */; };
 		155063E980E763D4910EA3CF /* Analytics+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CFE236419E830E8946639C /* Analytics+SwiftUI.swift */; };
 		1555A7643D85187D4851040C /* TemplateScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4549FCB53F43DB0B278374BC /* TemplateScreen.swift */; };
 		1583E2D766E4485FF91662FC /* PermalinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3EB5B1848CF4F64E63C6B7 /* PermalinkTests.swift */; };
@@ -781,6 +782,7 @@
 		7C1A7B594B2F8143F0DD0005 /* ElementXAttributeScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = C024C151639C4E1B91FCC68B /* ElementXAttributeScope.swift */; };
 		7C545FFEC9930F7247352593 /* SecurityAndPrivacyScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 978092B01BEAB39F2C4389AE /* SecurityAndPrivacyScreenViewModel.swift */; };
 		7C6376192F578E0BA801BFEC /* AnalyticsSettingsScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C64A14EE89928207E3B42B /* AnalyticsSettingsScreenModels.swift */; };
+		7C81239BB5C79382812D6446 /* MapLibreInterface.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 842F63AA68E8EB410B1BA29F /* MapLibreInterface.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7C9BDF1FC7BD46C4676536AB /* AuthenticationStartScreenBackgroundImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 682BC7BAF0EFEF512A8C5140 /* AuthenticationStartScreenBackgroundImage.swift */; };
 		7CD16990BA843BE9ED639129 /* ImageRoomTimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFE4453AB0B34C203447162 /* ImageRoomTimelineItem.swift */; };
 		7D249465ED00988EEEC14E05 /* JoinedRoomProxyMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 867DC9530C42F7B5176BE465 /* JoinedRoomProxyMock.swift */; };
@@ -1452,6 +1454,7 @@
 		EAB3C1F0BC7F671ED8BDF82D /* CompletionSuggestionServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ECF11669EF253E98AA2977A /* CompletionSuggestionServiceProtocol.swift */; };
 		EAC6FE2CD4F50A43068ADCD8 /* Mantis in Frameworks */ = {isa = PBXBuildFile; productRef = 8C30177487BBB5D000E4DDDA /* Mantis */; };
 		EAF2B3E6C6AEC4AD3A8BD454 /* RoomMemberDetailsScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A87D0471D438A233C2CF4A /* RoomMemberDetailsScreenViewModel.swift */; };
+		EB069CC36087F103C517C6A0 /* MapLibreLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51956E593E1AEEE6C6DA7DB9 /* MapLibreLoaderTests.swift */; };
 		EB5B79DD2BCAF8F3B8B01F2F /* LiveLocationSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C454F35D8884C0A952FF2F84 /* LiveLocationSheet.swift */; };
 		EB87DF90CF6F8D5D12404C6E /* SecureBackupLogoutConfirmationScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848F69921527D31CAACB93AF /* SecureBackupLogoutConfirmationScreenViewModelTests.swift */; };
 		EB88DBD77221E2CFE463018C /* NSE.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 0D8F620C8B314840D8602E3F /* NSE.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -1583,6 +1586,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		1B40BC202963A63B2DAD9A5C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = AC22997D58D612146053154D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 96435A765678A64A956EE59C;
+			remoteInfo = MapLibreInterface;
+		};
 		1CE0B5D9ECEB44A4A32285B4 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = AC22997D58D612146053154D /* Project object */;
@@ -1663,6 +1673,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		29A8B94D10A8659E02E4348C /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				7C81239BB5C79382812D6446 /* MapLibreInterface.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8E3CD0D0BB6697512E867C1D /* Embed Foundation Extensions */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2179,6 +2200,7 @@
 		510DA63AB273A68D659CEC95 /* ToolbarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarButton.swift; sourceTree = "<group>"; };
 		510E89B989477E5EE8E503C0 /* PinnedEventsTimelineScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedEventsTimelineScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		514363244AE7D68080D44C6F /* NotificationSettingsScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsScreenViewModelTests.swift; sourceTree = "<group>"; };
+		51956E593E1AEEE6C6DA7DB9 /* MapLibreLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapLibreLoaderTests.swift; sourceTree = "<group>"; };
 		51C2BCE0BC1FC69C1B36E688 /* BugReportScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugReportScreenModels.swift; sourceTree = "<group>"; };
 		51F14C0F5FD4A1814D5527E6 /* fa */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fa; path = fa.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		52135BD9E0E7A091688F627A /* MessageForwardingScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageForwardingScreenModels.swift; sourceTree = "<group>"; };
@@ -3216,6 +3238,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1524AAAE9BCAA32D65E97866 /* MapLibreInterface.framework in Frameworks */,
 				7FF27DA70D833CFC5724EFC5 /* MatrixRustSDK in Frameworks */,
 				BCA5E2157CE27AB6F1D043D3 /* AsyncAlgorithms in Frameworks */,
 				B5C40DCFFDFBA0F86E228602 /* Clocks in Frameworks */,
@@ -5163,6 +5186,7 @@
 				3DC1943ADE6A62ED5129D7C8 /* LoggingTests.swift */,
 				5A43964330459965AF048A8C /* LoginScreenViewModelTests.swift */,
 				D80807B554CF9C524F98674F /* ManageRoomMemberSheetViewModelTests.swift */,
+				51956E593E1AEEE6C6DA7DB9 /* MapLibreLoaderTests.swift */,
 				1D262A26713C18BB70C82CA5 /* MapTilerURLBuilderTests.swift */,
 				F31F59030205A6F65B057E1A /* MatrixEntityRegexTests.swift */,
 				F505E3D79018B6EFF953F647 /* MediaEventsTimelineScreenViewModelTests.swift */,
@@ -7416,11 +7440,13 @@
 				11F93544B4FC60F78F47D89C /* Sources */,
 				9B3512762CF4A1D45A79C340 /* Resources */,
 				A7A4BAD642A61DCC41621311 /* Frameworks */,
+				29A8B94D10A8659E02E4348C /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				0EEC1557A40FBA6DF49D83A2 /* PBXTargetDependency */,
+				F602D8F5F2DBDB5B9F6D0CD1 /* PBXTargetDependency */,
 			);
 			name = UnitTests;
 			packageProductDependencies = (
@@ -8221,6 +8247,7 @@
 				149D1942DC005D0485FB8D93 /* LoggingTests.swift in Sources */,
 				7434A7F02D587A920B376A9A /* LoginScreenViewModelTests.swift in Sources */,
 				1C1750C009F7214B967928BC /* ManageRoomMemberSheetViewModelTests.swift in Sources */,
+				EB069CC36087F103C517C6A0 /* MapLibreLoaderTests.swift in Sources */,
 				3BEBDCB42BABFA3B456FECA7 /* MapTilerURLBuilderTests.swift in Sources */,
 				2E43A3D221BE9587BC19C3F1 /* MatrixEntityRegexTests.swift in Sources */,
 				7070E5CA0095CBEFAA7DE466 /* MediaEventsTimelineScreenViewModelTests.swift in Sources */,
@@ -9628,6 +9655,11 @@
 		BE5BE6377A4171172FBD4D9A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			productRef = DB9D6197EEDBA2CC860208E2 /* MatrixRustSDK */;
+		};
+		F602D8F5F2DBDB5B9F6D0CD1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 96435A765678A64A956EE59C /* MapLibreInterface */;
+			targetProxy = 1B40BC202963A63B2DAD9A5C /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -343,15 +343,15 @@
 		36926D795D6D19177C7812F8 /* EncryptionResetPasswordScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6935A55AB3B0C94BC566DD6 /* EncryptionResetPasswordScreenCoordinator.swift */; };
 		369BF960E52BBEE61F8A5BD1 /* BlockedUsersScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED60E4D2CD678E1EBF16F77A /* BlockedUsersScreen.swift */; };
 		36AC963F2F04069B7FF1AA0C /* UIConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6D88E8AFFBF2C1D589C0FA /* UIConstants.swift */; };
-		36AD4DD4C798E22584ED3200 /* SwiftState in Frameworks */ = {isa = PBXBuildFile; productRef = 9573B94B1C86C6DF751AF3FD /* SwiftState */; };
-		36CD6E11B37396E14F032CB6 /* GZIP in Frameworks */ = {isa = PBXBuildFile; productRef = 997C7385E1A07E061D7E2100 /* GZIP */; };
+		36AD4DD4C798E22584ED3200 /* GZIP in Frameworks */ = {isa = PBXBuildFile; productRef = 997C7385E1A07E061D7E2100 /* GZIP */; };
+		36CD6E11B37396E14F032CB6 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 7731767AE437BA3BD2CC14A8 /* Sentry */; };
 		36DCA11EA7320A45A4CC8D07 /* SpaceRemoveChildrenConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44AC61A375CC2E47938B5D12 /* SpaceRemoveChildrenConfirmationView.swift */; };
 		36DE961B784087D5E18EF9BA /* LogViewerScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A07692536D66E3DA32C4964 /* LogViewerScreen.swift */; };
 		370AF5BFCD4384DD455479B6 /* ElementCallWidgetDriverProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C11AD9813045E44F950410 /* ElementCallWidgetDriverProtocol.swift */; };
 		377980ABF16525114E72DDE2 /* SwiftSoup in Frameworks */ = {isa = PBXBuildFile; productRef = D2330417C6BE2F6872FFF96B /* SwiftSoup */; };
 		37906355E207DB5703754675 /* AppLockSetupBiometricsScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F893F4A111CB7BA5C96949 /* AppLockSetupBiometricsScreenViewModel.swift */; };
 		37D789F24199B32E3FD1AA7B /* FileRoomTimelineItemContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216F0DDC98F2A2C162D09C28 /* FileRoomTimelineItemContent.swift */; };
-		37E47F5101C0C036289D3807 /* Emojibase in Frameworks */ = {isa = PBXBuildFile; productRef = C05729B1684C331F5FFE9232 /* Emojibase */; };
+		37E47F5101C0C036289D3807 /* WysiwygComposer in Frameworks */ = {isa = PBXBuildFile; productRef = CA07D57389DACE18AEB6A5E2 /* WysiwygComposer */; };
 		383063A7924F06D54BA9B24C /* SpaceSettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9475FD81B13D50103E5290EB /* SpaceSettingsScreen.swift */; };
 		384D6B9A7DFD7260139D6852 /* UITestsNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBEB8D9F4940E161B18FE4BC /* UITestsNotificationCenter.swift */; };
 		38546A6010A2CF240EC9AF73 /* BindableState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA1D2CBAEA5D0BD00B90D1B /* BindableState.swift */; };
@@ -422,11 +422,11 @@
 		441857143FC100E0A7DE42A8 /* RoomPowerLevelProxyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D635709C1D6D37C225AD40E /* RoomPowerLevelProxyProtocol.swift */; };
 		446BCD2D0AE27E0CFD1BDC8F /* ImageMediaEventsTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF584D757E768EA7776A532 /* ImageMediaEventsTimelineView.swift */; };
 		44BDD670FF9095ACE240A3A2 /* VoiceMessageMediaManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC4F10BDD56FA77FEC742333 /* VoiceMessageMediaManagerTests.swift */; };
-		44F0E1B576C7599DF8022071 /* SentrySwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 75361A9D8A3C5501EADB225D /* SentrySwiftUI */; };
+		44F0E1B576C7599DF8022071 /* Version in Frameworks */ = {isa = PBXBuildFile; productRef = A05AF81DDD14AD58CB0E1B9B /* Version */; };
 		454311EAC17D778E19F46592 /* NotificationPermissionsScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91868EB98818044E6FEBE532 /* NotificationPermissionsScreenCoordinator.swift */; };
 		454F8DDC4442C0DE54094902 /* LABiometryType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F219838588C62198E726E3 /* LABiometryType.swift */; };
 		45D6DC594816288983627484 /* UITestsScreenIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CEBE5EA91E8691EDF364EC2 /* UITestsScreenIdentifier.swift */; };
-		4610C57A4785FFF5E67F0C6D /* WysiwygComposer in Frameworks */ = {isa = PBXBuildFile; productRef = CA07D57389DACE18AEB6A5E2 /* WysiwygComposer */; };
+		4610C57A4785FFF5E67F0C6D /* SwiftOGG in Frameworks */ = {isa = PBXBuildFile; productRef = 391D11F92DFC91666AA1503F /* SwiftOGG */; };
 		46562110EE202E580A5FFD9C /* RoomScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CF7B19FFCF8EFBE0A8696A /* RoomScreenViewModelTests.swift */; };
 		4681820102DAC8BA586357D4 /* VoiceMessageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAB8D7926A5684E18196B538 /* VoiceMessageCache.swift */; };
 		46A183C6125A669AEB005699 /* UserProfileScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = F134D2D91DFF732FB75B2CB7 /* UserProfileScreenViewModelProtocol.swift */; };
@@ -723,7 +723,7 @@
 		74DF5BC17DE9F51E077FD457 /* LinkNewDeviceServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA257D747DD7E6FFA5C2BE2D /* LinkNewDeviceServiceMock.swift */; };
 		7501442D52A65F73DF79FFD4 /* PaginationIndicatorRoomTimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B987FC3FDBAA0E1C5AA235C /* PaginationIndicatorRoomTimelineItem.swift */; };
 		75072C529C9C363F531721F1 /* RecoveryKeyScreenHook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AE97AD18893E2D8120F559D /* RecoveryKeyScreenHook.swift */; };
-		754602A7B2AAD443C4228ED4 /* MapLibre in Frameworks */ = {isa = PBXBuildFile; productRef = ED146E565C4CB792FF2F37EA /* MapLibre */; };
+		754602A7B2AAD443C4228ED4 /* PostHog in Frameworks */ = {isa = PBXBuildFile; productRef = 4278261E147DB2DE5CFB7FC5 /* PostHog */; };
 		755395927DDD6EBDDA5E217A /* SettingsFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28F7A6CEEA4A2815B0F0F55 /* SettingsFlowCoordinator.swift */; };
 		755727E0B756430DFFEC4732 /* SessionVerificationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF05DA24F71B455E8EFEBC3B /* SessionVerificationViewModelTests.swift */; };
 		756BD0B80C1AF2A6DF0786CB /* CommonSettings+NotificationName.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB7A66212DC7D097886BD01F /* CommonSettings+NotificationName.swift */; };
@@ -788,6 +788,7 @@
 		7D6DC832DE7A3DE874E2E9BC /* MatrixRustSDK in Frameworks */ = {isa = PBXBuildFile; productRef = BB111AE9D390233CDD2C7FD5 /* MatrixRustSDK */; };
 		7DCFC31B49BDD2BC32184E58 /* TimelineControllerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C0D5AE752AF87DA0A920812 /* TimelineControllerFactory.swift */; };
 		7E2BB42805C59DB57E95610F /* PillView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7773CBFDBD458E0B7E270507 /* PillView.swift */; };
+		7E429C44DD0C99870C6E9972 /* MapLibre.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1DBA4A688563F86CC0D3E537 /* MapLibre.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7E43FBB918AAC136034F2758 /* test_image.png in Resources */ = {isa = PBXBuildFile; fileRef = 810133CF215075C285FC6F3A /* test_image.png */; };
 		7E91BAC17963ED41208F489B /* UserSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E8BDC092D817B68CD9040C5 /* UserSessionStore.swift */; };
 		7F0B6EB5CB52D7B7A2BB7D15 /* BannedRoomProxyMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FD7E851E2BA8C5A8D284B2A /* BannedRoomProxyMock.swift */; };
@@ -1013,7 +1014,7 @@
 		A076E0A9338FD2D950C3C4A1 /* ChatsSpaceFiltersScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63072981793CCA84EE12798 /* ChatsSpaceFiltersScreenViewModelProtocol.swift */; };
 		A0861B727B273B5B3DD7FBF6 /* KnockRequestsListScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09227E671DB30795C43FFFD /* KnockRequestsListScreenViewModel.swift */; };
 		A0868BDE84D2140A885BE3C9 /* EncryptionResetScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8562F4D7DE073BC32902AB /* EncryptionResetScreenViewModelProtocol.swift */; };
-		A0D7E5BD0298A97DCBDCE40B /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 7731767AE437BA3BD2CC14A8 /* Sentry */; };
+		A0D7E5BD0298A97DCBDCE40B /* SentrySwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 75361A9D8A3C5501EADB225D /* SentrySwiftUI */; };
 		A10D6CCDE2010C09EEA1A593 /* HomeScreenRoomList.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7661EFFCAA307A97D71132A /* HomeScreenRoomList.swift */; };
 		A14A9419105A1CD42F0511C4 /* UserIndicatorModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43005941B3A2C9671E23C85 /* UserIndicatorModalView.swift */; };
 		A1672EF491FE6F3BBF7878BE /* test_apple_image.heic in Resources */ = {isa = PBXBuildFile; fileRef = BB576F4118C35E6B5124FA22 /* test_apple_image.heic */; };
@@ -1060,18 +1061,17 @@
 		A6FFC4C5154C446BAD6B40D8 /* TimelineItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8520AFD6680CBAD388F6D927 /* TimelineItemProvider.swift */; };
 		A722F426FD81FC67706BB1E0 /* CustomLayoutLabelStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42236480CF0431535EBE8387 /* CustomLayoutLabelStyle.swift */; };
 		A74438ED16F8683A4B793E6A /* AnalyticsSettingsScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BCE3FAF40932AC7C7639AC4 /* AnalyticsSettingsScreenViewModel.swift */; };
-		A79634DCE52B5021F549E0E9 /* MapLibreShim.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44E8BAA982EC260E74CCCB22 /* MapLibreShim.framework */; };
 		A7D48E44D485B143AADDB77D /* Strings+Untranslated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A18F6CE4D694D21E4EA9B25 /* Strings+Untranslated.swift */; };
 		A7DB75E090542331F6668A23 /* CreateRoomScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF19027E7FFA5E63D148873A /* CreateRoomScreenViewModel.swift */; };
 		A808DC3F72D15C6C5A52317E /* TimelineItemDebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCDA016D05107DED3B9495CB /* TimelineItemDebugView.swift */; };
 		A816F7087C495D85048AC50E /* RoomMemberDetailsScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B6E30BB748F3F480F077969 /* RoomMemberDetailsScreenModels.swift */; };
 		A851635B3255C6DC07034A12 /* RoomScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8108C8F0ACF6A7EB72D0117 /* RoomScreenCoordinator.swift */; };
-		A88328D7E17F73AB64501B51 /* SwiftOGG in Frameworks */ = {isa = PBXBuildFile; productRef = 391D11F92DFC91666AA1503F /* SwiftOGG */; };
+		A88328D7E17F73AB64501B51 /* SwiftSoup in Frameworks */ = {isa = PBXBuildFile; productRef = EDFB92E97D9AC4BA8540C18C /* SwiftSoup */; };
 		A8DB299C5C891EDAE74A22F4 /* UserLocationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7482D5D1526E3399B00174 /* UserLocationCell.swift */; };
 		A8E324E700E596E36B0A311B /* BootDetectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F054DE7D47849687662C9D9 /* BootDetectionManager.swift */; };
 		A8FA7671948E3DF27F320026 /* BugReportFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7367B3B9A8CAF902220F31D1 /* BugReportFlowCoordinator.swift */; };
 		A91D125414C3D9ABBABCF2F1 /* KZFileWatchers in Frameworks */ = {isa = PBXBuildFile; productRef = 6690850AA47ECED7E1CAB345 /* KZFileWatchers */; };
-		A93661C962B12942C08864B6 /* Version in Frameworks */ = {isa = PBXBuildFile; productRef = A05AF81DDD14AD58CB0E1B9B /* Version */; };
+		A93661C962B12942C08864B6 /* Emojibase in Frameworks */ = {isa = PBXBuildFile; productRef = C05729B1684C331F5FFE9232 /* Emojibase */; };
 		A950C95855C474F75B30CA7B /* PollFormScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDAB580109C09A6AA97AF7E /* PollFormScreenTests.swift */; };
 		A969147E0EEE0E27EE226570 /* MediaUploadPreviewScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47F29139BC2A804CE5E0757E /* MediaUploadPreviewScreenViewModel.swift */; };
 		A975D60EA49F6AF73308809F /* RoomMembersListScreenMemberCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC03209FDE8CE0810617BFFF /* RoomMembersListScreenMemberCell.swift */; };
@@ -1104,7 +1104,7 @@
 		AFE2AB612A1460E49578D746 /* JoinRoomScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BDCCD2F6B405C14B9BCE94E /* JoinRoomScreenCoordinator.swift */; };
 		B004A08BE32F06832BF41CFC /* RoomDetailsScreenHook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3674212CAB6C5143DD437AC4 /* RoomDetailsScreenHook.swift */; };
 		B04E9EB589CE99C3929E817A /* HomeScreenRecoveryKeyConfirmationBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05512FB13987D221B7205DE0 /* HomeScreenRecoveryKeyConfirmationBanner.swift */; };
-		B0CB16349B96262AA65A04AF /* PostHog in Frameworks */ = {isa = PBXBuildFile; productRef = 4278261E147DB2DE5CFB7FC5 /* PostHog */; };
+		B0CB16349B96262AA65A04AF /* SwiftState in Frameworks */ = {isa = PBXBuildFile; productRef = 9573B94B1C86C6DF751AF3FD /* SwiftState */; };
 		B1088417801A962BA861C13F /* RoomPowerLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7E247E29C7A0E421DB839D7 /* RoomPowerLevel.swift */; };
 		B10F7D5C237417DA160F4603 /* LongPressWithFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9F148717D74F73BE724434 /* LongPressWithFeedback.swift */; };
 		B13774779EA19FDD7A35A4A8 /* RoomRolesAndPermissionsScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C28B70BEFD3676F11D5D51F /* RoomRolesAndPermissionsScreenCoordinator.swift */; };
@@ -1257,7 +1257,6 @@
 		C9F5B48D15B9BCAE1F8D564E /* RoomNotificationModeProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1511766C534367700C8DD75 /* RoomNotificationModeProxy.swift */; };
 		CA12AE0DCD57D49CD96C699A /* WaveformCursorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB9EABCA9348DFA27439A809 /* WaveformCursorView.swift */; };
 		CA2BFC5504AD91A028CFA45B /* AnalyticsConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA2397174D0DC3918A7A8A7B /* AnalyticsConfiguration.swift */; };
-		CAEE1AF71E8C13756D572CF4 /* DSWaveformImageViews in Frameworks */ = {isa = PBXBuildFile; productRef = 2A4106A0A96DC4C273128AA5 /* DSWaveformImageViews */; };
 		CB07184D37D5D65327A5A693 /* AuthenticationFlowCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F46CC4FD89ECF4CF26391A /* AuthenticationFlowCoordinatorTests.swift */; };
 		CB137BFB3E083C33E398A6CB /* DeviceKit in Frameworks */ = {isa = PBXBuildFile; productRef = A7CA6F33C553805035C3B114 /* DeviceKit */; };
 		CB498F4E27AA0545DCEF0F6F /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = 78A5A8DE1E2B09C978C7F3B0 /* KeychainAccess */; };
@@ -1408,14 +1407,14 @@
 		E4B07FF075C99D04D9AF792D /* AppLockSetupPINScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = B410B32B72C90BF94E481F33 /* AppLockSetupPINScreenModels.swift */; };
 		E4D261E237D5D45E6DF2D0F1 /* ManageRoomMemberSheetModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787E84119E626E2F0E0BFBE8 /* ManageRoomMemberSheetModels.swift */; };
 		E52F1E00FBAABA703DA510F9 /* ContentScannerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EDFCC7391761D4DB2CC0D97 /* ContentScannerService.swift */; };
-		E587A513B3E1EE9B56E9AB9C /* Flow in Frameworks */ = {isa = PBXBuildFile; productRef = 4D7E6BFC89715FC3CF0349D0 /* Flow */; };
+		E587A513B3E1EE9B56E9AB9C /* DSWaveformImageViews in Frameworks */ = {isa = PBXBuildFile; productRef = 2A4106A0A96DC4C273128AA5 /* DSWaveformImageViews */; };
 		E58F1F3276E98A93F7D39219 /* RoomPollsHistoryScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D8479BB704B7EF696F8ABE /* RoomPollsHistoryScreenCoordinator.swift */; };
 		E591742E509A2A009BF25F9D /* RoomEventStringBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AE5800184E93CD5E02C6543 /* RoomEventStringBuilderTests.swift */; };
 		E593841CEBFDDC5387A75EBA /* NotificationToneManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D148332A613AD27E9A2896C9 /* NotificationToneManagerTests.swift */; };
 		E5AB28123E2488F97E953AC0 /* CallNotificationRoomTimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1ED17433ADC77287F8904F9 /* CallNotificationRoomTimelineItem.swift */; };
 		E5E43A0CA99AF5BA11B194A2 /* EncryptionSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57AD14D3ADADE8F6A10F9E88 /* EncryptionSettingsTests.swift */; };
 		E5F4C992845388B50BABACAA /* ServerSelectionScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8BC4C791D0E88CFCF4E5DF /* ServerSelectionScreenCoordinator.swift */; };
-		E673A5442A9A912DE6CE097A /* SwiftSoup in Frameworks */ = {isa = PBXBuildFile; productRef = EDFB92E97D9AC4BA8540C18C /* SwiftSoup */; };
+		E673A5442A9A912DE6CE097A /* Flow in Frameworks */ = {isa = PBXBuildFile; productRef = 4D7E6BFC89715FC3CF0349D0 /* Flow */; };
 		E67418DACEDBC29E988E6ACD /* message.caf in Resources */ = {isa = PBXBuildFile; fileRef = ED482057AE39D5C6D9C5F3D8 /* message.caf */; };
 		E6A2F6E4795C1054025AACFF /* NotificationItemProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3AB32690C6CE5C62A86D6FA /* NotificationItemProxy.swift */; };
 		E6FA87F773424B27614B23E9 /* TimelineItemAccessibilityModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA7E93C2E148B96EF6A8500 /* TimelineItemAccessibilityModifier.swift */; };
@@ -1685,6 +1684,7 @@
 				C9C562D85999E436C7265AF1 /* MatrixRustSDK in Embed Frameworks */,
 				874704A177B0A6D78E037908 /* MapLibreInterface.framework in Embed Frameworks */,
 				5B2CE8FE14CB16F2FCAFC4B2 /* MapLibreShim.framework in Embed Frameworks */,
+				7E429C44DD0C99870C6E9972 /* MapLibre.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1885,6 +1885,7 @@
 		1D9F2E1FC5A0139571211CE8 /* SpaceHeaderTopicSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceHeaderTopicSheetView.swift; sourceTree = "<group>"; };
 		1DA7E93C2E148B96EF6A8500 /* TimelineItemAccessibilityModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineItemAccessibilityModifier.swift; sourceTree = "<group>"; };
 		1DB2FC2AA9A07EE792DF65CF /* NotificationPermissionsScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPermissionsScreenModels.swift; sourceTree = "<group>"; };
+		1DBA4A688563F86CC0D3E537 /* MapLibre.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = MapLibre.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1DD2A058F3566FEEBA1D11B3 /* RoomSelectionScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomSelectionScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		1DE7969EBCAF078813E18EA1 /* RoomRolesAndPermissionsScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomRolesAndPermissionsScreenModels.swift; sourceTree = "<group>"; };
 		1DF8F7A3AD83D04C08D75E01 /* RoomDetailsEditScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomDetailsEditScreenViewModelProtocol.swift; sourceTree = "<group>"; };
@@ -3307,20 +3308,18 @@
 				FC10228E73323BDC09526F97 /* LRUCache in Frameworks */,
 				EAC6FE2CD4F50A43068ADCD8 /* Mantis in Frameworks */,
 				76D4D5312ED8E42B35C29FA3 /* MapLibreInterface.framework in Frameworks */,
-				A79634DCE52B5021F549E0E9 /* MapLibreShim.framework in Frameworks */,
-				754602A7B2AAD443C4228ED4 /* MapLibre in Frameworks */,
-				B0CB16349B96262AA65A04AF /* PostHog in Frameworks */,
-				36AD4DD4C798E22584ED3200 /* SwiftState in Frameworks */,
-				36CD6E11B37396E14F032CB6 /* GZIP in Frameworks */,
-				A0D7E5BD0298A97DCBDCE40B /* Sentry in Frameworks */,
-				44F0E1B576C7599DF8022071 /* SentrySwiftUI in Frameworks */,
-				A93661C962B12942C08864B6 /* Version in Frameworks */,
-				37E47F5101C0C036289D3807 /* Emojibase in Frameworks */,
-				4610C57A4785FFF5E67F0C6D /* WysiwygComposer in Frameworks */,
-				A88328D7E17F73AB64501B51 /* SwiftOGG in Frameworks */,
-				E673A5442A9A912DE6CE097A /* SwiftSoup in Frameworks */,
-				E587A513B3E1EE9B56E9AB9C /* Flow in Frameworks */,
-				CAEE1AF71E8C13756D572CF4 /* DSWaveformImageViews in Frameworks */,
+				754602A7B2AAD443C4228ED4 /* PostHog in Frameworks */,
+				B0CB16349B96262AA65A04AF /* SwiftState in Frameworks */,
+				36AD4DD4C798E22584ED3200 /* GZIP in Frameworks */,
+				36CD6E11B37396E14F032CB6 /* Sentry in Frameworks */,
+				A0D7E5BD0298A97DCBDCE40B /* SentrySwiftUI in Frameworks */,
+				44F0E1B576C7599DF8022071 /* Version in Frameworks */,
+				A93661C962B12942C08864B6 /* Emojibase in Frameworks */,
+				37E47F5101C0C036289D3807 /* WysiwygComposer in Frameworks */,
+				4610C57A4785FFF5E67F0C6D /* SwiftOGG in Frameworks */,
+				A88328D7E17F73AB64501B51 /* SwiftSoup in Frameworks */,
+				E673A5442A9A912DE6CE097A /* Flow in Frameworks */,
+				E587A513B3E1EE9B56E9AB9C /* DSWaveformImageViews in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4322,6 +4321,7 @@
 				2197234282B4BC0CE79AAC74 /* Secrets */,
 				823ED0EC3F1B6CF47D284011 /* Tools */,
 				9413F680ECDFB2B0DDB0DEF2 /* Packages */,
+				DE77D5FC2A361306E4440687 /* Frameworks */,
 				681566846AF307E9BA4C72C6 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -6898,6 +6898,14 @@
 			path = View;
 			sourceTree = "<group>";
 		};
+		DE77D5FC2A361306E4440687 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				1DBA4A688563F86CC0D3E537 /* MapLibre.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		DF10E31B5AA21015971C3FAD /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -7568,7 +7576,6 @@
 				1A6B622CCFDEFB92D9CF1CA5 /* LoremSwiftum */,
 				1081D3630AAD3ACEDDEC3A98 /* LRUCache */,
 				8C30177487BBB5D000E4DDDA /* Mantis */,
-				ED146E565C4CB792FF2F37EA /* MapLibre */,
 				4278261E147DB2DE5CFB7FC5 /* PostHog */,
 				9573B94B1C86C6DF751AF3FD /* SwiftState */,
 				997C7385E1A07E061D7E2100 /* GZIP */,
@@ -11212,11 +11219,6 @@
 		E9170427ACFD3E9F67EB7116 /* Macros */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Macros;
-		};
-		ED146E565C4CB792FF2F37EA /* MapLibre */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 0CBF57301AA172C21F76CE86 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */;
-			productName = MapLibre;
 		};
 		EDFB92E97D9AC4BA8540C18C /* SwiftSoup */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/ElementX/MapLibre/MapLibreInterface/Sources/MapLibreShimProtocol.swift
+++ b/ElementX/MapLibre/MapLibreInterface/Sources/MapLibreShimProtocol.swift
@@ -1,0 +1,19 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import SwiftUI
+
+/// Implemented by MapLibreShim's entry point, which the app instantiates after
+/// `dlopen`-ing the framework.
+public protocol MapLibreShimProtocol {
+    /// Routes MapLibre's logs into the app's logger. Call once after loading the shim.
+    func configureLogging(_ handler: @escaping @Sendable (MapLogSeverity, String) -> Void)
+    
+    /// Builds the interactive map view. The app-side `MapLibreMapView` forwards every
+    /// body evaluation here so SwiftUI updates flow through to the underlying map.
+    func makeMapView(configuration: MapViewConfiguration) -> AnyView
+}

--- a/ElementX/MapLibre/MapLibreInterface/Sources/MapModels.swift
+++ b/ElementX/MapLibre/MapLibreInterface/Sources/MapModels.swift
@@ -1,0 +1,35 @@
+//
+// Copyright 2026 Element Creations Ltd.
+// Copyright 2023-2025 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Foundation
+
+/**
+ Behavior mode of the current user's location, can be hidden, only shown and shown following the user
+ */
+public enum ShowUserLocationMode: Equatable {
+    /// this mode will show the user pin in map
+    case show
+    /// this mode will show the user pin in map and track him, panning the map automatically
+    case showAndFollow
+    /// this mode will not show the user pin in map
+    case hide
+    /// this mode will not show the user pin in map and will follow the marker with the given id,
+    /// panning the map automatically.
+    case hideAndFollowMarker(id: String)
+    
+    /// The id of the marker the map should follow when in the `hideAndFollowMarker` mode, nil otherwise.
+    public var followedMarkerID: String? {
+        guard case .hideAndFollowMarker(let id) = self else { return nil }
+        return id
+    }
+}
+
+public enum MapLibreError: Error, Hashable {
+    case failedLoadingMap
+    case failedLocatingUser
+}

--- a/ElementX/MapLibre/MapLibreInterface/Sources/MapModels.swift
+++ b/ElementX/MapLibre/MapLibreInterface/Sources/MapModels.swift
@@ -6,6 +6,7 @@
 // Please see LICENSE files in the repository root for full details.
 //
 
+import CoreLocation
 import Foundation
 
 /**
@@ -32,4 +33,24 @@ public enum ShowUserLocationMode: Equatable {
 public enum MapLibreError: Error, Hashable {
     case failedLoadingMap
     case failedLocatingUser
+}
+
+/// The severity of a map log message forwarded to the app.
+public enum MapLogSeverity {
+    case error
+    case warning
+    case info
+    case debug
+    case verbose
+}
+
+/// A marker shown on the map, identified so that it can be moved in place when its coordinate changes.
+public struct MapAnnotation {
+    public let id: String
+    public let coordinate: CLLocationCoordinate2D
+    
+    public init(id: String, coordinate: CLLocationCoordinate2D) {
+        self.id = id
+        self.coordinate = coordinate
+    }
 }

--- a/ElementX/MapLibre/MapLibreInterface/Sources/MapViewConfiguration.swift
+++ b/ElementX/MapLibre/MapLibreInterface/Sources/MapViewConfiguration.swift
@@ -1,0 +1,76 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import CoreLocation
+import SwiftUI
+
+/// Everything the map implementation needs in order to render, expressed without app
+/// types so that the implementation framework can be loaded on demand.
+public struct MapViewConfiguration {
+    /// the final zoom level used when the first user location emit
+    public let zoomLevel: Double
+    /// The initial zoom level used when the map it firstly loaded and the user location is not yet available, in case of annotations this property is not being used
+    public let initialZoomLevel: Double
+    
+    /// The initial map center
+    public let mapCenter: CLLocationCoordinate2D
+    
+    /// Map annotations
+    public let annotations: [MapAnnotation]
+    
+    /// The style to load the map with, for either the dark or the light appearance.
+    public let styleURL: (_ isDark: Bool) -> URL?
+    
+    public let tintColor: UIColor
+    
+    /// The content of the marker representing the annotation with the given id.
+    public let markerView: (_ annotationID: String) -> AnyView?
+    
+    /// Behavior mode of the current user's location, can be hidden, only shown and shown following the user
+    public let showsUserLocationMode: Binding<ShowUserLocationMode>
+    /// Bind view errors if any
+    public let error: Binding<MapLibreError?>
+    /// Coordinate of the center of the map
+    public let mapCenterCoordinate: Binding<CLLocationCoordinate2D?>
+    public let hasLoadedUserLocation: Binding<Bool>
+    public let isLocationAuthorized: Binding<Bool?>
+    /// The radius of uncertainty for the location, measured in meters.
+    public let geolocationUncertainty: Binding<CLLocationAccuracy?>
+    
+    /// Called when the user pan on the map
+    public let userDidPan: (() -> Void)?
+    
+    public init(zoomLevel: Double,
+                initialZoomLevel: Double,
+                mapCenter: CLLocationCoordinate2D,
+                annotations: [MapAnnotation] = [],
+                styleURL: @escaping (_ isDark: Bool) -> URL?,
+                tintColor: UIColor,
+                markerView: @escaping (_ annotationID: String) -> AnyView?,
+                showsUserLocationMode: Binding<ShowUserLocationMode>,
+                error: Binding<MapLibreError?>,
+                mapCenterCoordinate: Binding<CLLocationCoordinate2D?>,
+                hasLoadedUserLocation: Binding<Bool>,
+                isLocationAuthorized: Binding<Bool?>,
+                geolocationUncertainty: Binding<CLLocationAccuracy?>,
+                userDidPan: (() -> Void)? = nil) {
+        self.zoomLevel = zoomLevel
+        self.initialZoomLevel = initialZoomLevel
+        self.mapCenter = mapCenter
+        self.annotations = annotations
+        self.styleURL = styleURL
+        self.tintColor = tintColor
+        self.markerView = markerView
+        self.showsUserLocationMode = showsUserLocationMode
+        self.error = error
+        self.mapCenterCoordinate = mapCenterCoordinate
+        self.hasLoadedUserLocation = hasLoadedUserLocation
+        self.isLocationAuthorized = isLocationAuthorized
+        self.geolocationUncertainty = geolocationUncertainty
+        self.userDidPan = userDidPan
+    }
+}

--- a/ElementX/MapLibre/MapLibreInterface/SupportingFiles/target.yml
+++ b/ElementX/MapLibre/MapLibreInterface/SupportingFiles/target.yml
@@ -1,0 +1,19 @@
+# The types shared between the app and the MapLibreShim framework. The app links this
+# (tiny, initialiser-free) framework instead of MapLibre, see MapLibreShim's target.yml.
+name: MapLibreInterface
+
+targets:
+  MapLibreInterface:
+    type: framework
+    platform: iOS
+
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: $(BASE_BUNDLE_IDENTIFIER).maplibre-interface
+        GENERATE_INFOPLIST_FILE: YES
+        SWIFT_VERSION: 6.2
+        SWIFT_APPROACHABLE_CONCURRENCY: YES
+        SWIFT_DEFAULT_ACTOR_ISOLATION: MainActor
+
+    sources:
+    - path: ../Sources

--- a/ElementX/MapLibre/MapLibreShim/Sources/CoordinateAnimator.swift
+++ b/ElementX/MapLibre/MapLibreShim/Sources/CoordinateAnimator.swift
@@ -8,7 +8,7 @@
 import CoreLocation
 import QuartzCore
 
-/// Smoothly animates a `LocationAnnotation`'s coordinate from its current
+/// Smoothly animates a `MapLibreAnnotation`'s coordinate from its current
 /// position to a new one using a `CADisplayLink` for frame-accurate updates.
 ///
 /// ## How it works
@@ -26,7 +26,7 @@ import QuartzCore
 /// cancels the previous one and begins from the annotation's current position.
 final class CoordinateAnimator {
     private var displayLink: CADisplayLink?
-    private weak var annotation: LocationAnnotation?
+    private weak var annotation: MapLibreAnnotation?
     private let startCoordinate: CLLocationCoordinate2D
     private let endCoordinate: CLLocationCoordinate2D
     private let duration: CFTimeInterval
@@ -36,7 +36,7 @@ final class CoordinateAnimator {
     /// while the display link is running. Keyed by annotation ID.
     private static var activeAnimators: [String: CoordinateAnimator] = [:]
     
-    private init(annotation: LocationAnnotation,
+    private init(annotation: MapLibreAnnotation,
                  to end: CLLocationCoordinate2D,
                  duration: CFTimeInterval) {
         self.annotation = annotation
@@ -48,7 +48,7 @@ final class CoordinateAnimator {
     /// Starts animating the annotation's coordinate to `end` over `duration` seconds.
     /// If the annotation is already being animated, the in-flight animation is
     /// cancelled and a new one starts from the current position.
-    static func animate(annotation: LocationAnnotation,
+    static func animate(annotation: MapLibreAnnotation,
                         to end: CLLocationCoordinate2D,
                         duration: CFTimeInterval) {
         guard annotation.coordinate.latitude != end.latitude

--- a/ElementX/MapLibre/MapLibreShim/Sources/MapLibreAnnotation.swift
+++ b/ElementX/MapLibre/MapLibreShim/Sources/MapLibreAnnotation.swift
@@ -1,0 +1,60 @@
+//
+// Copyright 2026 Element Creations Ltd.
+// Copyright 2023-2025 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import CoreLocation
+import MapLibre
+import MapLibreInterface
+import SwiftUI
+
+final class MapLibreAnnotation: NSObject, MLNAnnotation, Identifiable {
+    let id: String
+    // @objc dynamic is required to make animations work
+    @objc dynamic var coordinate: CLLocationCoordinate2D
+    
+    // MARK: - Setup
+    
+    init(_ annotation: MapAnnotation) {
+        id = annotation.id
+        coordinate = annotation.coordinate
+        super.init()
+    }
+}
+
+final class MapLibreAnnotationView: MLNUserLocationAnnotationView {
+    private var hostingController: UIHostingController<AnyView>?
+    
+    // MARK: - Setup
+    
+    override init(annotation: MLNAnnotation?, reuseIdentifier: String?) {
+        super.init(annotation: annotation, reuseIdentifier:
+            reuseIdentifier)
+    }
+    
+    convenience init(annotation: MapLibreAnnotation, content: AnyView?) {
+        self.init(annotation: annotation, reuseIdentifier: "\(Self.self)")
+        let hostingController = UIHostingController(rootView: content ?? AnyView(EmptyView()))
+        self.hostingController = hostingController
+        let view: UIView = hostingController.view
+        view.backgroundColor = .clear
+        view.anchorPoint = .init(x: 0.5, y: 1.0)
+        addSubview(view)
+        view.bounds.size = view.intrinsicContentSize
+    }
+    
+    func updateContent(_ content: AnyView?) {
+        hostingController?.rootView = content ?? AnyView(EmptyView())
+        if let hostedView = hostingController?.view {
+            hostedView.bounds.size = hostedView.intrinsicContentSize
+        }
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+}

--- a/ElementX/MapLibre/MapLibreShim/Sources/MapLibreMapView.swift
+++ b/ElementX/MapLibre/MapLibreShim/Sources/MapLibreMapView.swift
@@ -1,0 +1,297 @@
+//
+// Copyright 2026 Element Creations Ltd.
+// Copyright 2023-2025 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import MapLibre
+import MapLibreInterface
+import SwiftUI
+
+struct MapLibreMapView: UIViewRepresentable {
+    // MARK: - Properties
+    
+    @Environment(\.colorScheme) private var colorScheme
+    
+    let configuration: MapViewConfiguration
+    
+    // MARK: - UIViewRepresentable
+    
+    func makeUIView(context: Context) -> MLNMapView {
+        let mapView = makeMapView()
+        mapView.delegate = context.coordinator
+        setupMap(mapView: mapView)
+        return mapView
+    }
+    
+    func updateUIView(_ mapView: MLNMapView, context: Context) {
+        // Don't set the same value twice. Otherwise, if there is an error loading the map, a loop
+        // is caused as the `error` binding being set, which triggers this update, which sets a
+        // new URL, which causes another error, and so it goes on round and round in a circle.
+        let dynamicMapURL = configuration.styleURL(colorScheme == .dark)
+        if mapView.styleURL != dynamicMapURL {
+            mapView.styleURL = dynamicMapURL
+        }
+        
+        // If the center coordinate was updated externally (not by the map itself), move the map.
+        // Not applied while following a marker, where the camera is driven by the marker's position.
+        if configuration.showsUserLocationMode.wrappedValue.followedMarkerID == nil,
+           let newCenter = configuration.mapCenterCoordinate.wrappedValue,
+           newCenter.latitude != context.coordinator.lastReportedCenter?.latitude
+           || newCenter.longitude != context.coordinator.lastReportedCenter?.longitude {
+            context.coordinator.lastReportedCenter = newCenter
+            mapView.setCenter(newCenter, animated: true)
+        }
+        
+        // Update existing annotation views with fresh SwiftUI content.
+        // This handles the case where the annotation's view data changes after
+        // the annotation was initially placed (e.g. user avatar loads asynchronously).
+        updateAnnotations(in: mapView)
+        
+        showUserLocation(in: mapView)
+        
+        context.coordinator.updateMarkerFollowing(in: mapView, markerID: configuration.showsUserLocationMode.wrappedValue.followedMarkerID)
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+    
+    // MARK: - Private
+    
+    private func setupMap(mapView: MLNMapView) {
+        mapView.addAnnotations(configuration.annotations.map(MapLibreAnnotation.init))
+        mapView.zoomLevel = configuration.annotations.isEmpty ? configuration.initialZoomLevel : configuration.zoomLevel
+        mapView.centerCoordinate = configuration.mapCenter
+    }
+    
+    private func updateAnnotations(in mapView: MLNMapView) {
+        let existingByID = Dictionary(uniqueKeysWithValues:
+            (mapView.annotations ?? []).compactMap { $0 as? MapLibreAnnotation }.map { ($0.id, $0) })
+        let updatedByID = Dictionary(uniqueKeysWithValues: configuration.annotations.map { ($0.id, $0) })
+        
+        let existingIDs = Set(existingByID.keys)
+        let updatedIDs = Set(updatedByID.keys)
+        
+        // Remove annotations that are no longer present
+        let removedIDs = existingIDs.subtracting(updatedIDs)
+        if !removedIDs.isEmpty {
+            let toRemove = removedIDs.compactMap { existingByID[$0] }
+            mapView.removeAnnotations(toRemove)
+        }
+        
+        // Add new annotations
+        let addedIDs = updatedIDs.subtracting(existingIDs)
+        if !addedIDs.isEmpty {
+            let toAdd = addedIDs.compactMap { updatedByID[$0] }.map(MapLibreAnnotation.init)
+            mapView.addAnnotations(toAdd)
+        }
+        
+        // Update existing annotations that are still present
+        let keptIDs = existingIDs.intersection(updatedIDs)
+        for id in keptIDs {
+            guard let existingAnnotation = existingByID[id],
+                  let updatedAnnotation = updatedByID[id] else {
+                continue
+            }
+            CoordinateAnimator.animate(annotation: existingAnnotation,
+                                       to: updatedAnnotation.coordinate,
+                                       duration: 1.0)
+            if let annotationView = mapView.view(for: existingAnnotation) as? MapLibreAnnotationView {
+                annotationView.updateContent(configuration.markerView(id))
+            }
+        }
+    }
+    
+    private func makeMapView() -> MLNMapView {
+        let mapView = MLNMapView(frame: .zero, styleURL: configuration.styleURL(colorScheme == .dark))
+        mapView.logoViewPosition = .topLeft
+        mapView.attributionButtonPosition = .topLeft
+        mapView.attributionButtonMargins = .init(x: mapView.logoView.frame.maxX + 8, y: mapView.logoView.center.y / 2)
+        mapView.tintColor = configuration.tintColor
+        mapView.allowsRotating = false
+        mapView.allowsTilting = false
+        return mapView
+    }
+    
+    private func showUserLocation(in mapView: MLNMapView) {
+        switch (configuration.showsUserLocationMode.wrappedValue, configuration.annotations) {
+        case (.showAndFollow, _):
+            mapView.userTrackingMode = .follow
+        case (.show, let annotations) where !annotations.isEmpty:
+            // In the show mode, if there are annotations, we check the authorizationStatus,
+            // if it's not determined, we wont prompt the user with a request for permissions,
+            // because they should be able to see the annotations without sharing their location information.
+            guard mapView.locationManager.authorizationStatus != .notDetermined else { return }
+            fallthrough
+        case (.show, _):
+            mapView.showsUserLocation = true
+            mapView.setUserTrackingMode(.none, animated: false, completionHandler: nil)
+        case (.hide, _), (.hideAndFollowMarker, _):
+            // In hideAndFollowMarker mode the camera following is handled by the coordinator.
+            mapView.showsUserLocation = false
+            mapView.setUserTrackingMode(.none, animated: false, completionHandler: nil)
+        }
+    }
+}
+
+// MARK: - Coordinator
+
+extension MapLibreMapView {
+    class Coordinator: NSObject, MLNMapViewDelegate {
+        // MARK: - Properties
+        
+        var mapLibreView: MapLibreMapView
+        
+        private var previousUserLocation: MLNUserLocation?
+        /// Tracks the last center coordinate reported by the map (or set programmatically),
+        /// so that `updateUIView` can tell apart external binding changes from internal ones.
+        var lastReportedCenter: CLLocationCoordinate2D?
+        
+        /// The annotation the camera is currently locked on while in the `hideAndFollowMarker` mode.
+        private weak var followedAnnotation: MapLibreAnnotation?
+        /// Observes the followed annotation's coordinate, updated every frame by the `CoordinateAnimator`.
+        private var followedAnnotationObservation: NSKeyValueObservation?
+        
+        // MARK: - Setup
+        
+        init(_ mapLibreView: MapLibreMapView) {
+            self.mapLibreView = mapLibreView
+        }
+        
+        // MARK: - Marker following
+        
+        /// Keeps the camera locked on the marker with the given id, or stops following when nil.
+        func updateMarkerFollowing(in mapView: MLNMapView, markerID: String?) {
+            guard let markerID else {
+                stopFollowingMarker()
+                return
+            }
+            
+            guard let annotation = (mapView.annotations ?? [])
+                .compactMap({ $0 as? MapLibreAnnotation })
+                .first(where: { $0.id == markerID }) else {
+                // The marker isn't on the map (yet), resolve it again on the next update.
+                stopFollowingMarker()
+                return
+            }
+            
+            guard annotation !== followedAnnotation else { return }
+            startFollowingMarker(annotation, in: mapView)
+        }
+        
+        private func startFollowingMarker(_ annotation: MapLibreAnnotation, in mapView: MLNMapView) {
+            followedAnnotation = annotation
+            followedAnnotationObservation = nil
+            
+            // Animate to the marker first, attaching the per-frame tracking only on completion
+            // so that it doesn't cancel the transition.
+            mapView.setCenter(annotation.coordinate,
+                              zoomLevel: mapView.zoomLevel,
+                              direction: -1, // negative value keeps the current direction
+                              animated: true) { [weak self, weak annotation, weak mapView] in
+                guard let self, let annotation, let mapView, annotation === followedAnnotation else { return }
+                
+                // Mirror every animated coordinate update to keep the camera as smooth as the marker.
+                followedAnnotationObservation = annotation.observe(\.coordinate) { [weak mapView] annotation, _ in
+                    // The coordinate is only ever updated by SwiftUI so KVO fires on the main actor.
+                    MainActor.assumeIsolated {
+                        mapView?.setCenter(annotation.coordinate, animated: false)
+                    }
+                }
+            }
+        }
+        
+        private func stopFollowingMarker() {
+            followedAnnotation = nil
+            followedAnnotationObservation = nil
+        }
+        
+        // MARK: - MLNMapViewDelegate
+        
+        func mapView(_ mapView: MLNMapView, viewFor annotation: MLNAnnotation) -> MLNAnnotationView? {
+            guard let annotation = annotation as? MapLibreAnnotation else {
+                return nil
+            }
+            return MapLibreAnnotationView(annotation: annotation, content: mapLibreView.configuration.markerView(annotation.id))
+        }
+        
+        func mapViewDidFailLoadingMap(_ mapView: MLNMapView, withError error: Error) {
+            if mapLibreView.configuration.error.wrappedValue != .failedLoadingMap {
+                mapLibreView.configuration.error.wrappedValue = .failedLoadingMap
+            }
+        }
+        
+        func mapView(_ mapView: MLNMapView, didUpdate userLocation: MLNUserLocation?) {
+            guard let userLocation else { return }
+            mapLibreView.configuration.hasLoadedUserLocation.wrappedValue = true
+            
+            if previousUserLocation == nil, mapLibreView.configuration.annotations.isEmpty {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                    mapView.setCenter(userLocation.coordinate, zoomLevel: self.mapLibreView.configuration.zoomLevel, animated: true)
+                }
+            }
+            
+            previousUserLocation = userLocation
+            updateGeolocationUncertainty(location: userLocation)
+        }
+        
+        func mapView(_ mapView: MLNMapView, didChangeLocationManagerAuthorization manager: MLNLocationManager) {
+            switch manager.authorizationStatus {
+            case .denied, .restricted:
+                mapLibreView.configuration.isLocationAuthorized.wrappedValue = false
+            case .authorizedAlways, .authorizedWhenInUse:
+                mapLibreView.configuration.isLocationAuthorized.wrappedValue = true
+            case .notDetermined:
+                mapLibreView.configuration.isLocationAuthorized.wrappedValue = nil
+            @unknown default:
+                break
+            }
+        }
+        
+        func mapView(_ mapView: MLNMapView, regionDidChangeAnimated animated: Bool) {
+            // While following a marker, don't flood the center binding with per-frame camera updates.
+            // Leaving `lastReportedCenter` untouched avoids an external re-centering when following stops.
+            guard mapLibreView.configuration.showsUserLocationMode.wrappedValue.followedMarkerID == nil else { return }
+            
+            // Avoid `Publishing changes from within view update` warnings
+            DispatchQueue.main.async { [mapLibreView, weak self] in
+                let center = mapView.centerCoordinate
+                self?.lastReportedCenter = center
+                mapLibreView.configuration.mapCenterCoordinate.wrappedValue = center
+            }
+        }
+        
+        func mapView(_ mapView: MLNMapView, shouldChangeFrom oldCamera: MLNMapCamera, to newCamera: MLNMapCamera, reason: MLNCameraChangeReason) -> Bool {
+            // Send userDidPan only for gestures that actually change the map center. The reason
+            // is an option set and gestures can come combined with other reasons, so check for
+            // containment instead of an exact match.
+            let centerChangingGestures: MLNCameraChangeReason = [.gesturePan, .gesturePinch, .gestureRotate]
+            if !reason.isDisjoint(with: centerChangingGestures) {
+                // Stop following immediately, the camera would fight the gesture otherwise.
+                stopFollowingMarker()
+                mapLibreView.configuration.userDidPan?()
+            }
+            return true
+        }
+        
+        // MARK: Callout
+        
+        func mapView(_ mapView: MLNMapView, annotationCanShowCallout annotation: MLNAnnotation) -> Bool {
+            false
+        }
+        
+        // MARK: Private
+        
+        private func updateGeolocationUncertainty(location: MLNUserLocation) {
+            guard let clLocation = location.location, clLocation.horizontalAccuracy >= 0 else {
+                mapLibreView.configuration.geolocationUncertainty.wrappedValue = nil
+                return
+            }
+            
+            mapLibreView.configuration.geolocationUncertainty.wrappedValue = clLocation.horizontalAccuracy
+        }
+    }
+}

--- a/ElementX/MapLibre/MapLibreShim/Sources/MapLibreShim.swift
+++ b/ElementX/MapLibre/MapLibreShim/Sources/MapLibreShim.swift
@@ -1,0 +1,37 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import MapLibre
+import MapLibreInterface
+import SwiftUI
+
+/// The shim's entry point, vending the interactive map view to the app.
+public final class MapLibreShim: NSObject, MapLibreShimProtocol {
+    public func configureLogging(_ handler: @escaping @Sendable (MapLogSeverity, String) -> Void) {
+        MLNLoggingConfiguration.shared.loggingLevel = .debug
+        MLNLoggingConfiguration.shared.handler = { loggingLevel, _, _, message in
+            switch loggingLevel {
+            case .error:
+                handler(.error, message)
+            case .warning:
+                handler(.warning, message)
+            case .info:
+                handler(.info, message)
+            case .debug:
+                handler(.debug, message)
+            case .verbose:
+                handler(.verbose, message)
+            default:
+                break
+            }
+        }
+    }
+    
+    public func makeMapView(configuration: MapViewConfiguration) -> AnyView {
+        AnyView(MapLibreMapView(configuration: configuration))
+    }
+}

--- a/ElementX/MapLibre/MapLibreShim/Sources/MapLibreShim.swift
+++ b/ElementX/MapLibre/MapLibreShim/Sources/MapLibreShim.swift
@@ -9,7 +9,9 @@ import MapLibre
 import MapLibreInterface
 import SwiftUI
 
-/// The shim's entry point, vending the interactive map view to the app.
+/// The shim's entry point: the app looks this class up by name through the ObjC runtime
+/// after `dlopen`-ing the framework, keeping MapLibre off the app's launch path.
+@objc(MapLibreShim)
 public final class MapLibreShim: NSObject, MapLibreShimProtocol {
     public func configureLogging(_ handler: @escaping @Sendable (MapLogSeverity, String) -> Void) {
         MLNLoggingConfiguration.shared.loggingLevel = .debug

--- a/ElementX/MapLibre/MapLibreShim/SupportingFiles/target.yml
+++ b/ElementX/MapLibre/MapLibreShim/SupportingFiles/target.yml
@@ -1,0 +1,26 @@
+# The interactive map, split out of the app so MapLibre's static initialisers stay off the
+# launch path: the app links only the tiny MapLibreInterface framework, while MapLibreShim (the
+# only image linking MapLibre) is embedded unlinked and dlopen'd on first map use.
+name: MapLibreShim
+
+targets:
+  MapLibreShim:
+    type: framework
+    platform: iOS
+
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: $(BASE_BUNDLE_IDENTIFIER).maplibre-shim
+        GENERATE_INFOPLIST_FILE: YES
+        SWIFT_VERSION: 6.2
+        SWIFT_APPROACHABLE_CONCURRENCY: YES
+        SWIFT_DEFAULT_ACTOR_ISOLATION: MainActor
+
+    dependencies:
+    - target: MapLibreInterface
+      embed: false
+    - package: MapLibre
+      embed: false
+
+    sources:
+    - path: ../Sources

--- a/ElementX/Sources/Application/TargetConfiguration.swift
+++ b/ElementX/Sources/Application/TargetConfiguration.swift
@@ -8,9 +8,6 @@
 
 import Combine
 import Foundation
-#if IS_MAIN_APP
-import MapLibre
-#endif
 import MatrixRustSDK
 
 nonisolated enum Target: String {
@@ -65,36 +62,12 @@ nonisolated enum Target: String {
         
         MXLog.configure(currentTarget: rawValue)
         
-        configureMapLibreIfAvailable()
-        
         let hookCancellable = rageshakeURL.publisher
             .sink { _ in
                 appHooks.tracingHook.update(tracingConfiguration, with: rageshakeURL)
             }
         
         return ConfigurationResult(hookCancellable: hookCancellable)
-    }
-    
-    private func configureMapLibreIfAvailable() {
-        #if IS_MAIN_APP
-        MLNLoggingConfiguration.shared.loggingLevel = .debug
-        MLNLoggingConfiguration.shared.handler = { loggingLevel, _, _, message in
-            switch loggingLevel {
-            case .error:
-                MXLog.error(message)
-            case .warning:
-                MXLog.warning(message)
-            case .info:
-                MXLog.info(message)
-            case .debug:
-                MXLog.debug(message)
-            case .verbose:
-                MXLog.verbose(message)
-            default:
-                break
-            }
-        }
-        #endif
     }
     
     /// The result of calling ``configure(logLevel:traceLogPacks:sentryURL:)``.

--- a/ElementX/Sources/Other/MapLibre/LocationAnnotation.swift
+++ b/ElementX/Sources/Other/MapLibre/LocationAnnotation.swift
@@ -8,57 +8,9 @@
 
 import CoreLocation
 import Foundation
-import MapLibre
-import SwiftUI
 
-final class LocationAnnotation: NSObject, MLNAnnotation, Identifiable {
+struct LocationAnnotation: Identifiable {
     let id: String
-    // @objc dynamic is required to make animations work
-    @objc dynamic var coordinate: CLLocationCoordinate2D
-    var kind: LocationMarkerKind
-    
-    // MARK: - Setup
-    
-    init(id: String, coordinate: CLLocationCoordinate2D, kind: LocationMarkerKind) {
-        self.id = id
-        self.coordinate = coordinate
-        self.kind = kind
-        super.init()
-    }
-}
-
-final class LocationAnnotationView: MLNUserLocationAnnotationView {
-    private var hostingController: UIHostingController<AnyView>?
-    
-    // MARK: - Setup
-    
-    override init(annotation: MLNAnnotation?, reuseIdentifier: String?) {
-        super.init(annotation: annotation, reuseIdentifier:
-            reuseIdentifier)
-    }
-    
-    convenience init(annotation: LocationAnnotation, mediaProvider: MediaProviderProtocol?) {
-        self.init(annotation: annotation, reuseIdentifier: "\(Self.self)")
-        let markerView = LocationMarkerView(kind: annotation.kind, mediaProvider: mediaProvider)
-        let hostingController = UIHostingController(rootView: AnyView(markerView))
-        self.hostingController = hostingController
-        let view: UIView = hostingController.view
-        view.backgroundColor = .clear
-        view.anchorPoint = .init(x: 0.5, y: 1.0)
-        addSubview(view)
-        view.bounds.size = view.intrinsicContentSize
-    }
-    
-    func updateContent(with kind: LocationMarkerKind, mediaProvider: MediaProviderProtocol?) {
-        let markerView = LocationMarkerView(kind: kind, mediaProvider: mediaProvider)
-        hostingController?.rootView = AnyView(markerView)
-        if let hostedView = hostingController?.view {
-            hostedView.bounds.size = hostedView.intrinsicContentSize
-        }
-    }
-    
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError()
-    }
+    let coordinate: CLLocationCoordinate2D
+    let kind: LocationMarkerKind
 }

--- a/ElementX/Sources/Other/MapLibre/MapLibreMapView.swift
+++ b/ElementX/Sources/Other/MapLibre/MapLibreMapView.swift
@@ -8,6 +8,7 @@
 
 import Combine
 import MapLibre
+import MapLibreInterface
 import SwiftUI
 
 struct MapLibreMapView: UIViewRepresentable {

--- a/ElementX/Sources/Other/MapLibre/MapLibreMapView.swift
+++ b/ElementX/Sources/Other/MapLibre/MapLibreMapView.swift
@@ -9,33 +9,14 @@
 import Compound
 import CoreLocation
 import MapLibreInterface
-import MapLibreShim
 import SwiftUI
 
-/// The interactive map, rendered by the `MapLibreShim` framework.
+/// The interactive map, rendered by the `MapLibreShim` framework which is loaded on first use.
+///
+/// The app deliberately doesn't link MapLibre: dyld would otherwise load it, run its static
+/// initialisers and register its classes on every single launch, for a map that is only shown
+/// on the location screens.
 struct MapLibreMapView: View {
-    /// Built once, so that MapLibre's logging is only configured once.
-    private static let shim: MapLibreShimProtocol = {
-        let shim = MapLibreShim()
-        
-        shim.configureLogging { severity, message in
-            switch severity {
-            case .error:
-                MXLog.error(message)
-            case .warning:
-                MXLog.warning(message)
-            case .info:
-                MXLog.info(message)
-            case .debug:
-                MXLog.debug(message)
-            case .verbose:
-                MXLog.verbose(message)
-            }
-        }
-        
-        return shim
-    }()
-    
     struct Options {
         /// the final zoom level used when the first user location emit
         let zoomLevel: Double
@@ -77,7 +58,13 @@ struct MapLibreMapView: View {
     var userDidPan: (() -> Void)?
     
     var body: some View {
-        Self.shim.makeMapView(configuration: configuration)
+        if let shim = MapLibreLoader.shim {
+            shim.makeMapView(configuration: configuration)
+        } else {
+            // The shim failed to load, surface it the same way as a map loading failure.
+            Color.clear
+                .onAppear { error = .failedLoadingMap }
+        }
     }
     
     /// The configuration for the shim, with the app-only pieces (marker views, tint, styles)
@@ -105,4 +92,42 @@ struct MapLibreMapView: View {
                      geolocationUncertainty: $geolocationUncertainty,
                      userDidPan: userDidPan)
     }
+}
+
+/// Loads the `MapLibreShim` framework on first use.
+enum MapLibreLoader {
+    static let shim: MapLibreShimProtocol? = {
+        guard let frameworksPath = Bundle.main.privateFrameworksPath else {
+            MXLog.error("Missing frameworks path.")
+            return nil
+        }
+        
+        guard dlopen("\(frameworksPath)/MapLibreShim.framework/MapLibreShim", RTLD_NOW) != nil else {
+            MXLog.error("Failed loading MapLibreShim: \(dlerror().map { String(cString: $0) } ?? "unknown error")")
+            return nil
+        }
+        
+        guard let shimClass = NSClassFromString("MapLibreShim") as? NSObject.Type,
+              let shim = shimClass.init() as? MapLibreShimProtocol else {
+            MXLog.error("Failed resolving MapLibreShim.")
+            return nil
+        }
+        
+        shim.configureLogging { severity, message in
+            switch severity {
+            case .error:
+                MXLog.error(message)
+            case .warning:
+                MXLog.warning(message)
+            case .info:
+                MXLog.info(message)
+            case .debug:
+                MXLog.debug(message)
+            case .verbose:
+                MXLog.verbose(message)
+            }
+        }
+        
+        return shim
+    }()
 }

--- a/ElementX/Sources/Other/MapLibre/MapLibreMapView.swift
+++ b/ElementX/Sources/Other/MapLibre/MapLibreMapView.swift
@@ -1,17 +1,41 @@
 //
-// Copyright 2025 Element Creations Ltd.
+// Copyright 2026 Element Creations Ltd.
 // Copyright 2023-2025 New Vector Ltd.
 //
 // SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
 // Please see LICENSE files in the repository root for full details.
 //
 
-import Combine
-import MapLibre
+import Compound
+import CoreLocation
 import MapLibreInterface
+import MapLibreShim
 import SwiftUI
 
-struct MapLibreMapView: UIViewRepresentable {
+/// The interactive map, rendered by the `MapLibreShim` framework.
+struct MapLibreMapView: View {
+    /// Built once, so that MapLibre's logging is only configured once.
+    private static let shim: MapLibreShimProtocol = {
+        let shim = MapLibreShim()
+        
+        shim.configureLogging { severity, message in
+            switch severity {
+            case .error:
+                MXLog.error(message)
+            case .warning:
+                MXLog.warning(message)
+            case .info:
+                MXLog.info(message)
+            case .debug:
+                MXLog.debug(message)
+            case .verbose:
+                MXLog.verbose(message)
+            }
+        }
+        
+        return shim
+    }()
+    
     struct Options {
         /// the final zoom level used when the first user location emit
         let zoomLevel: Double
@@ -31,10 +55,6 @@ struct MapLibreMapView: UIViewRepresentable {
             self.annotations = annotations
         }
     }
-    
-    // MARK: - Properties
-    
-    @Environment(\.colorScheme) private var colorScheme
     
     let mapURLBuilder: MapTilerURLBuilderProtocol
     
@@ -56,295 +76,33 @@ struct MapLibreMapView: UIViewRepresentable {
     /// Called when the user pan on the map
     var userDidPan: (() -> Void)?
     
-    // MARK: - UIViewRepresentable
-    
-    func makeUIView(context: Context) -> MLNMapView {
-        let mapView = makeMapView()
-        mapView.delegate = context.coordinator
-        setupMap(mapView: mapView, with: options)
-        return mapView
+    var body: some View {
+        Self.shim.makeMapView(configuration: configuration)
     }
     
-    func updateUIView(_ mapView: MLNMapView, context: Context) {
-        // Don't set the same value twice. Otherwise, if there is an error loading the map, a loop
-        // is caused as the `error` binding being set, which triggers this update, which sets a
-        // new URL, which causes another error, and so it goes on round and round in a circle.
-        let dynamicMapURL = mapURLBuilder.interactiveMapURL(for: .init(colorScheme))
-        if mapView.styleURL != dynamicMapURL {
-            mapView.styleURL = dynamicMapURL
-        }
+    /// The configuration for the shim, with the app-only pieces (marker views, tint, styles)
+    /// resolved into the shared types it understands.
+    private var configuration: MapViewConfiguration {
+        let annotations = options.annotations
+        let mapURLBuilder = mapURLBuilder
+        let mediaProvider = mediaProvider
         
-        // If the center coordinate was updated externally (not by the map itself), move the map.
-        // Not applied while following a marker, where the camera is driven by the marker's position.
-        if showsUserLocationMode.followedMarkerID == nil,
-           let newCenter = mapCenterCoordinate,
-           newCenter != context.coordinator.lastReportedCenter {
-            context.coordinator.lastReportedCenter = newCenter
-            mapView.setCenter(newCenter, animated: true)
-        }
-        
-        // Update existing annotation views with fresh SwiftUI content.
-        // This handles the case where the annotation's view data changes after
-        // the annotation was initially placed (e.g. user avatar loads asynchronously).
-        updateAnnotations(in: mapView)
-        
-        showUserLocation(in: mapView)
-        
-        context.coordinator.updateMarkerFollowing(in: mapView, markerID: showsUserLocationMode.followedMarkerID)
-    }
-    
-    func makeCoordinator() -> Coordinator {
-        Coordinator(self)
-    }
-    
-    // MARK: - Private
-    
-    private func setupMap(mapView: MLNMapView, with options: Options) {
-        mapView.addAnnotations(options.annotations)
-        mapView.zoomLevel = options.annotations.isEmpty ? options.initialZoomLevel : options.zoomLevel
-        mapView.centerCoordinate = options.mapCenter
-    }
-    
-    private func updateAnnotations(in mapView: MLNMapView) {
-        let existingByID = Dictionary(uniqueKeysWithValues:
-            (mapView.annotations ?? []).compactMap { $0 as? LocationAnnotation }.map { ($0.id, $0) })
-        let updatedByID = Dictionary(uniqueKeysWithValues: options.annotations.map { ($0.id, $0) })
-        
-        let existingIDs = Set(existingByID.keys)
-        let updatedIDs = Set(updatedByID.keys)
-        
-        // Remove annotations that are no longer present
-        let removedIDs = existingIDs.subtracting(updatedIDs)
-        if !removedIDs.isEmpty {
-            let toRemove = removedIDs.compactMap { existingByID[$0] }
-            mapView.removeAnnotations(toRemove)
-        }
-        
-        // Add new annotations
-        let addedIDs = updatedIDs.subtracting(existingIDs)
-        if !addedIDs.isEmpty {
-            let toAdd = addedIDs.compactMap { updatedByID[$0] }
-            mapView.addAnnotations(toAdd)
-        }
-        
-        // Update existing annotations that are still present
-        let keptIDs = existingIDs.intersection(updatedIDs)
-        for id in keptIDs {
-            guard let existingAnnotation = existingByID[id],
-                  let updatedAnnotation = updatedByID[id] else {
-                continue
-            }
-            CoordinateAnimator.animate(annotation: existingAnnotation,
-                                       to: updatedAnnotation.coordinate,
-                                       duration: 1.0)
-            if let annotationView = mapView.view(for: existingAnnotation) as? LocationAnnotationView {
-                annotationView.updateContent(with: updatedAnnotation.kind, mediaProvider: mediaProvider)
-            }
-        }
-    }
-    
-    private func makeMapView() -> MLNMapView {
-        let mapView = MLNMapView(frame: .zero, styleURL: mapURLBuilder.interactiveMapURL(for: colorScheme == .dark ? .dark : .light))
-        mapView.logoViewPosition = .topLeft
-        mapView.attributionButtonPosition = .topLeft
-        mapView.attributionButtonMargins = .init(x: mapView.logoView.frame.maxX + 8, y: mapView.logoView.center.y / 2)
-        mapView.tintColor = .compound.iconAccentPrimary
-        mapView.allowsRotating = false
-        mapView.allowsTilting = false
-        return mapView
-    }
-    
-    private func showUserLocation(in mapView: MLNMapView) {
-        switch (showsUserLocationMode, options.annotations) {
-        case (.showAndFollow, _):
-            mapView.userTrackingMode = .follow
-        case (.show, let annotations) where !annotations.isEmpty:
-            // In the show mode, if there are annotations, we check the authorizationStatus,
-            // if it's not determined, we wont prompt the user with a request for permissions,
-            // because they should be able to see the annotations without sharing their location information.
-            guard mapView.locationManager.authorizationStatus != .notDetermined else { return }
-            fallthrough
-        case (.show, _):
-            mapView.showsUserLocation = true
-            mapView.setUserTrackingMode(.none, animated: false, completionHandler: nil)
-        case (.hide, _), (.hideAndFollowMarker, _):
-            // In hideAndFollowMarker mode the camera following is handled by the coordinator.
-            mapView.showsUserLocation = false
-            mapView.setUserTrackingMode(.none, animated: false, completionHandler: nil)
-        }
-    }
-}
-
-// MARK: - Coordinator
-
-extension MapLibreMapView {
-    class Coordinator: NSObject, MLNMapViewDelegate {
-        // MARK: - Properties
-        
-        var mapLibreView: MapLibreMapView
-        
-        private var previousUserLocation: MLNUserLocation?
-        /// Tracks the last center coordinate reported by the map (or set programmatically),
-        /// so that `updateUIView` can tell apart external binding changes from internal ones.
-        var lastReportedCenter: CLLocationCoordinate2D?
-        
-        /// The annotation the camera is currently locked on while in the `hideAndFollowMarker` mode.
-        private weak var followedAnnotation: LocationAnnotation?
-        /// Observes the followed annotation's coordinate, updated every frame by the `CoordinateAnimator`.
-        private var followedAnnotationObservation: NSKeyValueObservation?
-        
-        // MARK: - Setup
-        
-        init(_ mapLibreView: MapLibreMapView) {
-            self.mapLibreView = mapLibreView
-        }
-        
-        // MARK: - Marker following
-        
-        /// Keeps the camera locked on the marker with the given id, or stops following when nil.
-        func updateMarkerFollowing(in mapView: MLNMapView, markerID: String?) {
-            guard let markerID else {
-                stopFollowingMarker()
-                return
-            }
-            
-            guard let annotation = (mapView.annotations ?? [])
-                .compactMap({ $0 as? LocationAnnotation })
-                .first(where: { $0.id == markerID }) else {
-                // The marker isn't on the map (yet), resolve it again on the next update.
-                stopFollowingMarker()
-                return
-            }
-            
-            guard annotation !== followedAnnotation else { return }
-            startFollowingMarker(annotation, in: mapView)
-        }
-        
-        private func startFollowingMarker(_ annotation: LocationAnnotation, in mapView: MLNMapView) {
-            followedAnnotation = annotation
-            followedAnnotationObservation = nil
-            
-            // Animate to the marker first, attaching the per-frame tracking only on completion
-            // so that it doesn't cancel the transition.
-            mapView.setCenter(annotation.coordinate,
-                              zoomLevel: mapView.zoomLevel,
-                              direction: -1, // negative value keeps the current direction
-                              animated: true) { [weak self, weak annotation, weak mapView] in
-                guard let self, let annotation, let mapView, annotation === followedAnnotation else { return }
-                
-                // Mirror every animated coordinate update to keep the camera as smooth as the marker.
-                followedAnnotationObservation = annotation.observe(\.coordinate) { [weak mapView] annotation, _ in
-                    // The coordinate is only ever updated by SwiftUI so KVO fires on the main actor.
-                    MainActor.assumeIsolated {
-                        mapView?.setCenter(annotation.coordinate, animated: false)
-                    }
-                }
-            }
-        }
-        
-        private func stopFollowingMarker() {
-            followedAnnotation = nil
-            followedAnnotationObservation = nil
-        }
-        
-        // MARK: - MLNMapViewDelegate
-        
-        func mapView(_ mapView: MLNMapView, viewFor annotation: MLNAnnotation) -> MLNAnnotationView? {
-            guard let annotation = annotation as? LocationAnnotation else {
-                return nil
-            }
-            return LocationAnnotationView(annotation: annotation, mediaProvider: mapLibreView.mediaProvider)
-        }
-        
-        func mapViewDidFailLoadingMap(_ mapView: MLNMapView, withError error: Error) {
-            if mapLibreView.error != .failedLoadingMap {
-                mapLibreView.error = .failedLoadingMap
-            }
-        }
-        
-        func mapView(_ mapView: MLNMapView, didUpdate userLocation: MLNUserLocation?) {
-            guard let userLocation else { return }
-            mapLibreView.hasLoadedUserLocation = true
-            
-            if previousUserLocation == nil, mapLibreView.options.annotations.isEmpty {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                    mapView.setCenter(userLocation.coordinate, zoomLevel: self.mapLibreView.options.zoomLevel, animated: true)
-                }
-            }
-            
-            previousUserLocation = userLocation
-            updateGeolocationUncertainty(location: userLocation)
-        }
-        
-        func mapView(_ mapView: MLNMapView, didChangeLocationManagerAuthorization manager: MLNLocationManager) {
-            switch manager.authorizationStatus {
-            case .denied, .restricted:
-                mapLibreView.isLocationAuthorized = false
-            case .authorizedAlways, .authorizedWhenInUse:
-                mapLibreView.isLocationAuthorized = true
-            case .notDetermined:
-                mapLibreView.isLocationAuthorized = nil
-            @unknown default:
-                break
-            }
-        }
-        
-        func mapView(_ mapView: MLNMapView, regionDidChangeAnimated animated: Bool) {
-            // While following a marker, don't flood the center binding with per-frame camera updates.
-            // Leaving `lastReportedCenter` untouched avoids an external re-centering when following stops.
-            guard mapLibreView.showsUserLocationMode.followedMarkerID == nil else { return }
-            
-            // Avoid `Publishing changes from within view update` warnings
-            DispatchQueue.main.async { [mapLibreView, weak self] in
-                let center = mapView.centerCoordinate
-                self?.lastReportedCenter = center
-                mapLibreView.mapCenterCoordinate = center
-            }
-        }
-        
-        func mapView(_ mapView: MLNMapView, shouldChangeFrom oldCamera: MLNMapCamera, to newCamera: MLNMapCamera, reason: MLNCameraChangeReason) -> Bool {
-            // Send userDidPan only for gestures that actually change the map center. The reason
-            // is an option set and gestures can come combined with other reasons, so check for
-            // containment instead of an exact match.
-            let centerChangingGestures: MLNCameraChangeReason = [.gesturePan, .gesturePinch, .gestureRotate]
-            if !reason.isDisjoint(with: centerChangingGestures) {
-                // Stop following immediately, the camera would fight the gesture otherwise.
-                stopFollowingMarker()
-                mapLibreView.userDidPan?()
-            }
-            return true
-        }
-        
-        // MARK: Callout
-        
-        func mapView(_ mapView: MLNMapView, annotationCanShowCallout annotation: MLNAnnotation) -> Bool {
-            false
-        }
-        
-        // MARK: Private
-        
-        private func updateGeolocationUncertainty(location: MLNUserLocation) {
-            guard let clLocation = location.location, clLocation.horizontalAccuracy >= 0 else {
-                mapLibreView.geolocationUncertainty = nil
-                return
-            }
-            
-            mapLibreView.geolocationUncertainty = clLocation.horizontalAccuracy
-        }
-    }
-}
-
-// MARK: - MLNMapView convenient methods
-
-private extension MapTilerStyle {
-    init(_ colorScheme: ColorScheme) {
-        switch colorScheme {
-        case .light:
-            self = .light
-        case .dark:
-            self = .dark
-        @unknown default:
-            fatalError()
-        }
+        return .init(zoomLevel: options.zoomLevel,
+                     initialZoomLevel: options.initialZoomLevel,
+                     mapCenter: options.mapCenter,
+                     annotations: annotations.map { .init(id: $0.id, coordinate: $0.coordinate) },
+                     styleURL: { mapURLBuilder.interactiveMapURL(for: $0 ? .dark : .light) },
+                     tintColor: .compound.iconAccentPrimary,
+                     markerView: { annotationID in
+                         guard let kind = annotations.first(where: { $0.id == annotationID })?.kind else { return nil }
+                         return AnyView(LocationMarkerView(kind: kind, mediaProvider: mediaProvider))
+                     },
+                     showsUserLocationMode: $showsUserLocationMode,
+                     error: $error,
+                     mapCenterCoordinate: $mapCenterCoordinate,
+                     hasLoadedUserLocation: $hasLoadedUserLocation,
+                     isLocationAuthorized: $isLocationAuthorized,
+                     geolocationUncertainty: $geolocationUncertainty,
+                     userDidPan: userDidPan)
     }
 }

--- a/ElementX/Sources/Other/MapLibre/MapLibreModels.swift
+++ b/ElementX/Sources/Other/MapLibre/MapLibreModels.swift
@@ -8,32 +8,6 @@
 
 import Foundation
 
-/**
- Behavior mode of the current user's location, can be hidden, only shown and shown following the user
- */
-enum ShowUserLocationMode: Equatable {
-    /// this mode will show the user pin in map
-    case show
-    /// this mode will show the user pin in map and track him, panning the map automatically
-    case showAndFollow
-    /// this mode will not show the user pin in map
-    case hide
-    /// this mode will not show the user pin in map and will follow the marker with the given id,
-    /// panning the map automatically.
-    case hideAndFollowMarker(id: String)
-    
-    /// The id of the marker the map should follow when in the `hideAndFollowMarker` mode, nil otherwise.
-    var followedMarkerID: String? {
-        guard case .hideAndFollowMarker(let id) = self else { return nil }
-        return id
-    }
-}
-
-enum MapLibreError: Error {
-    case failedLoadingMap
-    case failedLocatingUser
-}
-
 /// The style to show a map in.
 ///
 /// There can be any number of styles, we have defined one for light and another for dark.

--- a/ElementX/Sources/Screens/LocationSharing/LocationSharingScreenModels.swift
+++ b/ElementX/Sources/Screens/LocationSharing/LocationSharingScreenModels.swift
@@ -8,6 +8,7 @@
 
 import CoreLocation
 import Foundation
+import MapLibreInterface
 import MatrixRustSDK
 
 enum LocationSharingViewAlert: Hashable {

--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -250,6 +250,8 @@ targets:
     - package: Mantis
     - target: MapLibreInterface
       embed: true
+    - target: MapLibreShim
+      embed: true
     - package: MapLibre
     - package: PostHog
     - package: SwiftState

--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -250,9 +250,16 @@ targets:
     - package: Mantis
     - target: MapLibreInterface
       embed: true
+    # Embedded but not linked, dlopen'd on first map use
     - target: MapLibreShim
+      link: false
       embed: true
-    - package: MapLibre
+    # The app just embeds the framework so it's in the bundle for the shim's load 
+    # command to resolve against.
+    - framework: ../../MapLibre.framework
+      implicit: true
+      link: false
+      embed: true
     - package: PostHog
     - package: SwiftState
     - package: GZIP

--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -248,6 +248,8 @@ targets:
     - package: LoremSwiftum
     - package: LRUCache
     - package: Mantis
+    - target: MapLibreInterface
+      embed: true
     - package: MapLibre
     - package: PostHog
     - package: SwiftState

--- a/UnitTests/Sources/MapLibreLoaderTests.swift
+++ b/UnitTests/Sources/MapLibreLoaderTests.swift
@@ -1,0 +1,19 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+@testable import ElementX
+import Testing
+
+@MainActor
+struct MapLibreLoaderTests {
+    /// The shim is embedded but not linked, if it ever stops being copied into the app (or
+    /// the class is renamed) the interactive map would silently stop working.
+    @Test
+    func loadsTheShim() {
+        #expect(MapLibreLoader.shim != nil)
+    }
+}

--- a/UnitTests/SupportingFiles/target.yml
+++ b/UnitTests/SupportingFiles/target.yml
@@ -31,6 +31,7 @@ targets:
 
     dependencies:
     - target: ElementX
+    - target: MapLibreInterface
     - package: MatrixRustSDK
     - package: AsyncAlgorithms
     - package: Clocks

--- a/project.yml
+++ b/project.yml
@@ -59,6 +59,7 @@ settings:
 
 include:
 - path: app.yml
+- path: ElementX/MapLibre/MapLibreInterface/SupportingFiles/target.yml
 - path: ElementX/SupportingFiles/target.yml
 - path: NSE/SupportingFiles/target.yml
 - path: ShareExtension/SupportingFiles/target.yml

--- a/project.yml
+++ b/project.yml
@@ -60,6 +60,7 @@ settings:
 include:
 - path: app.yml
 - path: ElementX/MapLibre/MapLibreInterface/SupportingFiles/target.yml
+- path: ElementX/MapLibre/MapLibreShim/SupportingFiles/target.yml
 - path: ElementX/SupportingFiles/target.yml
 - path: NSE/SupportingFiles/target.yml
 - path: ShareExtension/SupportingFiles/target.yml


### PR DESCRIPTION
MapLibre ships as a dynamic framework and the app links it, which means dyld loads it before `main` runs on every launch: 7.3 MB paged in, 133 C++ static initialisers run, a hundred-odd classes registered. None of that is needed unless someone opens a location screen, which most sessions never do.

Moved the map components into a new `MapLibreShim` framework which is embedded in the bundle but deliberately left unlinked, and is the only image that links MapLibre. The app links a second `MapLibreInterface` framework that holds the handful of types that cross the boundary.

> Measured it with two otherwise identical probe apps on an iPhone 17 Pro, launched alternately. Linking MapLibre takes pre-main from 11.1 ms to 23.2 ms, and on a cold launch from 32.9 ms to 60.7 ms. Loading it on demand instead brings pre-main back to 11.1 ms, and the ~11 ms it costs to `dlopen` lands when the map first appears. Numbers are most likely significantly worse on older silicon.