### PR TITLE
Say so when this session has no secrets to verify another one with

### DIFF
--- a/ElementX/Resources/Localizations/en.lproj/Untranslated.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Untranslated.strings
@@ -4,6 +4,8 @@
 "screen_search_no_results_message" = "There are no results for “%1$@.” Try a new search term.";
 "screen_search_tab_chats" = "Chats";
 "screen_search_tab_messages" = "Messages";
+"screen_session_verification_unavailable_subtitle" = "Please use another device or recovery key.";
+"screen_session_verification_unavailable_title" = "Verification with this device is currently unavailable";
 "soft_logout_clear_data_dialog_content" = "Clear all data currently stored on this device?\nSign in again to access your account data and messages.";
 "soft_logout_clear_data_dialog_title" = "Clear data";
 "soft_logout_clear_data_notice" = "Warning: Your personal data (including encryption keys) is still stored on this device.\n\nClear it if you’re finished using this device, or want to sign in to another account.";

--- a/ElementX/Sources/FlowCoordinators/OnboardingFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/OnboardingFlowCoordinator.swift
@@ -280,6 +280,7 @@ class OnboardingFlowCoordinator: FlowCoordinatorProtocol {
         }
         
         let parameters = SessionVerificationScreenCoordinatorParameters(sessionVerificationControllerProxy: sessionVerificationController,
+                                                                        secureBackupController: userSession.clientProxy.secureBackupController,
                                                                         flow: .deviceInitiator,
                                                                         appSettings: appSettings,
                                                                         mediaProvider: userSession.mediaProvider)

--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -431,6 +431,7 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
         let navigationStackCoordinator = NavigationStackCoordinator()
         
         let parameters = SessionVerificationScreenCoordinatorParameters(sessionVerificationControllerProxy: sessionVerificationController,
+                                                                        secureBackupController: userSession.clientProxy.secureBackupController,
                                                                         flow: flow,
                                                                         appSettings: flowParameters.appSettings,
                                                                         mediaProvider: userSession.mediaProvider)

