### PR TITLE
NativeCall | Bridge the SDK widget driver for MatrixRTC state and to-device traffic

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -295,6 +295,7 @@
 		2D2D8A53B35BE8D8A01449C6 /* PinnedEventsBannerStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FA38E813BE14149F173F461 /* PinnedEventsBannerStateTests.swift */; };
 		2D38D39B1789B91AE69F477F /* PhotoLibraryManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD955A0380C287C418F1A74D /* PhotoLibraryManagerMock.swift */; };
 		2D45A04699BB6BA3B3A0CB9A /* TracingHook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A95C9B8299A36A6495DECA6 /* TracingHook.swift */; };
+		2D463F34BB7EDFD3CE71321B /* WidgetMatrixBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFCE12583E705E5F31459303 /* WidgetMatrixBridgeTests.swift */; };
 		2D76463CE5A9238B5BB5F393 /* TimelineItemKeyForwarder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB6F137B69DCB59353E37B80 /* TimelineItemKeyForwarder.swift */; };
 		2DA27D78560D5F79B917E163 /* AudioConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E44E35AA87F49503E7B3BF6E /* AudioConverter.swift */; };
 		2DD9D0FE7CB5CFC80D071451 /* AppLockScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C3E67E09FE5A35D73818C39 /* AppLockScreenModels.swift */; };
@@ -573,6 +574,7 @@
 		5C02841B2A86327B2C377682 /* NotificationConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C830A64609CBD152F06E0457 /* NotificationConstants.swift */; };
 		5C33976A720B64094CBC56B1 /* VideoMediaEventsTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B1FB56520A847DD2532D5C8 /* VideoMediaEventsTimelineView.swift */; };
 		5C8804B4F25903516E2DAB81 /* RoomInfoProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A66E8BC8D9AE4A08EFB2DF /* RoomInfoProxy.swift */; };
+		5CDFAF0A860C1F71D936C2E3 /* WidgetMatrixBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10B75F0616CDDBDD385208A /* WidgetMatrixBridge.swift */; };
 		5CEA0BF496F00339A9E4486B /* TimelineItemProviderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829D3CE4F6C4DF6CC02D33C3 /* TimelineItemProviderProtocol.swift */; };
 		5D27B6537591471A42C89027 /* EmoteRoomTimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450E04B2A976CC4C8CC1807C /* EmoteRoomTimelineItem.swift */; };
 		5D52925FEB1B780C65B0529F /* PinnedEventsTimelineScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA4F6D7000EDCD187E0989E7 /* PinnedEventsTimelineScreen.swift */; };
@@ -2937,6 +2939,7 @@
 		BF8349149254469E24483FB0 /* SpaceScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceScreenViewModel.swift; sourceTree = "<group>"; };
 		BFA9EA59D5C0DA1BFC7B3621 /* QRCodeLoginScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeLoginScreen.swift; sourceTree = "<group>"; };
 		BFBF273BC2BFB9F3EEFA988B /* CollapsibleRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleRoomTimelineView.swift; sourceTree = "<group>"; };
+		BFCE12583E705E5F31459303 /* WidgetMatrixBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetMatrixBridgeTests.swift; sourceTree = "<group>"; };
 		BFDCAC6CAAD65A2C24EA9C4B /* Dictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dictionary.swift; sourceTree = "<group>"; };
 		BFEA446F8618DBA79A9239CC /* MessageForwardingScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageForwardingScreen.swift; sourceTree = "<group>"; };
 		BFEE91FB8ABB5F5884B6D940 /* WaveformInteractionModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaveformInteractionModifier.swift; sourceTree = "<group>"; };
@@ -3036,6 +3039,7 @@
 		D09020DC830A83F768DCE4C8 /* portrait_test_image.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = portrait_test_image.jpg; sourceTree = "<group>"; };
 		D09227E671DB30795C43FFFD /* KnockRequestsListScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnockRequestsListScreenViewModel.swift; sourceTree = "<group>"; };
 		D0C2D52E36AD614B3C003EF6 /* RoomTimelineItemViewState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomTimelineItemViewState.swift; sourceTree = "<group>"; };
+		D10B75F0616CDDBDD385208A /* WidgetMatrixBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetMatrixBridge.swift; sourceTree = "<group>"; };
 		D148332A613AD27E9A2896C9 /* NotificationToneManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationToneManagerTests.swift; sourceTree = "<group>"; };
 		D17F49E39CC38DAB7B305701 /* LiveLocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveLocationManager.swift; sourceTree = "<group>"; };
 		D1896F6288D80E1F3EFB3DF8 /* ka */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ka; path = ka.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
@@ -5883,6 +5887,7 @@
 			isa = PBXGroup;
 			children = (
 				9FE1A562624B61D12B172006 /* MatrixRtcCommandSenderTests.swift */,
+				BFCE12583E705E5F31459303 /* WidgetMatrixBridgeTests.swift */,
 			);
 			path = NativeCall;
 			sourceTree = "<group>";
@@ -6157,6 +6162,7 @@
 			children = (
 				ED07427D8F56675BAFC6861D /* WidgetDriverChannel.swift */,
 				66CE98F6D8750C092C3C64F6 /* WidgetJSON.swift */,
+				D10B75F0616CDDBDD385208A /* WidgetMatrixBridge.swift */,
 			);
 			path = Widget;
 			sourceTree = "<group>";
@@ -8603,6 +8609,7 @@
 				44BDD670FF9095ACE240A3A2 /* VoiceMessageMediaManagerTests.swift in Sources */,
 				A3D7110C1E75E7B4A73BE71C /* VoiceMessageRecorderTests.swift in Sources */,
 				0B9436A91CFA658202400465 /* WaitingConfirmation.swift in Sources */,
+				2D463F34BB7EDFD3CE71321B /* WidgetMatrixBridgeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -9835,6 +9842,7 @@
 				B773ACD8881DB18E876D950C /* WaveformSource.swift in Sources */,
 				F78B473DA4176E680EEB62C4 /* WidgetDriverChannel.swift in Sources */,
 				F68F5F595531235D4C4CF699 /* WidgetJSON.swift in Sources */,
+				5CDFAF0A860C1F71D936C2E3 /* WidgetMatrixBridge.swift in Sources */,
 				08CB4BD12CEEDE6AAE4A18DD /* WindowManager.swift in Sources */,
 				AE5AAD9E32511544FDFA5560 /* WindowManagerProtocol.swift in Sources */,
 			);

