### PR TITLE
NativeCall | Feed room state and media keys into the MatrixRTC core

### DIFF
--- a/Components/MatrixRtcKit/Sources/Session/MatrixRtcCommandSender.swift
+++ b/Components/MatrixRtcKit/Sources/Session/MatrixRtcCommandSender.swift
@@ -1,0 +1,123 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Foundation
+import MatrixRtc
+
+/// The outbound bridge: the core decides *what* goes on the Matrix wire, this is *how*.
+///
+/// Every body is passed through verbatim (the core emits the unstable types itself) and every
+/// failure is turned into a `CommandSenderError` — anything else crossing the FFI aborts the process.
+/// Cancellation stays a cancellation: dressing it as a send failure would tell the core the command
+/// was attempted when its session is simply gone.
+final nonisolated class MatrixRtcCommandSender: CommandSenderCallback, Sendable {
+    /// The released SDK's `sendStickyRaw` returns nothing, so a sticky send has no event ID to report.
+    static let noEventID = ""
+    
+    private let transport: MatrixRtcMatrixTransport
+    
+    init(transport: MatrixRtcMatrixTransport) {
+        self.transport = transport
+    }
+    
+    func sendStickyEvent(roomId: String, eventType: String, contentJson: String, durationMs: UInt64) async throws -> String {
+        // The lifetime is the core's to choose: it knows when it will next refresh the membership.
+        try await command("sendStickyEvent(\(eventType), \(durationMs)ms)") {
+            _ = try await transport.sendStickyEvent(roomID: roomId, eventType: eventType, contentJSON: contentJson, durationMs: durationMs)
+            return Self.noEventID
+        }
+    }
+    
+    func sendStateEvent(roomId: String, eventType: String, stateKey: String, contentJson: String) async throws -> String {
+        try await command("sendStateEvent(\(eventType))") {
+            try await transport.sendStateEvent(roomID: roomId, eventType: eventType, stateKey: stateKey, contentJSON: contentJson)
+        }
+    }
+    
+    /// Failing the dead man's switch is not fatal: the core shortens the membership lifetime instead.
+    /// What matters is the classification — `NotSupported` retires it for the session, `SendError` re-probes.
+    func sendDelayedEvent(roomId: String, eventType: String, contentJson: String, delayMs: UInt64) async throws -> String {
+        try await command("sendDelayedEvent(\(eventType))") {
+            try await transport.sendDelayedEvent(roomID: roomId, eventType: eventType, contentJSON: contentJson, delayMs: delayMs)
+        }
+    }
+    
+    func sendDelayedStateEvent(roomId: String, eventType: String, stateKey: String, contentJson: String, delayMs: UInt64) async throws -> String {
+        try await command("sendDelayedStateEvent(\(eventType))") {
+            try await transport.sendDelayedStateEvent(roomID: roomId, eventType: eventType, stateKey: stateKey, contentJSON: contentJson, delayMs: delayMs)
+        }
+    }
+    
+    // Cancel and restart differ only by the action; swapping them retires the membership the switch
+    // protects, dropping us out of a live call minutes later. Pinned by tests.
+    func cancelDelayedEvent(roomId: String, delayId: String) async throws {
+        try await command("cancelDelayedEvent") {
+            try await transport.updateDelayedEvent(roomID: roomId, delayID: delayId, action: .cancel)
+        }
+    }
+    
+    func restartDelayedEvent(roomId: String, delayId: String) async throws {
+        try await command("restartDelayedEvent") {
+            try await transport.updateDelayedEvent(roomID: roomId, delayID: delayId, action: .restart)
+        }
+    }
+    
+    /// Media keys never go out in the clear, and every recipient gets a verdict: one reported as
+    /// delivered is never re-sent to, so a failure reported as a success leaves a member keyless.
+    func sendToDeviceMessage(recipients: [FfiToDeviceRecipient], messageType: String, contentJson: String) async throws -> [FfiToDeviceDelivery] {
+        var messages = [String: [String: String]]()
+        for recipient in recipients {
+            messages[recipient.userId, default: [:]][recipient.deviceId] = contentJson
+        }
+        
+        MatrixRtcLog.info("sendToDeviceMessage(\(messageType)) to \(recipients.map { "\($0.userId)/\($0.deviceId)" })")
+        
+        return try await command("sendToDeviceMessage(\(messageType))") {
+            let failures = try await transport.sendToDeviceMessage(eventType: messageType, messages: messages)
+            return recipients.map { recipient in
+                let failed = failures[recipient.userId]?.contains(recipient.deviceId) ?? false
+                return FfiToDeviceDelivery(userId: recipient.userId,
+                                           deviceId: recipient.deviceId,
+                                           error: failed ? "Not delivered by the homeserver" : nil)
+            }
+        }
+    }
+    
+    func sendRoomEvent(roomId: String, eventType: String, contentJson: String) async throws -> String {
+        try await command("sendRoomEvent(\(eventType))") {
+            try await transport.sendRoomEvent(roomID: roomId, eventType: eventType, contentJSON: contentJson)
+        }
+    }
+    
+    func redactEvent(roomId: String, eventId: String, reason: String?) async throws {
+        try await command("redactEvent") {
+            try await transport.redactEvent(roomID: roomId, eventID: eventId, reason: reason)
+        }
+    }
+    
+    // MARK: - Private
+    
+    private func command<T>(_ description: String, _ body: () async throws -> T) async throws -> T {
+        do {
+            return try await body()
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let error as MatrixRtcTransportError {
+            switch error {
+            case .notSupported(let message):
+                MatrixRtcLog.warning("\(description) refused by the homeserver: \(message)")
+                throw CommandSenderError.NotSupported("\(description): \(message)")
+            case .failed(let message):
+                MatrixRtcLog.error("\(description) failed: \(message)")
+                throw CommandSenderError.SendError("\(description): \(message)")
+            }
+        } catch {
+            MatrixRtcLog.error("\(description) failed: \(error)")
+            throw CommandSenderError.SendError("\(description): \(error)")
+        }
+    }
+}

--- a/Components/MatrixRtcKit/Sources/Session/RoomStateFeeder.swift
+++ b/Components/MatrixRtcKit/Sources/Session/RoomStateFeeder.swift
@@ -1,0 +1,179 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Foundation
+import MatrixRtc
+import Synchronization
+
+/// Feeds one room's state to the core: joined members, encryption, then memberships.
+///
+/// Ordering is not cosmetic. Members and encryption go in **before** the join (a sender the core
+/// cannot place in the room is rejected as `SenderNotInRoom`); memberships only **after** the join,
+/// because the compat mode fixed by the join decides how they are parsed.
+final nonisolated class RoomStateFeeder: Sendable {
+    private let manager: RtcSessionManagerHandle
+    private let transport: MatrixRtcMatrixTransport
+    private let roomID: String
+    private let slotID: String
+    private let compat: MatrixRtcElementCallCompat
+    private let onMemberCount: @Sendable (Int) -> Void
+    
+    private let tasks: Mutex<[Task<Void, Never>]> = .init([])
+    private let roomMembersFed: Mutex<CheckedContinuation<Void, Never>?> = .init(nil)
+    private let haveRoomMembers = Mutex(false)
+    
+    init(manager: RtcSessionManagerHandle,
+         transport: MatrixRtcMatrixTransport,
+         roomID: String,
+         slotID: String,
+         compat: MatrixRtcElementCallCompat,
+         onMemberCount: @escaping @Sendable (Int) -> Void) {
+        self.manager = manager
+        self.transport = transport
+        self.roomID = roomID
+        self.slotID = slotID
+        self.compat = compat
+        self.onMemberCount = onMemberCount
+    }
+    
+    /// Members and encryption. Call before joining; `awaitRoomMembers()` gates the join itself.
+    func start() {
+        // `onRoomSlotsReceived` is deliberately not fed: no Element Call generation publishes
+        // `m.rtc.slot`, and a truthful "no open slots" would project out every member, us included.
+        let members = Task { [self] in
+            for await userIDs in transport.joinedMemberIDs(roomID: roomID) {
+                // A room we are joined to always contains us: empty means "not loaded yet", and
+                // feeding it says the room is deserted, excluding every membership.
+                guard !userIDs.isEmpty else { continue }
+                MatrixRtcLog.info("Feeding \(userIDs.count) joined member(s) for \(roomID)")
+                await feed("room members") { try await manager.onRoomMembersReceived(roomId: roomID, joinedUserIds: userIDs) }
+                markRoomMembersFed()
+            }
+        }
+        let encryption = Task { [self] in
+            let isEncrypted = await transport.isRoomEncrypted(roomID: roomID)
+            MatrixRtcLog.info("Feeding encryption=\(isEncrypted) for \(roomID)")
+            await feed("room encryption") { try await manager.onRoomEncryptionReceived(roomId: roomID, encrypted: isEncrypted) }
+        }
+        tasks.withLock { $0 += [members, encryption] }
+    }
+    
+    /// Suspends until the first non-empty member list reached the core.
+    func awaitRoomMembers() async {
+        let alreadyFed = haveRoomMembers.withLock { $0 }
+        if alreadyFed {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            let fedMeanwhile = haveRoomMembers.withLock { fed -> Bool in
+                if fed {
+                    return true
+                }
+                roomMembersFed.withLock { $0 = continuation }
+                return false
+            }
+            if fedMeanwhile {
+                continuation.resume()
+            }
+        }
+    }
+    
+    /// Memberships. Call after the join and after `subscribeMembershipSnapshots`.
+    func startMemberships() {
+        let task: Task<Void, Never> = switch compat {
+        case .stateEvents:
+            Task { [self] in await feedStateMemberships() }
+        case .off, .stickyEvents:
+            // Sticky-event memberships need a sticky-event feed the released SDK bindings do not expose yet.
+            Task { MatrixRtcLog.warning("Membership feed for compat mode \(compat) is not implemented on iOS") }
+        }
+        tasks.withLock { $0.append(task) }
+    }
+    
+    func stop() {
+        tasks.withLock { tasks in
+            tasks.forEach { $0.cancel() }
+            tasks.removeAll()
+        }
+    }
+    
+    // MARK: - Private
+    
+    private func markRoomMembersFed() {
+        let continuation = haveRoomMembers.withLock { fed -> CheckedContinuation<Void, Never>? in
+            fed = true
+            return roomMembersFed.withLock { continuation in
+                defer { continuation = nil }
+                return continuation
+            }
+        }
+        continuation?.resume()
+    }
+    
+    /// Room state is replaced, never removed: a departure is a present event with `{}` content, so
+    /// an empty list can only mean the bucket has not synced. Feeding it states the call is deserted,
+    /// ourselves included, and ~20 s later the dead man's switch empties our membership mid-call.
+    private func feedStateMemberships() async {
+        var lastFed: [LegacyStateMemberEvent]?
+        for await events in transport.roomStateEvents(roomID: roomID, eventType: MatrixRtcEventTypes.legacyStateMember) {
+            let memberships = events
+                .filter { $0.eventType == MatrixRtcEventTypes.legacyStateMember || $0.eventType == "m.call.member" }
+                .map(Self.legacyStateMemberEvent)
+                .sorted { $0.stateKey < $1.stateKey }
+            
+            guard !memberships.isEmpty else {
+                MatrixRtcLog.info("Not feeding an empty state membership snapshot for \(roomID), it would read as a deserted call")
+                continue
+            }
+            // The SDK re-reads whole room state far more often than a membership changes.
+            guard memberships != lastFed else { continue }
+            lastFed = memberships
+            
+            let departures = memberships.filter { $0.contentJson.trimmingCharacters(in: .whitespacesAndNewlines) == "{}" }.count
+            MatrixRtcLog.info("Feeding \(memberships.count) state membership(s) for \(roomID) (departures=\(departures)): \(memberships.map { "\($0.sender)@\($0.stateKey)" })")
+            await feed("state memberships") {
+                try await manager.setCurrentMembership(roomId: roomID, memberEvents: [], legacyStateEvents: memberships)
+            }
+            await updateMemberCount()
+        }
+    }
+    
+    /// A missing timestamp becomes 0 ("long expired"), which is better than dropping the event and far
+    /// better than the wall clock, which would resurrect an expired membership as a phantom member.
+    private static func legacyStateMemberEvent(_ event: MatrixRtcRoomStateEvent) -> LegacyStateMemberEvent {
+        let timestamp = event.originServerTimestamp.map { UInt64($0.timeIntervalSince1970 * 1000) } ?? 0
+        return LegacyStateMemberEvent(eventId: event.eventID,
+                                      sender: event.sender,
+                                      stateKey: event.stateKey,
+                                      originServerTs: timestamp,
+                                      contentJson: event.contentJSON)
+    }
+    
+    /// The count is a query, right whenever it is read; the snapshot subscription is not woken in
+    /// every compat mode, so this is the number the UI should trust.
+    private func updateMemberCount() async {
+        do {
+            let count = try await manager.memberCount(roomId: roomID, slotId: slotID)
+            MatrixRtcLog.info("Core reports \(count.map(String.init) ?? "no") member(s) for \(roomID)/\(slotID)")
+            if let count {
+                onMemberCount(Int(count))
+            }
+        } catch {
+            MatrixRtcLog.warning("Cannot read the member count for \(roomID)/\(slotID): \(error)")
+        }
+    }
+    
+    /// Feeding is best effort: the next snapshot supersedes what this one failed to deliver, and an
+    /// error escaping a background task would take the process (and the log) with it.
+    private func feed(_ what: String, _ body: () async throws -> Void) async {
+        do {
+            try await body()
+        } catch {
+            MatrixRtcLog.error("Core rejected \(what) for \(roomID): \(error)")
+        }
+    }
+}

--- a/Components/MatrixRtcKit/Sources/Session/SessionKeyFeeder.swift
+++ b/Components/MatrixRtcKit/Sources/Session/SessionKeyFeeder.swift
@@ -1,0 +1,79 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Foundation
+import MatrixRtc
+import Synchronization
+
+/// Feeds media keys to the core for the whole Matrix session.
+///
+/// To-device delivery cannot be caught up on: the SDK hands each message to whoever is subscribed
+/// at that moment and forgets it. Subscribing per call would drop the key the far end rotates the
+/// instant it sees us join, leaving a member at `MISSING_KEY` for the entire call.
+final nonisolated class SessionKeyFeeder: Sendable {
+    private let manager: RtcSessionManagerHandle
+    private let transport: MatrixRtcMatrixTransport
+    private let tasks: Mutex<[Task<Void, Never>]> = .init([])
+    
+    init(manager: RtcSessionManagerHandle, transport: MatrixRtcMatrixTransport) {
+        self.manager = manager
+        self.transport = transport
+    }
+    
+    func start() {
+        let specKeys = Task { [manager, transport] in
+            for await message in transport.toDeviceMessages(eventTypes: [MatrixRtcEventTypes.encryptionKey]) {
+                guard let key = EncryptionKeyMapper.map(message) else {
+                    MatrixRtcLog.warning("Ignoring an unusable encryption key from \(message.attestedSenderID)")
+                    continue
+                }
+                // `crossSigned` is what makes the core silently drop a key, so log what we claimed.
+                MatrixRtcLog.info("Encryption key for \(key.memberId) index \(key.keyIndex) from \(key.senderUserId ?? "?")/\(key.senderDeviceId ?? "?") crossSigned=\(key.senderIsCrossSigned)")
+                await Self.feed("encryption key for \(key.memberId)") { try await manager.receiveEncryptionKey(key: key) }
+            }
+        }
+        
+        // Element Call sends its keys under its own type *instead of* the spec one, with a `keys`
+        // array the core parses itself. Subscribed unconditionally: the compat mode is chosen at join
+        // time, far too late for a message that is delivered exactly once.
+        let legacyKeys = Task { [manager, transport] in
+            for await message in transport.toDeviceMessages(eventTypes: [MatrixRtcEventTypes.legacyEncryptionKey]) {
+                guard message.wasEncrypted else {
+                    MatrixRtcLog.warning("Dropping a cleartext Element Call encryption key")
+                    continue
+                }
+                MatrixRtcLog.info("Element Call encryption key from \(message.attestedSenderID)/\(message.senderDeviceID ?? "?") crossSigned=\(message.isSenderCrossSigned)")
+                await Self.feed("Element Call key from \(message.attestedSenderID)") {
+                    try await manager.receiveLegacyEncryptionKey(sender: message.attestedSenderID,
+                                                                 contentJson: message.contentJSON,
+                                                                 wasEncrypted: true,
+                                                                 senderDeviceId: message.senderDeviceID,
+                                                                 senderIsCrossSigned: message.isSenderCrossSigned)
+                }
+            }
+        }
+        
+        tasks.withLock { $0 += [specKeys, legacyKeys] }
+    }
+    
+    func stop() {
+        tasks.withLock { tasks in
+            tasks.forEach { $0.cancel() }
+            tasks.removeAll()
+        }
+    }
+    
+    /// Losing one key is recoverable (the sender rotates again on the next membership change), losing
+    /// the process is not — so nothing thrown by the core escapes here.
+    private static func feed(_ what: String, _ body: () async throws -> Void) async {
+        do {
+            try await body()
+        } catch {
+            MatrixRtcLog.error("Core rejected the \(what): \(error)")
+        }
+    }
+}

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -173,6 +173,7 @@
 		19946B8EEE158356EB5E1107 /* LocationShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9406BD5F99685C5ABDEDD93 /* LocationShareSheet.swift */; };
 		19DED23340D0855B59693ED2 /* VoiceMessageRecorderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D45C9EAA86423D7D3126DE4F /* VoiceMessageRecorderProtocol.swift */; };
 		19DF5600A7F547B22DD7872A /* CompletionSuggestionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A12D3D8138F1B71AFA7C858 /* CompletionSuggestionService.swift */; };