--- a/ElementX/Sources/Generated/Strings+Untranslated.swift
+++ b/ElementX/Sources/Generated/Strings+Untranslated.swift
@@ -24,6 +24,10 @@ internal nonisolated enum UntranslatedL10n {
   internal static var screenSearchTabChats: String { return UntranslatedL10n.tr("Untranslated", "screen_search_tab_chats") }
   /// Messages
   internal static var screenSearchTabMessages: String { return UntranslatedL10n.tr("Untranslated", "screen_search_tab_messages") }
+  /// Please use another device or recovery key.
+  internal static var screenSessionVerificationUnavailableSubtitle: String { return UntranslatedL10n.tr("Untranslated", "screen_session_verification_unavailable_subtitle") }
+  /// Verification with this device is currently unavailable
+  internal static var screenSessionVerificationUnavailableTitle: String { return UntranslatedL10n.tr("Untranslated", "screen_session_verification_unavailable_title") }
   /// Clear all data currently stored on this device?
   /// Sign in again to access your account data and messages.
   internal static var softLogoutClearDataDialogContent: String { return UntranslatedL10n.tr("Untranslated", "soft_logout_clear_data_dialog_content") }

--- a/ElementX/Sources/Screens/Onboarding/SessionVerificationScreen/SessionVerificationScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Onboarding/SessionVerificationScreen/SessionVerificationScreenCoordinator.swift
@@ -32,6 +32,7 @@ enum SessionVerificationScreenFlow {
 
 struct SessionVerificationScreenCoordinatorParameters {
     let sessionVerificationControllerProxy: SessionVerificationControllerProxyProtocol
+    let secureBackupController: SecureBackupControllerProtocol
     let flow: SessionVerificationScreenFlow
     let appSettings: AppSettings
     let mediaProvider: MediaProviderProtocol
@@ -49,6 +50,7 @@ final class SessionVerificationScreenCoordinator: CoordinatorProtocol {
     
     init(parameters: SessionVerificationScreenCoordinatorParameters) {
         viewModel = SessionVerificationScreenViewModel(sessionVerificationControllerProxy: parameters.sessionVerificationControllerProxy,
+                                                       secureBackupController: parameters.secureBackupController,
                                                        flow: parameters.flow,
                                                        appSettings: parameters.appSettings,
                                                        mediaProvider: parameters.mediaProvider)

--- a/ElementX/Sources/Screens/Onboarding/SessionVerificationScreen/SessionVerificationScreenModels.swift
+++ b/ElementX/Sources/Screens/Onboarding/SessionVerificationScreen/SessionVerificationScreenModels.swift
@@ -30,7 +30,19 @@ struct SessionVerificationScreenViewState: BindableState {
     
     var verificationState: SessionVerificationScreenStateMachine.State
     
+    /// Whether this session is missing the secrets it would need to verify another one.
+    var isMissingSecrets: Bool
+    
+    /// Whether the user should be told that this session can't be used to verify the one asking.
+    var isUnavailable: Bool {
+        isMissingSecrets && flow.isResponder && verificationState == .initial
+    }
+    
     var headerIcon: (keyPath: KeyPath<CompoundIcons, Image>, style: BigIcon.Style) {
+        if isUnavailable {
+            return (\.errorSolid, .alertSolid)
+        }
+        
         switch verificationState {
         case .initial, .acceptingVerificationRequest, .requestingVerification,
              .verificationRequestAccepted, .startingSasVerification, .sasVerificationStarted,
@@ -59,6 +71,10 @@ struct SessionVerificationScreenViewState: BindableState {
     }
     
     var title: String? {
+        if isUnavailable {
+            return UntranslatedL10n.screenSessionVerificationUnavailableTitle
+        }
+        
         switch verificationState {
         case .initial, .acceptingVerificationRequest, .requestingVerification,
              .verificationRequestAccepted, .startingSasVerification, .sasVerificationStarted,
@@ -90,6 +106,10 @@ struct SessionVerificationScreenViewState: BindableState {
     }
     
     var message: String {
+        if isUnavailable {
+            return UntranslatedL10n.screenSessionVerificationUnavailableSubtitle
+        }
+        
         switch verificationState {
         case .initial, .acceptingVerificationRequest, .requestingVerification,
              .verificationRequestAccepted, .startingSasVerification, .sasVerificationStarted,

--- a/ElementX/Sources/Screens/Onboarding/SessionVerificationScreen/SessionVerificationScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Onboarding/SessionVerificationScreen/SessionVerificationScreenViewModel.swift
@@ -24,6 +24,7 @@ class SessionVerificationScreenViewModel: SessionVerificationViewModelType, Sess
     }
     
     init(sessionVerificationControllerProxy: SessionVerificationControllerProxyProtocol,
+         secureBackupController: SecureBackupControllerProtocol,
          flow: SessionVerificationScreenFlow,
          appSettings: AppSettings,
          mediaProvider: MediaProviderProtocol,
@@ -35,10 +36,18 @@ class SessionVerificationScreenViewModel: SessionVerificationViewModelType, Sess
         
         super.init(initialViewState: .init(flow: flow,
                                            learnMoreURL: appSettings.encryptionURL,
-                                           verificationState: verificationState),
+                                           verificationState: verificationState,
+                                           isMissingSecrets: secureBackupController.recoveryState.value == .incomplete),
                    mediaProvider: mediaProvider)
         
         setupStateMachine()
+        
+        secureBackupController.recoveryState
+            .map { $0 == .incomplete }
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .weakAssign(to: \.state.isMissingSecrets, on: self)
+            .store(in: &cancellables)
         
         sessionVerificationControllerProxy.actions
             .receive(on: DispatchQueue.main)

--- a/ElementX/Sources/Screens/Onboarding/SessionVerificationScreen/View/SessionVerificationScreen.swift
+++ b/ElementX/Sources/Screens/Onboarding/SessionVerificationScreen/View/SessionVerificationScreen.swift
@@ -80,31 +80,35 @@ struct SessionVerificationScreen: View {
     
     @ViewBuilder
     private var mainContent: some View {
-        switch context.viewState.verificationState {
-        case .initial, .acceptingVerificationRequest, .requestingVerification, .verificationRequestAccepted, .startingSasVerification, .sasVerificationStarted:
-            switch context.viewState.flow {
-            case .deviceResponder(let details):
-                SessionVerificationRequestDetailsView(details: details,
-                                                      isUserVerification: false,
-                                                      mediaProvider: context.mediaProvider)
-            case .userResponder(let details):
-                SessionVerificationRequestDetailsView(details: details,
-                                                      isUserVerification: true,
-                                                      mediaProvider: context.mediaProvider)
-            case .userInitiator:
-                Button(L10n.actionLearnMore) {
-                    UIApplication.shared.open(context.viewState.learnMoreURL)
+        if context.viewState.isUnavailable {
+            EmptyView()
+        } else {
+            switch context.viewState.verificationState {
+            case .initial, .acceptingVerificationRequest, .requestingVerification, .verificationRequestAccepted, .startingSasVerification, .sasVerificationStarted:
+                switch context.viewState.flow {
+                case .deviceResponder(let details):
+                    SessionVerificationRequestDetailsView(details: details,
+                                                          isUserVerification: false,
+                                                          mediaProvider: context.mediaProvider)
+                case .userResponder(let details):
+                    SessionVerificationRequestDetailsView(details: details,
+                                                          isUserVerification: true,
+                                                          mediaProvider: context.mediaProvider)
+                case .userInitiator:
+                    Button(L10n.actionLearnMore) {
+                        UIApplication.shared.open(context.viewState.learnMoreURL)
+                    }
+                    .buttonStyle(.compound(.tertiary, size: .small))
+                default:
+                    EmptyView()
                 }
-                .buttonStyle(.compound(.tertiary, size: .small))
+                
+            case .showingChallenge(let emojis), .acceptingChallenge(let emojis), .decliningChallenge(let emojis):
+                emojisPanel(with: emojis)
+                    .accessibilityIdentifier(A11yIdentifiers.sessionVerificationScreen.emojiWrapper)
             default:
                 EmptyView()
             }
-            
-        case .showingChallenge(let emojis), .acceptingChallenge(let emojis), .decliningChallenge(let emojis):
-            emojisPanel(with: emojis)
-                .accessibilityIdentifier(A11yIdentifiers.sessionVerificationScreen.emojiWrapper)
-        default:
-            EmptyView()
         }
     }
     
@@ -125,52 +129,60 @@ struct SessionVerificationScreen: View {
     
     @ViewBuilder
     private var actionButtons: some View {
-        switch context.viewState.verificationState {
-        case .initial, .acceptingVerificationRequest, .requestingVerification,
-             .verificationRequestAccepted, .startingSasVerification, .sasVerificationStarted, .cancelling:
-            VStack(spacing: 16) {
-                startVerificationButton
+        if context.viewState.isUnavailable {
+            Button(L10n.actionIgnore) {
+                context.send(viewAction: .ignoreVerificationRequest)
+            }
+            .buttonStyle(.compound(.primary))
+            .accessibilityIdentifier(A11yIdentifiers.sessionVerificationScreen.ignoreVerificationRequest)
+        } else {
+            switch context.viewState.verificationState {
+            case .initial, .acceptingVerificationRequest, .requestingVerification,
+                 .verificationRequestAccepted, .startingSasVerification, .sasVerificationStarted, .cancelling:
+                VStack(spacing: 16) {
+                    startVerificationButton
+                    
+                    if context.viewState.showIgnoreButton {
+                        Button(L10n.actionIgnore) {
+                            context.send(viewAction: .ignoreVerificationRequest)
+                        }
+                        .buttonStyle(.compound(.tertiary))
+                        .accessibilityIdentifier(A11yIdentifiers.sessionVerificationScreen.ignoreVerificationRequest)
+                        .disabled(context.viewState.isWaiting)
+                    }
+                }
+            case .cancelled:
+                switch context.viewState.flow {
+                case .deviceInitiator, .userInitiator:
+                    Button(L10n.actionRetry) {
+                        context.send(viewAction: .restart)
+                    }
+                    .buttonStyle(.compound(.primary))
+                case .deviceResponder, .userResponder:
+                    Button(L10n.actionDone) {
+                        context.send(viewAction: .done)
+                    }
+                    .buttonStyle(.compound(.primary))
+                }
                 
-                if context.viewState.showIgnoreButton {
-                    Button(L10n.actionIgnore) {
-                        context.send(viewAction: .ignoreVerificationRequest)
+            case .showingChallenge:
+                VStack(spacing: 16) {
+                    Button(L10n.screenSessionVerificationTheyMatch) {
+                        context.send(viewAction: .accept)
+                    }
+                    .buttonStyle(.compound(.primary))
+                    .accessibilityIdentifier(A11yIdentifiers.sessionVerificationScreen.acceptChallenge)
+                    
+                    Button(L10n.screenSessionVerificationTheyDontMatch) {
+                        context.send(viewAction: .decline)
                     }
                     .buttonStyle(.compound(.tertiary))
-                    .accessibilityIdentifier(A11yIdentifiers.sessionVerificationScreen.ignoreVerificationRequest)
-                    .disabled(context.viewState.isWaiting)
+                    .accessibilityIdentifier(A11yIdentifiers.sessionVerificationScreen.declineChallenge)
                 }
-            }
-        case .cancelled:
-            switch context.viewState.flow {
-            case .deviceInitiator, .userInitiator:
-                Button(L10n.actionRetry) {
-                    context.send(viewAction: .restart)
-                }
-                .buttonStyle(.compound(.primary))
-            case .deviceResponder, .userResponder:
-                Button(L10n.actionDone) {
-                    context.send(viewAction: .done)
-                }
-                .buttonStyle(.compound(.primary))
-            }
-            
-        case .showingChallenge:
-            VStack(spacing: 16) {
-                Button(L10n.screenSessionVerificationTheyMatch) {
-                    context.send(viewAction: .accept)
-                }
-                .buttonStyle(.compound(.primary))
-                .accessibilityIdentifier(A11yIdentifiers.sessionVerificationScreen.acceptChallenge)
                 
-                Button(L10n.screenSessionVerificationTheyDontMatch) {
-                    context.send(viewAction: .decline)
-                }
-                .buttonStyle(.compound(.tertiary))
-                .accessibilityIdentifier(A11yIdentifiers.sessionVerificationScreen.declineChallenge)
+            default:
+                EmptyView()
             }
-            
-        default:
-            EmptyView()
         }
     }
     
@@ -248,6 +260,11 @@ struct SessionVerification_Previews: PreviewProvider, TestablePreview {
                                   flow: .userResponder(requestDetails: details))
             .previewDisplayName("Initial - User Responder")
         
+        sessionVerificationScreen(state: .initial,
+                                  flow: .deviceResponder(requestDetails: details),
+                                  recoveryState: .incomplete)
+            .previewDisplayName("Unavailable - Device Responder")
+        
         sessionVerificationScreen(state: .acceptingVerificationRequest,
                                   flow: .deviceResponder(requestDetails: details))
             .previewDisplayName("Accepting Verification Request - Device Responder")
@@ -286,8 +303,10 @@ struct SessionVerification_Previews: PreviewProvider, TestablePreview {
     }
     
     static func sessionVerificationScreen(state: SessionVerificationScreenStateMachine.State,
-                                          flow: SessionVerificationScreenFlow = .deviceInitiator) -> some View {
+                                          flow: SessionVerificationScreenFlow = .deviceInitiator,
+                                          recoveryState: SecureBackupRecoveryState = .enabled) -> some View {
         let viewModel = SessionVerificationScreenViewModel(sessionVerificationControllerProxy: SessionVerificationControllerProxyMock.configureMock(),
+                                                           secureBackupController: SecureBackupControllerMock(.init(recoveryState: recoveryState)),
                                                            flow: flow,
                                                            appSettings: .volatile(),
                                                            mediaProvider: MediaProviderMock(.init()),

--- a/ElementX/Sources/UITests/UITestsAppCoordinator.swift
+++ b/ElementX/Sources/UITests/UITestsAppCoordinator.swift
@@ -604,6 +604,7 @@ class MockScreen: Identifiable {
             var sessionVerificationControllerProxy = SessionVerificationControllerProxyMock.configureMock(otherDeviceStartsSasVerification: true,
                                                                                                           requestDelay: .seconds(5))
             let parameters = SessionVerificationScreenCoordinatorParameters(sessionVerificationControllerProxy: sessionVerificationControllerProxy,
+                                                                            secureBackupController: SecureBackupControllerMock(.init()),
                                                                             flow: .deviceInitiator,
                                                                             appSettings: appSettings,
                                                                             mediaProvider: MediaProviderMock(.init()))

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/sessionVerification.Unavailable-Device-Responder-iPad-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/sessionVerification.Unavailable-Device-Responder-iPad-en-GB.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2f083530d0a40685177193afdec3c589616134cd48d5ba0853fc317dc6ec8e5
+size 94831

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/sessionVerification.Unavailable-Device-Responder-iPad-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/sessionVerification.Unavailable-Device-Responder-iPad-pseudo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dab915cd5394273801201a2a8f2c3fb81884b363955c47ac20a2554a117bc5f5
+size 111223

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/sessionVerification.Unavailable-Device-Responder-iPhone-en-GB.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/sessionVerification.Unavailable-Device-Responder-iPhone-en-GB.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:280ccce0e6925d3371488069939e83cc94d4e30fa88fa71bc31ec2046e39b966
+size 52983

--- a/PreviewTests/Sources/__Snapshots__/PreviewTests/sessionVerification.Unavailable-Device-Responder-iPhone-pseudo.png
+++ b/PreviewTests/Sources/__Snapshots__/PreviewTests/sessionVerification.Unavailable-Device-Responder-iPhone-pseudo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:139afeeb9781c5713225ce8d01c83504d0fec0b3a8aea361d7cef340e0fc92ee
+size 72323

--- a/UnitTests/Sources/SessionVerificationViewModelTests.swift
+++ b/UnitTests/Sources/SessionVerificationViewModelTests.swift
@@ -20,6 +20,7 @@ struct SessionVerificationViewModelTests {
     init() throws {
         sessionVerificationController = SessionVerificationControllerProxyMock.configureMock()
         viewModel = SessionVerificationScreenViewModel(sessionVerificationControllerProxy: sessionVerificationController,
+                                                       secureBackupController: SecureBackupControllerMock(.init()),
                                                        flow: .deviceInitiator,
                                                        appSettings: .volatile(),
                                                        mediaProvider: MediaProviderMock(.init()))
@@ -108,7 +109,45 @@ struct SessionVerificationViewModelTests {
         #expect(sessionVerificationController.declineVerificationCallsCount == 1)
     }
     
+    @Test
+    func missingSecretsMakesVerificationUnavailable() async throws {
+        let sessionVerificationController = SessionVerificationControllerProxyMock.configureMock()
+        let viewModel = makeResponderViewModel(sessionVerificationController: sessionVerificationController,
+                                               recoveryState: .incomplete)
+        
+        #expect(viewModel.context.viewState.isUnavailable)
+        #expect(viewModel.context.viewState.title == UntranslatedL10n.screenSessionVerificationUnavailableTitle)
+        #expect(viewModel.context.viewState.message == UntranslatedL10n.screenSessionVerificationUnavailableSubtitle)
+        
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(sessionVerificationController.acceptVerificationRequestCallsCount == 0)
+    }
+    
+    @Test
+    func holdingSecretsAllowsVerification() {
+        let viewModel = makeResponderViewModel(sessionVerificationController: SessionVerificationControllerProxyMock.configureMock(),
+                                               recoveryState: .enabled)
+        
+        #expect(!viewModel.context.viewState.isUnavailable)
+        #expect(viewModel.context.viewState.title == L10n.screenSessionVerificationRequestTitle)
+    }
+    
     // MARK: - Private
+    
+    private func makeResponderViewModel(sessionVerificationController: SessionVerificationControllerProxyMock,
+                                        recoveryState: SecureBackupRecoveryState) -> SessionVerificationScreenViewModelProtocol {
+        let details = SessionVerificationRequestDetails(senderProfile: UserProfile(userID: "@bob:matrix.org"),
+                                                        flowID: "flow-id",
+                                                        deviceID: "CODEMISTAKE",
+                                                        deviceDisplayName: "Bob's Element X iOS",
+                                                        firstSeenDate: .init(timeIntervalSince1970: 0))
+        
+        return SessionVerificationScreenViewModel(sessionVerificationControllerProxy: sessionVerificationController,
+                                                  secureBackupController: SecureBackupControllerMock(.init(recoveryState: recoveryState)),
+                                                  flow: .deviceResponder(requestDetails: details),
+                                                  appSettings: .volatile(),
+                                                  mediaProvider: MediaProviderMock(.init()))
+    }
     
     private mutating func setupChallengeReceived() async throws {
         let actionsPublisher = sessionVerificationController.actions.delay(for: .seconds(0.1), scheduler: DispatchQueue.main)


### PR DESCRIPTION
When an incoming verification request arrives, this session offers "Start verification" whatever state its own cross-signing secrets are in. If the recovery state is `incomplete` the secrets are not on this device, so the flow can only fail — and it fails at the very end, after the user has compared the emojis.

The screen now shows the alert step from the design instead — "Verification with this device is currently unavailable" / "Please use another device or recovery key." — with only the Ignore action. It applies to the initial step of a responder flow only; a verification already under way is untouched, as is the request acknowledgement the view model already sends. `SecureBackupRecoveryState.incomplete` is the signal `SecureBackupScreen` already uses to tell the user their recovery is broken, so no new notion of "missing secrets" is introduced.

The two new strings use the same keys as the Android ones, so they line up on the Localazy import.

`SessionVerificationViewModelTests` covers both sides: a responder flow whose recovery is `incomplete` reaches the unavailable state with the design's title and subtitle and never calls `acceptVerificationRequest`, and the same flow with `enabled` recovery is unaffected. The state is added to `SessionVerification_Previews`, so the snapshot and accessibility tests cover it too.

iOS counterpart of element-hq/element-x-android#7551. Part of #4507, using the copy from the design attached to the issue.

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