--- a/ElementX/Sources/Services/NativeCall/Widget/WidgetMatrixBridge.swift
+++ b/ElementX/Sources/Services/NativeCall/Widget/WidgetMatrixBridge.swift
@@ -1,0 +1,486 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Foundation
+import MatrixRtcKit
+
+// Temporary: the widget-driver stopgap. The released SDK bindings lack delayed events, a room-state
+// feed and to-device messaging, but their widget driver implements all of them for Element Call web.
+// This speaks the widget API to that driver in-process, with no web view. Delete this folder once
+// the bindings gain those entry points (delayed and delayed-state sends, delayed-event updates, a
+// room-state subscription, to-device send and subscribe with encryption info), and give
+// `MatrixRtcTransportAdapter` an SDK-backed `MatrixRtcRoomBridgeProtocol`.
+
+/// One widget driver for one room, as the RTC core's Matrix bridge.
+///
+/// Wire protocol (verified against the SDK's widget machine): every message is
+/// `{api, widgetId, requestId, action, data}`; a response echoes the request with a `response` key.
+/// With `initAfterContentLoad` off the driver opens with a `capabilities` request, calls the
+/// capabilities provider, confirms with `notify_capabilities`, then pushes the current room state.
+/// Requests sent before that are silently dropped, and the driver keeps at most 15 unanswered
+/// requests of its own, so everything it sends is answered inline.
+///
+/// State arrives as deltas (`update_state` from sync, `send_event` for timeline-borne state) while the
+/// core wants the full state on every tick. Room state is replace-only, a leave being a present `{}`
+/// event, so the latest event per state key *is* the full state and the map below re-emits it whole.
+actor WidgetMatrixBridge: MatrixRtcRoomBridgeProtocol {
+    nonisolated let roomID: String
+    
+    private enum Phase: Equatable {
+        case idle, negotiating, ready, stopped
+    }
+    
+    private struct PendingRequest {
+        let continuation: CheckedContinuation<Result<Data, MatrixRtcRoomBridgeError>, Never>
+        let timeout: Task<Void, Never>
+    }
+    
+    private let widgetID: String
+    private let runDriver: @Sendable () async -> Void
+    private let requestTimeout: Duration
+    
+    private var channel: (any WidgetDriverChannel)?
+    private var phase: Phase = .idle
+    private var negotiationWaiters = [CheckedContinuation<Result<Void, MatrixRtcRoomBridgeError>, Never>]()
+    private var negotiationTimeout: Task<Void, Never>?
+    private var pending = [String: PendingRequest]()
+    
+    /// Event type → state key → latest event: the current state of every type we receive.
+    private var state = [String: [String: MatrixRtcRoomStateEvent]]()
+    private var stateSubscribers = [UUID: (eventType: String, continuation: AsyncStream<[MatrixRtcRoomStateEvent]>.Continuation)]()
+    private var toDeviceSubscribers = [UUID: AsyncStream<MatrixRtcToDeviceMessage>.Continuation]()
+    
+    /// - Parameters:
+    ///   - channel: the driver's handle (or a fake in tests).
+    ///   - runDriver: runs the driver; must not capture the handle, or the driver never stops.
+    init(roomID: String,
+         widgetID: String,
+         channel: any WidgetDriverChannel,
+         requestTimeout: Duration = .seconds(30),
+         runDriver: @escaping @Sendable () async -> Void) {
+        self.roomID = roomID
+        self.widgetID = widgetID
+        self.channel = channel
+        self.requestTimeout = requestTimeout
+        self.runDriver = runDriver
+    }
+    
+    // MARK: - Lifecycle
+    
+    func start() async -> Result<Void, MatrixRtcRoomBridgeError> {
+        guard phase == .idle, let channel else { return .failure(.notRunning) }
+        phase = .negotiating
+        MXLog.info("WidgetBridge: starting for \(roomID)")
+        
+        let runDriver = runDriver
+        Task.detached { await runDriver() }
+        
+        // Receiving must be under way before negotiation is awaited: the driver's first request
+        // times out after 10 s.
+        Task { [weak self] in
+            while let raw = await channel.recv() {
+                guard let self, await self.handleIncoming(raw) else { return }
+            }
+            await self?.driverStopped()
+        }
+        
+        negotiationTimeout = Task { [weak self, requestTimeout] in
+            try? await Task.sleep(for: requestTimeout)
+            await self?.failNegotiation(with: .timedOut)
+        }
+        return await withCheckedContinuation { continuation in
+            negotiationWaiters.append(continuation)
+        }
+    }
+    
+    func stop() async {
+        guard phase != .stopped, let channel else { return }
+        MXLog.info("WidgetBridge: stopping for \(roomID)")
+        tearDown()
+        // The driver only stops once its handle is gone, and the pending `recv()` holds the handle:
+        // a request the machine always answers makes that `recv()` return, after which nothing
+        // receives again and the handle is released.
+        _ = await channel.send(msg: WidgetJSON.serialize(["api": "fromWidget",
+                                                          "widgetId": widgetID,
+                                                          "requestId": UUID().uuidString,
+                                                          "action": "supported_api_versions",
+                                                          "data": [String: Any]()]) ?? "")
+    }
+    
+    // MARK: - Sends
+    
+    func sendDelayedEvent(eventType: String, stateKey: String?, contentJSON: String, delayMs: UInt64) async -> Result<String, MatrixRtcRoomBridgeError> {
+        guard let content = WidgetJSON.parseObject(contentJSON) else { return .failure(.invalidResponse("content is not a JSON object")) }
+        var data: [String: Any] = ["type": eventType, "content": content, "delay": delayMs]
+        if let stateKey {
+            data["state_key"] = stateKey
+        }
+        return await request(action: "send_event", data: data).flatMap { response in
+            guard let delayID = response["delay_id"] as? String else {
+                return .failure(.invalidResponse("no delay_id in the send_event response"))
+            }
+            return .success(delayID)
+        }
+    }
+    
+    func updateDelayedEvent(delayID: String, action: MatrixRtcDelayedEventAction) async -> Result<Void, MatrixRtcRoomBridgeError> {
+        let wireAction = switch action {
+        case .cancel: "cancel"
+        case .restart: "restart"
+        }
+        return await request(action: "org.matrix.msc4157.update_delayed_event", data: ["delay_id": delayID, "action": wireAction]).map { _ in }
+    }
+    
+    func sendRoomEvent(eventType: String, contentJSON: String) async -> Result<String, MatrixRtcRoomBridgeError> {
+        guard let content = WidgetJSON.parseObject(contentJSON) else { return .failure(.invalidResponse("content is not a JSON object")) }
+        return await request(action: "send_event", data: ["type": eventType, "content": content]).flatMap { response in
+            guard let eventID = response["event_id"] as? String else {
+                return .failure(.invalidResponse("no event_id in the send_event response"))
+            }
+            return .success(eventID)
+        }
+    }
+    
+    func sendToDeviceMessage(eventType: String, messages: [String: [String: String]]) async -> Result<[String: [String]], MatrixRtcRoomBridgeError> {
+        var wireMessages = [String: [String: Any]]()
+        for (userID, devices) in messages {
+            for (deviceID, contentJSON) in devices {
+                guard let content = WidgetJSON.parseObject(contentJSON) else { return .failure(.invalidResponse("content is not a JSON object")) }
+                wireMessages[userID, default: [:]][deviceID] = content
+            }
+        }
+        return await request(action: "send_to_device", data: ["type": eventType, "messages": wireMessages]).map { response in
+            response["failures"] as? [String: [String]] ?? [:]
+        }
+    }
+    
+    // MARK: - Feeds
+    
+    nonisolated func stateEvents(eventType: String) -> AsyncStream<[MatrixRtcRoomStateEvent]> {
+        let (stream, continuation) = AsyncStream<[MatrixRtcRoomStateEvent]>.makeStream()
+        let id = UUID()
+        Task { await self.addStateSubscriber(id: id, eventType: eventType, continuation: continuation) }
+        continuation.onTermination = { _ in
+            Task { await self.removeStateSubscriber(id: id) }
+        }
+        return stream
+    }
+    
+    nonisolated func toDeviceMessages() -> AsyncStream<MatrixRtcToDeviceMessage> {
+        let (stream, continuation) = AsyncStream<MatrixRtcToDeviceMessage>.makeStream()
+        let id = UUID()
+        Task { await self.addToDeviceSubscriber(id: id, continuation: continuation) }
+        continuation.onTermination = { _ in
+            Task { await self.removeToDeviceSubscriber(id: id) }
+        }
+        return stream
+    }
+    
+    private func addStateSubscriber(id: UUID, eventType: String, continuation: AsyncStream<[MatrixRtcRoomStateEvent]>.Continuation) {
+        guard phase != .stopped else {
+            continuation.finish()
+            return
+        }
+        stateSubscribers[id] = (eventType, continuation)
+        if let current = state[eventType], !current.isEmpty {
+            continuation.yield(Array(current.values))
+        }
+    }
+    
+    private func removeStateSubscriber(id: UUID) {
+        stateSubscribers[id] = nil
+    }
+    
+    private func addToDeviceSubscriber(id: UUID, continuation: AsyncStream<MatrixRtcToDeviceMessage>.Continuation) {
+        guard phase != .stopped else {
+            continuation.finish()
+            return
+        }
+        toDeviceSubscribers[id] = continuation
+    }
+    
+    private func removeToDeviceSubscriber(id: UUID) {
+        toDeviceSubscribers[id] = nil
+    }
+    
+    // MARK: - Requests
+    
+    private func request(action: String, data: [String: Any]) async -> Result<[String: Any], MatrixRtcRoomBridgeError> {
+        guard phase == .ready, let channel else { return .failure(.notRunning) }
+        let requestID = UUID().uuidString
+        guard let message = WidgetJSON.serialize(["api": "fromWidget",
+                                                  "widgetId": widgetID,
+                                                  "requestId": requestID,
+                                                  "action": action,
+                                                  "data": data]) else {
+            return .failure(.invalidResponse("cannot encode the \(action) request"))
+        }
+        MXLog.verbose("WidgetBridge: → \(action) \(requestID)")
+        
+        let reply: Result<Data, MatrixRtcRoomBridgeError> = await withCheckedContinuation { continuation in
+            let timeout = Task { [weak self, requestTimeout] in
+                try? await Task.sleep(for: requestTimeout)
+                await self?.resume(requestID, with: .failure(.timedOut))
+            }
+            pending[requestID] = PendingRequest(continuation: continuation, timeout: timeout)
+            Task {
+                if await !channel.send(msg: message) {
+                    resume(requestID, with: .failure(.notRunning))
+                }
+            }
+        }
+        return reply.flatMap { data in
+            guard let response = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                return .failure(.invalidResponse("the \(action) response is not a JSON object"))
+            }
+            return .success(response)
+        }
+    }
+    
+    private func resume(_ requestID: String, with result: Result<Data, MatrixRtcRoomBridgeError>) {
+        guard let request = pending.removeValue(forKey: requestID) else { return }
+        request.timeout.cancel()
+        request.continuation.resume(returning: result)
+    }
+    
+    // MARK: - Incoming
+    
+    /// - Returns: whether to keep receiving.
+    private func handleIncoming(_ raw: String) async -> Bool {
+        guard phase != .stopped else { return false }
+        guard let message = WidgetJSON.parseObject(raw), message["widgetId"] as? String == widgetID else {
+            MXLog.warning("WidgetBridge: ignoring a message for another widget")
+            return true
+        }
+        let api = message["api"] as? String
+        let action = message["action"] as? String ?? ""
+        let requestID = message["requestId"] as? String ?? ""
+        
+        if api == "fromWidget", let response = message["response"] {
+            handleResponse(response, action: action, requestID: requestID)
+            return true
+        }
+        guard api == "toWidget" else { return true }
+        
+        MXLog.verbose("WidgetBridge: ← \(action) \(requestID)")
+        let data = message["data"] as? [String: Any] ?? [:]
+        var response: [String: Any] = [:]
+        switch action {
+        case "capabilities":
+            response["capabilities"] = WidgetCapabilityGrant.capabilityStrings
+        case "notify_capabilities":
+            didNegotiate(approved: data["approved"] as? [String] ?? [])
+        case "update_state":
+            var changedTypes = Set<String>()
+            for case let event as [String: Any] in data["state"] as? [Any] ?? [] {
+                if let eventType = upsert(event) {
+                    changedTypes.insert(eventType)
+                }
+            }
+            changedTypes.forEach(emitSnapshot)
+        case "send_event":
+            if data["state_key"] != nil, let eventType = upsert(data) {
+                emitSnapshot(of: eventType)
+            }
+        case "send_to_device":
+            deliverToDevice(data)
+        default:
+            break
+        }
+        
+        var echo = message
+        echo["response"] = response
+        if let channel, let encoded = WidgetJSON.serialize(echo) {
+            if await !channel.send(msg: encoded) {
+                driverStopped()
+                return false
+            }
+        }
+        return phase != .stopped
+    }
+    
+    private func handleResponse(_ response: Any, action: String, requestID: String) {
+        guard pending[requestID] != nil else {
+            // Our own stop poke, or a request that already timed out.
+            MXLog.verbose("WidgetBridge: unmatched response to \(action) \(requestID)")
+            return
+        }
+        guard let object = response as? [String: Any] else {
+            resume(requestID, with: .failure(.invalidResponse("the \(action) response is not a JSON object")))
+            return
+        }
+        if let error = object["error"] as? [String: Any] {
+            let message = error["message"] as? String ?? "unknown error"
+            let matrixError = error["matrix_api_error"] as? [String: Any]
+            let body = matrixError?["response"] as? [String: Any]
+            MXLog.warning("WidgetBridge: \(action) \(requestID) failed: \(message)")
+            resume(requestID, with: .failure(.matrixAPI(errcode: body?["errcode"] as? String,
+                                                        httpStatus: matrixError?["http_status"] as? Int,
+                                                        message: message)))
+            return
+        }
+        guard let data = try? JSONSerialization.data(withJSONObject: object) else {
+            resume(requestID, with: .failure(.invalidResponse("cannot encode the \(action) response")))
+            return
+        }
+        resume(requestID, with: .success(data))
+    }
+    
+    private func didNegotiate(approved: [String]) {
+        guard phase == .negotiating else { return }
+        MXLog.info("WidgetBridge: negotiated \(approved.count) capabilities for \(roomID)")
+        phase = .ready
+        negotiationTimeout?.cancel()
+        negotiationTimeout = nil
+        let waiters = negotiationWaiters
+        negotiationWaiters.removeAll()
+        waiters.forEach { $0.resume(returning: .success(())) }
+    }
+    
+    private func failNegotiation(with error: MatrixRtcRoomBridgeError) {
+        guard phase == .negotiating else { return }
+        MXLog.error("WidgetBridge: negotiation failed for \(roomID): \(error)")
+        tearDown()
+    }
+    
+    /// A state event arrived (initial read, sync state block or timeline): remember the latest per
+    /// state key. One batch yields one snapshot, so emitting is the caller's.
+    /// - Returns: the event type when the state changed.
+    private func upsert(_ event: [String: Any]) -> String? {
+        guard let eventType = event["type"] as? String,
+              let stateKey = event["state_key"] as? String,
+              let sender = event["sender"] as? String,
+              let content = event["content"] as? [String: Any],
+              let contentJSON = WidgetJSON.serialize(content) else {
+            MXLog.warning("WidgetBridge: ignoring a malformed state event")
+            return nil
+        }
+        let eventID = event["event_id"] as? String
+        if let eventID, state[eventType]?[stateKey]?.eventID == eventID {
+            return nil // The same change through both routes.
+        }
+        let timestamp = (event["origin_server_ts"] as? NSNumber).map { Date(timeIntervalSince1970: $0.doubleValue / 1000) }
+        state[eventType, default: [:]][stateKey] = MatrixRtcRoomStateEvent(eventID: eventID,
+                                                                           eventType: eventType,
+                                                                           stateKey: stateKey,
+                                                                           sender: sender,
+                                                                           originServerTimestamp: timestamp,
+                                                                           contentJSON: contentJSON)
+        return eventType
+    }
+    
+    /// Hands subscribers the whole current state of the type.
+    private func emitSnapshot(of eventType: String) {
+        let snapshot = Array(state[eventType, default: [:]].values)
+        guard !snapshot.isEmpty else { return }
+        for (subscribedType, continuation) in stateSubscribers.values where subscribedType == eventType {
+            continuation.yield(snapshot)
+        }
+    }
+    
+    /// The driver hands over `{type, content, sender, encrypted}` only: it has already dropped
+    /// cleartext in an encrypted room and attested the sender of an encrypted message, but reports
+    /// neither the sender's device nor whether it is cross-signed. The device is read from the key
+    /// message itself, or failing that from the sender's one live membership, and an encrypted
+    /// message is taken as cross-signed: the trust Element Call web gets through this same driver, and
+    /// a relaxation of the core's own rule for as long as the driver is the transport.
+    private func deliverToDevice(_ data: [String: Any]) {
+        guard let eventType = data["type"] as? String,
+              let sender = data["sender"] as? String,
+              let content = data["content"] as? [String: Any],
+              let contentJSON = WidgetJSON.serialize(content) else {
+            MXLog.warning("WidgetBridge: ignoring a malformed to-device message")
+            return
+        }
+        let wasEncrypted = data["encrypted"] as? Bool ?? false
+        let claimedDeviceID = Self.claimedDeviceID(in: content)
+        let deviceID = claimedDeviceID ?? membershipDeviceID(of: sender)
+        if claimedDeviceID == nil {
+            // Field names only, never values: which shape of key message the peer speaks.
+            MXLog.info("WidgetBridge: \(eventType) from \(sender) names no device (fields: \(content.keys.sorted())), inferred \(deviceID ?? "none")")
+        }
+        let message = MatrixRtcToDeviceMessage(eventType: eventType,
+                                               attestedSenderID: sender,
+                                               senderDeviceID: deviceID,
+                                               isSenderCrossSigned: wasEncrypted,
+                                               wasEncrypted: wasEncrypted,
+                                               contentJSON: contentJSON)
+        toDeviceSubscribers.values.forEach { $0.yield(message) }
+    }
+    
+    /// The device the key message claims to come from: Element Call has written it at the top level
+    /// (`device_id`) and, more recently, as `member.claimed_device_id` (matrix-js-sdk's
+    /// `EncryptionKeysToDeviceEventContent`). Claimed is the right word: nothing here verifies it against
+    /// the Olm sender device, see `deliverToDevice`.
+    private nonisolated static func claimedDeviceID(in content: [String: Any]) -> String? {
+        if let deviceID = content["device_id"] as? String {
+            return deviceID
+        }
+        let member = content["member"] as? [String: Any]
+        return (member?["claimed_device_id"] ?? member?["device_id"]) as? String
+    }
+    
+    /// The device behind the user's live call membership, when there is exactly one. Element Call's
+    /// key messages do not always name their device, while the core refuses a key whose device it
+    /// cannot match to the membership.
+    private func membershipDeviceID(of userID: String) -> String? {
+        let memberships = (state[MatrixRtcEventTypes.legacyStateMember] ?? [:]).values.filter { $0.sender == userID && $0.contentJSON != "{}" }
+        var deviceIDs = Set<String>()
+        for membership in memberships {
+            if let content = WidgetJSON.parseObject(membership.contentJSON) {
+                for case let entry as [String: Any] in content["memberships"] as? [Any] ?? [] {
+                    if let deviceID = entry["device_id"] as? String {
+                        deviceIDs.insert(deviceID)
+                    }
+                }
+            }
+            if deviceIDs.isEmpty, let deviceID = Self.deviceID(inStateKey: membership.stateKey, userID: userID) {
+                deviceIDs.insert(deviceID)
+            }
+        }
+        return deviceIDs.count == 1 ? deviceIDs.first : nil
+    }
+    
+    /// Element Call keys its membership `_{user}_{device}_m.call` (or `{user}_{device}`, or just the
+    /// user); the device is whatever follows the user ID.
+    private nonisolated static func deviceID(inStateKey stateKey: String, userID: String) -> String? {
+        var key = stateKey
+        if key.hasPrefix("_") {
+            key.removeFirst()
+        }
+        guard key.hasPrefix(userID + "_") else { return nil }
+        key.removeFirst(userID.count + 1)
+        if key.hasSuffix("_m.call") {
+            key.removeLast("_m.call".count)
+        }
+        return key.isEmpty ? nil : key
+    }
+    
+    private func driverStopped() {
+        guard phase != .stopped else { return }
+        MXLog.warning("WidgetBridge: driver stopped for \(roomID)")
+        tearDown()
+    }
+    
+    /// Fails everything in flight and closes every feed; the channel reference goes with it.
+    private func tearDown() {
+        phase = .stopped
+        negotiationTimeout?.cancel()
+        negotiationTimeout = nil
+        let waiters = negotiationWaiters
+        negotiationWaiters.removeAll()
+        waiters.forEach { $0.resume(returning: .failure(.notRunning)) }
+        for requestID in Array(pending.keys) {
+            resume(requestID, with: .failure(.notRunning))
+        }
+        stateSubscribers.values.forEach { $0.continuation.finish() }
+        stateSubscribers.removeAll()
+        toDeviceSubscribers.values.forEach { $0.finish() }
+        toDeviceSubscribers.removeAll()
+        channel = nil
+    }
+}