+		19F1848BE34E30486878517F /* SessionKeyFeeder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F87A9DA8EABF5ADBFA67535 /* SessionKeyFeeder.swift */; };
 		19FE025AE9BA2959B6589B0D /* RoomMemberDetailsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CC575D1895FA62591451A93 /* RoomMemberDetailsScreen.swift */; };
 		1A3783005E6945F8583AF997 /* NSItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F72EFC8C634469F9262659C7 /* NSItemProvider.swift */; };
 		1A3B073568D1DC8F76F1F3A0 /* UserProfileScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EE69982BBA18C6D51AD08E /* UserProfileScreen.swift */; };
@@ -418,6 +419,7 @@
 		42B084FDE621FBEE433AF444 /* LegalInformationScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4176C3E20C772DE8D182863C /* LegalInformationScreen.swift */; };
 		42F1C8731166633E35A6D7E6 /* RoomEventStringBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A307A44F952CD73E63AE31 /* RoomEventStringBuilder.swift */; };
 		432EA37BDC97CEDBAB7B23A6 /* RoomInfoProxyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14517E5597594956FCE1950D /* RoomInfoProxyProtocol.swift */; };
+		43E995A6880155C00DFE7DBF /* MatrixRtcCommandSenderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FE1A562624B61D12B172006 /* MatrixRtcCommandSenderTests.swift */; };
 		43F35A7E5703D64DB0519C59 /* ServerSelectionScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD469F7513574341181F7EAA /* ServerSelectionScreen.swift */; };
 		440123E29E2F9B001A775BBE /* TimelineItemProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D505843AB66822EB91F0DF0 /* TimelineItemProxy.swift */; };
 		441857143FC100E0A7DE42A8 /* RoomPowerLevelProxyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D635709C1D6D37C225AD40E /* RoomPowerLevelProxyProtocol.swift */; };
