### PR TITLE
NativeCall | Add the MatrixRTC logging, type mappers and encryption key mapper

### DIFF
--- a/Components/MatrixRtcKit/Sources/Session/EncryptionKeyMapper.swift
+++ b/Components/MatrixRtcKit/Sources/Session/EncryptionKeyMapper.swift
@@ -1,0 +1,45 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Foundation
+import MatrixRtc
+
+/// Turns an MSC4143 media-key to-device message into the record the core expects.
+nonisolated enum EncryptionKeyMapper {
+    /// - Returns: nil when the message is untrusted or unusable.
+    static func map(_ message: MatrixRtcToDeviceMessage) -> FfiReceivedEncryptionKey? {
+        // A cleartext to-device message has no attested sender: anyone could inject a media key.
+        guard message.wasEncrypted else {
+            MatrixRtcLog.warning("Dropping a cleartext encryption key")
+            return nil
+        }
+        guard let senderDeviceID = message.senderDeviceID else {
+            MatrixRtcLog.warning("Dropping an encryption key with no sender device")
+            return nil
+        }
+        guard let data = message.contentJSON.data(using: .utf8),
+              let content = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let roomID = content["room_id"] as? String,
+              let memberID = content["member_id"] as? String,
+              // `format` names the media_key encoding and is the core's to interpret; unknown ones still go through.
+              let mediaKey = content["media_key"] as? [String: Any],
+              let keyB64 = mediaKey["key"] as? String,
+              let keyIndex = mediaKey["index"] as? Int, let index = UInt8(exactly: keyIndex) else {
+            MatrixRtcLog.warning("Cannot parse encryption key content")
+            return nil
+        }
+        
+        return FfiReceivedEncryptionKey(roomId: roomID,
+                                        memberId: memberID,
+                                        keyB64: keyB64,
+                                        keyIndex: index,
+                                        wasEncrypted: true,
+                                        senderUserId: message.attestedSenderID,
+                                        senderDeviceId: senderDeviceID,
+                                        senderIsCrossSigned: message.isSenderCrossSigned)
+    }
+}