--- a/UnitTests/Sources/NativeCall/WidgetMatrixBridgeTests.swift
+++ b/UnitTests/Sources/NativeCall/WidgetMatrixBridgeTests.swift
@@ -1,0 +1,482 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+@testable import ElementX
+import Foundation
+import MatrixRtcKit
+import Synchronization
+import Testing
+
+/// The widget-driver stopgap's wire handling, against a fake driver pipe.
+@Suite(.timeLimit(.minutes(1)))
+struct WidgetMatrixBridgeTests {
+    private let widgetID = "widget"
+    private let channel = FakeWidgetChannel()
+    
+    private func makeBridge(requestTimeout: Duration = .seconds(5)) -> WidgetMatrixBridge {
+        WidgetMatrixBridge(roomID: "!room:example.org", widgetID: widgetID, channel: channel, requestTimeout: requestTimeout) { }
+    }
+    
+    // MARK: - Negotiation
+    
+    @Test
+    func negotiationAnswersCapabilitiesAndResolvesStart() async throws {
+        let bridge = makeBridge()
+        let start = Task { await bridge.start() }
+        
+        channel.push(toWidget(action: "capabilities", requestID: "cap"))
+        let reply = try await nextSent()
+        #expect(reply["requestId"] as? String == "cap")
+        #expect(reply["api"] as? String == "toWidget")
+        let response = try #require(reply["response"] as? [String: Any])
+        let strings = try #require(response["capabilities"] as? [String])
+        #expect(strings.contains("org.matrix.msc2762.receive.state_event:org.matrix.msc3401.call.member"))
+        #expect(strings.contains("org.matrix.msc3819.receive.to_device:io.element.call.encryption_keys"))
+        #expect(strings.contains("org.matrix.msc4157.send.delayed_event"))
+        
+        // Nothing is served before the driver confirms.
+        #expect(await bridge.sendRoomEvent(eventType: "m.reaction", contentJSON: "{}") == .failure(.notRunning))
+        
+        channel.push(toWidget(action: "notify_capabilities", requestID: "notify", data: ["requested": [], "approved": strings]))
+        let echo = try await nextSent()
+        #expect(echo["requestId"] as? String == "notify")
+        #expect((echo["response"] as? [String: Any])?.isEmpty == true)
+        
+        #expect(await start.value.failure == nil)
+    }
+    
+    @Test
+    func startFailsWhenTheDriverStopsFirst() async {
+        let bridge = makeBridge()
+        let start = Task { await bridge.start() }
+        channel.close()
+        #expect(await start.value.failure == .notRunning)
+    }
+    
+    @Test
+    func startTimesOutWithoutNegotiation() async {
+        let bridge = makeBridge(requestTimeout: .milliseconds(50))
+        #expect(await bridge.start().failure == .notRunning)
+    }
+    
+    // MARK: - Driver requests
+    
+    @Test
+    func everyDriverRequestIsEchoedOnce() async throws {
+        let bridge = try await negotiated(makeBridge())
+        for (index, action) in ["update_state", "send_event", "send_to_device", "openid_credentials", "something_new"].enumerated() {
+            channel.push(toWidget(action: action, requestID: "req\(index)", data: ["state": []]))
+            let echo = try await nextSent()
+            #expect(echo["requestId"] as? String == "req\(index)")
+            #expect(echo["action"] as? String == action)
+            #expect((echo["response"] as? [String: Any])?.isEmpty == true)
+        }
+        _ = bridge
+    }
+    
+    @Test
+    func messagesForAnotherWidgetAreIgnored() async throws {
+        let bridge = try await negotiated(makeBridge())
+        var stranger = toWidget(action: "update_state", requestID: "other", data: ["state": [stateEvent(key: "@x", eventID: "$x")]])
+        stranger["widgetId"] = "someone-else"
+        channel.push(stranger)
+        channel.push(toWidget(action: "openid_credentials", requestID: "mine"))
+        let echo = try await nextSent()
+        #expect(echo["requestId"] as? String == "mine")
+        _ = bridge
+    }
+    
+    // MARK: - State
+    
+    @Test
+    func stateDeltasBecomeFullSnapshots() async throws {
+        let bridge = try await negotiated(makeBridge())
+        var snapshots = bridge.stateEvents(eventType: "org.matrix.msc3401.call.member").makeAsyncIterator()
+        
+        channel.push(toWidget(action: "update_state", requestID: "s1", data: ["state": [stateEvent(key: "@alice", eventID: "$a1", content: ["v": 1]),
+                                                                                        stateEvent(key: "@bob", eventID: "$b1")]]))
+        _ = try await nextSent()
+        let first = try #require(await snapshots.next())
+        #expect(first.count == 2)
+        
+        // Timeline-borne state for one member replaces that member only.
+        var change = stateEvent(key: "@alice", eventID: "$a2", content: ["v": 2])
+        change["room_id"] = "!room:example.org"
+        channel.push(toWidget(action: "send_event", requestID: "s2", data: change))
+        _ = try await nextSent()
+        let second = try #require(await snapshots.next())
+        #expect(second.count == 2)
+        #expect(second.first { $0.stateKey == "@alice" }?.eventID == "$a2")
+        #expect(second.first { $0.stateKey == "@alice" }?.contentJSON == #"{"v":2}"#)
+        #expect(second.first { $0.stateKey == "@bob" }?.eventID == "$b1")
+        
+        // The same change through the other route is not a new emission; a leave is a present `{}`.
+        channel.push(toWidget(action: "update_state", requestID: "s3", data: ["state": [change]]))
+        _ = try await nextSent()
+        channel.push(toWidget(action: "update_state", requestID: "s4", data: ["state": [stateEvent(key: "@bob", eventID: "$b2", content: [:])]]))
+        _ = try await nextSent()
+        let third = try #require(await snapshots.next())
+        #expect(third.count == 2)
+        #expect(third.first { $0.stateKey == "@bob" }?.contentJSON == "{}")
+        #expect(third.first { $0.stateKey == "@bob" }?.originServerTimestamp == Date(timeIntervalSince1970: 1.7))
+    }
+    
+    @Test
+    func lateSubscriberGetsTheCurrentStateAndEmptyStateIsNeverEmitted() async throws {
+        let bridge = try await negotiated(makeBridge())
+        channel.push(toWidget(action: "update_state", requestID: "empty", data: ["state": []]))
+        _ = try await nextSent()
+        channel.push(toWidget(action: "update_state", requestID: "s1", data: ["state": [stateEvent(key: "@alice", eventID: "$a1")]]))
+        _ = try await nextSent()
+        
+        var late = bridge.stateEvents(eventType: "org.matrix.msc3401.call.member").makeAsyncIterator()
+        let snapshot = try #require(await late.next())
+        #expect(snapshot.map(\.stateKey) == ["@alice"])
+        
+        var other = bridge.stateEvents(eventType: "m.room.name").makeAsyncIterator()
+        channel.push(toWidget(action: "update_state", requestID: "s2", data: ["state": [stateEvent(key: "@bob", eventID: "$b1")]]))
+        _ = try await nextSent()
+        // Only the subscribed type is fed; the name feed stays silent.
+        let next = try #require(await late.next())
+        #expect(next.count == 2)
+        await bridge.stop()
+        #expect(await other.next() == nil)
+    }
+    
+    // MARK: - To-device
+    
+    @Test
+    func toDeviceMessagesAreTrustedWhenEncrypted() async throws {
+        let bridge = try await negotiated(makeBridge())
+        var messages = bridge.toDeviceMessages().makeAsyncIterator()
+        channel.push(toWidget(action: "send_to_device", requestID: "td", data: ["type": "io.element.call.encryption_keys",
+                                                                                "sender": "@bob:example.org",
+                                                                                "encrypted": true,
+                                                                                "content": ["device_id": "BOBDEVICE", "keys": [["index": 0, "key": "k"]]]]))
+        _ = try await nextSent()
+        let message = try #require(await messages.next())
+        #expect(message.eventType == "io.element.call.encryption_keys")
+        #expect(message.attestedSenderID == "@bob:example.org")
+        #expect(message.senderDeviceID == "BOBDEVICE")
+        #expect(message.wasEncrypted)
+        #expect(message.isSenderCrossSigned)
+        #expect(message.contentJSON.contains(#""device_id":"BOBDEVICE""#))
+        
+        // The current Element Call shape puts the device inside `member`.
+        channel.push(toWidget(action: "send_to_device", requestID: "claimed", data: ["type": "io.element.call.encryption_keys",
+                                                                                     "sender": "@bob:example.org",
+                                                                                     "encrypted": true,
+                                                                                     "content": ["member": ["id": "@bob:example.org:BOBDEVICE", "claimed_device_id": "BOBDEVICE"],
+                                                                                                 "keys": [["index": 0, "key": "k"]]]]))
+        _ = try await nextSent()
+        #expect(try #require(await messages.next()).senderDeviceID == "BOBDEVICE")
+        
+        channel.push(toWidget(action: "send_to_device", requestID: "clear", data: ["type": "io.element.call.encryption_keys",
+                                                                                   "sender": "@bob:example.org",
+                                                                                   "encrypted": false,
+                                                                                   "content": [String: Any]()]))
+        _ = try await nextSent()
+        let cleartext = try #require(await messages.next())
+        #expect(!cleartext.wasEncrypted)
+        #expect(!cleartext.isSenderCrossSigned)
+        #expect(cleartext.senderDeviceID == nil)
+    }
+    
+    @Test
+    func senderDeviceIsInferredFromTheMembershipWhenTheKeyNamesNone() async throws {
+        let bridge = try await negotiated(makeBridge())
+        var messages = bridge.toDeviceMessages().makeAsyncIterator()
+        var membership = stateEvent(key: "_@bob:example.org_BOBDEVICE_m.call", eventID: "$m", content: ["memberships": [["device_id": "BOBDEVICE", "application": "m.call"]]])
+        membership["sender"] = "@bob:example.org"
+        var bare = stateEvent(key: "_@carol:example.org_CARDEV_m.call", eventID: "$c", content: ["memberships": []])
+        bare["sender"] = "@carol:example.org"
+        channel.push(toWidget(action: "update_state", requestID: "s", data: ["state": [membership, bare]]))
+        _ = try await nextSent()
+        
+        for sender in ["@bob:example.org", "@carol:example.org", "@dave:example.org"] {
+            channel.push(toWidget(action: "send_to_device", requestID: sender, data: ["type": "io.element.call.encryption_keys",
+                                                                                      "sender": sender,
+                                                                                      "encrypted": true,
+                                                                                      "content": ["keys": [["index": 0, "key": "k"]]]]))
+            _ = try await nextSent()
+        }
+        #expect(try #require(await messages.next()).senderDeviceID == "BOBDEVICE")
+        #expect(try #require(await messages.next()).senderDeviceID == "CARDEV")
+        #expect(try #require(await messages.next()).senderDeviceID == nil)
+    }
+    
+    @Test
+    func requestsPutTheActionBeforeTheData() async throws {
+        let bridge = try await negotiated(makeBridge())
+        let send = Task { await bridge.sendRoomEvent(eventType: "m.reaction", contentJSON: "{}") }
+        let raw = try #require(await channel.nextSent())
+        let actionIndex = try #require(raw.range(of: #""action""#)?.lowerBound)
+        let dataIndex = try #require(raw.range(of: #""data""#)?.lowerBound)
+        #expect(actionIndex < dataIndex)
+        try channel.push(response(to: #require(JSONSerialization.jsonObject(with: Data(raw.utf8)) as? [String: Any]), ["event_id": "$e"]))
+        #expect(await send.value == .success("$e"))
+    }
+    
+    // MARK: - Our requests
+    
+    @Test
+    func delayedStateEventReturnsTheDelayID() async throws {
+        let bridge = try await negotiated(makeBridge())
+        let send = Task { await bridge.sendDelayedEvent(eventType: "org.matrix.msc3401.call.member", stateKey: "_@a_DEV", contentJSON: #"{"memberships":[]}"#, delayMs: 8000) }
+        let request = try await nextSent()
+        #expect(request["api"] as? String == "fromWidget")
+        #expect(request["action"] as? String == "send_event")
+        let data = try #require(request["data"] as? [String: Any])
+        #expect(data["type"] as? String == "org.matrix.msc3401.call.member")
+        #expect(data["state_key"] as? String == "_@a_DEV")
+        #expect(data["delay"] as? Int == 8000)
+        #expect((data["content"] as? [String: Any])?["memberships"] is [Any])
+        
+        channel.push(response(to: request, ["room_id": "!room:example.org", "delay_id": "syd_abc"]))
+        #expect(await send.value == .success("syd_abc"))
+    }
+    
+    @Test
+    func roomEventReturnsTheEventIDAndAnUnexpectedShapeIsAnError() async throws {
+        let bridge = try await negotiated(makeBridge())
+        let send = Task { await bridge.sendRoomEvent(eventType: "m.reaction", contentJSON: "{}") }
+        let request = try await nextSent()
+        #expect((request["data"] as? [String: Any])?["state_key"] == nil)
+        channel.push(response(to: request, ["room_id": "!room:example.org", "event_id": "$ev"]))
+        #expect(await send.value == .success("$ev"))
+        
+        let delayed = Task { await bridge.sendDelayedEvent(eventType: "m.reaction", stateKey: nil, contentJSON: "{}", delayMs: 1) }
+        let delayedRequest = try await nextSent()
+        channel.push(response(to: delayedRequest, ["room_id": "!room:example.org", "event_id": "$oops"]))
+        #expect(await delayed.value == .failure(.invalidResponse("no delay_id in the send_event response")))
+    }
+    
+    @Test
+    func updateDelayedEventSendsTheAction() async throws {
+        let bridge = try await negotiated(makeBridge())
+        let update = Task { await bridge.updateDelayedEvent(delayID: "syd", action: .restart) }
+        let request = try await nextSent()
+        #expect(request["action"] as? String == "org.matrix.msc4157.update_delayed_event")
+        #expect((request["data"] as? [String: Any])?["action"] as? String == "restart")
+        #expect((request["data"] as? [String: Any])?["delay_id"] as? String == "syd")
+        channel.push(response(to: request, [:]))
+        #expect(await update.value.failure == nil)
+    }
+    
+    @Test
+    func toDeviceSendReportsFailuresPerRecipient() async throws {
+        let bridge = try await negotiated(makeBridge())
+        let send = Task {
+            await bridge.sendToDeviceMessage(eventType: "io.element.call.encryption_keys",
+                                             messages: ["@bob:example.org": ["DEV1": #"{"k":1}"#, "DEV2": #"{"k":1}"#]])
+        }
+        let request = try await nextSent()
+        let messages = try #require((request["data"] as? [String: Any])?["messages"] as? [String: [String: [String: Any]]])
+        #expect(messages["@bob:example.org"]?["DEV1"]?["k"] as? Int == 1)
+        channel.push(response(to: request, ["failures": ["@bob:example.org": ["DEV2"]]]))
+        #expect(await send.value == .success(["@bob:example.org": ["DEV2"]]))
+        
+        let clean = Task { await bridge.sendToDeviceMessage(eventType: "t", messages: [:]) }
+        try await channel.push(response(to: nextSent(), [:]))
+        #expect(await clean.value == .success([:]))
+    }
+    
+    @Test
+    func homeserverErrorsCarryTheErrcode() async throws {
+        let bridge = try await negotiated(makeBridge())
+        let send = Task { await bridge.sendDelayedEvent(eventType: "t", stateKey: "k", contentJSON: "{}", delayMs: 1) }
+        let request = try await nextSent()
+        channel.push(response(to: request, error: ["message": "Sending delayed events has been disallowed",
+                                                   "matrix_api_error": ["http_status": 403,
+                                                                        "response": ["errcode": "M_FORBIDDEN", "error": "Sending delayed events has been disallowed"]]]))
+        #expect(await send.value == .failure(.matrixAPI(errcode: "M_FORBIDDEN", httpStatus: 403, message: "Sending delayed events has been disallowed")))
+        
+        let denied = Task { await bridge.sendRoomEvent(eventType: "t", contentJSON: "{}") }
+        try await channel.push(response(to: nextSent(), error: ["message": "Not allowed"]))
+        #expect(await denied.value == .failure(.matrixAPI(errcode: nil, httpStatus: nil, message: "Not allowed")))
+    }
+    
+    @Test
+    func unansweredRequestsTimeOut() async throws {
+        let bridge = try await negotiated(makeBridge(requestTimeout: .milliseconds(50)))
+        let send = Task { await bridge.sendRoomEvent(eventType: "t", contentJSON: "{}") }
+        _ = try await nextSent()
+        #expect(await send.value == .failure(.timedOut))
+    }
+    
+    @Test
+    func aDyingDriverFailsWhatIsInFlight() async throws {
+        let bridge = try await negotiated(makeBridge())
+        var messages = bridge.toDeviceMessages().makeAsyncIterator()
+        let send = Task { await bridge.sendRoomEvent(eventType: "t", contentJSON: "{}") }
+        _ = try await nextSent()
+        channel.close()
+        #expect(await send.value == .failure(.notRunning))
+        #expect(await messages.next() == nil)
+    }
+    
+    // MARK: - Stop
+    
+    @Test
+    func stopPokesTheDriverAndStopsServing() async throws {
+        let bridge = try await negotiated(makeBridge())
+        var snapshots = bridge.stateEvents(eventType: "org.matrix.msc3401.call.member").makeAsyncIterator()
+        await bridge.stop()
+        let poke = try await nextSent()
+        #expect(poke["action"] as? String == "supported_api_versions")
+        #expect(poke["api"] as? String == "fromWidget")
+        #expect(await snapshots.next() == nil)
+        #expect(await bridge.sendRoomEvent(eventType: "t", contentJSON: "{}") == .failure(.notRunning))
+        
+        // The poke's answer is the last thing received; the pipe is then left alone.
+        channel.push(response(to: poke, ["supported_versions": []]))
+        channel.push(toWidget(action: "update_state", requestID: "late", data: ["state": []]))
+        #expect(channel.unreadCount() == 1)
+    }
+    
+    // MARK: - Helpers
+    
+    private func negotiated(_ bridge: WidgetMatrixBridge) async throws -> WidgetMatrixBridge {
+        let start = Task { await bridge.start() }
+        channel.push(toWidget(action: "capabilities", requestID: "cap"))
+        _ = try await nextSent()
+        channel.push(toWidget(action: "notify_capabilities", requestID: "notify", data: ["requested": [], "approved": WidgetCapabilityGrant.capabilityStrings]))
+        _ = try await nextSent()
+        try #require(await start.value.failure == nil)
+        return bridge
+    }
+    
+    private func nextSent() async throws -> [String: Any] {
+        let raw = try #require(await channel.nextSent())
+        return try #require(JSONSerialization.jsonObject(with: Data(raw.utf8)) as? [String: Any])
+    }
+    
+    private func toWidget(action: String, requestID: String, data: [String: Any] = [:]) -> [String: Any] {
+        ["api": "toWidget", "widgetId": widgetID, "requestId": requestID, "action": action, "data": data]
+    }
+    
+    private func response(to request: [String: Any], _ response: [String: Any]) -> [String: Any] {
+        var message = request
+        message["response"] = response
+        return message
+    }
+    
+    private func response(to request: [String: Any], error: [String: Any]) -> [String: Any] {
+        response(to: request, ["error": error])
+    }
+    
+    private func stateEvent(key: String, eventID: String, content: [String: Any] = ["memberships": []]) -> [String: Any] {
+        ["type": "org.matrix.msc3401.call.member",
+         "state_key": key,
+         "sender": "@sender:example.org",
+         "event_id": eventID,
+         "origin_server_ts": 1700,
+         "content": content]
+    }
+}
+
+/// A driver pipe the test drives by hand: `push` is what the driver would say, `nextSent` what the bridge said.
+private final nonisolated class FakeWidgetChannel: WidgetDriverChannel, Sendable {
+    /// A queue with waiting readers; `nil` is delivered once closed.
+    private final class Pipe: Sendable {
+        private struct State {
+            var queue = [String]()
+            var waiters = [CheckedContinuation<String?, Never>]()
+            var isOpen = true
+        }
+        
+        private let state = Mutex(State())
+        
+        func write(_ message: String) {
+            let waiter = state.withLock { state -> CheckedContinuation<String?, Never>? in
+                if state.waiters.isEmpty {
+                    state.queue.append(message)
+                    return nil
+                }
+                return state.waiters.removeFirst()
+            }
+            waiter?.resume(returning: message)
+        }
+        
+        func close() {
+            let waiters = state.withLock { state in
+                state.isOpen = false
+                defer { state.waiters.removeAll() }
+                return state.waiters
+            }
+            waiters.forEach { $0.resume(returning: nil) }
+        }
+        
+        var isOpen: Bool {
+            state.withLock { $0.isOpen }
+        }
+        
+        var unreadCount: Int {
+            state.withLock { $0.queue.count }
+        }
+        
+        func read() async -> String? {
+            await withCheckedContinuation { continuation in
+                let ready = state.withLock { state -> String?? in
+                    if !state.queue.isEmpty {
+                        return .some(state.queue.removeFirst())
+                    }
+                    if !state.isOpen {
+                        return .some(nil)
+                    }
+                    state.waiters.append(continuation)
+                    return nil
+                }
+                if let ready {
+                    continuation.resume(returning: ready)
+                }
+            }
+        }
+    }
+    
+    private let toBridge = Pipe()
+    private let fromBridge = Pipe()
+    
+    func push(_ message: [String: Any]) {
+        guard let data = try? JSONSerialization.data(withJSONObject: message), let raw = String(data: data, encoding: .utf8) else {
+            fatalError("Test message is not JSON")
+        }
+        toBridge.write(raw)
+    }
+    
+    func close() {
+        toBridge.close()
+    }
+    
+    /// The next message the bridge sent.
+    func nextSent() async -> String? {
+        await fromBridge.read()
+    }
+    
+    /// Messages the bridge has not asked for; only meaningful once it stopped receiving.
+    func unreadCount() -> Int {
+        toBridge.unreadCount
+    }
+    
+    func recv() async -> String? {
+        await toBridge.read()
+    }
+    
+    func send(msg: String) async -> Bool {
+        fromBridge.write(msg)
+        return toBridge.isOpen
+    }
+}
+
+private extension Result {
+    var failure: Failure? {
+        if case .failure(let error) = self {
+            return error
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
Fifth step of the native MatrixRTC calls stack (spike: `valere/native_call`; previous: #6120).

The released Rust SDK bindings lack three things the RTC core needs: delayed events (MSC4140), a room-state feed for call member events, and to-device send/receive for media keys. Their widget driver implements all three for Element Call web, so `WidgetMatrixBridge` speaks the widget API to that driver in-process, with no web view. It negotiates a minimal capability set, answers every request the machine sends (the machine drops beyond 15 unanswered), merges the driver's state deltas (`update_state` from sync, `send_event` for timeline-borne state) into full per-type snapshots, delivers decrypted to-device keys with the device the message claims (`member.claimed_device_id`, older `device_id`, else inferred from the sender's single live membership), and maps homeserver errors so a refused delayed event reads as "not supported".

This is a stopgap by design: everything temporary lives in `Services/NativeCall/Widget/`, behind the app-owned `MatrixRtcRoomBridgeProtocol`, with a removal checklist and the trust notes in the integration feedback notes kept on the spike branch (`Components/MatrixRtcKit/FEEDBACK.md`, "Widget-driver stopgap"). Android is doing the same; write-up shared with them.

`WidgetMatrixBridgeTests` drive it through a fake channel: negotiation order and gating, echoing every request once, the snapshot merge through both doors, to-device trust and device inference, request decoding, error codes, timeouts, a dying driver and the stop poke.

No behaviour change: nothing constructs a bridge yet (the room hook comes with the transport adapter).

### Pull Request Checklist

- [ ] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [ ] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
