### PR TITLE
Use server name from user id function

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -10805,7 +10805,7 @@
 			repositoryURL = "https://github.com/element-hq/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 26.08.25;
+				version = 26.08.27;
 			};
 		};
 		701C7BEF8F70F7A83E852DCC /* XCRemoteSwiftPackageReference "GZIP" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fcbb6b37066bc1bd45f559c3f4c7eed601bf038dd9e298f5edd77ffc2ea8a008",
+  "originHash" : "20b091ffed1191ab205d228b4682ceec9698235e1d8eb82e9aba1703fc8e9f05",
   "pins" : [
     {
       "identity" : "compound-design-tokens",
@@ -167,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/matrix-rust-components-swift",
       "state" : {
-        "revision" : "decad9ee1e9a10a341cc61e40dc8a7f7028b7437",
-        "version" : "26.8.25"
+        "revision" : "13503ceebfa90f7cc3c0c5de6392fcc73d993570",
+        "version" : "26.8.27"
       }
     },
     {

--- a/ElementX/Sources/Screens/Authentication/LoginScreen/LoginScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Authentication/LoginScreen/LoginScreenViewModel.swift
@@ -7,6 +7,7 @@
 //
 
 import Combine
+import MatrixRustSDK
 import SwiftUI
 
 typealias LoginScreenViewModelType = StateStoreViewModelV2<LoginScreenViewState, LoginScreenViewAction>
@@ -66,9 +67,7 @@ class LoginScreenViewModel: LoginScreenViewModelType, LoginScreenViewModelProtoc
     private func parseUsername() {
         let username = state.bindings.username
         
-        guard MatrixEntityRegex.isMatrixUserIdentifier(username) else { return }
-        
-        let homeserverDomain = String(username.split(separator: ":")[1])
+        guard let homeserverDomain = try? serverNameFromUserId(userId: username) else { return }
         
         startLoading(isInteractionBlocking: false)
         

--- a/ElementX/Sources/Screens/Authentication/ServerSelectionScreen/ServerSelectionScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerSelectionScreen/ServerSelectionScreenViewModel.swift
@@ -7,6 +7,7 @@
 //
 
 import Combine
+import MatrixRustSDK
 import SwiftUI
 
 typealias ServerSelectionScreenViewModelType = StateStoreViewModelV2<ServerSelectionScreenViewState, ServerSelectionScreenViewAction>
@@ -101,7 +102,9 @@ class ServerSelectionScreenViewModel: ServerSelectionScreenViewModelType, Server
     
     /// Updates the login flow using the supplied homeserver address, or shows an error when this isn't possible.
     private func configureHomeserver() async {
-        let homeserverAddress = state.bindings.homeserverAddress
+        let userInput = state.bindings.homeserverAddress
+        // People often enter their Matrix ID here, so use the server name from it when they do.
+        let homeserverAddress = (try? serverNameFromUserId(userId: userInput)) ?? userInput
         startLoading()
         
         switch await authenticationService.configure(for: homeserverAddress, flow: authenticationFlow) {

--- a/ElementX/Sources/Services/Authentication/ClassicApp/ClassicAppAccountManager.swift
+++ b/ElementX/Sources/Services/Authentication/ClassicApp/ClassicAppAccountManager.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import MatrixRustSDK
 
 class ClassicAppAccountManager {
     private let cacheFolder: URL
@@ -64,7 +65,7 @@ class ClassicAppAccountManager {
         let userID = mxAccount.userID
         let user = loadUser(for: mxAccount) // We need an MXUser for the profile as MXAccount doesn't contain that data.
         
-        guard let serverName = serverName(for: userID) else { return nil }
+        guard let serverName = try? serverNameFromUserId(userId: userID) else { return nil }
         
         return ClassicAppAccount(userID: userID,
                                  displayName: user?.displayName,
@@ -101,13 +102,6 @@ class ClassicAppAccountManager {
             MXLog.warning("Users group \(groupID) file for \(mxAccount.userID) has been corrupted.")
             return nil
         }
-    }
-    
-    /// The server name extracted from the user's ID.
-    private func serverName(for userID: String) -> String? {
-        let components = userID.components(separatedBy: ":")
-        guard components.count > 1 else { return nil }
-        return components[1] // Directly use [1] as .last may be the port number.
     }
     
     // MARK: - File URLs

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -212,7 +212,7 @@ extension JoinedRoomProxyProtocol {
     func knownServerNames(maxCount: Int) -> any Sequence<String> {
         membersPublisher.value
             .prefix(1000) // No need to go crazy here…
-            .compactMap { $0.userID.split(separator: ":").last.map(String.init) }
+            .compactMap { try? serverNameFromUserId(userId: $0.userID) }
             .uniqued()
             .prefix(maxCount)
     }

--- a/UnitTests/Sources/ServerSelectionScreenViewModelTests.swift
+++ b/UnitTests/Sources/ServerSelectionScreenViewModelTests.swift
@@ -45,6 +45,23 @@ struct ServerSelectionScreenViewModelTests {
     }
     
     @Test
+    mutating func selectForLoginUsingMatrixID() async throws {
+        // Given a view model for login.
+        try setup(authenticationFlow: .login)
+        #expect(service.homeserver.value.loginMode == .unknown)
+        
+        // When entering a Matrix ID instead of an account provider.
+        context.homeserverAddress = "@alice:matrix.org"
+        let deferred = deferFulfillment(viewModel.actions) { $0.isContinueWithOAuth }
+        context.send(viewAction: .confirm)
+        try await deferred.fulfill()
+        
+        // Then the homeserver from the ID should be used.
+        #expect(clientFactory.makeAuthenticationClientHomeserverAddressSessionDirectoriesPassphraseClientSessionDelegateAppSettingsAppHooksReceivedArguments?.homeserverAddress == "matrix.org")
+        #expect(service.homeserver.value == .mockMatrixDotOrg)
+    }
+    
+    @Test
     mutating func loginNotSupportedAlert() async throws {
         // Given a view model for login.
         try setup(authenticationFlow: .login)

--- a/project.yml
+++ b/project.yml
@@ -74,7 +74,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/element-hq/matrix-rust-components-swift
-    exactVersion: 26.08.25
+    exactVersion: 26.08.27
     # path: ../matrix-rust-sdk
   Compound:
     path: compound-ios


### PR DESCRIPTION
This PR does essentially 3 things:
- updates the sdk
- replaces all instances of trying to parse the server name from the user id with a dedicated sdk function
- allows to determine the server name from a user id, if a user inputs it in the server selection screen by mistake

fixes #6027