--- a/Components/MatrixRtcKit/Sources/Session/Mappers.swift
+++ b/Components/MatrixRtcKit/Sources/Session/Mappers.swift
@@ -1,0 +1,151 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Foundation
+import MatrixRtc
+
+nonisolated extension MatrixRtcStreamKind {
+    init(_ kind: FfiStreamKind) {
+        switch kind {
+        case .microphone: self = .microphone
+        case .camera: self = .camera
+        case .screenShare: self = .screenShare
+        case .screenShareAudio: self = .screenShareAudio
+        case .data: self = .data
+        }
+    }
+    
+    var ffi: FfiStreamKind {
+        switch self {
+        case .microphone: .microphone
+        case .camera: .camera
+        case .screenShare: .screenShare
+        case .screenShareAudio: .screenShareAudio
+        case .data: .data
+        }
+    }
+}
+
+nonisolated extension MatrixRtcElementCallCompat {
+    var ffi: FfiElementCallCompat {
+        switch self {
+        case .off: .off
+        case .stickyEvents: .stickyEvents
+        case .stateEvents: .stateEvents
+        }
+    }
+}
+
+nonisolated extension MatrixRtcTransport {
+    var ffi: FfiTransportConfig? {
+        switch self {
+        case .liveKit(let serviceURL): FfiTransportConfig(type: "livekit", livekitServiceUrl: serviceURL.absoluteString)
+        case .unsupported: nil
+        }
+    }
+}
+
+nonisolated extension MatrixRtcNotify {
+    var ffi: FfiNotifyConfig {
+        FfiNotifyConfig(notificationType: kind == .ring ? .ring : .notification,
+                        intent: intent.rawValue,
+                        lifetimeMs: nil,
+                        mentionUserIds: [],
+                        mentionRoom: false)
+    }
+}
+
+nonisolated extension MatrixRtcMembership {
+    init(_ membership: JoinedMembership) {
+        self.init(memberID: membership.memberId,
+                  userID: membership.sender,
+                  deviceID: membership.senderDeviceId,
+                  application: membership.application)
+    }
+}
+
+nonisolated extension MatrixRtcParticipant {
+    init(_ participant: FfiParticipant) {
+        self.init(memberID: participant.memberId,
+                  userID: participant.userId,
+                  deviceID: participant.deviceId,
+                  isLocal: participant.isLocal,
+                  isReachable: participant.reachable,
+                  streams: participant.streams.map { .init(kind: .init($0.kind), isMuted: $0.muted) },
+                  handRaisedAt: participant.handRaisedAtMs.map { Date(timeIntervalSince1970: Double($0) / 1000) })
+    }
+}
+
+nonisolated extension MatrixRtcReceiveStats {
+    init(_ stats: FfiReceiveStats) {
+        self.init(packetsReceived: stats.packetsReceived,
+                  packetsLost: stats.packetsLost,
+                  bytesReceived: stats.bytesReceived,
+                  jitter: stats.jitter,
+                  framesDecoded: stats.framesDecoded,
+                  framesDropped: stats.framesDropped,
+                  totalSamplesReceived: stats.totalSamplesReceived,
+                  concealedSamples: stats.concealedSamples)
+    }
+}
+
+nonisolated extension MatrixRtcFrameEncryptionState {
+    init(_ state: FfiFrameEncryptionState) {
+        switch state {
+        case .ok: self = .ok
+        case .missingKey: self = .missingKey
+        case .decryptionFailed: self = .decryptionFailed
+        case .encryptionFailed: self = .encryptionFailed
+        case .internalError: self = .internalError
+        }
+    }
+}
+
+nonisolated extension MatrixRtcCallEvent {
+    init(_ event: FfiCallEvent) {
+        switch event {
+        case .participantJoined(let memberId, let userId):
+            self = .participantJoined(memberID: memberId, userID: userId)
+        case .participantLeft(let memberId):
+            self = .participantLeft(memberID: memberId)
+        case .streamStarted(let memberId, let kind):
+            self = .streamStarted(memberID: memberId, kind: .init(kind))
+        case .streamStopped(let memberId, let kind):
+            self = .streamStopped(memberID: memberId, kind: .init(kind))
+        case .streamMuted(let memberId, let kind):
+            self = .streamMuted(memberID: memberId, kind: .init(kind))
+        case .streamUnmuted(let memberId, let kind):
+            self = .streamUnmuted(memberID: memberId, kind: .init(kind))
+        case .activeSpeakers(let speakers):
+            self = .activeSpeakers(speakers.map { .init(memberID: $0.memberId, level: $0.level) })
+        case .keyImported(let memberId, let keyIndex):
+            self = .keyImported(memberID: memberId, keyIndex: keyIndex)
+        case .frameEncryptionState(let memberId, let state, _):
+            self = .frameEncryptionState(memberID: memberId, state: .init(state))
+        case .keyDiscarded(let memberId, let keyIndex, let senderUserId, let senderDeviceId, let reason):
+            self = .keyDiscarded(memberID: memberId,
+                                 reason: "index \(keyIndex.map(String.init) ?? "?") from \(senderUserId ?? "?")/\(senderDeviceId ?? "?"): \(reason)")
+        case .handRaised(let memberId, let raisedAtMs):
+            self = .handRaised(memberID: memberId, raisedAt: Date(timeIntervalSince1970: Double(raisedAtMs) / 1000))
+        case .handLowered(let memberId):
+            self = .handLowered(memberID: memberId)
+        case .reaction(let memberId, let emoji, let name, _):
+            self = .reaction(memberID: memberId, emoji: emoji, name: name)
+        case .unknownParticipant(let identity):
+            // Not surfaced: the transport knows an identity the membership projection doesn't (yet).
+            self = .mediaConnectionDegraded(false)
+            MatrixRtcLog.debug("Unknown participant on the transport: \(identity)")
+        case .mediaConnectionState(let degraded):
+            self = .mediaConnectionDegraded(degraded)
+        case .ended(let reason):
+            switch reason {
+            case .left: self = .ended(.left)
+            case .connectionClosed(let message): self = .ended(.connectionClosed(message: message))
+            }
+        }
+    }
+}

