### PR TITLE
Try using Danger with the Node/Docker fix?

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -23,6 +23,6 @@ jobs:
           persist-credentials: false
 
       - name: Danger
-        uses: danger/swift@434d7c25f3b02d490a340b23f5e78dd15a5670bc # 3.22.1
+        uses: danger/swift@751aa740b2bd69ea1b54444a945961e64c38fc22 # 3.22.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -11,6 +11,10 @@ jobs:
     name: Danger
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write # The token is still read-only for forks.
+      statuses: write
 
     concurrency:
       # Only allow a single run of this workflow on each branch, automatically cancelling older runs.


### PR DESCRIPTION
Uses the merge commit for https://github.com/danger/swift/pull/667

Additionally puts back the permissions to write PR comments and statuses.