### PR TITLE
Add Periphery unused code workflow

### DIFF
--- a/.github/workflows/periphery-comment.yml
+++ b/.github/workflows/periphery-comment.yml
@@ -1,0 +1,16 @@
+name: Unused code comment
+
+on:
+  workflow_run:
+    workflows: ["Unused code"]
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  comment:
+    if: github.event.workflow_run.event == 'pull_request'
+    permissions:
+      actions: read
+      pull-requests: write
+    uses: periphery-pro/actions/.github/workflows/comment.yml@v1

--- a/.github/workflows/periphery.yml
+++ b/.github/workflows/periphery.yml
@@ -1,0 +1,17 @@
+name: Unused code
+
+on:
+  pull_request:
+  push:
+    branches: ["develop"]
+
+jobs:
+  periphery:
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    uses: periphery-pro/actions/.github/workflows/scan.yml@v1
+    with:
+      runner: macos-26
+      setup: git lfs pull


### PR DESCRIPTION
Any interest in detecting unused code in PRs?

This change integrates the [Periphery reusable workflow](https://github.com/periphery-pro/actions). On pushes to the main branch, it scans for unused code and records a baseline. On PRs, it pulls the baseline for the merge-base commit and then reports any code that’s newly identified as unused.

The results are reported as inline comments in the diff for newly introduced unused code, and also a PR comment which also includes any results that aren’t present in the diff (i.e the change removes the final references to some existing code).

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [ ] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