@@ -585,6 +587,7 @@
 		5E73893669BB56307A44AAAD /* RoomListActivityVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5DA892E8643240C7BC41900 /* RoomListActivityVisibility.swift */; };
 		5EB116B58533C9A0EBA22717 /* ThreadTimelineScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC2E7CEE6E9314FD69FE0ED9 /* ThreadTimelineScreen.swift */; };
 		5EDBDE802761B5ECB54E6787 /* LogLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2711E5996016ABD6EAAEB58A /* LogLevel.swift */; };
+		5EFAB767D88D3D44E9AE89A4 /* MatrixRtcCommandSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3EBB4F8D3DA4CD7F772CF2A /* MatrixRtcCommandSender.swift */; };
 		5F06AD3C66884CE793AE6119 /* FileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04DF593C3F7AF4B2FBAEB05D /* FileManager.swift */; };
 		5F0B5797D1BFF2A51084B4C3 /* PinnedEventsTimelineScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86D7CD5CA270BFC3EBB450CA /* PinnedEventsTimelineScreenViewModel.swift */; };
 		5F5488FBC9CFEB6F433D74A4 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 7109E709A7738E6BCC4553E6 /* Localizable.strings */; };
@@ -682,6 +685,7 @@
 		6BAE34CFA9821709CFE61E50 /* DeveloperOptionsScreenHook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F60FDB3AEFC60830BD289FE /* DeveloperOptionsScreenHook.swift */; };
 		6BEB10499149444909EBE42F /* TrackedUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D751743B20B314D84D79FE /* TrackedUserDefaults.swift */; };
 		6C34237AFB808E38FC8776B9 /* RoomStateEventStringBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D55702474F279D910D2D162 /* RoomStateEventStringBuilder.swift */; };
