### PR TITLE
NativeCall | Expose raw sends, redaction and OpenID tokens on the proxies, and the…

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -1498,6 +1498,7 @@
 		EBE13FAB4E29738AC41BD3E5 /* InfoPlistReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A580295A56B55A856CC4084 /* InfoPlistReader.swift */; };
 		EC09E502A21E4EAA8B367AB8 /* ReportContentScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30EA681527A8FE65E4C8E9A9 /* ReportContentScreenViewModelTests.swift */; };
 		EC1A0E85CEE50BF0C64EEFA5 /* LabsScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4D9DF4F2DF3507F99B5B97B /* LabsScreenViewModel.swift */; };
+		EC236C92F6FA50062273AEE1 /* MatrixRtcRoomBridgeProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 936085D12BB0094F78E1FB67 /* MatrixRtcRoomBridgeProtocol.swift */; };
 		EC3320639828BED8B3E5F2C6 /* EncryptionResetScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5875F7C0A2398E9F134B1284 /* EncryptionResetScreenViewModel.swift */; };
 		EC5B6D717560B9E275A0EA2F /* landscape_test_image.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 028CAFDBB60E2DBB24C3F621 /* landscape_test_image.jpg */; };
 		ECE4E03D17E309724013F825 /* TimelineInteractionHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C65A839BC897F6C236E8A5 /* TimelineInteractionHandlerTests.swift */; };
@@ -1568,6 +1569,7 @@
 		F66BBBE51B258BBB0B918C68 /* MatrixRustSDK in Frameworks */ = {isa = PBXBuildFile; productRef = C79D91A7F9F378CECEF64B5A /* MatrixRustSDK */; };
 		F66BCCC825D6CA51724A94D0 /* MediaPlayerProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8A1F98AE670377B20679FF5 /* MediaPlayerProvider.swift */; };
 		F6767F17D538578B370DD805 /* TimelineItemBubbleBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE739A6836E86E3780748477 /* TimelineItemBubbleBackground.swift */; };
+		F68F5F595531235D4C4CF699 /* WidgetJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66CE98F6D8750C092C3C64F6 /* WidgetJSON.swift */; };
 		F6BF52CB027393EE03CEC523 /* TimelineMediaPreviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C1F000589F2CEE6B03ECFAB /* TimelineMediaPreviewViewModelTests.swift */; };
 		F6C343C6D1D12B0944E5EF14 /* preview_avatar_user.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 94A561C542596126DAE211AD /* preview_avatar_user.jpg */; };
 		F6D07D834279BE17D18A33E9 /* LocationSharingScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EED6D8956E554CEDFD4FE00D /* LocationSharingScreenViewModelTests.swift */; };
@@ -1576,6 +1578,7 @@
 		F737B847EE57E07CDACFF435 /* CoordinateAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C66FE72035CD1A870E8CB7 /* CoordinateAnimator.swift */; };
 		F7567DD6635434E8C563BF85 /* AnalyticsClientProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3B97591B2D3D4D67553506D /* AnalyticsClientProtocol.swift */; };
 		F777C6FEE7D106136E2ED2B2 /* MessageForwardingScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F6E6EDC4BBF962B2ED595A4 /* MessageForwardingScreenViewModelTests.swift */; };
+		F78B473DA4176E680EEB62C4 /* WidgetDriverChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED07427D8F56675BAFC6861D /* WidgetDriverChannel.swift */; };
 		F78BAD28482A467287A9A5A3 /* EventBasedMessageTimelineItemProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0900BBF0A5D5D775E917C70 /* EventBasedMessageTimelineItemProtocol.swift */; };
 		F7932A3F075B0D3F24DEECB5 /* VoiceMessagePreviewComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AE807361805463F5AEDD1CA /* VoiceMessagePreviewComposer.swift */; };
 		F7977C53B2B1D73030C69761 /* LiveLocationRoomTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52947F8F356F0BA5B1F50912 /* LiveLocationRoomTimelineView.swift */; };