--- a/Components/MatrixRtcKit/Sources/Session/MatrixRtcLogging.swift
+++ b/Components/MatrixRtcKit/Sources/Session/MatrixRtcLogging.swift
@@ -1,0 +1,78 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Foundation
+import MatrixRtc
+import Synchronization
+
+public nonisolated enum MatrixRtcLogLevel: Sendable {
+    case error, warning, info, debug, verbose
+}
+
+/// A log record emitted by the Rust core. Delivered on a dedicated Rust thread, never the main actor.
+public nonisolated struct MatrixRtcLogRecord: Sendable {
+    public let level: MatrixRtcLogLevel
+    public let target: String
+    public let message: String
+}
+
+/// Routes the Rust core's tracing output into the host app's logger.
+///
+/// The core installs a process-wide subscriber on first use and refuses a second one, so this
+/// must run once, before anything else touches the FFI — `RtcSessionManagerHandle` included.
+/// Without it the core is completely silent, errors included.
+public nonisolated enum MatrixRtcLogging {
+    /// Leaves the per-frame media/livekit flood out while keeping SFU connection and ICE progress
+    /// (reported by `livekit` at info) readable.
+    public static let defaultFilter = "matrix_rtc_media=debug,matrix_rtc_livekit=debug,livekit=info,libwebrtc=warn,webrtc_sys=warn"
+    
+    private static let isInstalled = Mutex(false)
+    
+    /// Installs the log sink. Idempotent; subsequent calls are ignored as the core only takes one subscriber.
+    /// - Returns: `false` if the core refused the subscriber (already installed by an earlier call).
+    @discardableResult
+    public static func install(filter: String = defaultFilter,
+                               handler: @escaping @Sendable (MatrixRtcLogRecord) -> Void) -> Bool {
+        isInstalled.withLock { isInstalled in
+            guard !isInstalled else { return true }
+            
+            do {
+                try setupLogging(config: RtcLogConfig(level: .debug, filter: filter, writeToSystem: false),
+                                 sink: Sink(handler: handler))
+                isInstalled = true
+                return true
+            } catch {
+                handler(.init(level: .error, target: "matrix_rtc_ffi", message: "Failed installing the log sink: \(error)"))
+                return false
+            }
+        }
+    }
+    
+    private final class Sink: RtcLogSink, Sendable {
+        private let handler: @Sendable (MatrixRtcLogRecord) -> Void
+        
+        init(handler: @escaping @Sendable (MatrixRtcLogRecord) -> Void) {
+            self.handler = handler
+        }
+        
+        func log(record: RtcLogRecord) {
+            handler(.init(level: .init(record.level), target: record.target, message: record.message))
+        }
+    }
+}
+
+private nonisolated extension MatrixRtcLogLevel {
+    init(_ level: RtcLogLevel) {
+        switch level {
+        case .error: self = .error
+        case .warn: self = .warning
+        case .info: self = .info
+        case .debug: self = .debug
+        case .trace: self = .verbose
+        }
+    }
+}

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -339,6 +339,7 @@
 		358290C2E4574456FE0C2DF6 /* LocationSharingScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B73675A21580971E9ADF66A /* LocationSharingScreenViewModelProtocol.swift */; };
 		35E975CFDA60E05362A7CF79 /* target.yml in Resources */ = {isa = PBXBuildFile; fileRef = 1222DB76B917EB8A55365BA5 /* target.yml */; };
 		36206F74DDEBF9BEAF6A6A1F /* ExtensionLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A8571A8A071FB41778C016 /* ExtensionLogger.swift */; };
+		365D4AB2BD42729490C93146 /* Mappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D181FBD3D73887CDF42718 /* Mappers.swift */; };
 		3683C4C0DBFA397BE0105B0D /* NotificationTone.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF08D6FC1919CB804A9191E8 /* NotificationTone.swift */; };
 		3684AD01C5FCB7616B28F629 /* TimelineMediaPreviewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CDE60FEE95039CCCEEEE3B0 /* TimelineMediaPreviewController.swift */; };
 		36926D795D6D19177C7812F8 /* EncryptionResetPasswordScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6935A55AB3B0C94BC566DD6 /* EncryptionResetPasswordScreenCoordinator.swift */; };
