### PR TITLE
Pin project dependencies to exact versions given we have Renovate.

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -10748,32 +10748,32 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/maplibre/maplibre-gl-native-distribution";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 6.28.0;
+				kind = exactVersion;
+				version = 6.28.0;
 			};
 		};
 		395DE6AE429B7ACC7C7FE31D /* XCRemoteSwiftPackageReference "KZFileWatchers" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/krzysztofzablocki/KZFileWatchers";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 1.2.0;
+				kind = exactVersion;
+				version = 1.2.0;
 			};
 		};
 		4A8D3ABF18EABB8066BBD46E /* XCRemoteSwiftPackageReference "swift-async-algorithms" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-async-algorithms";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 1.1.5;
+				kind = exactVersion;
+				version = 1.1.5;
 			};
 		};
 		4BDA7F6042968E8422470F3F /* XCRemoteSwiftPackageReference "LoremSwiftum" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/lukaskubanek/LoremSwiftum";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 2.2.3;
+				kind = exactVersion;
+				version = 2.2.3;
 			};
 		};
 		4C34425923978C97409A3EF2 /* XCRemoteSwiftPackageReference "DSWaveformImage" */ = {
@@ -10788,16 +10788,16 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/kishikawakatsumi/KeychainAccess";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 4.2.2;
+				kind = exactVersion;
+				version = 4.2.2;
 			};
 		};
 		6582B5AF3F104B0F7E031E7D /* XCRemoteSwiftPackageReference "SwiftState" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ReactKit/SwiftState";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 6.0.1;
+				kind = exactVersion;
+				version = 6.0.1;
 			};
 		};
 		6FC4820D8D4559CEECA064D7 /* XCRemoteSwiftPackageReference "matrix-rust-components-swift" */ = {
@@ -10812,8 +10812,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/nicklockwood/GZIP";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 1.3.2;
+				kind = exactVersion;
+				version = 1.3.2;
 			};
 		};
 		75CC627F59499C9E93D8FDAD /* XCRemoteSwiftPackageReference "Dynamic" */ = {
@@ -10828,8 +10828,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/guoyingtao/Mantis";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 3.1.0;
+				kind = exactVersion;
+				version = 3.1.0;
 			};
 		};
 		8213398B60F9B660D9216ADF /* XCRemoteSwiftPackageReference "element-call-swift" */ = {
@@ -10852,96 +10852,96 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/PostHog/posthog-ios";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 3.69.6;
+				kind = exactVersion;
+				version = 3.69.6;
 			};
 		};
 		A08925A9D5E3770DEB9D8509 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 9.26.0;
+				kind = exactVersion;
+				version = 9.26.0;
 			};
 		};
 		AB8E808A59756170682BEC20 /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/scinfu/SwiftSoup.git";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 2.13.7;