@@ -2394,6 +2397,7 @@
 		6695C64F066628411EAD21E9 /* RoomPreviewProxyMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomPreviewProxyMock.swift; sourceTree = "<group>"; };
 		669F35C505ACE1110589F875 /* MediaUploadingPreprocessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaUploadingPreprocessor.swift; sourceTree = "<group>"; };
 		66AFD800AF033D8B0D11191A /* UserPropertiesExt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPropertiesExt.swift; sourceTree = "<group>"; };
+		66CE98F6D8750C092C3C64F6 /* WidgetJSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetJSON.swift; sourceTree = "<group>"; };
 		66F91544AC136BF6477BDAB8 /* TimelineDeliveryStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineDeliveryStatusView.swift; sourceTree = "<group>"; };
 		671C338B7259DC5774816885 /* AuthenticationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationServiceTests.swift; sourceTree = "<group>"; };
 		6722709BD6178E10B70C9641 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/SAS.strings; sourceTree = "<group>"; };
@@ -2655,6 +2659,7 @@
 		9332DFE9642F0A46ECA0497B /* BlurHashEncode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurHashEncode.swift; sourceTree = "<group>"; };
 		933B074F006F8E930DB98B4E /* TimelineMediaFrame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineMediaFrame.swift; sourceTree = "<group>"; };
 		9349F590E35CE514A71E6764 /* LoginHomeserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginHomeserver.swift; sourceTree = "<group>"; };
+		936085D12BB0094F78E1FB67 /* MatrixRtcRoomBridgeProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatrixRtcRoomBridgeProtocol.swift; sourceTree = "<group>"; };
 		93C713D124FE915ABF47A6B7 /* TimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineView.swift; sourceTree = "<group>"; };
 		93CF7B19FFCF8EFBE0A8696A /* RoomScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomScreenViewModelTests.swift; sourceTree = "<group>"; };
 		93E1FF0DFBB3768F79FDBF6D /* AVMetadataMachineReadableCodeObjectExtensionsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVMetadataMachineReadableCodeObjectExtensionsTest.swift; sourceTree = "<group>"; };
@@ -3198,6 +3203,7 @@
 		ECF79FB25E2D4BD6F50CE7C9 /* RoomMembersListScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomMembersListScreenViewModel.swift; sourceTree = "<group>"; };
 		ECFB21A2FF41CF0E118790DD /* StaticLocationData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticLocationData.swift; sourceTree = "<group>"; };
 		ED044D00F2176681CC02CD54 /* HomeScreenRoomCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenRoomCell.swift; sourceTree = "<group>"; };
+		ED07427D8F56675BAFC6861D /* WidgetDriverChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetDriverChannel.swift; sourceTree = "<group>"; };
 		ED096460D7F26F10168FA33B /* LinkNewDeviceScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkNewDeviceScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		ED0AD0C652385F69FA90FAF5 /* TimelineMediaPreviewDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineMediaPreviewDataSourceTests.swift; sourceTree = "<group>"; };
 		ED0CBEAB5F796BEFBAF7BB6A /* VideoRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoRoomTimelineView.swift; sourceTree = "<group>"; };
@@ -4232,6 +4238,8 @@
 			isa = PBXGroup;
 			children = (
 				364DFC4CB8071AB4DB1BDAB9 /* MatrixRtcLogBridge.swift */,
+				936085D12BB0094F78E1FB67 /* MatrixRtcRoomBridgeProtocol.swift */,
+				9964009E0A18BE38FADB062B /* Widget */,
 			);
 			path = NativeCall;
 			sourceTree = "<group>";
@@ -6142,6 +6150,15 @@
 				B7AAC1DB9CBE8947CC05A0D5 /* SpacesScreen */,
 			);
 			path = Spaces;
+			sourceTree = "<group>";
+		};
+		9964009E0A18BE38FADB062B /* Widget */ = {
+			isa = PBXGroup;
+			children = (
+				ED07427D8F56675BAFC6861D /* WidgetDriverChannel.swift */,
+				66CE98F6D8750C092C3C64F6 /* WidgetJSON.swift */,
+			);
+			path = Widget;
 			sourceTree = "<group>";
 		};
 		99B9B46F2D621380428E68F7 /* ElementX */ = {
@@ -9179,6 +9196,7 @@
 				F382E2FE3AC3719BC1F22D9C /* MapURLs.swift in Sources */,
 				67C05C50AD734283374605E3 /* MatrixEntityRegex.swift in Sources */,
 				8D1B84634C0074690175F3FC /* MatrixRtcLogBridge.swift in Sources */,
+				EC236C92F6FA50062273AEE1 /* MatrixRtcRoomBridgeProtocol.swift in Sources */,
 				8658F5034EAD7357CE7F9AC7 /* MatrixUserShareLink.swift in Sources */,
 				84E514915DF0C168B08A3A0A /* MediaEventsTimelineFlowCoordinator.swift in Sources */,
 				BEC6DFEA506085D3027E353C /* MediaEventsTimelineScreen.swift in Sources */,
@@ -9815,6 +9833,8 @@
 				CA12AE0DCD57D49CD96C699A /* WaveformCursorView.swift in Sources */,
 				63CDC201A5980F304F6D0A1C /* WaveformInteractionModifier.swift in Sources */,
 				B773ACD8881DB18E876D950C /* WaveformSource.swift in Sources */,
+				F78B473DA4176E680EEB62C4 /* WidgetDriverChannel.swift in Sources */,
+				F68F5F595531235D4C4CF699 /* WidgetJSON.swift in Sources */,
 				08CB4BD12CEEDE6AAE4A18DD /* WindowManager.swift in Sources */,
 				AE5AAD9E32511544FDFA5560 /* WindowManagerProtocol.swift in Sources */,
 			);

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -2448,6 +2448,76 @@ nonisolated class ClientProxyMock: ClientProxyProtocol, @unchecked Sendable {
     }
     nonisolated(unsafe) var underlyingLiveLocationOwnInfoUpdatesPublisher: AnyPublisher<LiveLocationOwnInfoUpdate, Never>!
 
