### PR TITLE
Stop the integration tests from backgrounding the web authentication session

### DIFF
--- a/IntegrationTests/Sources/Common.swift
+++ b/IntegrationTests/Sources/Common.swift
@@ -61,7 +61,6 @@ extension XCUIApplication {
         
         let webAuthenticationView = XCUIApplication(bundleIdentifier: "com.apple.SafariViewService")
         XCTAssertTrue(webAuthenticationView.waitForExistence(timeout: 10.0))
-        webAuthenticationView.tap(.top) // Tap the web view to properly focus the app again.
         
         // The user may already be authenticated on MAS. Sign them out.
         // The button label varies by MAS version: "Sign out" or "Use another account".


### PR DESCRIPTION
Tapping the SafariViewService app object makes XCUITest activate it as a standalone app. That backgrounds Element X, which hosts the web view, so the hosted scene goes to the background too and WebKit suspends it mid load. The sign in page is fetched successfully but never rendered, and the test times out waiting for the username field.

The tap dates from when the element was a web view inside the app, where it was a plain in app tap, so it no longer does what its comment describes.