+				kind = exactVersion;
+				version = 2.13.7;
 			};
 		};
 		AC3475112CA40C2C6E78D1EB /* XCRemoteSwiftPackageReference "matrix-analytics-events" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/matrix-org/matrix-analytics-events";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 0.37.0;
+				kind = exactVersion;
+				version = 0.37.0;
 			};
 		};
 		CCD235515AFCEE6D2005B705 /* XCRemoteSwiftPackageReference "LRUCache" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/nicklockwood/LRUCache";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 1.2.1;
+				kind = exactVersion;
+				version = 1.2.1;
 			};
 		};
 		D283517192CAC3E2E6920765 /* XCRemoteSwiftPackageReference "Kingfisher" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/onevcat/Kingfisher";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 8.11.0;
+				kind = exactVersion;
+				version = 8.11.0;
 			};
 		};
 		D5F7D47BBAAE0CF1DDEB3034 /* XCRemoteSwiftPackageReference "DeviceKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/devicekit/DeviceKit";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 5.8.0;
+				kind = exactVersion;
+				version = 5.8.0;
 			};
 		};
 		E025F19D013D9BA6C58B37F4 /* XCRemoteSwiftPackageReference "swift-algorithms" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-algorithms";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 1.2.1;
+				kind = exactVersion;
+				version = 1.2.1;
 			};
 		};
 		E2F3DA35D462724CCC61DE2C /* XCRemoteSwiftPackageReference "swift-ogg" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/element-hq/swift-ogg";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 0.0.4;
+				kind = exactVersion;
+				version = 0.0.4;
 			};
 		};
 		E9C4F3A12AA1F65C13A8C8EB /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pointfreeco/swift-snapshot-testing";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 1.19.4;
+				kind = exactVersion;
+				version = 1.19.4;
 			};
 		};
 		EBD512E01D6AED903C15C5F5 /* XCRemoteSwiftPackageReference "SwiftUI-Flow" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/tevelee/SwiftUI-Flow.git";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 3.5.1;
+				kind = exactVersion;
+				version = 3.5.1;
 			};
 		};
 		EC6D0C817B1C21D9D096505A /* XCRemoteSwiftPackageReference "Version" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mxcl/Version";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 2.2.1;
+				kind = exactVersion;
+				version = 2.2.1;
 			};
 		};
 		EE40B0E16A55BD23ECBFFD22 /* XCRemoteSwiftPackageReference "matrix-rich-text-editor-swift" */ = {
@@ -10956,8 +10956,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-collections";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 1.6.0;
+				kind = exactVersion;
+				version = 1.6.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/compound-ios/Package.swift
+++ b/compound-ios/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/element-hq/compound-design-tokens", exact: "10.2.4"),
         // .package(path: "../compound-design-tokens"),
-        .package(url: "https://github.com/siteline/SwiftUI-Introspect", from: "26.0.1"),
-        .package(url: "https://github.com/SFSafeSymbols/SFSafeSymbols", from: "7.0.0"),
+        .package(url: "https://github.com/siteline/SwiftUI-Introspect", exact: "26.0.1"),
+        .package(url: "https://github.com/SFSafeSymbols/SFSafeSymbols", exact: "7.0.0"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", exact: "1.19.4")
     ],
     targets: [

--- a/project.yml
+++ b/project.yml
@@ -82,7 +82,7 @@ packages:
     path: Components/BuildExtensions
   AnalyticsEvents:
     url: https://github.com/matrix-org/matrix-analytics-events
-    minorVersion: 0.37.0
+    exactVersion: 0.37.0
     # path: ../matrix-analytics-events
   EmbeddedElementCall:
     url: https://github.com/element-hq/element-call-swift
@@ -90,11 +90,11 @@ packages:
   Emojibase:
     url: https://github.com/matrix-org/emojibase-bindings
     revision: 60bc01f2e3b31445dc723f5af1a777b63d18e6c2 # pinned due to https://github.com/matrix-org/emojibase-bindings/issues/59
-    # minorVersion: 1.5.0
+    # exactVersion: 1.5.0
     # path: ../emojibase-bindings
   SwiftOGG:
     url: https://github.com/element-hq/swift-ogg
-    minorVersion: 0.0.4
+    exactVersion: 0.0.4
     # path: ../swift-ogg
   WysiwygComposer:
     url: https://github.com/element-hq/matrix-rich-text-editor-swift
@@ -104,16 +104,16 @@ packages:
   # External dependencies
   Algorithms:
     url: https://github.com/apple/swift-algorithms
-    minorVersion: 1.2.1
+    exactVersion: 1.2.1
   AsyncAlgorithms:
     url: https://github.com/apple/swift-async-algorithms
-    minorVersion: 1.1.5
+    exactVersion: 1.1.5
   Collections:
     url: https://github.com/apple/swift-collections
-    minorVersion: 1.6.0
+    exactVersion: 1.6.0
   DeviceKit:
     url: https://github.com/devicekit/DeviceKit
-    minorVersion: 5.8.0
+    exactVersion: 5.8.0
   DSWaveformImage:
     url: https://github.com/dmrschmidt/DSWaveformImage
     exactVersion: 14.5.0
@@ -122,49 +122,49 @@ packages:
     exactVersion: 1.2
   GZIP:
     url: https://github.com/nicklockwood/GZIP
-    minorVersion: 1.3.2
+    exactVersion: 1.3.2
   KeychainAccess:
     url: https://github.com/kishikawakatsumi/KeychainAccess
-    minorVersion: 4.2.2
+    exactVersion: 4.2.2
   Kingfisher:
     url: https://github.com/onevcat/Kingfisher
-    minorVersion: 8.11.0
+    exactVersion: 8.11.0
   KZFileWatchers:
     url: https://github.com/krzysztofzablocki/KZFileWatchers
-    minorVersion: 1.2.0
+    exactVersion: 1.2.0
   LoremSwiftum:
     url: https://github.com/lukaskubanek/LoremSwiftum
-    minorVersion: 2.2.3
+    exactVersion: 2.2.3
   LRUCache:
     url: https://github.com/nicklockwood/LRUCache
-    minorVersion: 1.2.1
+    exactVersion: 1.2.1
   Mantis:
     url: https://github.com/guoyingtao/Mantis
-    minorVersion: 3.1.0
+    exactVersion: 3.1.0
   MapLibre:
     url: https://github.com/maplibre/maplibre-gl-native-distribution
-    minorVersion: 6.28.0
+    exactVersion: 6.28.0
   PostHog:
     url: https://github.com/PostHog/posthog-ios
-    minorVersion: 3.69.6
+    exactVersion: 3.69.6
   Sentry:
     url: https://github.com/getsentry/sentry-cocoa
-    minorVersion: 9.26.0
+    exactVersion: 9.26.0
   SnapshotTesting:
     url: https://github.com/pointfreeco/swift-snapshot-testing
-    minorVersion: 1.19.4
+    exactVersion: 1.19.4
   SwiftFlow:
     url: https://github.com/tevelee/SwiftUI-Flow.git
-    minorVersion: 3.5.1
+    exactVersion: 3.5.1
   SwiftSoup:
     url: https://github.com/scinfu/SwiftSoup.git
-    minorVersion: 2.13.7
+    exactVersion: 2.13.7
   SwiftState:
     url: https://github.com/ReactKit/SwiftState
-    minorVersion: 6.0.1
+    exactVersion: 6.0.1
   Version:
     url: https://github.com/mxcl/Version
-    minorVersion: 2.2.1
+    exactVersion: 2.2.1
 
 aggregateTargets:
   Periphery:


### PR DESCRIPTION
It was helpful before we had automatic PRs from Renovate for XcodeGen, but doesn't really make sense any more.