+		6C408E7E641533FABC9C41CC /* RoomStateFeeder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D742BDC7819B045C83A6588 /* RoomStateFeeder.swift */; };
 		6C8BAF1E91618D69E7D652B2 /* NotificationServiceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A1AD6389A4659AF0CEAE62 /* NotificationServiceExtension.swift */; };
 		6C98153D60FF9B648C166C27 /* TimelineItemMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FFE1F410969ECB23FE9BB2 /* TimelineItemMenu.swift */; };
 		6CAADDC6318E41C7D7AA9526 /* SpaceScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 646B50583A2CE6DA67F7739A /* SpaceScreen.swift */; };
@@ -1960,6 +1964,7 @@
 		1D652E78832289CD9EB64488 /* hu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		1D67E616BCA82D8A1258D488 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
 		1D70253004A5AEC9C73D6A4F /* ComposerDraftService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerDraftService.swift; sourceTree = "<group>"; };
+		1D742BDC7819B045C83A6588 /* RoomStateFeeder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomStateFeeder.swift; sourceTree = "<group>"; };
 		1D8C38663020DF2EB2D13F5E /* AppLockSetupSettingsScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockSetupSettingsScreenViewModel.swift; sourceTree = "<group>"; };
 		1D9F148717D74F73BE724434 /* LongPressWithFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongPressWithFeedback.swift; sourceTree = "<group>"; };
 		1D9F2E1FC5A0139571211CE8 /* SpaceHeaderTopicSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceHeaderTopicSheetView.swift; sourceTree = "<group>"; };
@@ -2717,8 +2722,10 @@
 		9F3E4640982CE98C6ADD7896 /* SearchServiceProxyProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchServiceProxyProtocol.swift; sourceTree = "<group>"; };
 		9F40FB0A43DAECEC27C73722 /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bg; path = bg.lproj/SAS.strings; sourceTree = "<group>"; };
 		9F62DA377B741D7B99AA7742 /* PresenceService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresenceService.swift; sourceTree = "<group>"; };
+		9F87A9DA8EABF5ADBFA67535 /* SessionKeyFeeder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionKeyFeeder.swift; sourceTree = "<group>"; };
 		9FD40B92FCF20165658296AD /* TimelineMediaPreviewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineMediaPreviewModifier.swift; sourceTree = "<group>"; };
 		9FD7E851E2BA8C5A8D284B2A /* BannedRoomProxyMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannedRoomProxyMock.swift; sourceTree = "<group>"; };
+		9FE1A562624B61D12B172006 /* MatrixRtcCommandSenderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatrixRtcCommandSenderTests.swift; sourceTree = "<group>"; };
 		9FE8A35B4AD5256F4B562274 /* SettingsScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScreenViewModelTests.swift; sourceTree = "<group>"; };
 		A0013D4F8EA288D589CFBF37 /* ContentScannerProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentScannerProxy.swift; sourceTree = "<group>"; };
 		A00C7A331B72C0F05C00392F /* RoomScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomScreenViewModelProtocol.swift; sourceTree = "<group>"; };
@@ -3133,6 +3140,7 @@
 		E36CB905A2B9EC2C92A2DA7C /* KeychainController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainController.swift; sourceTree = "<group>"; };
 		E3877D3CFAC1D33823359BAF /* HTMLParserStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLParserStyle.swift; sourceTree = "<group>"; };
 		E3B97591B2D3D4D67553506D /* AnalyticsClientProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsClientProtocol.swift; sourceTree = "<group>"; };
+		E3EBB4F8D3DA4CD7F772CF2A /* MatrixRtcCommandSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatrixRtcCommandSender.swift; sourceTree = "<group>"; };
 		E4103AB4340F2974D690A12A /* CallScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallScreen.swift; sourceTree = "<group>"; };
 		E413F4CBD7BF0588F394A9DD /* RoomDetailsEditScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomDetailsEditScreenViewModel.swift; sourceTree = "<group>"; };
 		E43005941B3A2C9671E23C85 /* UserIndicatorModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserIndicatorModalView.swift; sourceTree = "<group>"; };
@@ -4881,8 +4889,11 @@
 			children = (
 				09B9FCEB43FD29D422409981 /* EncryptionKeyMapper.swift */,
 				B0D181FBD3D73887CDF42718 /* Mappers.swift */,