+    //MARK: - requestOpenIDToken
+
+    private let requestOpenIDTokenCallsCountLock = NSLock()
+    private nonisolated(unsafe) var requestOpenIDTokenUnderlyingCallsCount = 0
+    var requestOpenIDTokenCallsCount: Int {
+        get { requestOpenIDTokenCallsCountLock.withLock { requestOpenIDTokenUnderlyingCallsCount } }
+        set { requestOpenIDTokenCallsCountLock.withLock { requestOpenIDTokenUnderlyingCallsCount = newValue } }
+    }
+    var requestOpenIDTokenCalled: Bool {
+        return requestOpenIDTokenCallsCount > 0
+    }
+
+    private let requestOpenIDTokenReturnValueLock = NSLock()
+    private nonisolated(unsafe) var requestOpenIDTokenUnderlyingReturnValue: Result<OpenIDToken, ClientProxyError>!
+    var requestOpenIDTokenReturnValue: Result<OpenIDToken, ClientProxyError>! {
+        get { requestOpenIDTokenReturnValueLock.withLock { requestOpenIDTokenUnderlyingReturnValue } }
+        set { requestOpenIDTokenReturnValueLock.withLock { requestOpenIDTokenUnderlyingReturnValue = newValue } }
+    }
+    nonisolated(unsafe) var requestOpenIDTokenClosure: (() async -> Result<OpenIDToken, ClientProxyError>)?
+
+    @concurrent func requestOpenIDToken() async -> Result<OpenIDToken, ClientProxyError> {
+        requestOpenIDTokenCallsCountLock.withLock { requestOpenIDTokenUnderlyingCallsCount += 1 }
+        if let requestOpenIDTokenClosure = requestOpenIDTokenClosure {
+            return await requestOpenIDTokenClosure()
+        } else {
+            return requestOpenIDTokenReturnValue
+        }
+    }
+    //MARK: - getURL
+
+    private let getURLCallsCountLock = NSLock()
+    private nonisolated(unsafe) var getURLUnderlyingCallsCount = 0
+    var getURLCallsCount: Int {
+        get { getURLCallsCountLock.withLock { getURLUnderlyingCallsCount } }
+        set { getURLCallsCountLock.withLock { getURLUnderlyingCallsCount = newValue } }
+    }
+    var getURLCalled: Bool {
+        return getURLCallsCount > 0
+    }
+    private let getURLReceivedUrlLock = NSLock()
+    private nonisolated(unsafe) var getURLUnderlyingReceivedUrl: String?
+    var getURLReceivedUrl: String? {
+        get { getURLReceivedUrlLock.withLock { getURLUnderlyingReceivedUrl } }
+        set { getURLReceivedUrlLock.withLock { getURLUnderlyingReceivedUrl = newValue } }
+    }
+    private let getURLReceivedInvocationsLock = NSLock()
+    private nonisolated(unsafe) var getURLUnderlyingReceivedInvocations: [String] = []
+    var getURLReceivedInvocations: [String] {
+        get { getURLReceivedInvocationsLock.withLock { getURLUnderlyingReceivedInvocations } }
+        set { getURLReceivedInvocationsLock.withLock { getURLUnderlyingReceivedInvocations = newValue } }
+    }
+
+    private let getURLReturnValueLock = NSLock()
+    private nonisolated(unsafe) var getURLUnderlyingReturnValue: Result<Data, ClientProxyError>!
+    var getURLReturnValue: Result<Data, ClientProxyError>! {
+        get { getURLReturnValueLock.withLock { getURLUnderlyingReturnValue } }
+        set { getURLReturnValueLock.withLock { getURLUnderlyingReturnValue = newValue } }
+    }
+    nonisolated(unsafe) var getURLClosure: ((String) async -> Result<Data, ClientProxyError>)?
+
+    @concurrent func getURL(_ url: String) async -> Result<Data, ClientProxyError> {
+        getURLCallsCountLock.withLock { getURLUnderlyingCallsCount += 1 }
+        getURLReceivedUrl = url
+        getURLReceivedInvocationsLock.withLock { getURLUnderlyingReceivedInvocations.append(url) }
+        if let getURLClosure = getURLClosure {
+            return await getURLClosure(url)
+        } else {
+            return getURLReturnValue
+        }
+    }
     //MARK: - isOnlyDeviceLeft
 
     private let isOnlyDeviceLeftCallsCountLock = NSLock()
