### PR TITLE
Update the SDK.

### DIFF
--- a/Components/SDKMocks/Sources/Generated/SDKGeneratedMocks.swift
+++ b/Components/SDKMocks/Sources/Generated/SDKGeneratedMocks.swift
@@ -659,6 +659,38 @@ open class ClientSDKMock: MatrixRustSDK.Client, @unchecked Sendable {
         }
     }
 
+    //MARK: - disableWellKnownLookup
+
+    private let disableWellKnownLookupDisableCallsCountLock = NSLock()
+    private var disableWellKnownLookupDisableUnderlyingCallsCount = 0
+    open var disableWellKnownLookupDisableCallsCount: Int {
+        get { disableWellKnownLookupDisableCallsCountLock.withLock { disableWellKnownLookupDisableUnderlyingCallsCount } }
+        set { disableWellKnownLookupDisableCallsCountLock.withLock { disableWellKnownLookupDisableUnderlyingCallsCount = newValue } }
+    }
+    open var disableWellKnownLookupDisableCalled: Bool {
+        return disableWellKnownLookupDisableCallsCount > 0
+    }
+    private let disableWellKnownLookupDisableReceivedDisableLock = NSLock()
+    private var disableWellKnownLookupDisableUnderlyingReceivedDisable: Bool?
+    open var disableWellKnownLookupDisableReceivedDisable: Bool? {
+        get { disableWellKnownLookupDisableReceivedDisableLock.withLock { disableWellKnownLookupDisableUnderlyingReceivedDisable } }
+        set { disableWellKnownLookupDisableReceivedDisableLock.withLock { disableWellKnownLookupDisableUnderlyingReceivedDisable = newValue } }
+    }
+    private let disableWellKnownLookupDisableReceivedInvocationsLock = NSLock()
+    private var disableWellKnownLookupDisableUnderlyingReceivedInvocations: [Bool] = []
+    open var disableWellKnownLookupDisableReceivedInvocations: [Bool] {
+        get { disableWellKnownLookupDisableReceivedInvocationsLock.withLock { disableWellKnownLookupDisableUnderlyingReceivedInvocations } }
+        set { disableWellKnownLookupDisableReceivedInvocationsLock.withLock { disableWellKnownLookupDisableUnderlyingReceivedInvocations = newValue } }
+    }
+    open var disableWellKnownLookupDisableClosure: ((Bool) -> Void)?
+
+    open override func disableWellKnownLookup(disable: Bool) {
+        disableWellKnownLookupDisableCallsCountLock.withLock { disableWellKnownLookupDisableUnderlyingCallsCount += 1 }
+        disableWellKnownLookupDisableReceivedDisable = disable
+        disableWellKnownLookupDisableReceivedInvocationsLock.withLock { disableWellKnownLookupDisableUnderlyingReceivedInvocations.append(disable) }
+        disableWellKnownLookupDisableClosure?(disable)
+    }
+
     //MARK: - displayName
 
     open var displayNameThrowableError: Error?
