### PR TITLE
Fix photo picker selection tint on iOS 26

### DIFF
--- a/ElementX/Sources/Screens/MediaPickerScreen/PhotoLibraryPicker.swift
+++ b/ElementX/Sources/Screens/MediaPickerScreen/PhotoLibraryPicker.swift
@@ -50,9 +50,19 @@ struct PhotoLibraryPicker: UIViewControllerRepresentable {
     }
     
     func updateUIViewController(_ uiViewController: PHPickerViewController, context: Context) {
-        // Override the app wide tint color (currently set to `.compound.texActionPrimary
+        // Override the app wide tint color (currently set to `.compound.texActionPrimary`)
         // as it's not legible enough in dark mode
         uiViewController.view.tintColor = .compound.textActionAccent
+        
+        // On iOS 26 the picker reads the window's tint instead so we need
+        // to make this workaround to override the window tint
+        DispatchQueue.main.async { [coordinator = context.coordinator] in
+            coordinator.overrideWindowTint(of: uiViewController)
+        }
+    }
+    
+    static func dismantleUIViewController(_ uiViewController: PHPickerViewController, coordinator: Coordinator) {
+        coordinator.restoreWindowTint()
     }
     
     func makeCoordinator() -> Coordinator {
@@ -62,8 +72,23 @@ struct PhotoLibraryPicker: UIViewControllerRepresentable {
     final class Coordinator: NSObject, PHPickerViewControllerDelegate {
         private var photoLibraryPicker: PhotoLibraryPicker
         
+        private weak var overriddenWindow: UIWindow?
+        private var originalWindowTint: UIColor?
+        
         init(_ photoLibraryPicker: PhotoLibraryPicker) {
             self.photoLibraryPicker = photoLibraryPicker
+        }
+        
+        func overrideWindowTint(of pickerViewController: PHPickerViewController) {
+            guard overriddenWindow == nil, let window = pickerViewController.view.window else { return }
+            overriddenWindow = window
+            originalWindowTint = window.tintColor
+            window.tintColor = .compound.textActionAccent
+        }
+        
+        func restoreWindowTint() {
+            overriddenWindow?.tintColor = originalWindowTint
+            overriddenWindow = nil
         }
         
         // MARK: PHPickerViewControllerDelegate
@@ -71,6 +96,8 @@ struct PhotoLibraryPicker: UIViewControllerRepresentable {
         private static let loadingIndicatorIdentifier = "\(PhotoLibraryPicker.self)-Loading"
         
         func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+            restoreWindowTint()
+            
             guard !results.isEmpty else {
                 photoLibraryPicker.callback(.cancel)
                 return


### PR DESCRIPTION
On iOS 26 the picker's remote process samples the window's tint color when it connects  ignoring the view override, which left the selection badges white on grey in dark mode. 
temporarily override the window tint while the picker is presented and restore it when picking finishes or the picker is dismantled.

fixes https://github.com/element-hq/element-x-ios/issues/4576 


**BEFORE** 

https://github.com/user-attachments/assets/2aa85d9f-2d12-4884-850f-29db5b30fbbc

**AFTER**

https://github.com/user-attachments/assets/d6e2b344-f049-49e6-93a8-a024b47cb51b 

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [ ] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [x] iPhone and iPad simulators in portrait and landscape orientations.
- [x] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