@@ -6766,6 +6836,132 @@ nonisolated class JoinedRoomProxyMock: JoinedRoomProxyProtocol, @unchecked Senda
             return subscribeToCallDeclineEventsRtcNotificationEventIDListenerClosure(rtcNotificationEventID, listener)
         } else {
             return subscribeToCallDeclineEventsRtcNotificationEventIDListenerReturnValue
+        }
+    }
+    //MARK: - sendStateEventRaw
+
+    private let sendStateEventRawEventTypeStateKeyContentJSONCallsCountLock = NSLock()
+    private nonisolated(unsafe) var sendStateEventRawEventTypeStateKeyContentJSONUnderlyingCallsCount = 0
+    var sendStateEventRawEventTypeStateKeyContentJSONCallsCount: Int {
+        get { sendStateEventRawEventTypeStateKeyContentJSONCallsCountLock.withLock { sendStateEventRawEventTypeStateKeyContentJSONUnderlyingCallsCount } }
+        set { sendStateEventRawEventTypeStateKeyContentJSONCallsCountLock.withLock { sendStateEventRawEventTypeStateKeyContentJSONUnderlyingCallsCount = newValue } }
+    }
+    var sendStateEventRawEventTypeStateKeyContentJSONCalled: Bool {
+        return sendStateEventRawEventTypeStateKeyContentJSONCallsCount > 0
+    }
+    private let sendStateEventRawEventTypeStateKeyContentJSONReceivedArgumentsLock = NSLock()
+    private nonisolated(unsafe) var sendStateEventRawEventTypeStateKeyContentJSONUnderlyingReceivedArguments: (eventType: String, stateKey: String, contentJSON: String)?
+    var sendStateEventRawEventTypeStateKeyContentJSONReceivedArguments: (eventType: String, stateKey: String, contentJSON: String)? {
+        get { sendStateEventRawEventTypeStateKeyContentJSONReceivedArgumentsLock.withLock { sendStateEventRawEventTypeStateKeyContentJSONUnderlyingReceivedArguments } }
+        set { sendStateEventRawEventTypeStateKeyContentJSONReceivedArgumentsLock.withLock { sendStateEventRawEventTypeStateKeyContentJSONUnderlyingReceivedArguments = newValue } }
+    }
+    private let sendStateEventRawEventTypeStateKeyContentJSONReceivedInvocationsLock = NSLock()
+    private nonisolated(unsafe) var sendStateEventRawEventTypeStateKeyContentJSONUnderlyingReceivedInvocations: [(eventType: String, stateKey: String, contentJSON: String)] = []
+    var sendStateEventRawEventTypeStateKeyContentJSONReceivedInvocations: [(eventType: String, stateKey: String, contentJSON: String)] {
+        get { sendStateEventRawEventTypeStateKeyContentJSONReceivedInvocationsLock.withLock { sendStateEventRawEventTypeStateKeyContentJSONUnderlyingReceivedInvocations } }
+        set { sendStateEventRawEventTypeStateKeyContentJSONReceivedInvocationsLock.withLock { sendStateEventRawEventTypeStateKeyContentJSONUnderlyingReceivedInvocations = newValue } }
+    }
+
+    private let sendStateEventRawEventTypeStateKeyContentJSONReturnValueLock = NSLock()
+    private nonisolated(unsafe) var sendStateEventRawEventTypeStateKeyContentJSONUnderlyingReturnValue: Result<String, RoomProxyError>!
+    var sendStateEventRawEventTypeStateKeyContentJSONReturnValue: Result<String, RoomProxyError>! {
+        get { sendStateEventRawEventTypeStateKeyContentJSONReturnValueLock.withLock { sendStateEventRawEventTypeStateKeyContentJSONUnderlyingReturnValue } }
+        set { sendStateEventRawEventTypeStateKeyContentJSONReturnValueLock.withLock { sendStateEventRawEventTypeStateKeyContentJSONUnderlyingReturnValue = newValue } }
+    }
+    nonisolated(unsafe) var sendStateEventRawEventTypeStateKeyContentJSONClosure: ((String, String, String) async -> Result<String, RoomProxyError>)?
+
+    @concurrent func sendStateEventRaw(eventType: String, stateKey: String, contentJSON: String) async -> Result<String, RoomProxyError> {
+        sendStateEventRawEventTypeStateKeyContentJSONCallsCountLock.withLock { sendStateEventRawEventTypeStateKeyContentJSONUnderlyingCallsCount += 1 }
+        sendStateEventRawEventTypeStateKeyContentJSONReceivedArguments = (eventType: eventType, stateKey: stateKey, contentJSON: contentJSON)
+        sendStateEventRawEventTypeStateKeyContentJSONReceivedInvocationsLock.withLock { sendStateEventRawEventTypeStateKeyContentJSONUnderlyingReceivedInvocations.append((eventType: eventType, stateKey: stateKey, contentJSON: contentJSON)) }
+        if let sendStateEventRawEventTypeStateKeyContentJSONClosure = sendStateEventRawEventTypeStateKeyContentJSONClosure {
+            return await sendStateEventRawEventTypeStateKeyContentJSONClosure(eventType, stateKey, contentJSON)
+        } else {
+            return sendStateEventRawEventTypeStateKeyContentJSONReturnValue
+        }
+    }
+    //MARK: - sendRaw
+
+    private let sendRawEventTypeContentJSONCallsCountLock = NSLock()
+    private nonisolated(unsafe) var sendRawEventTypeContentJSONUnderlyingCallsCount = 0
+    var sendRawEventTypeContentJSONCallsCount: Int {
+        get { sendRawEventTypeContentJSONCallsCountLock.withLock { sendRawEventTypeContentJSONUnderlyingCallsCount } }
+        set { sendRawEventTypeContentJSONCallsCountLock.withLock { sendRawEventTypeContentJSONUnderlyingCallsCount = newValue } }
+    }
+    var sendRawEventTypeContentJSONCalled: Bool {
+        return sendRawEventTypeContentJSONCallsCount > 0
+    }
+    private let sendRawEventTypeContentJSONReceivedArgumentsLock = NSLock()
+    private nonisolated(unsafe) var sendRawEventTypeContentJSONUnderlyingReceivedArguments: (eventType: String, contentJSON: String)?
+    var sendRawEventTypeContentJSONReceivedArguments: (eventType: String, contentJSON: String)? {
+        get { sendRawEventTypeContentJSONReceivedArgumentsLock.withLock { sendRawEventTypeContentJSONUnderlyingReceivedArguments } }
+        set { sendRawEventTypeContentJSONReceivedArgumentsLock.withLock { sendRawEventTypeContentJSONUnderlyingReceivedArguments = newValue } }
+    }
+    private let sendRawEventTypeContentJSONReceivedInvocationsLock = NSLock()
+    private nonisolated(unsafe) var sendRawEventTypeContentJSONUnderlyingReceivedInvocations: [(eventType: String, contentJSON: String)] = []
+    var sendRawEventTypeContentJSONReceivedInvocations: [(eventType: String, contentJSON: String)] {
+        get { sendRawEventTypeContentJSONReceivedInvocationsLock.withLock { sendRawEventTypeContentJSONUnderlyingReceivedInvocations } }
+        set { sendRawEventTypeContentJSONReceivedInvocationsLock.withLock { sendRawEventTypeContentJSONUnderlyingReceivedInvocations = newValue } }
+    }
+
+    private let sendRawEventTypeContentJSONReturnValueLock = NSLock()
+    private nonisolated(unsafe) var sendRawEventTypeContentJSONUnderlyingReturnValue: Result<Void, RoomProxyError>!
+    var sendRawEventTypeContentJSONReturnValue: Result<Void, RoomProxyError>! {
+        get { sendRawEventTypeContentJSONReturnValueLock.withLock { sendRawEventTypeContentJSONUnderlyingReturnValue } }
+        set { sendRawEventTypeContentJSONReturnValueLock.withLock { sendRawEventTypeContentJSONUnderlyingReturnValue = newValue } }
+    }
+    nonisolated(unsafe) var sendRawEventTypeContentJSONClosure: ((String, String) async -> Result<Void, RoomProxyError>)?
+
+    @concurrent func sendRaw(eventType: String, contentJSON: String) async -> Result<Void, RoomProxyError> {
+        sendRawEventTypeContentJSONCallsCountLock.withLock { sendRawEventTypeContentJSONUnderlyingCallsCount += 1 }
+        sendRawEventTypeContentJSONReceivedArguments = (eventType: eventType, contentJSON: contentJSON)
+        sendRawEventTypeContentJSONReceivedInvocationsLock.withLock { sendRawEventTypeContentJSONUnderlyingReceivedInvocations.append((eventType: eventType, contentJSON: contentJSON)) }
+        if let sendRawEventTypeContentJSONClosure = sendRawEventTypeContentJSONClosure {
+            return await sendRawEventTypeContentJSONClosure(eventType, contentJSON)
+        } else {
+            return sendRawEventTypeContentJSONReturnValue
+        }
+    }
+    //MARK: - redact
+
+    private let redactEventIDReasonCallsCountLock = NSLock()
+    private nonisolated(unsafe) var redactEventIDReasonUnderlyingCallsCount = 0
+    var redactEventIDReasonCallsCount: Int {
+        get { redactEventIDReasonCallsCountLock.withLock { redactEventIDReasonUnderlyingCallsCount } }
+        set { redactEventIDReasonCallsCountLock.withLock { redactEventIDReasonUnderlyingCallsCount = newValue } }
+    }
+    var redactEventIDReasonCalled: Bool {
+        return redactEventIDReasonCallsCount > 0
+    }
+    private let redactEventIDReasonReceivedArgumentsLock = NSLock()
+    private nonisolated(unsafe) var redactEventIDReasonUnderlyingReceivedArguments: (eventID: String, reason: String?)?
+    var redactEventIDReasonReceivedArguments: (eventID: String, reason: String?)? {
+        get { redactEventIDReasonReceivedArgumentsLock.withLock { redactEventIDReasonUnderlyingReceivedArguments } }
+        set { redactEventIDReasonReceivedArgumentsLock.withLock { redactEventIDReasonUnderlyingReceivedArguments = newValue } }
+    }
+    private let redactEventIDReasonReceivedInvocationsLock = NSLock()
+    private nonisolated(unsafe) var redactEventIDReasonUnderlyingReceivedInvocations: [(eventID: String, reason: String?)] = []
+    var redactEventIDReasonReceivedInvocations: [(eventID: String, reason: String?)] {
+        get { redactEventIDReasonReceivedInvocationsLock.withLock { redactEventIDReasonUnderlyingReceivedInvocations } }
+        set { redactEventIDReasonReceivedInvocationsLock.withLock { redactEventIDReasonUnderlyingReceivedInvocations = newValue } }
+    }
+
+    private let redactEventIDReasonReturnValueLock = NSLock()
+    private nonisolated(unsafe) var redactEventIDReasonUnderlyingReturnValue: Result<Void, RoomProxyError>!
+    var redactEventIDReasonReturnValue: Result<Void, RoomProxyError>! {
+        get { redactEventIDReasonReturnValueLock.withLock { redactEventIDReasonUnderlyingReturnValue } }
+        set { redactEventIDReasonReturnValueLock.withLock { redactEventIDReasonUnderlyingReturnValue = newValue } }
+    }
+    nonisolated(unsafe) var redactEventIDReasonClosure: ((String, String?) async -> Result<Void, RoomProxyError>)?
+
+    @concurrent func redact(eventID: String, reason: String?) async -> Result<Void, RoomProxyError> {
+        redactEventIDReasonCallsCountLock.withLock { redactEventIDReasonUnderlyingCallsCount += 1 }
+        redactEventIDReasonReceivedArguments = (eventID: eventID, reason: reason)
+        redactEventIDReasonReceivedInvocationsLock.withLock { redactEventIDReasonUnderlyingReceivedInvocations.append((eventID: eventID, reason: reason)) }
+        if let redactEventIDReasonClosure = redactEventIDReasonClosure {
+            return await redactEventIDReasonClosure(eventID, reason)
+        } else {
+            return redactEventIDReasonReturnValue
         }
     }
     //MARK: - matrixToPermalink

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -370,6 +370,30 @@ class ClientProxy: ClientProxyProtocol {
         }
     }
     