@@ -902,6 +903,7 @@
 		8CFB8BB99F25FA34B6C6BE86 /* UserDefaultsProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCA4547BE58E17899E95CDE /* UserDefaultsProtocol.swift */; };
 		8CFDA5F1562479CB3A34D277 /* RedactedRoomTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91C8BD78F7B9247AC57FA1A3 /* RedactedRoomTimelineView.swift */; };
 		8CFDC1309E8E5192EC2B04FE /* portrait_test_video.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = D48D415C7A4284DEBEB34924 /* portrait_test_video.mp4 */; };
+		8D1B84634C0074690175F3FC /* MatrixRtcLogBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364DFC4CB8071AB4DB1BDAB9 /* MatrixRtcLogBridge.swift */; };
 		8D24671992A1C1753B211221 /* EncryptionResetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89BB11A792EF6F70B95B467E /* EncryptionResetTests.swift */; };
 		8D3E1FADD78E72504DE0E402 /* UserAgentBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB3B237387B8288A5A938F1B /* UserAgentBuilderTests.swift */; };
 		8D71E5E53F372202379BECCE /* BugReportScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 303FCADE77DF1F3670C086ED /* BugReportScreenViewModel.swift */; };
@@ -1016,6 +1018,7 @@
 		9EE71509E6E7519A2B2388B3 /* KnockRequestsListScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD9C9A31D9AB3B6D8128E69 /* KnockRequestsListScreenModels.swift */; };
 		9EF72884B74BC39B01640098 /* BugReportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27DF257F5D968E5DD719583C /* BugReportTests.swift */; };
 		9F11B9F347F9E2D236799FB3 /* ElementCallServiceConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 406C90AF8C3E98DF5D4E5430 /* ElementCallServiceConstants.swift */; };
+		9F6EFBB1D710D34236F87430 /* EncryptionKeyMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B9FCEB43FD29D422409981 /* EncryptionKeyMapper.swift */; };
 		9F8BEA86540D8980BDD7C176 /* AuthenticationStartScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE3AB4D399D39FBD78119011 /* AuthenticationStartScreenModels.swift */; };
 		9FB41B0E8B2AA9B404E52C8B /* AppLockSetupBiometricsScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCC6C31102E1D8B9106DEDE /* AppLockSetupBiometricsScreenViewModelProtocol.swift */; };
 		9FBE1FB20171012260A32492 /* TimelineSenderAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53FCCE44F96E0BC411A6CF0 /* TimelineSenderAvatarView.swift */; };
@@ -1258,6 +1261,7 @@
 		C7CEFC1FB0547CFC8F5C84EF /* Room.swift in Sources */ = {isa = PBXBuildFile; fileRef = D78C13EF5035879B6131030F /* Room.swift */; };
 		C85C7A201E4CFDA477ACEBEB /* AppLockSetupSettingsScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8610C1D21565C950BCA6A454 /* AppLockSetupSettingsScreenViewModelProtocol.swift */; };
 		C8A9C595038AFA2D707AC8C1 /* NotificationPermissionsScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E69F67D2A70ABD08CA6D54 /* NotificationPermissionsScreenViewModelProtocol.swift */; };
+		C8B3100A1CC12F9FFDC64937 /* MatrixRtcLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649FCD89E514713DC785F91D /* MatrixRtcLogging.swift */; };
 		C8BD80891BAD688EF2C15CDB /* MediaUploadPreviewScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74DD0855F2F76D47E5555082 /* MediaUploadPreviewScreenCoordinator.swift */; };
 		C8D0AC22E03F652118A2BB73 /* LiveLocationRoomTimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8DCBD0ABAADFDE5AF17E1F /* LiveLocationRoomTimelineItem.swift */; };
 		C8D1D18E22672D48C11A5366 /* AccessibilityIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BB8DDE245ED86C489BA983 /* AccessibilityIdentifiers.swift */; };