+				E3EBB4F8D3DA4CD7F772CF2A /* MatrixRtcCommandSender.swift */,
 				D57B7AE0E195E737317E87FD /* MatrixRtcLog.swift */,
 				649FCD89E514713DC785F91D /* MatrixRtcLogging.swift */,
+				1D742BDC7819B045C83A6588 /* RoomStateFeeder.swift */,
+				9F87A9DA8EABF5ADBFA67535 /* SessionKeyFeeder.swift */,
 			);
 			path = Session;
 			sourceTree = "<group>";
@@ -5417,6 +5428,7 @@
 				9613851C68D8C01EABFB3569 /* AppLock */,
 				A6AA0A048CAE428A5CA4CBBB /* LayoutTests */,
 				7583EAC171059A86B767209F /* MediaProvider */,
+				8AC69B8E27B84645A8533518 /* NativeCall */,
 				7DBC911559934065993A5FF4 /* NotificationManager */,
 				638665D7260F974BA9A3BFA1 /* TestUtilities */,
 				1C62F5382CC9D9F7DCEC344A /* UserDiscoveryService */,
@@ -5857,6 +5869,14 @@
 				6765932445C053E15E63C29A /* SupportingFiles */,
 			);
 			path = IntegrationTests;
+			sourceTree = "<group>";
+		};
+		8AC69B8E27B84645A8533518 /* NativeCall */ = {
+			isa = PBXGroup;
+			children = (
+				9FE1A562624B61D12B172006 /* MatrixRtcCommandSenderTests.swift */,
+			);
+			path = NativeCall;
 			sourceTree = "<group>";
 		};
 		8ACEC7D7B74641FF4DB6A6D3 /* View */ = {
@@ -8473,6 +8493,7 @@
 				EB069CC36087F103C517C6A0 /* MapLibreLoaderTests.swift in Sources */,
 				3BEBDCB42BABFA3B456FECA7 /* MapTilerURLBuilderTests.swift in Sources */,
 				2E43A3D221BE9587BC19C3F1 /* MatrixEntityRegexTests.swift in Sources */,
+				43E995A6880155C00DFE7DBF /* MatrixRtcCommandSenderTests.swift in Sources */,
 				7070E5CA0095CBEFAA7DE466 /* MediaEventsTimelineScreenViewModelTests.swift in Sources */,
 				4B978C09567387EF4366BD7A /* MediaLoaderTests.swift in Sources */,
 				3582056513A384F110EC8274 /* MediaPlayerProviderTests.swift in Sources */,
@@ -8656,10 +8677,13 @@
 			files = (
 				9F6EFBB1D710D34236F87430 /* EncryptionKeyMapper.swift in Sources */,
 				365D4AB2BD42729490C93146 /* Mappers.swift in Sources */,
+				5EFAB767D88D3D44E9AE89A4 /* MatrixRtcCommandSender.swift in Sources */,
 				B63D2F54666E6BF9B7C35024 /* MatrixRtcLog.swift in Sources */,
 				C8B3100A1CC12F9FFDC64937 /* MatrixRtcLogging.swift in Sources */,
 				6F2925C185654654802C36C1 /* MatrixRtcMatrixTransport.swift in Sources */,
 				6D04ED80374F085C20AF8FC7 /* MatrixRtcModels.swift in Sources */,
+				6C408E7E641533FABC9C41CC /* RoomStateFeeder.swift in Sources */,
+				19F1848BE34E30486878517F /* SessionKeyFeeder.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/UnitTests/Sources/NativeCall/MatrixRtcCommandSenderTests.swift
+++ b/UnitTests/Sources/NativeCall/MatrixRtcCommandSenderTests.swift
@@ -1,0 +1,145 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+@testable import ElementX
+import MatrixRtc
+@testable import MatrixRtcKit
+import Testing
+
+/// Pins the outbound bridge: each callback maps to exactly one transport call, cancel and restart
+/// are never swapped, failures are classified, and every to-device recipient gets a verdict.
+struct MatrixRtcCommandSenderTests {
+    @Test
+    func cancelAndRestartAreNotSwapped() async throws {
+        let transport = RecordingTransport()
+        let sender = MatrixRtcCommandSender(transport: transport)
+        
+        try await sender.cancelDelayedEvent(roomId: "!r", delayId: "d1")
+        try await sender.restartDelayedEvent(roomId: "!r", delayId: "d2")
+        
+        #expect(transport.delayedUpdates == ["d1:cancel", "d2:restart"])
+    }
+    
+    @Test
+    func stickyEventPassesContentAndDurationThroughVerbatim() async throws {
+        let transport = RecordingTransport()
+        let sender = MatrixRtcCommandSender(transport: transport)
+        
+        let eventID = try await sender.sendStickyEvent(roomId: "!r", eventType: "org.matrix.msc4143.rtc.member", contentJson: "{\"a\":1}", durationMs: 7_200_000)
+        
+        #expect(eventID == MatrixRtcCommandSender.noEventID)
+        #expect(transport.stickyEvents == ["org.matrix.msc4143.rtc.member|{\"a\":1}|7200000"])
+    }
+    
+    @Test
+    func permanentRefusalIsNotSupported() async {
+        let transport = RecordingTransport()
+        transport.delayedEventError = .notSupported("M_UNRECOGNIZED")
+        let sender = MatrixRtcCommandSender(transport: transport)
+        
+        await #expect(throws: CommandSenderError.NotSupported("sendDelayedEvent(m.rtc.member): M_UNRECOGNIZED")) {
+            _ = try await sender.sendDelayedEvent(roomId: "!r", eventType: "m.rtc.member", contentJson: "{}", delayMs: 20000)
+        }
+    }
+    
+    @Test
+    func transientFailureIsSendError() async {
+        let transport = RecordingTransport()
+        transport.delayedEventError = .failed("timeout")
+        let sender = MatrixRtcCommandSender(transport: transport)
+        
+        await #expect(throws: CommandSenderError.SendError("sendDelayedEvent(m.rtc.member): timeout")) {
+            _ = try await sender.sendDelayedEvent(roomId: "!r", eventType: "m.rtc.member", contentJson: "{}", delayMs: 20000)
+        }
+    }
+    
+    @Test
+    func toDeviceReportsOneVerdictPerRecipient() async throws {
+        let transport = RecordingTransport()
+        transport.toDeviceFailures = ["@bob:example.org": ["DEV2"]]
+        let sender = MatrixRtcCommandSender(transport: transport)
+        
+        let deliveries = try await sender.sendToDeviceMessage(recipients: [.init(userId: "@bob:example.org", deviceId: "DEV1"),
+                                                                           .init(userId: "@bob:example.org", deviceId: "DEV2"),
+                                                                           .init(userId: "@carol:example.org", deviceId: "DEV3")],
+                                                              messageType: "org.matrix.msc4143.rtc.encryption_key",
+                                                              contentJson: "{}")
+        
+        #expect(deliveries.map(\.deviceId) == ["DEV1", "DEV2", "DEV3"])
+        #expect(deliveries.map { $0.error == nil } == [true, false, true])
+        #expect(transport.toDeviceMessages == ["@bob:example.org": ["DEV1": "{}", "DEV2": "{}"], "@carol:example.org": ["DEV3": "{}"]])
+    }
+}
+
+/// Records every send; failures are configurable per kind.
+private final nonisolated class RecordingTransport: MatrixRtcMatrixTransport, @unchecked Sendable {
+    let userID = "@alice:example.org"
+    let deviceID = "ALICE"
+    
+    var stickyEvents = [String]()
+    var delayedUpdates = [String]()
+    var toDeviceMessages = [String: [String: String]]()
+    var toDeviceFailures = [String: [String]]()
+    var delayedEventError: MatrixRtcTransportError?
+    
+    func sendStateEvent(roomID: String, eventType: String, stateKey: String, contentJSON: String) async throws -> String {
+        "$state"
+    }
+    
+    func sendStickyEvent(roomID: String, eventType: String, contentJSON: String, durationMs: UInt64) async throws -> String {
+        stickyEvents.append("\(eventType)|\(contentJSON)|\(durationMs)")
+        return ""
+    }
+    
+    func sendDelayedEvent(roomID: String, eventType: String, contentJSON: String, delayMs: UInt64) async throws -> String {
+        if let delayedEventError {
+            throw delayedEventError
+        }
+        return "delay"
+    }
+    
+    func sendDelayedStateEvent(roomID: String, eventType: String, stateKey: String, contentJSON: String, delayMs: UInt64) async throws -> String {
+        if let delayedEventError {
+            throw delayedEventError
+        }
+        return "delay"
+    }
+    
+    func updateDelayedEvent(roomID: String, delayID: String, action: MatrixRtcDelayedEventAction) async throws {
+        delayedUpdates.append("\(delayID):\(action)")
+    }
+    
+    func sendToDeviceMessage(eventType: String, messages: [String: [String: String]]) async throws -> [String: [String]] {
+        toDeviceMessages = messages
+        return toDeviceFailures
+    }
+    
+    func sendRoomEvent(roomID: String, eventType: String, contentJSON: String) async throws -> String {
+        ""
+    }
+    
+    func redactEvent(roomID: String, eventID: String, reason: String?) async throws { }
+    func requestOpenIDToken() async throws -> MatrixRtcOpenIDToken {
+        .init(accessToken: "t", tokenType: "Bearer", matrixServerName: "example.org", expiresIn: 60)
+    }
+    
+    func toDeviceMessages(eventTypes: [String]) -> AsyncStream<MatrixRtcToDeviceMessage> {
+        AsyncStream { $0.finish() }
+    }
+    
+    func roomStateEvents(roomID: String, eventType: String) -> AsyncStream<[MatrixRtcRoomStateEvent]> {
+        AsyncStream { $0.finish() }
+    }
+    
+    func joinedMemberIDs(roomID: String) -> AsyncStream<[String]> {
+        AsyncStream { $0.finish() }
+    }
+    
+    func isRoomEncrypted(roomID: String) async -> Bool {
+        true
+    }
+}


### PR DESCRIPTION
Third step of the native MatrixRTC calls stack (spike: `valere/native_call`; previous: #6117).

matrix-rust-rtc is fed by its host rather than fetching from Matrix itself. `RoomStateFeeder` subscribes to the transport's room-state stream for a room's call member events and pushes each full snapshot into the session manager; `SessionKeyFeeder` does the same for the session's to-device media keys through the key mapper. `MatrixRtcCommandSender` is the outbound direction: the core's command callback, mapping each command (state, room, delayed and to-device sends, redactions, delayed-event updates) onto exactly one `MatrixRtcMatrixTransport` call and transport errors onto the core's error kinds. `MatrixRtcCommandSenderTests` pins that mapping with a recording transport.

No behaviour change: the app has no transport implementation yet.

### Pull Request Checklist

- [ ] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [ ] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