+    // MARK: Native calls (MatrixRTC)
+    
+    func requestOpenIDToken() async -> Result<OpenIDToken, ClientProxyError> {
+        do {
+            let token = try await client.requestOpenidToken()
+            return .success(OpenIDToken(accessToken: token.accessToken,
+                                        tokenType: token.tokenType,
+                                        matrixServerName: token.matrixServerName,
+                                        expiresIn: TimeInterval(token.expiresInSeconds)))
+        } catch {
+            MXLog.error("Failed requesting an OpenID token with error: \(error)")
+            return .failure(.sdkError(error))
+        }
+    }
+    
+    func getURL(_ url: String) async -> Result<Data, ClientProxyError> {
+        do {
+            return try await .success(client.getUrl(url: url))
+        } catch {
+            MXLog.info("Failed fetching \(url) with error: \(error)")
+            return .failure(.sdkError(error))
+        }
+    }
+    
     var isLoginWithQRCodeSupported: Bool {
         get async {
             do {

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -35,6 +35,14 @@ enum ClientProxyPresence: Equatable, Sendable {
     case offline
 }
 
+/// An OpenID token proving this Matrix identity to a third party (the RTC authorisation service).
+nonisolated struct OpenIDToken: Sendable {
+    let accessToken: String
+    let tokenType: String
+    let matrixServerName: String
+    let expiresIn: TimeInterval
+}
+
 enum ClientProxyError: Error {
     case sdkError(Error)
     case forbiddenAccess
@@ -167,6 +175,12 @@ protocol ClientProxyProtocol: AnyObject {
     
     var isReportRoomSupported: Bool { get async }
     var isLiveKitRTCSupported: Bool { get async }
+    
+    // MARK: Native calls (MatrixRTC)
+    
+    func requestOpenIDToken() async -> Result<OpenIDToken, ClientProxyError>
+    /// Authenticated GET of an arbitrary URL (transport discovery).
+    func getURL(_ url: String) async -> Result<Data, ClientProxyError>
     
     var isLoginWithQRCodeSupported: Bool { get async }
     

--- a/ElementX/Sources/Services/NativeCall/MatrixRtcRoomBridgeProtocol.swift
+++ b/ElementX/Sources/Services/NativeCall/MatrixRtcRoomBridgeProtocol.swift
@@ -1,0 +1,48 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Foundation
+import MatrixRtcKit
+
+nonisolated enum MatrixRtcRoomBridgeError: Error, Sendable, Equatable {
+    /// The bridge is not (or no longer) running for the room.
+    case notRunning
+    case timedOut
+    /// The bridge answered, but not with what the operation needs.
+    case invalidResponse(String)
+    /// The homeserver refused the request; `errcode` when the bridge could tell.
+    case matrixAPI(errcode: String?, httpStatus: Int?, message: String)
+}
+
+/// Exactly the Matrix operations the released SDK bindings do not expose yet for a room: delayed
+/// events, room event IDs, the room-state feed and to-device messaging. `MatrixRtcTransportAdapter`
+/// routes those through whatever implements this; everything else goes straight to the SDK proxies.
+///
+/// Today's implementation is `WidgetMatrixBridge`, driving the SDK widget driver in-process because
+/// the released bindings lack delayed events, a room-state feed and to-device messaging. Once they
+/// gain those entry points, an SDK-backed implementation replaces it and the adapter does not change.
+nonisolated protocol MatrixRtcRoomBridgeProtocol: AnyObject, Sendable {
+    var roomID: String { get }
+    
+    /// Returns once the bridge can serve requests.
+    func start() async -> Result<Void, MatrixRtcRoomBridgeError>
+    func stop() async
+    
+    /// - Returns: the MSC4140 delay ID.
+    func sendDelayedEvent(eventType: String, stateKey: String?, contentJSON: String, delayMs: UInt64) async -> Result<String, MatrixRtcRoomBridgeError>
+    func updateDelayedEvent(delayID: String, action: MatrixRtcDelayedEventAction) async -> Result<Void, MatrixRtcRoomBridgeError>
+    /// - Returns: the event ID.
+    func sendRoomEvent(eventType: String, contentJSON: String) async -> Result<String, MatrixRtcRoomBridgeError>
+    /// `messages` is user ID → device ID → content JSON.
+    /// - Returns: the recipients that were **not** served, user ID → device IDs.
+    func sendToDeviceMessage(eventType: String, messages: [String: [String: String]]) async -> Result<[String: [String]], MatrixRtcRoomBridgeError>
+    
+    /// The full current list of state events of that type, immediately when there are any, and on every change.
+    func stateEvents(eventType: String) -> AsyncStream<[MatrixRtcRoomStateEvent]>
+    /// Every to-device message the bridge is allowed to receive, for as long as it runs.
+    func toDeviceMessages() -> AsyncStream<MatrixRtcToDeviceMessage>
+}

--- a/ElementX/Sources/Services/NativeCall/Widget/WidgetDriverChannel.swift
+++ b/ElementX/Sources/Services/NativeCall/Widget/WidgetDriverChannel.swift
@@ -1,0 +1,60 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Foundation
+import MatrixRtcKit
+import MatrixRustSDK
+
+// Temporary: part of the widget-driver stopgap that stands in for SDK bindings the released
+// package lacks (delayed events, a room-state feed, to-device messaging). Retired once the bindings
+// expose them.
+
+/// The two ends of the widget driver's message pipe, as a protocol so the bridge can be tested
+/// without the SDK.
+nonisolated protocol WidgetDriverChannel: Sendable {
+    /// The next message for the widget; nil once the driver has stopped.
+    func recv() async -> String?
+    /// False once the driver has stopped.
+    func send(msg: String) async -> Bool
+}
+
+extension WidgetDriverHandle: WidgetDriverChannel { }
+
+/// The capabilities the bridge grants itself: only what the RTC core needs. Not Element Call's set,
+/// which also reads `m.room.member` and would push the whole member list through the pipe.
+///
+/// The machine stores whatever `acquireCapabilities` returns, so the strings answered to the
+/// `capabilities` request and the value returned here describe the same set.
+final nonisolated class WidgetCapabilityGrant: WidgetCapabilitiesProvider, Sendable {
+    static let stateEventTypes = [MatrixRtcEventTypes.legacyStateMember]
+    static let toDeviceEventTypes = [MatrixRtcEventTypes.encryptionKey, MatrixRtcEventTypes.legacyEncryptionKey]
+    static let roomEventTypes = ["org.matrix.msc4075.call.notify",
+                                 "org.matrix.msc4310.rtc.notification",
+                                 "m.rtc.notification",
+                                 "io.element.call.reaction",
+                                 "m.reaction"]
+    
+    /// MSC2762 / MSC3819 / MSC4157 capability strings for the same set.
+    static let capabilityStrings: [String] =
+        stateEventTypes.flatMap { ["org.matrix.msc2762.receive.state_event:\($0)", "org.matrix.msc2762.send.state_event:\($0)"] }
+            + toDeviceEventTypes.flatMap { ["org.matrix.msc3819.receive.to_device:\($0)", "org.matrix.msc3819.send.to_device:\($0)"] }
+            + roomEventTypes.map { "org.matrix.msc2762.send.event:\($0)" }
+            + ["org.matrix.msc4157.send.delayed_event", "org.matrix.msc4157.update_delayed_event"]
+    
+    /// Called by the SDK on a blocking thread, once, during negotiation.
+    func acquireCapabilities(capabilities: WidgetCapabilities) -> WidgetCapabilities {
+        let stateFilters = Self.stateEventTypes.map { WidgetEventFilter.stateWithType(eventType: $0) }
+        let toDeviceFilters = Self.toDeviceEventTypes.map { WidgetEventFilter.toDevice(eventType: $0) }
+        return WidgetCapabilities(read: stateFilters + toDeviceFilters,
+                                  send: stateFilters + toDeviceFilters + Self.roomEventTypes.map { .messageLikeWithType(eventType: $0) },
+                                  requiresClient: false,
+                                  updateDelayedEvent: true,
+                                  sendDelayedEvent: true,
+                                  downloadFiles: false,
+                                  rtcTransports: false)
+    }
+}

--- a/ElementX/Sources/Services/NativeCall/Widget/WidgetJSON.swift
+++ b/ElementX/Sources/Services/NativeCall/Widget/WidgetJSON.swift
@@ -1,0 +1,28 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Foundation
+
+// Temporary: part of the widget-driver stopgap, see `WidgetDriverChannel`.
+
+/// The JSON the widget API is spoken in: untyped objects, since the messages mirror the SDK widget
+/// machine's own loosely typed envelope and only a handful of fields are ever read.
+enum WidgetJSON {
+    nonisolated static func parseObject(_ json: String) -> [String: Any]? {
+        guard let data = json.data(using: .utf8) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    }
+    
+    /// Sorted keys, deliberately: the machine's request enum is tagged on `action` with `data` as
+    /// its content, and `data` arriving first makes serde buffer it, which its raw JSON fields
+    /// cannot be read from. Alphabetical order puts `action` before `data` every time.
+    nonisolated static func serialize(_ object: [String: Any]) -> String? {
+        guard JSONSerialization.isValidJSONObject(object),
+              let data = try? JSONSerialization.data(withJSONObject: object, options: .sortedKeys) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+}

--- a/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
@@ -643,6 +643,36 @@ class JoinedRoomProxy: JoinedRoomProxyProtocol {
         }
     }
     
+    // MARK: - Native calls (MatrixRTC)
+    
+    func sendStateEventRaw(eventType: String, stateKey: String, contentJSON: String) async -> Result<String, RoomProxyError> {
+        await sdkCall("sendStateEventRaw(\(eventType))") {
+            try await room.sendStateEventRaw(eventType: eventType, stateKey: stateKey, content: contentJSON)
+        }
+    }
+    
+    func sendRaw(eventType: String, contentJSON: String) async -> Result<Void, RoomProxyError> {
+        await sdkCall("sendRaw(\(eventType))") {
+            try await room.sendRaw(eventType: eventType, content: contentJSON)
+        }
+    }
+    
+    func redact(eventID: String, reason: String?) async -> Result<Void, RoomProxyError> {
+        await sdkCall("redact") {
+            try await room.redact(eventId: eventID, reason: reason)
+        }
+    }
+    
+    /// Logs and wraps an SDK failure; the message never includes content.
+    private func sdkCall<T>(_ description: String, _ body: () async throws -> T) async -> Result<T, RoomProxyError> {
+        do {
+            return try await .success(body())
+        } catch {
+            MXLog.error("MatrixRTC: \(description) failed in \(id) with error: \(error)")
+            return .failure(.sdkError(error))
+        }
+    }
+    
     // MARK: - Permalinks
     
     func matrixToPermalink() async -> Result<URL, RoomProxyError> {

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -165,6 +165,12 @@ protocol JoinedRoomProxyProtocol: RoomProxyProtocol {
     func declineCall(notificationID: String) async -> Result<Void, RoomProxyError>
     func subscribeToCallDeclineEvents(rtcNotificationEventID: String, listener: CallDeclineListener) -> Result<TaskHandle, RoomProxyError>
     
+    // MARK: - Native calls (MatrixRTC)
+    
+    func sendStateEventRaw(eventType: String, stateKey: String, contentJSON: String) async -> Result<String, RoomProxyError>
+    func sendRaw(eventType: String, contentJSON: String) async -> Result<Void, RoomProxyError>
+    func redact(eventID: String, reason: String?) async -> Result<Void, RoomProxyError>
+    
     // MARK: - Permalinks
     
     func matrixToPermalink() async -> Result<URL, RoomProxyError>


### PR DESCRIPTION

Fourth step of the native MatrixRTC calls stack (spike: `valere/native_call`; previous: #6119).

The native call transport needs a few Rust SDK calls the proxies did not expose. `JoinedRoomProxy` gains `sendStateEventRaw` (returns the event ID), `sendRaw` and `redact`, all from raw JSON because the RTC core produces the event content. `ClientProxy` gains `requestOpenIDToken` (the token the RTC authorisation service exchanges for a LiveKit JWT) and `getURL`, an authenticated GET used by transport discovery.

Also the pieces the next PR's widget-driver bridge is built on: `MatrixRtcRoomBridgeProtocol`, the app-owned contract for what the released bindings still lack (delayed events, a room-state feed, to-device traffic); `WidgetDriverChannel` + `WidgetCapabilityGrant`, the thin layer over the SDK's `WidgetDriverHandle` and capability provider; and `WidgetJSON` for the widget envelope (sorted keys on purpose, the SDK's request enum needs `action` before `data`). These are the only files in the stack that name SDK widget types.

Mocks are regenerated. No behaviour change.

### Pull Request Checklist

- [ ] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [ ] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