@@ -1822,6 +1826,7 @@
 		0833F51229E166BCA141D004 /* RoomRolesAndPermissionsFlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomRolesAndPermissionsFlowCoordinator.swift; sourceTree = "<group>"; };
 		094F6B21835890B470DF540C /* SpaceScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceScreenCoordinator.swift; sourceTree = "<group>"; };
 		099F2D36C141D845A445B1E6 /* EmojiProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiProviderTests.swift; sourceTree = "<group>"; };
+		09B9FCEB43FD29D422409981 /* EncryptionKeyMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptionKeyMapper.swift; sourceTree = "<group>"; };
 		0A2074C0449B83D5858BD2D7 /* FrequentlyUsedEmoji.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrequentlyUsedEmoji.swift; sourceTree = "<group>"; };
 		0A3534D37BFC074DD26F2FFE /* RoomThreadListScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomThreadListScreenModels.swift; sourceTree = "<group>"; };
 		0A3E77399BD262D301451BF2 /* RoomDetailsEditScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomDetailsEditScreenCoordinator.swift; sourceTree = "<group>"; };
@@ -2099,6 +2104,7 @@
 		35A057BA9BE0F079784CD061 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		35A5AB4E2E5CA98F99BFC552 /* GalleryRoomTimelineItemContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryRoomTimelineItemContent.swift; sourceTree = "<group>"; };
 		35AFCF4C05DEED04E3DB1A16 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
+		364DFC4CB8071AB4DB1BDAB9 /* MatrixRtcLogBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatrixRtcLogBridge.swift; sourceTree = "<group>"; };
 		3674212CAB6C5143DD437AC4 /* RoomDetailsScreenHook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomDetailsScreenHook.swift; sourceTree = "<group>"; };
 		369236171C351AB8C70BB161 /* preview_video.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = preview_video.jpg; sourceTree = "<group>"; };
 		36DA824791172B9821EACBED /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
@@ -2367,6 +2373,7 @@
 		646B50583A2CE6DA67F7739A /* SpaceScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceScreen.swift; sourceTree = "<group>"; };
 		648DD1C10E4957CB791FE0B8 /* OverridableAvatarImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverridableAvatarImage.swift; sourceTree = "<group>"; };
 		6493AC9979CEB1410302BFE3 /* RoomDetailsScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomDetailsScreenCoordinator.swift; sourceTree = "<group>"; };
+		649FCD89E514713DC785F91D /* MatrixRtcLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatrixRtcLogging.swift; sourceTree = "<group>"; };
 		64AC8FCE224D4185F28636FF /* CreateRoomScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateRoomScreenCoordinator.swift; sourceTree = "<group>"; };
 		64F49FB9EE2913234F06CE68 /* MediaPickerScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPickerScreenCoordinator.swift; sourceTree = "<group>"; };
 		6509708F54FC883604DFDC95 /* TimelineViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineViewModelTests.swift; sourceTree = "<group>"; };
@@ -2829,6 +2836,7 @@
 		B0A307A44F952CD73E63AE31 /* RoomEventStringBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomEventStringBuilder.swift; sourceTree = "<group>"; };
 		B0BA67B3E4EF9D29D14A78CE /* AppLockSettingsScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockSettingsScreenViewModelTests.swift; sourceTree = "<group>"; };
 		B0C5E5931A668B18D8C09028 /* cy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cy; path = cy.lproj/Localizable.strings; sourceTree = "<group>"; };
+		B0D181FBD3D73887CDF42718 /* Mappers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mappers.swift; sourceTree = "<group>"; };
 		B0F5CC38803B8382D2C63222 /* TimelineControllerFactoryMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineControllerFactoryMock.swift; sourceTree = "<group>"; };
 		B14B1DE3E2D5D26732C49036 /* RoomChangeRolesScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomChangeRolesScreenViewModel.swift; sourceTree = "<group>"; };
 		B16048D30F0438731C41F775 /* StateRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateRoomTimelineItem.swift; sourceTree = "<group>"; };
@@ -3593,6 +3601,7 @@
 				90FD376E9373246E4925CE95 /* Location */,
 				79E560F5113ED25D172E550C /* Media */,
 				6709362D60732DED2069AE0F /* MediaPlayer */,
+				3331AF1BFF699CE25B734F9D /* NativeCall */,
 				6DE13A7AE6587B079F4049D7 /* Notification */,
 				114DC16B28140F885FD833E2 /* NotificationSettings */,
 				599DFFE0805B08454E40D64A /* Polls */,
@@ -4209,6 +4218,14 @@
 				82F77DDA38D41A185D3536F4 /* View */,
 			);
 			path = ChatsSpaceFiltersScreen;
