### PR TITLE
Keep the send button when the composer is emptied while editing a message

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarModels.swift
+++ b/ElementX/Sources/Screens/RoomScreen/ComposerToolbar/ComposerToolbarModels.swift
@@ -98,6 +98,8 @@ struct ComposerToolbarViewState: BindableState {
             return false
         case .previewVoiceMessage:
             return true
+        case .edit:
+            return true
         default:
             if bindings.composerFormattingEnabled {
                 return !composerEmpty

--- a/UnitTests/Sources/ComposerToolbarViewModelTests.swift
+++ b/UnitTests/Sources/ComposerToolbarViewModelTests.swift
@@ -50,6 +50,31 @@ final class ComposerToolbarViewModelTests {
     }
     
     @Test
+    func sendButtonRemainsVisibleWhenTheComposerIsEmptiedWhileEditing() {
+        for editType in [ComposerMode.EditType.default, .addCaption, .editCaption] {
+            setUpViewModel()
+            viewModel.context.composerFormattingEnabled = false
+            viewModel.context.plainComposerText = .init(string: "A message")
+            viewModel.process(timelineAction: .setMode(mode: .edit(originalEventOrTransactionID: .eventID("mock"), type: editType)))
+            #expect(viewModel.state.showSendButton)
+            
+            viewModel.context.plainComposerText = .init(string: "")
+            #expect(viewModel.state.showSendButton)
+            #expect(viewModel.state.sendButtonDisabled)
+        }
+    }
+    
+    @Test
+    func sendButtonIsReplacedWhenTheComposerIsEmptiedOutsideOfEditing() {
+        viewModel.context.composerFormattingEnabled = false
+        viewModel.context.plainComposerText = .init(string: "A message")
+        #expect(viewModel.state.showSendButton)
+        
+        viewModel.context.plainComposerText = .init(string: "")
+        #expect(!viewModel.state.showSendButton)
+    }
+    
+    @Test
     func handleKeyCommand() {
         #expect(viewModel.context.viewState.keyCommands.count == 1)
     }


### PR DESCRIPTION
Emptying the composer while editing a message replaces the confirm button with the voice message recorder, so the affordance for the action being carried out disappears mid-edit.

`showSendButton` special-cased only the two voice message modes and otherwise fell through to a plain "is there any text" check, which is the wrong question while editing. `sendButtonMode`, `sendButtonAccessibilityLabel` and `sendButtonDisabled` already handle edit mode, so keeping the button visible is enough: it renders as the confirm tick and disables itself while the text is empty. The caption edit types go through the same path.

iOS counterpart of element-hq/element-x-android#7456, which fixes element-hq/element-x-android#3756.

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