@@ -1723,48 +1755,34 @@ open class ClientSDKMock: MatrixRustSDK.Client, @unchecked Sendable {
 
     //MARK: - isLivekitRtcSupported
 
-    open var isLivekitRtcSupportedFallbackToWellKnownThrowableError: Error?
-    private let isLivekitRtcSupportedFallbackToWellKnownCallsCountLock = NSLock()
-    private var isLivekitRtcSupportedFallbackToWellKnownUnderlyingCallsCount = 0
-    open var isLivekitRtcSupportedFallbackToWellKnownCallsCount: Int {
-        get { isLivekitRtcSupportedFallbackToWellKnownCallsCountLock.withLock { isLivekitRtcSupportedFallbackToWellKnownUnderlyingCallsCount } }
-        set { isLivekitRtcSupportedFallbackToWellKnownCallsCountLock.withLock { isLivekitRtcSupportedFallbackToWellKnownUnderlyingCallsCount = newValue } }
+    open var isLivekitRtcSupportedThrowableError: Error?
+    private let isLivekitRtcSupportedCallsCountLock = NSLock()
+    private var isLivekitRtcSupportedUnderlyingCallsCount = 0
+    open var isLivekitRtcSupportedCallsCount: Int {
+        get { isLivekitRtcSupportedCallsCountLock.withLock { isLivekitRtcSupportedUnderlyingCallsCount } }
+        set { isLivekitRtcSupportedCallsCountLock.withLock { isLivekitRtcSupportedUnderlyingCallsCount = newValue } }
     }
-    open var isLivekitRtcSupportedFallbackToWellKnownCalled: Bool {
-        return isLivekitRtcSupportedFallbackToWellKnownCallsCount > 0
-    }
-    private let isLivekitRtcSupportedFallbackToWellKnownReceivedFallbackToWellKnownLock = NSLock()
-    private var isLivekitRtcSupportedFallbackToWellKnownUnderlyingReceivedFallbackToWellKnown: Bool?
-    open var isLivekitRtcSupportedFallbackToWellKnownReceivedFallbackToWellKnown: Bool? {
-        get { isLivekitRtcSupportedFallbackToWellKnownReceivedFallbackToWellKnownLock.withLock { isLivekitRtcSupportedFallbackToWellKnownUnderlyingReceivedFallbackToWellKnown } }
-        set { isLivekitRtcSupportedFallbackToWellKnownReceivedFallbackToWellKnownLock.withLock { isLivekitRtcSupportedFallbackToWellKnownUnderlyingReceivedFallbackToWellKnown = newValue } }
-    }
-    private let isLivekitRtcSupportedFallbackToWellKnownReceivedInvocationsLock = NSLock()
-    private var isLivekitRtcSupportedFallbackToWellKnownUnderlyingReceivedInvocations: [Bool] = []
-    open var isLivekitRtcSupportedFallbackToWellKnownReceivedInvocations: [Bool] {
-        get { isLivekitRtcSupportedFallbackToWellKnownReceivedInvocationsLock.withLock { isLivekitRtcSupportedFallbackToWellKnownUnderlyingReceivedInvocations } }
-        set { isLivekitRtcSupportedFallbackToWellKnownReceivedInvocationsLock.withLock { isLivekitRtcSupportedFallbackToWellKnownUnderlyingReceivedInvocations = newValue } }
+    open var isLivekitRtcSupportedCalled: Bool {
+        return isLivekitRtcSupportedCallsCount > 0
     }
 
-    private let isLivekitRtcSupportedFallbackToWellKnownReturnValueLock = NSLock()
-    open var isLivekitRtcSupportedFallbackToWellKnownUnderlyingReturnValue: Bool!
-    open var isLivekitRtcSupportedFallbackToWellKnownReturnValue: Bool! {
-        get { isLivekitRtcSupportedFallbackToWellKnownReturnValueLock.withLock { isLivekitRtcSupportedFallbackToWellKnownUnderlyingReturnValue } }
-        set { isLivekitRtcSupportedFallbackToWellKnownReturnValueLock.withLock { isLivekitRtcSupportedFallbackToWellKnownUnderlyingReturnValue = newValue } }
+    private let isLivekitRtcSupportedReturnValueLock = NSLock()
+    open var isLivekitRtcSupportedUnderlyingReturnValue: Bool!
+    open var isLivekitRtcSupportedReturnValue: Bool! {
+        get { isLivekitRtcSupportedReturnValueLock.withLock { isLivekitRtcSupportedUnderlyingReturnValue } }
+        set { isLivekitRtcSupportedReturnValueLock.withLock { isLivekitRtcSupportedUnderlyingReturnValue = newValue } }
     }
-    open var isLivekitRtcSupportedFallbackToWellKnownClosure: ((Bool) async throws -> Bool)?
+    open var isLivekitRtcSupportedClosure: (() async throws -> Bool)?
 
-    open override func isLivekitRtcSupported(fallbackToWellKnown: Bool = false) async throws -> Bool {
-        if let error = isLivekitRtcSupportedFallbackToWellKnownThrowableError {
+    open override func isLivekitRtcSupported() async throws -> Bool {
+        if let error = isLivekitRtcSupportedThrowableError {
             throw error
         }
-        isLivekitRtcSupportedFallbackToWellKnownCallsCountLock.withLock { isLivekitRtcSupportedFallbackToWellKnownUnderlyingCallsCount += 1 }
-        isLivekitRtcSupportedFallbackToWellKnownReceivedFallbackToWellKnown = fallbackToWellKnown
-        isLivekitRtcSupportedFallbackToWellKnownReceivedInvocationsLock.withLock { isLivekitRtcSupportedFallbackToWellKnownUnderlyingReceivedInvocations.append(fallbackToWellKnown) }
-        if let isLivekitRtcSupportedFallbackToWellKnownClosure = isLivekitRtcSupportedFallbackToWellKnownClosure {
-            return try await isLivekitRtcSupportedFallbackToWellKnownClosure(fallbackToWellKnown)
+        isLivekitRtcSupportedCallsCountLock.withLock { isLivekitRtcSupportedUnderlyingCallsCount += 1 }
+        if let isLivekitRtcSupportedClosure = isLivekitRtcSupportedClosure {
+            return try await isLivekitRtcSupportedClosure()
         } else {
-            return isLivekitRtcSupportedFallbackToWellKnownReturnValue
+            return isLivekitRtcSupportedReturnValue
         }
     }
 
@@ -1798,6 +1816,39 @@ open class ClientSDKMock: MatrixRustSDK.Client, @unchecked Sendable {
             return try await isLoginWithQrCodeSupportedClosure()
         } else {
             return isLoginWithQrCodeSupportedReturnValue
+        }
+    }
+
+    //MARK: - isProfilesSlidingSyncExtensionSupported
+
+    open var isProfilesSlidingSyncExtensionSupportedThrowableError: Error?
+    private let isProfilesSlidingSyncExtensionSupportedCallsCountLock = NSLock()
+    private var isProfilesSlidingSyncExtensionSupportedUnderlyingCallsCount = 0
+    open var isProfilesSlidingSyncExtensionSupportedCallsCount: Int {
+        get { isProfilesSlidingSyncExtensionSupportedCallsCountLock.withLock { isProfilesSlidingSyncExtensionSupportedUnderlyingCallsCount } }
+        set { isProfilesSlidingSyncExtensionSupportedCallsCountLock.withLock { isProfilesSlidingSyncExtensionSupportedUnderlyingCallsCount = newValue } }
+    }
+    open var isProfilesSlidingSyncExtensionSupportedCalled: Bool {
+        return isProfilesSlidingSyncExtensionSupportedCallsCount > 0
+    }
+
+    private let isProfilesSlidingSyncExtensionSupportedReturnValueLock = NSLock()
+    open var isProfilesSlidingSyncExtensionSupportedUnderlyingReturnValue: Bool!
+    open var isProfilesSlidingSyncExtensionSupportedReturnValue: Bool! {
+        get { isProfilesSlidingSyncExtensionSupportedReturnValueLock.withLock { isProfilesSlidingSyncExtensionSupportedUnderlyingReturnValue } }
+        set { isProfilesSlidingSyncExtensionSupportedReturnValueLock.withLock { isProfilesSlidingSyncExtensionSupportedUnderlyingReturnValue = newValue } }
+    }
+    open var isProfilesSlidingSyncExtensionSupportedClosure: (() async throws -> Bool)?
+
+    open override func isProfilesSlidingSyncExtensionSupported() async throws -> Bool {
+        if let error = isProfilesSlidingSyncExtensionSupportedThrowableError {
+            throw error
+        }
+        isProfilesSlidingSyncExtensionSupportedCallsCountLock.withLock { isProfilesSlidingSyncExtensionSupportedUnderlyingCallsCount += 1 }
+        if let isProfilesSlidingSyncExtensionSupportedClosure = isProfilesSlidingSyncExtensionSupportedClosure {
+            return try await isProfilesSlidingSyncExtensionSupportedClosure()
+        } else {
+            return isProfilesSlidingSyncExtensionSupportedReturnValue
         }
     }
 
@@ -4791,6 +4842,49 @@ open class ClientBuilderSDKMock: MatrixRustSDK.ClientBuilder, @unchecked Sendabl
             return disableSslVerificationClosure()
         } else {
             return disableSslVerificationReturnValue
+        }
+    }
+
+    //MARK: - disableWellKnownLookup
+
+    private let disableWellKnownLookupDisableWellKnownLookupCallsCountLock = NSLock()
+    private var disableWellKnownLookupDisableWellKnownLookupUnderlyingCallsCount = 0
+    open var disableWellKnownLookupDisableWellKnownLookupCallsCount: Int {
+        get { disableWellKnownLookupDisableWellKnownLookupCallsCountLock.withLock { disableWellKnownLookupDisableWellKnownLookupUnderlyingCallsCount } }
+        set { disableWellKnownLookupDisableWellKnownLookupCallsCountLock.withLock { disableWellKnownLookupDisableWellKnownLookupUnderlyingCallsCount = newValue } }
+    }
+    open var disableWellKnownLookupDisableWellKnownLookupCalled: Bool {
+        return disableWellKnownLookupDisableWellKnownLookupCallsCount > 0
+    }
+    private let disableWellKnownLookupDisableWellKnownLookupReceivedDisableWellKnownLookupLock = NSLock()
+    private var disableWellKnownLookupDisableWellKnownLookupUnderlyingReceivedDisableWellKnownLookup: Bool?
+    open var disableWellKnownLookupDisableWellKnownLookupReceivedDisableWellKnownLookup: Bool? {
+        get { disableWellKnownLookupDisableWellKnownLookupReceivedDisableWellKnownLookupLock.withLock { disableWellKnownLookupDisableWellKnownLookupUnderlyingReceivedDisableWellKnownLookup } }
+        set { disableWellKnownLookupDisableWellKnownLookupReceivedDisableWellKnownLookupLock.withLock { disableWellKnownLookupDisableWellKnownLookupUnderlyingReceivedDisableWellKnownLookup = newValue } }
+    }
+    private let disableWellKnownLookupDisableWellKnownLookupReceivedInvocationsLock = NSLock()
+    private var disableWellKnownLookupDisableWellKnownLookupUnderlyingReceivedInvocations: [Bool] = []
+    open var disableWellKnownLookupDisableWellKnownLookupReceivedInvocations: [Bool] {
+        get { disableWellKnownLookupDisableWellKnownLookupReceivedInvocationsLock.withLock { disableWellKnownLookupDisableWellKnownLookupUnderlyingReceivedInvocations } }
+        set { disableWellKnownLookupDisableWellKnownLookupReceivedInvocationsLock.withLock { disableWellKnownLookupDisableWellKnownLookupUnderlyingReceivedInvocations = newValue } }
+    }
+
+    private let disableWellKnownLookupDisableWellKnownLookupReturnValueLock = NSLock()
+    open var disableWellKnownLookupDisableWellKnownLookupUnderlyingReturnValue: ClientBuilder!
+    open var disableWellKnownLookupDisableWellKnownLookupReturnValue: ClientBuilder! {
+        get { disableWellKnownLookupDisableWellKnownLookupReturnValueLock.withLock { disableWellKnownLookupDisableWellKnownLookupUnderlyingReturnValue } }
+        set { disableWellKnownLookupDisableWellKnownLookupReturnValueLock.withLock { disableWellKnownLookupDisableWellKnownLookupUnderlyingReturnValue = newValue } }
+    }
+    open var disableWellKnownLookupDisableWellKnownLookupClosure: ((Bool) -> ClientBuilder)?
+
+    open override func disableWellKnownLookup(disableWellKnownLookup: Bool) -> ClientBuilder {
+        disableWellKnownLookupDisableWellKnownLookupCallsCountLock.withLock { disableWellKnownLookupDisableWellKnownLookupUnderlyingCallsCount += 1 }
+        disableWellKnownLookupDisableWellKnownLookupReceivedDisableWellKnownLookup = disableWellKnownLookup
+        disableWellKnownLookupDisableWellKnownLookupReceivedInvocationsLock.withLock { disableWellKnownLookupDisableWellKnownLookupUnderlyingReceivedInvocations.append(disableWellKnownLookup) }
+        if let disableWellKnownLookupDisableWellKnownLookupClosure = disableWellKnownLookupDisableWellKnownLookupClosure {
+            return disableWellKnownLookupDisableWellKnownLookupClosure(disableWellKnownLookup)
+        } else {
+            return disableWellKnownLookupDisableWellKnownLookupReturnValue
         }
     }
 

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -10750,7 +10750,7 @@
 			repositoryURL = "https://github.com/element-hq/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 26.08.11;
+				version = 26.08.14;
 			};
 		};
 		701C7BEF8F70F7A83E852DCC /* XCRemoteSwiftPackageReference "GZIP" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fbe2663429af94e60cfa70345bffe72998cbc19f6f659bd6f3c1a0ddc50b941d",
+  "originHash" : "515d7858f8d13128cb330ef4e14c9bb41516cd04a0280a625a852155c53a610e",
   "pins" : [
     {
       "identity" : "compound-design-tokens",
@@ -167,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/matrix-rust-components-swift",
       "state" : {
-        "revision" : "cd2aca60da2e59765b5a949e497f56cad29b88cf",
-        "version" : "26.8.11"
+        "revision" : "de262a6ef0e249cf0c82a44abf958a4c0e9e0518",
+        "version" : "26.8.14"
       }
     },
     {

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -281,7 +281,8 @@ class ClientProxy: ClientProxyProtocol {
         
         try await client.setUtdDelegate(utdDelegate: ClientDecryptionErrorDelegate(actionsSubject: actionsSubject))
         
-        let canSubscribeToUserProfile = if appSettings.userStatusEnabled, case .success(true) = await isUserStatusSupported() {
+        let canSubscribeToUserProfile = if appSettings.userStatusEnabled,
+                                           await (try? client.isProfilesSlidingSyncExtensionSupported()) == true {
             true
         } else {
             false
@@ -369,7 +370,7 @@ class ClientProxy: ClientProxyProtocol {
     var isLiveKitRTCSupported: Bool {
         get async {
             do {
-                return try await client.isLivekitRtcSupported(fallbackToWellKnown: true)
+                return try await client.isLivekitRtcSupported()
             } catch {
                 MXLog.error("Failed checking LiveKit RTC support with error: \(error)")
                 return false

--- a/project.yml
+++ b/project.yml
@@ -74,7 +74,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/element-hq/matrix-rust-components-swift
-    exactVersion: 26.08.11
+    exactVersion: 26.08.14
     # path: ../matrix-rust-sdk
   Compound:
     path: compound-ios


### PR DESCRIPTION
Also use the new `Client.isProfilesSlidingSyncExtensionSupported` to check for user profile subscription support so that the user's profile is still reactive if the homeserver disables the User Status feature.