+			sourceTree = "<group>";
+		};
+		3331AF1BFF699CE25B734F9D /* NativeCall */ = {
+			isa = PBXGroup;
+			children = (
+				364DFC4CB8071AB4DB1BDAB9 /* MatrixRtcLogBridge.swift */,
+			);
+			path = NativeCall;
 			sourceTree = "<group>";
 		};
 		3348D14DBDB54E72FC67E2F3 /* MessageForwardingScreen */ = {
@@ -4862,7 +4879,10 @@
 		536A4216AB97AEC3AA97AFCE /* Session */ = {
 			isa = PBXGroup;
 			children = (
+				09B9FCEB43FD29D422409981 /* EncryptionKeyMapper.swift */,
+				B0D181FBD3D73887CDF42718 /* Mappers.swift */,
 				D57B7AE0E195E737317E87FD /* MatrixRtcLog.swift */,
+				649FCD89E514713DC785F91D /* MatrixRtcLogging.swift */,
 			);
 			path = Session;
 			sourceTree = "<group>";
@@ -8634,7 +8654,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9F6EFBB1D710D34236F87430 /* EncryptionKeyMapper.swift in Sources */,
+				365D4AB2BD42729490C93146 /* Mappers.swift in Sources */,
 				B63D2F54666E6BF9B7C35024 /* MatrixRtcLog.swift in Sources */,
+				C8B3100A1CC12F9FFDC64937 /* MatrixRtcLogging.swift in Sources */,
 				6F2925C185654654802C36C1 /* MatrixRtcMatrixTransport.swift in Sources */,
 				6D04ED80374F085C20AF8FC7 /* MatrixRtcModels.swift in Sources */,
 			);
@@ -9131,6 +9154,7 @@
 				63DCEBC1DD555E0D645B9E98 /* MapTilerURLBuilderProtocol.swift in Sources */,
 				F382E2FE3AC3719BC1F22D9C /* MapURLs.swift in Sources */,
 				67C05C50AD734283374605E3 /* MatrixEntityRegex.swift in Sources */,
+				8D1B84634C0074690175F3FC /* MatrixRtcLogBridge.swift in Sources */,
 				8658F5034EAD7357CE7F9AC7 /* MatrixUserShareLink.swift in Sources */,
 				84E514915DF0C168B08A3A0A /* MediaEventsTimelineFlowCoordinator.swift in Sources */,
 				BEC6DFEA506085D3027E353C /* MediaEventsTimelineScreen.swift in Sources */,

--- a/ElementX/Sources/Services/NativeCall/MatrixRtcLogBridge.swift
+++ b/ElementX/Sources/Services/NativeCall/MatrixRtcLogBridge.swift
@@ -1,0 +1,26 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Foundation
+import MatrixRtcKit
+
+/// Feeds the Rust RTC core's log records into `MXLog` so they end up in rageshakes next to the SDK's.
+nonisolated enum MatrixRtcLogBridge {
+    /// Idempotent, must run before any other use of the `MatrixRtc` framework.
+    static func install() {
+        MatrixRtcLogging.install { record in
+            let message = "[\(record.target)] \(record.message)"
+            switch record.level {
+            case .error: MXLog.error(message)
+            case .warning: MXLog.warning(message)
+            case .info: MXLog.info(message)
+            case .debug: MXLog.debug(message)
+            case .verbose: MXLog.verbose(message)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Second step of the native MatrixRTC calls stack (spike: `valere/native_call`; previous: #6116).

Adds the translation layer between the framework's app-owned models and matrix-rust-rtc's uniffi records and enums (`Mappers.swift`: `init(_ ffi:)` and `var ffi` on each model, following the `init(rustValue:)` / `rustValue` convention used for the Rust SDK). `EncryptionKeyMapper` turns a decrypted to-device message into the core's received key record and drops what the core would refuse (no sender device, sender not cross-signed). `MatrixRtcLogging` routes the Rust core's `tracing` output to a sink; the app installs one (`MatrixRtcLogBridge`) that forwards to `MXLog` with the record's target and level, mapping Rust levels to ours.

No behaviour change: nothing calls into the framework yet.

### Pull Request Checklist

- [ ] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [ ] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
