### PR TITLE
NativeCall | Add the Matrix transport adapter, RTC transport discovery and the native call flags

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -565,6 +565,7 @@
 		59C41313AED7566C3AC51163 /* RoomSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29A953B6C0C431DBF4DD00B4 /* RoomSummary.swift */; };
 		59F940FCBE6BC343AECEF75E /* ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E2245243369B99216C7D84E /* ImageCache.swift */; };
 		5A58C7C1837D3E5F2C3E8C8C /* SpaceScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8349149254469E24483FB0 /* SpaceScreenViewModel.swift */; };
+		5A957410069409FA933B903C /* MatrixRtcTransportAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D751F919817CD7BE132FC3 /* MatrixRtcTransportAdapterTests.swift */; };
 		5AA81A4E2D40A32A9E7F71F2 /* ShareExtensionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C3ADF21BE301D0DA48F2A7E /* ShareExtensionView.swift */; };
 		5AC5CD6D893073EE4D9A277E /* ShareExtensionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D27299A36536DBF91AE8FA6 /* ShareExtensionViewController.swift */; };
 		5AE6404C4FD4848ACCFF9EDC /* SecureBackupLogoutConfirmationScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1573D28C8A9FB6399D0EEFB /* SecureBackupLogoutConfirmationScreenCoordinator.swift */; };
@@ -612,6 +613,7 @@
 		62811275F1ED9EA55638838E /* RoomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7728AA8046D460145EAC740 /* RoomTests.swift */; };
 		6298AB0906DDD3525CD78C6B /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 0DD568A494247444A4B56031 /* Kingfisher */; };
 		62A7FC3A0191BC7181AA432B /* AudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907FA4DE17DEA1A3738EFB83 /* AudioRecorder.swift */; };
+		62C2EC71BB58DEEAD2A7407F /* ToDeviceRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8EF945AD322588BE2D3C884 /* ToDeviceRelay.swift */; };
 		62C5876C4254C58C2086F0DE /* HomeScreenContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B4B58B79A6FA250B24A1EC /* HomeScreenContent.swift */; };
 		633400018E07D2DC7175B16E /* LiveLocationShareProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA12A7F5EF5C6D0B992869ED /* LiveLocationShareProxy.swift */; };
 		633501761094E09DFBEBFFAD /* CopyTextButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B682FE2C44C5E163E7023B05 /* CopyTextButton.swift */; };
@@ -1145,6 +1147,7 @@
 		B245583C63F8F90357B87FAE /* PostHog in Frameworks */ = {isa = PBXBuildFile; productRef = CCE5BF78B125320CBF3BB834 /* PostHog */; };
 		B2F8E01ABA1BA30265B4ECBE /* RoundedCornerShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = 839E2C35DF3F9C7B54C3CE49 /* RoundedCornerShape.swift */; };
 		B2FDF69AC0C316F12142F91A /* RoomMembershipDetailsProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12B09A94C519227264A41208 /* RoomMembershipDetailsProxy.swift */; };
+		B34BEE84697F27A03AC4AB95 /* MatrixRtcTransportAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E110889C205CD3254AA10C98 /* MatrixRtcTransportAdapter.swift */; };
 		B3D652AA1654270742072FB3 /* DeveloperOptionsScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86A6F283BC574FDB96ABBB07 /* DeveloperOptionsScreenViewModel.swift */; };
 		B3D8AA9988F8A000B162DCB5 /* TombstonedAvatarImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D353E10A64172D863769BF /* TombstonedAvatarImage.swift */; };
 		B402708F8728DD0DB7C324E2 /* StartChatScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78910787F967CBC6042A101E /* StartChatScreenViewModelProtocol.swift */; };
@@ -1335,6 +1338,7 @@
 		D12F440F7973F1489F61389D /* NotificationSettingsScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F64447FF544298A6A3BEF85 /* NotificationSettingsScreenModels.swift */; };
 		D150D6E96CA6CA09FA50E13C /* LabsScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CF17EFB2833B4CE5C06E7F8 /* LabsScreenCoordinator.swift */; };
 		D16B3134A7FF4FBA0749014A /* AuthenticationClassicAppAccountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C45578F406698388B97C07 /* AuthenticationClassicAppAccountView.swift */; };
+		D17611E563589D762CE53DAE /* RTCTransportDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A0069A4D4ECBF63B2974641 /* RTCTransportDiscovery.swift */; };
 		D18B70975644C24F60656C0D /* KnockRequestProxyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07851F4EA81AA3339806A7B /* KnockRequestProxyProtocol.swift */; };
 		D19A748E95E2FAB2940570F0 /* CallScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4103AB4340F2974D690A12A /* CallScreen.swift */; };
 		D1C942421F607285C50FB792 /* SearchServiceSDKMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EF5721148A5D59B476BA976 /* SearchServiceSDKMock.swift */; };
@@ -1572,6 +1576,7 @@
 		F66BCCC825D6CA51724A94D0 /* MediaPlayerProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8A1F98AE670377B20679FF5 /* MediaPlayerProvider.swift */; };
 		F6767F17D538578B370DD805 /* TimelineItemBubbleBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE739A6836E86E3780748477 /* TimelineItemBubbleBackground.swift */; };
 		F68F5F595531235D4C4CF699 /* WidgetJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66CE98F6D8750C092C3C64F6 /* WidgetJSON.swift */; };
+		F6A9A8E634F888F2D9C0724D /* RTCTransportDiscoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C68F43D625A0D8757FABCF07 /* RTCTransportDiscoveryTests.swift */; };
 		F6BF52CB027393EE03CEC523 /* TimelineMediaPreviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C1F000589F2CEE6B03ECFAB /* TimelineMediaPreviewViewModelTests.swift */; };
 		F6C343C6D1D12B0944E5EF14 /* preview_avatar_user.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 94A561C542596126DAE211AD /* preview_avatar_user.jpg */; };
 		F6D07D834279BE17D18A33E9 /* LocationSharingScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EED6D8956E554CEDFD4FE00D /* LocationSharingScreenViewModelTests.swift */; };
@@ -1836,6 +1841,7 @@
 		094F6B21835890B470DF540C /* SpaceScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceScreenCoordinator.swift; sourceTree = "<group>"; };
 		099F2D36C141D845A445B1E6 /* EmojiProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiProviderTests.swift; sourceTree = "<group>"; };
 		09B9FCEB43FD29D422409981 /* EncryptionKeyMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptionKeyMapper.swift; sourceTree = "<group>"; };
+		0A0069A4D4ECBF63B2974641 /* RTCTransportDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RTCTransportDiscovery.swift; sourceTree = "<group>"; };
 		0A2074C0449B83D5858BD2D7 /* FrequentlyUsedEmoji.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrequentlyUsedEmoji.swift; sourceTree = "<group>"; };
 		0A3534D37BFC074DD26F2FFE /* RoomThreadListScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomThreadListScreenModels.swift; sourceTree = "<group>"; };
 		0A3E77399BD262D301451BF2 /* RoomDetailsEditScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomDetailsEditScreenCoordinator.swift; sourceTree = "<group>"; };
@@ -2743,6 +2749,7 @@
 		A04EFA0E3139C01E1CFDC93B /* GalleryRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryRoomTimelineView.swift; sourceTree = "<group>"; };
 		A057F2FDC14866C3026A89A4 /* NotificationManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManagerProtocol.swift; sourceTree = "<group>"; };
 		A07B011547B201A836C03052 /* EncryptionResetFlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptionResetFlowCoordinator.swift; sourceTree = "<group>"; };
+		A0D751F919817CD7BE132FC3 /* MatrixRtcTransportAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatrixRtcTransportAdapterTests.swift; sourceTree = "<group>"; };
 		A0E7B059E84E7E374D3322A2 /* SpaceRoomCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceRoomCell.swift; sourceTree = "<group>"; };
 		A103580EBA06155B1343EF16 /* HomeScreenKnockedCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenKnockedCell.swift; sourceTree = "<group>"; };
 		A1087DCC491CD4C027173DDA /* EmojiPickerScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiPickerScreenViewModelTests.swift; sourceTree = "<group>"; };
@@ -2979,6 +2986,7 @@
 		C5CB64E711E86270B722FAF7 /* LiveLocationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveLocationManagerTests.swift; sourceTree = "<group>"; };
 		C5F06F2F09B2EDD067DC2174 /* NotificationSettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsScreen.swift; sourceTree = "<group>"; };
 		C687844F60BFF532D49A994C /* AnalyticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsTests.swift; sourceTree = "<group>"; };
+		C68F43D625A0D8757FABCF07 /* RTCTransportDiscoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RTCTransportDiscoveryTests.swift; sourceTree = "<group>"; };
 		C6A9F49B3EE59147AF2F70BB /* SeparatorRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeparatorRoomTimelineItem.swift; sourceTree = "<group>"; };
 		C705E605EF57C19DBE86FFA1 /* PlaceholderAvatarImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceholderAvatarImage.swift; sourceTree = "<group>"; };
 		C715CFE00686DACA59D836EA /* fa */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fa; path = fa.lproj/SAS.strings; sourceTree = "<group>"; };
@@ -3091,6 +3099,7 @@
 		D879DC5515B1D42577F96C94 /* RoomSelectionScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomSelectionScreen.swift; sourceTree = "<group>"; };
 		D8AA084E10B80D64449C02A9 /* SessionVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionVerificationTests.swift; sourceTree = "<group>"; };
 		D8E60332509665C00179ACF6 /* MessageForwardingScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageForwardingScreenViewModel.swift; sourceTree = "<group>"; };
+		D8EF945AD322588BE2D3C884 /* ToDeviceRelay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDeviceRelay.swift; sourceTree = "<group>"; };
 		D8F5F9E02B1AB5350B1815E7 /* TimelineStartRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineStartRoomTimelineItem.swift; sourceTree = "<group>"; };
 		D8FC33C3F6BF597E095CE9FA /* HomeScreenInviteCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenInviteCell.swift; sourceTree = "<group>"; };
 		D93C94C30E3135BC9290DE13 /* VoiceMessageRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceMessageRecorderTests.swift; sourceTree = "<group>"; };
@@ -3132,6 +3141,7 @@
 		E0FCA0957FAA0E15A9F5579D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Untranslated.stringsdict; sourceTree = "<group>"; };
 		E0FF9CB3EFA753277291F609 /* EncryptionResetScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptionResetScreenCoordinator.swift; sourceTree = "<group>"; };
 		E10DA51DBC8C7E1460DBCCBD /* UserProfileListRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileListRow.swift; sourceTree = "<group>"; };
+		E110889C205CD3254AA10C98 /* MatrixRtcTransportAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatrixRtcTransportAdapter.swift; sourceTree = "<group>"; };
 		E157152B11E347F735C3FD6E /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = tr; path = tr.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		E1573D28C8A9FB6399D0EEFB /* SecureBackupLogoutConfirmationScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureBackupLogoutConfirmationScreenCoordinator.swift; sourceTree = "<group>"; };
 		E1714DD78BFE27ADD40A6F89 /* LinkNewDeviceScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkNewDeviceScreenViewModelTests.swift; sourceTree = "<group>"; };
@@ -4243,6 +4253,8 @@
 			children = (
 				364DFC4CB8071AB4DB1BDAB9 /* MatrixRtcLogBridge.swift */,
 				936085D12BB0094F78E1FB67 /* MatrixRtcRoomBridgeProtocol.swift */,
+				E110889C205CD3254AA10C98 /* MatrixRtcTransportAdapter.swift */,
+				0A0069A4D4ECBF63B2974641 /* RTCTransportDiscovery.swift */,
 				9964009E0A18BE38FADB062B /* Widget */,
 			);
 			path = NativeCall;
@@ -5887,6 +5899,8 @@
 			isa = PBXGroup;
 			children = (
 				9FE1A562624B61D12B172006 /* MatrixRtcCommandSenderTests.swift */,
+				A0D751F919817CD7BE132FC3 /* MatrixRtcTransportAdapterTests.swift */,
+				C68F43D625A0D8757FABCF07 /* RTCTransportDiscoveryTests.swift */,
 				BFCE12583E705E5F31459303 /* WidgetMatrixBridgeTests.swift */,
 			);
 			path = NativeCall;
@@ -6160,6 +6174,7 @@
 		9964009E0A18BE38FADB062B /* Widget */ = {
 			isa = PBXGroup;
 			children = (
+				D8EF945AD322588BE2D3C884 /* ToDeviceRelay.swift */,
 				ED07427D8F56675BAFC6861D /* WidgetDriverChannel.swift */,
 				66CE98F6D8750C092C3C64F6 /* WidgetJSON.swift */,
 				D10B75F0616CDDBDD385208A /* WidgetMatrixBridge.swift */,
@@ -8517,6 +8532,7 @@
 				3BEBDCB42BABFA3B456FECA7 /* MapTilerURLBuilderTests.swift in Sources */,
 				2E43A3D221BE9587BC19C3F1 /* MatrixEntityRegexTests.swift in Sources */,
 				43E995A6880155C00DFE7DBF /* MatrixRtcCommandSenderTests.swift in Sources */,
+				5A957410069409FA933B903C /* MatrixRtcTransportAdapterTests.swift in Sources */,
 				7070E5CA0095CBEFAA7DE466 /* MediaEventsTimelineScreenViewModelTests.swift in Sources */,
 				4B978C09567387EF4366BD7A /* MediaLoaderTests.swift in Sources */,
 				3582056513A384F110EC8274 /* MediaPlayerProviderTests.swift in Sources */,
@@ -8546,6 +8562,7 @@
 				8B6ED1393F94AEEFAE74C8BB /* PresenceServiceTests.swift in Sources */,
 				E3EBC3BF7CE3960B41757BAA /* Publisher.swift in Sources */,
 				BDC4EB54CC3036730475CB8B /* QRCodeLoginScreenViewModelTests.swift in Sources */,
+				F6A9A8E634F888F2D9C0724D /* RTCTransportDiscoveryTests.swift in Sources */,
 				522269133E6F65F68482F4F4 /* RemotePreferenceTests.swift in Sources */,
 				EC09E502A21E4EAA8B367AB8 /* ReportContentScreenViewModelTests.swift in Sources */,
 				513AF15E0E84711B80D04B1B /* ReportRoomScreenViewModelTests.swift in Sources */,
@@ -9204,6 +9221,7 @@
 				67C05C50AD734283374605E3 /* MatrixEntityRegex.swift in Sources */,
 				8D1B84634C0074690175F3FC /* MatrixRtcLogBridge.swift in Sources */,
 				EC236C92F6FA50062273AEE1 /* MatrixRtcRoomBridgeProtocol.swift in Sources */,
+				B34BEE84697F27A03AC4AB95 /* MatrixRtcTransportAdapter.swift in Sources */,
 				8658F5034EAD7357CE7F9AC7 /* MatrixUserShareLink.swift in Sources */,
 				84E514915DF0C168B08A3A0A /* MediaEventsTimelineFlowCoordinator.swift in Sources */,
 				BEC6DFEA506085D3027E353C /* MediaEventsTimelineScreen.swift in Sources */,
@@ -9352,6 +9370,7 @@
 				30E5628F74AD3C27A061BF25 /* QRCodeLoginScreenViewModel.swift in Sources */,
 				E9D2ED1C4186931E3D5FDA4E /* QRCodeLoginScreenViewModelProtocol.swift in Sources */,
 				FDD5B4B616D9FF4DE3E9A418 /* QRCodeScannerView.swift in Sources */,
+				D17611E563589D762CE53DAE /* RTCTransportDiscovery.swift in Sources */,
 				C292A8DA07E6DBD66E946383 /* RageshakeConfiguration.swift in Sources */,
 				C9A631FD968249B4BA0B7B3C /* ReactionsSummaryView.swift in Sources */,
 				743790BF6A5B0577EA74AF14 /* ReadMarkerRoomTimelineItem.swift in Sources */,
@@ -9750,6 +9769,7 @@
 				67EFF46180B939CBF389AECD /* TimelineView.swift in Sources */,
 				98EE4259A4A49BC757BA442C /* TimelineViewModel.swift in Sources */,
 				F8B2F5CBCF2A0E0798E8D646 /* TimelineViewModelProtocol.swift in Sources */,
+				62C2EC71BB58DEEAD2A7407F /* ToDeviceRelay.swift in Sources */,
 				B3D8AA9988F8A000B162DCB5 /* TombstonedAvatarImage.swift in Sources */,
 				66C48B5B35C861C2089DBB12 /* ToolbarButton.swift in Sources */,
 				1AF4A82B4332CAD2DB3EB5DA /* TopBannerModifier.swift in Sources */,

--- a/ElementX/Sources/Application/Settings/AppSettings.swift
+++ b/ElementX/Sources/Application/Settings/AppSettings.swift
@@ -449,6 +449,14 @@ final nonisolated class AppSettings: @unchecked Sendable {
     @UserPreference(defaultValue: AppBuildType.current != .release)
     var developerOptionsEnabled: Bool
     
+    /// Runs calls through the native matrix-rust-rtc stack instead of the Element Call web view.
+    @UserPreference(defaultValue: false)
+    var nativeCallEnabled: Bool
+    
+    /// Shows minimized native video calls in the system Picture in Picture window.
+    @UserPreference(defaultValue: true)
+    var nativeCallPictureInPictureEnabled: Bool
+    
     init(store: UserDefaultsProtocol) {
         self.store = store
     }

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -6964,6 +6964,34 @@ nonisolated class JoinedRoomProxyMock: JoinedRoomProxyProtocol, @unchecked Senda
             return redactEventIDReasonReturnValue
         }
     }
+    //MARK: - matrixRtcRoomBridge
+
+    private let matrixRtcRoomBridgeCallsCountLock = NSLock()
+    private nonisolated(unsafe) var matrixRtcRoomBridgeUnderlyingCallsCount = 0
+    var matrixRtcRoomBridgeCallsCount: Int {
+        get { matrixRtcRoomBridgeCallsCountLock.withLock { matrixRtcRoomBridgeUnderlyingCallsCount } }
+        set { matrixRtcRoomBridgeCallsCountLock.withLock { matrixRtcRoomBridgeUnderlyingCallsCount = newValue } }
+    }
+    var matrixRtcRoomBridgeCalled: Bool {
+        return matrixRtcRoomBridgeCallsCount > 0
+    }
+
+    private let matrixRtcRoomBridgeReturnValueLock = NSLock()
+    private nonisolated(unsafe) var matrixRtcRoomBridgeUnderlyingReturnValue: MatrixRtcRoomBridgeProtocol?
+    var matrixRtcRoomBridgeReturnValue: MatrixRtcRoomBridgeProtocol? {
+        get { matrixRtcRoomBridgeReturnValueLock.withLock { matrixRtcRoomBridgeUnderlyingReturnValue } }
+        set { matrixRtcRoomBridgeReturnValueLock.withLock { matrixRtcRoomBridgeUnderlyingReturnValue = newValue } }
+    }
+    nonisolated(unsafe) var matrixRtcRoomBridgeClosure: (() -> MatrixRtcRoomBridgeProtocol?)?
+
+    func matrixRtcRoomBridge() -> MatrixRtcRoomBridgeProtocol? {
+        matrixRtcRoomBridgeCallsCountLock.withLock { matrixRtcRoomBridgeUnderlyingCallsCount += 1 }
+        if let matrixRtcRoomBridgeClosure = matrixRtcRoomBridgeClosure {
+            return matrixRtcRoomBridgeClosure()
+        } else {
+            return matrixRtcRoomBridgeReturnValue
+        }
+    }
     //MARK: - matrixToPermalink
 
     private let matrixToPermalinkCallsCountLock = NSLock()

--- a/ElementX/Sources/Mocks/JoinedRoomProxyMock.swift
+++ b/ElementX/Sources/Mocks/JoinedRoomProxyMock.swift
@@ -126,6 +126,7 @@ extension JoinedRoomProxyMock {
         widgetDriver.startBaseURLClientIDColorSchemeVoiceOnlyRageshakeURLAnalyticsConfigurationReturnValue = .success(url)
         
         elementCallWidgetDriverDeviceIDReturnValue = widgetDriver
+        matrixRtcRoomBridgeReturnValue = nil
         
         matrixToPermalinkReturnValue = .success(.homeDirectory)
         matrixToEventPermalinkReturnValue = .success(.homeDirectory)

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
@@ -72,6 +72,9 @@ protocol DeveloperOptionsProtocol: AnyObject {
     var linkNewDeviceEnabled: Bool { get set }
     
     var globalSearchEnabled: Bool { get set }
+    
+    var nativeCallEnabled: Bool { get set }
+    var nativeCallPictureInPictureEnabled: Bool { get set }
 }
 
 extension AppSettings: DeveloperOptionsProtocol { }

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
@@ -125,6 +125,22 @@ struct DeveloperOptionsScreen: View {
                     }
             }
             
+            Section {
+                Toggle(isOn: $context.nativeCallEnabled) {
+                    Text("Native calls")
+                    Text("Uses the matrix-rust-rtc stack instead of the Element Call web view.")
+                }
+                
+                Toggle(isOn: $context.nativeCallPictureInPictureEnabled) {
+                    Text("Picture in Picture")
+                    Text("Minimized video calls use the system window; off, they use the bar.")
+                }
+            } header: {
+                Text("Native call")
+            } footer: {
+                Text("Experimental. Joins in Element Call state-event compatibility mode for interop with Element Web.")
+            }
+            
             Section("Notifications") {
                 Toggle(isOn: $context.hideQuietNotificationAlerts) {
                     Text("Hide quiet alerts")

--- a/ElementX/Sources/Services/NativeCall/MatrixRtcTransportAdapter.swift
+++ b/ElementX/Sources/Services/NativeCall/MatrixRtcTransportAdapter.swift
@@ -1,0 +1,291 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Combine
+import Foundation
+import MatrixRtcKit
+import MatrixRustSDK
+
+/// The Matrix side of the RTC core, over the app's SDK proxies. The only place where the RTC
+/// framework meets `MatrixRustSDK` types (through the proxies' Swift wrappers).
+///
+/// What the released bindings do not expose yet (delayed events, the room-state feed, to-device
+/// messaging, room event IDs) goes through a per-room `MatrixRtcRoomBridgeProtocol`, opened in
+/// `willJoinRoom` and closed in `didLeaveRoom`.
+///
+/// Main-actor bound like the proxies it wraps; the core awaits every send, and the feeds hop onto
+/// the main actor inside their streams.
+@MainActor
+final class MatrixRtcTransportAdapter: MatrixRtcMatrixTransport {
+    nonisolated let userID: String
+    nonisolated let deviceID: String
+    
+    private let clientProxy: ClientProxyProtocol
+    private var bridges = [String: any MatrixRtcRoomBridgeProtocol]()
+    private var toDeviceForwarders = [String: Task<Void, Never>]()
+    /// The core subscribes once per session; bridges come and go with calls.
+    private nonisolated let toDeviceRelay = ToDeviceRelay()
+    
+    init?(clientProxy: ClientProxyProtocol) {
+        guard let deviceID = clientProxy.deviceID else { return nil }
+        self.clientProxy = clientProxy
+        userID = clientProxy.userID
+        self.deviceID = deviceID
+    }
+    
+    // MARK: - Lifecycle
+    
+    nonisolated func willJoinRoom(roomID: String) async throws {
+        try await onMain { adapter in
+            guard adapter.bridges[roomID] == nil else { return }
+            guard let bridge = try await adapter.room(roomID).matrixRtcRoomBridge() else {
+                throw MatrixRtcTransportError.failed("Cannot open a Matrix bridge for \(roomID)")
+            }
+            if case .failure(let error) = await bridge.start() {
+                throw error.transportError
+            }
+            adapter.bridges[roomID] = bridge
+            adapter.toDeviceForwarders[roomID] = Task { [toDeviceRelay = adapter.toDeviceRelay] in
+                for await message in bridge.toDeviceMessages() {
+                    toDeviceRelay.publish(message)
+                }
+            }
+        }
+    }
+    
+    nonisolated func didLeaveRoom(roomID: String) async {
+        let bridge = await Task { @MainActor in
+            toDeviceForwarders.removeValue(forKey: roomID)?.cancel()
+            return bridges.removeValue(forKey: roomID)
+        }.value
+        await bridge?.stop()
+    }
+    
+    // MARK: - Sends
+    
+    // Every witness is nonisolated (async protocol requirements run on the caller), so each hops
+    // onto the main actor where the proxies live.
+    
+    nonisolated func sendStateEvent(roomID: String, eventType: String, stateKey: String, contentJSON: String) async throws -> String {
+        try await onMain { try await $0.room(roomID).sendStateEventRaw(eventType: eventType, stateKey: stateKey, contentJSON: contentJSON).mapTransportError() }
+    }
+    
+    /// Sticky events (MSC4354) need bindings the released SDK lacks; only the state-event compat
+    /// mode is joined for now, which never sends one.
+    nonisolated func sendStickyEvent(roomID: String, eventType: String, contentJSON: String, durationMs: UInt64) async throws -> String {
+        throw MatrixRtcTransportError.notSupported("Sticky events are not available with the released SDK")
+    }
+    
+    nonisolated func sendDelayedEvent(roomID: String, eventType: String, contentJSON: String, delayMs: UInt64) async throws -> String {
+        try await bridge(roomID).sendDelayedEvent(eventType: eventType, stateKey: nil, contentJSON: contentJSON, delayMs: delayMs).mapTransportError()
+    }
+    
+    nonisolated func sendDelayedStateEvent(roomID: String, eventType: String, stateKey: String, contentJSON: String, delayMs: UInt64) async throws -> String {
+        try await bridge(roomID).sendDelayedEvent(eventType: eventType, stateKey: stateKey, contentJSON: contentJSON, delayMs: delayMs).mapTransportError()
+    }
+    
+    nonisolated func updateDelayedEvent(roomID: String, delayID: String, action: MatrixRtcDelayedEventAction) async throws {
+        try await bridge(roomID).updateDelayedEvent(delayID: delayID, action: action).mapTransportError()
+    }
+    
+    /// The core does not say which room the keys are for, and neither does the bridge need to: it
+    /// encrypts whenever its room is encrypted. Only one call runs at a time.
+    nonisolated func sendToDeviceMessage(eventType: String, messages: [String: [String: String]]) async throws -> [String: [String]] {
+        let bridge = try await onMain { adapter -> any MatrixRtcRoomBridgeProtocol in
+            if adapter.bridges.count > 1 {
+                MXLog.warning("MatrixRTC: \(adapter.bridges.count) live bridges, sending to-device through the first")
+            }
+            guard let bridge = adapter.bridges.values.first else {
+                throw MatrixRtcTransportError.failed("No live call to send to-device messages through")
+            }
+            return bridge
+        }
+        return try await bridge.sendToDeviceMessage(eventType: eventType, messages: messages).mapTransportError()
+    }
+    
+    /// Through the bridge when the room has one, which reports the event ID; the SDK's own `sendRaw`
+    /// returns nothing, so the fallback answers an empty string.
+    nonisolated func sendRoomEvent(roomID: String, eventType: String, contentJSON: String) async throws -> String {
+        if let bridge = await liveBridge(roomID) {
+            return try await bridge.sendRoomEvent(eventType: eventType, contentJSON: contentJSON).mapTransportError()
+        }
+        try await onMain { try await $0.room(roomID).sendRaw(eventType: eventType, contentJSON: contentJSON).mapTransportError() }
+        return ""
+    }
+    
+    nonisolated func redactEvent(roomID: String, eventID: String, reason: String?) async throws {
+        try await onMain { try await $0.room(roomID).redact(eventID: eventID, reason: reason).mapTransportError() }
+    }
+    
+    nonisolated func requestOpenIDToken() async throws -> MatrixRtcOpenIDToken {
+        let token = try await onMain { try await $0.clientProxy.requestOpenIDToken().mapTransportError() }
+        return MatrixRtcOpenIDToken(accessToken: token.accessToken,
+                                    tokenType: token.tokenType,
+                                    matrixServerName: token.matrixServerName,
+                                    expiresIn: token.expiresIn)
+    }
+    
+    // MARK: - Feeds
+    
+    nonisolated func toDeviceMessages(eventTypes: [String]) -> AsyncStream<MatrixRtcToDeviceMessage> {
+        toDeviceRelay.subscribe(eventTypes: eventTypes)
+    }
+    
+    nonisolated func roomStateEvents(roomID: String, eventType: String) -> AsyncStream<[MatrixRtcRoomStateEvent]> {
+        AsyncStream { continuation in
+            let task = Task {
+                guard let bridge = await liveBridge(roomID) else {
+                    MXLog.error("MatrixRTC: no bridge for \(roomID), the state feed stays empty")
+                    continuation.finish()
+                    return
+                }
+                for await events in bridge.stateEvents(eventType: eventType) {
+                    continuation.yield(events)
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+    
+    nonisolated func joinedMemberIDs(roomID: String) -> AsyncStream<[String]> {
+        AsyncStream { continuation in
+            let task = Task { @MainActor in
+                guard let room = try? await self.room(roomID) else {
+                    continuation.finish()
+                    return
+                }
+                // The publisher stays empty until an explicit update; without it nobody would ever be fed.
+                await room.updateMembers()
+                for await members in room.membersPublisher.values {
+                    let joined = members.filter { $0.membership == .join }.map(\.userID)
+                    if !joined.isEmpty {
+                        continuation.yield(joined)
+                    }
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+    
+    nonisolated func isRoomEncrypted(roomID: String) async -> Bool {
+        await Task { @MainActor in
+            guard let room = try? await self.room(roomID) else { return false }
+            return room.infoPublisher.value.isEncrypted
+        }.value
+    }
+    
+    // MARK: - Private
+    
+    private nonisolated func onMain<T: Sendable>(_ body: @escaping @MainActor (MatrixRtcTransportAdapter) async throws -> T) async throws -> T {
+        try await Task { @MainActor in try await body(self) }.value
+    }
+    
+    private nonisolated func liveBridge(_ roomID: String) async -> (any MatrixRtcRoomBridgeProtocol)? {
+        await Task { @MainActor in bridges[roomID] }.value
+    }
+    
+    private nonisolated func bridge(_ roomID: String) async throws -> any MatrixRtcRoomBridgeProtocol {
+        guard let bridge = await liveBridge(roomID) else {
+            throw MatrixRtcTransportError.failed("No live bridge for \(roomID)")
+        }
+        return bridge
+    }
+    
+    private func room(_ roomID: String) async throws -> JoinedRoomProxyProtocol {
+        guard case .joined(let room) = await clientProxy.roomForIdentifier(roomID) else {
+            throw MatrixRtcTransportError.failed("Not joined to \(roomID)")
+        }
+        return room
+    }
+}
+
+// MARK: - Error mapping
+
+nonisolated extension MatrixRtcRoomBridgeError {
+    /// A permanent refusal retires the feature for the session; anything else is retried. 404
+    /// `M_UNRECOGNIZED` means the homeserver doesn't implement the endpoint; matrix.org answers 403
+    /// "Sending delayed events has been disallowed", which the message alone separates from a
+    /// genuine power-level rejection that would clear the moment our power level changed.
+    var transportError: MatrixRtcTransportError {
+        switch self {
+        case .matrixAPI(let errcode, _, let message):
+            if errcode == "M_UNRECOGNIZED" {
+                return .notSupported(message)
+            }
+            if errcode == "M_FORBIDDEN", message.localizedCaseInsensitiveContains("delayed event") {
+                return .notSupported(message)
+            }
+            return .failed(message)
+        case .notRunning, .timedOut, .invalidResponse:
+            return .failed("\(self)")
+        }
+    }
+}
+
+private nonisolated extension Result where Failure == MatrixRtcRoomBridgeError {
+    func mapTransportError() throws -> Success {
+        switch self {
+        case .success(let value): return value
+        case .failure(let error): throw error.transportError
+        }
+    }
+}
+
+private nonisolated extension Result where Failure == RoomProxyError {
+    func mapTransportError() throws -> Success {
+        switch self {
+        case .success(let value): return value
+        case .failure(let error): throw error.transportError
+        }
+    }
+}
+
+private nonisolated extension Result where Failure == ClientProxyError {
+    func mapTransportError() throws -> Success {
+        switch self {
+        case .success(let value): return value
+        case .failure(let error): throw error.transportError
+        }
+    }
+}
+
+private nonisolated extension RoomProxyError {
+    var transportError: MatrixRtcTransportError {
+        if case .sdkError(let error) = self {
+            return error.transportError
+        }
+        return .failed("\(self)")
+    }
+}
+
+private nonisolated extension ClientProxyError {
+    var transportError: MatrixRtcTransportError {
+        if case .sdkError(let error) = self {
+            return error.transportError
+        }
+        return .failed("\(self)")
+    }
+}
+
+private nonisolated extension Error {
+    /// Same classification as `MatrixRtcRoomBridgeError.transportError`, for the proxy paths.
+    var transportError: MatrixRtcTransportError {
+        if let clientError = self as? ClientError, case .MatrixApi(let kind, _, let message, _) = clientError {
+            switch kind {
+            case .unrecognized:
+                return .notSupported(message)
+            case .forbidden where message.localizedCaseInsensitiveContains("delayed event"):
+                return .notSupported(message)
+            default:
+                break
+            }
+        }
+        return .failed("\(self)")
+    }
+}

--- a/ElementX/Sources/Services/NativeCall/RTCTransportDiscovery.swift
+++ b/ElementX/Sources/Services/NativeCall/RTCTransportDiscovery.swift
@@ -1,0 +1,85 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Foundation
+import MatrixRtcKit
+
+/// Finds out which RTC transports the homeserver offers.
+///
+/// Two sources, in order: the MSC4143 discovery endpoint (still unstable-only in ruma), then the
+/// deprecated `rtc_foci` list in the well-known for servers that answer 404 — matrix.org is one.
+/// The Rust SDK does exactly this in `Client::discover_rtc_transports`, with caching, but only
+/// exposes a boolean over the FFI; replace this with a call through once the list is exposed.
+nonisolated struct RTCTransportDiscovery {
+    static let transportsPath = "/_matrix/client/unstable/org.matrix.msc4143/rtc/transports"
+    static let wellKnownPath = "/.well-known/matrix/client"
+    static let transportsKey = "rtc_transports"
+    static let rtcFociKey = "org.matrix.msc4143.rtc_foci"
+    static let rtcFociKeyAlias = "m.rtc_foci"
+    
+    let homeserverURL: String
+    let serverName: String?
+    /// An authenticated GET; the SDK's `getUrl`.
+    let fetch: (String) async throws -> Data
+    
+    func discover() async -> [MatrixRtcTransport] {
+        if let transports = await fromEndpoint() {
+            return transports
+        }
+        return await fromWellKnown()
+    }
+    
+    /// - Returns: nil when the endpoint is unavailable, in which case fall back.
+    private func fromEndpoint() async -> [MatrixRtcTransport]? {
+        let url = homeserverURL.trimmingCharacters(in: CharacterSet(charactersIn: "/")) + Self.transportsPath
+        do {
+            let body = try await fetch(url)
+            let transports = Self.parseTransports(body, key: Self.transportsKey)
+            MXLog.info("MatrixRTC: discovery endpoint advertises \(transports)")
+            return transports
+        } catch {
+            MXLog.info("MatrixRTC: discovery endpoint unavailable (\(error)), falling back to well-known")
+            return nil
+        }
+    }
+    
+    private func fromWellKnown() async -> [MatrixRtcTransport] {
+        guard let serverName else {
+            MXLog.warning("MatrixRTC: no server name for the well-known lookup")
+            return []
+        }
+        // Well-known is served from the server name, usually not the homeserver URL.
+        let url = "https://\(serverName)\(Self.wellKnownPath)"
+        do {
+            let body = try await fetch(url)
+            var transports = Self.parseTransports(body, key: Self.rtcFociKey)
+            if transports.isEmpty {
+                transports = Self.parseTransports(body, key: Self.rtcFociKeyAlias)
+            }
+            MXLog.info("MatrixRTC: well-known advertises \(transports)")
+            return transports
+        } catch {
+            MXLog.warning("MatrixRTC: cannot read well-known from \(url): \(error)")
+            return []
+        }
+    }
+    
+    static func parseTransports(_ body: Data, key: String) -> [MatrixRtcTransport] {
+        guard let root = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
+              let transports = root[key] as? [[String: Any]] else {
+            return []
+        }
+        return transports.compactMap { transport in
+            guard let type = transport["type"] as? String else { return nil }
+            if type == "livekit" {
+                guard let urlString = transport["livekit_service_url"] as? String, let url = URL(string: urlString) else { return nil }
+                return .liveKit(serviceURL: url)
+            }
+            return .unsupported(type: type)
+        }
+    }
+}

--- a/ElementX/Sources/Services/NativeCall/Widget/ToDeviceRelay.swift
+++ b/ElementX/Sources/Services/NativeCall/Widget/ToDeviceRelay.swift
@@ -1,0 +1,44 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Foundation
+import MatrixRtcKit
+import Synchronization
+
+// Temporary: part of the widget-driver stopgap. Only needed because a widget driver is per room
+// and per call while the core subscribes to to-device messages once per Matrix session; it goes
+// with the bridge once the SDK exposes to-device messaging directly.
+
+/// Fans to-device messages from whichever room bridges are live into session-long streams.
+final nonisolated class ToDeviceRelay: Sendable {
+    private struct Subscriber {
+        let eventTypes: Set<String>
+        let continuation: AsyncStream<MatrixRtcToDeviceMessage>.Continuation
+    }
+    
+    private let subscribers = Mutex<[UUID: Subscriber]>([:])
+    
+    /// Messages of the given types for as long as the stream is iterated, whichever bridge delivers them.
+    func subscribe(eventTypes: [String]) -> AsyncStream<MatrixRtcToDeviceMessage> {
+        let (stream, continuation) = AsyncStream<MatrixRtcToDeviceMessage>.makeStream()
+        let id = UUID()
+        subscribers.withLock { $0[id] = Subscriber(eventTypes: Set(eventTypes), continuation: continuation) }
+        continuation.onTermination = { [weak self] _ in
+            self?.subscribers.withLock { _ = $0.removeValue(forKey: id) }
+        }
+        return stream
+    }
+    
+    func publish(_ message: MatrixRtcToDeviceMessage) {
+        let continuations = subscribers.withLock { subscribers in
+            subscribers.values.filter { $0.eventTypes.contains(message.eventType) }.map(\.continuation)
+        }
+        for continuation in continuations {
+            continuation.yield(message)
+        }
+    }
+}

--- a/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/JoinedRoomProxy.swift
@@ -663,6 +663,30 @@ class JoinedRoomProxy: JoinedRoomProxyProtocol {
         }
     }
     
+    /// Temporary: drives the SDK widget driver in-process as the bridge for bindings the released
+    /// package lacks (delayed events, a room-state feed, to-device messaging). The driver needs the
+    /// concrete `Room`.
+    func matrixRtcRoomBridge() -> MatrixRtcRoomBridgeProtocol? {
+        guard let room = room as? Room else { return nil }
+        let widgetID = UUID().uuidString
+        // Negotiation starts at `run()` rather than on a `content_loaded` no web view will send; the
+        // URL only has to parse, nothing loads it.
+        let settings = WidgetSettings(widgetId: widgetID, initAfterContentLoad: false, rawUrl: "https://call.element.io/")
+        let driverAndHandle: WidgetDriverAndHandle
+        do {
+            driverAndHandle = try makeWidgetDriver(settings: settings)
+        } catch {
+            MXLog.error("MatrixRTC: cannot make a widget driver for \(id): \(error)")
+            return nil
+        }
+        // The closure must not hold the handle: the driver only stops once the handle is released.
+        let driver = driverAndHandle.driver
+        let grant = WidgetCapabilityGrant()
+        return WidgetMatrixBridge(roomID: id, widgetID: widgetID, channel: driverAndHandle.handle) {
+            await driver.run(room: room, capabilitiesProvider: grant)
+        }
+    }
+    
     /// Logs and wraps an SDK failure; the message never includes content.
     private func sdkCall<T>(_ description: String, _ body: () async throws -> T) async -> Result<T, RoomProxyError> {
         do {

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -170,6 +170,9 @@ protocol JoinedRoomProxyProtocol: RoomProxyProtocol {
     func sendStateEventRaw(eventType: String, stateKey: String, contentJSON: String) async -> Result<String, RoomProxyError>
     func sendRaw(eventType: String, contentJSON: String) async -> Result<Void, RoomProxyError>
     func redact(eventID: String, reason: String?) async -> Result<Void, RoomProxyError>
+    /// The stand-in for the SDK bindings the native call stack still lacks (delayed events, state
+    /// feed, to-device), or nil when the room cannot host one.
+    func matrixRtcRoomBridge() -> MatrixRtcRoomBridgeProtocol?
     
     // MARK: - Permalinks
     

--- a/UnitTests/Sources/NativeCall/MatrixRtcTransportAdapterTests.swift
+++ b/UnitTests/Sources/NativeCall/MatrixRtcTransportAdapterTests.swift
@@ -1,0 +1,56 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+@testable import ElementX
+import Foundation
+import MatrixRtcKit
+import Testing
+
+/// The parts of the transport adapter that survive the widget-driver stopgap: how bridge failures are
+/// classified for the core, and the session-long to-device relay.
+@Suite(.timeLimit(.minutes(1)))
+struct MatrixRtcTransportAdapterTests {
+    @Test
+    func permanentRefusalsRetireTheFeature() {
+        #expect(MatrixRtcRoomBridgeError.matrixAPI(errcode: "M_UNRECOGNIZED", httpStatus: 404, message: "Unrecognized request").transportError
+            == .notSupported("Unrecognized request"))
+        #expect(MatrixRtcRoomBridgeError.matrixAPI(errcode: "M_FORBIDDEN", httpStatus: 403, message: "Sending delayed events has been disallowed").transportError
+            == .notSupported("Sending delayed events has been disallowed"))
+    }
+    
+    @Test
+    func everythingElseIsRetried() {
+        #expect(MatrixRtcRoomBridgeError.matrixAPI(errcode: "M_FORBIDDEN", httpStatus: 403, message: "You don't have permission").transportError
+            == .failed("You don't have permission"))
+        #expect(MatrixRtcRoomBridgeError.matrixAPI(errcode: "M_LIMIT_EXCEEDED", httpStatus: 429, message: "Too many requests").transportError
+            == .failed("Too many requests"))
+        #expect(MatrixRtcRoomBridgeError.timedOut.transportError == .failed("timedOut"))
+        #expect(MatrixRtcRoomBridgeError.notRunning.transportError == .failed("notRunning"))
+    }
+    
+    @Test
+    func relayFansInByEventTypeUntilUnsubscribed() async throws {
+        let relay = ToDeviceRelay()
+        var keys = relay.subscribe(eventTypes: ["io.element.call.encryption_keys"]).makeAsyncIterator()
+        var both = relay.subscribe(eventTypes: ["io.element.call.encryption_keys", "org.matrix.msc4143.rtc.encryption_key"]).makeAsyncIterator()
+        
+        relay.publish(message(type: "org.matrix.msc4143.rtc.encryption_key", sender: "@a:example.org"))
+        relay.publish(message(type: "io.element.call.encryption_keys", sender: "@b:example.org"))
+        
+        #expect(try #require(await keys.next()).attestedSenderID == "@b:example.org")
+        #expect(try #require(await both.next()).attestedSenderID == "@a:example.org")
+        #expect(try #require(await both.next()).attestedSenderID == "@b:example.org")
+        
+        relay.publish(message(type: "m.other", sender: "@c:example.org"))
+        relay.publish(message(type: "io.element.call.encryption_keys", sender: "@d:example.org"))
+        #expect(try #require(await keys.next()).attestedSenderID == "@d:example.org")
+    }
+    
+    private func message(type: String, sender: String) -> MatrixRtcToDeviceMessage {
+        MatrixRtcToDeviceMessage(eventType: type, attestedSenderID: sender, senderDeviceID: "DEV", isSenderCrossSigned: true, wasEncrypted: true, contentJSON: "{}")
+    }
+}

--- a/UnitTests/Sources/NativeCall/RTCTransportDiscoveryTests.swift
+++ b/UnitTests/Sources/NativeCall/RTCTransportDiscoveryTests.swift
@@ -1,0 +1,46 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+@testable import ElementX
+import Foundation
+import MatrixRtcKit
+import Testing
+
+struct RTCTransportDiscoveryTests {
+    @Test
+    func parsesLiveKitAndUnsupportedTransports() throws {
+        let body = Data("""
+        {"rtc_transports": [{"type": "livekit", "livekit_service_url": "https://livekit.example.org"}, {"type": "sfu2"}]}
+        """.utf8)
+        
+        let transports = RTCTransportDiscovery.parseTransports(body, key: RTCTransportDiscovery.transportsKey)
+        
+        #expect(try transports == [.liveKit(serviceURL: #require(URL(string: "https://livekit.example.org"))), .unsupported(type: "sfu2")])
+    }
+    
+    @Test
+    func fallsBackToWellKnownWhenTheEndpointFails() async throws {
+        let discovery = RTCTransportDiscovery(homeserverURL: "https://matrix.example.org/", serverName: "example.org") { url in
+            if url == "https://matrix.example.org/_matrix/client/unstable/org.matrix.msc4143/rtc/transports" {
+                throw MatrixRtcTransportError.failed("404")
+            }
+            #expect(url == "https://example.org/.well-known/matrix/client")
+            return Data("""
+            {"m.rtc_foci": [{"type": "livekit", "livekit_service_url": "https://focus.example.org"}]}
+            """.utf8)
+        }
+        
+        let transports = await discovery.discover()
+        
+        #expect(try transports == [.liveKit(serviceURL: #require(URL(string: "https://focus.example.org")))])
+    }
+    
+    @Test
+    func unparseableBodyYieldsNothing() {
+        #expect(RTCTransportDiscovery.parseTransports(Data("nope".utf8), key: RTCTransportDiscovery.transportsKey).isEmpty)
+    }
+}


### PR DESCRIPTION


Sixth step of the native MatrixRTC calls stack (spike: `valere/native_call`; previous: #6121).

`MatrixRtcTransportAdapter` is the app's implementation of the framework's `MatrixRtcMatrixTransport`: state events, room events, redactions, OpenID tokens, member lists and room encryption go through the proxies; delayed events, the room-state feed and to-device traffic go through the room bridge from the previous PR, created per room in `willJoinRoom` (`JoinedRoomProxy.matrixRtcRoomBridge()`, the hook that constructs the widget bridge) and stopped in `didLeaveRoom`. `ToDeviceRelay` fans each live bridge's keys into the one session-long stream the key feeder subscribes to. Homeserver errors are classified so that a refused delayed event (`M_FORBIDDEN` on matrix.org today) means "no dead man's switch" rather than a failed join. `RTCTransportDiscovery` finds the LiveKit service URL (MSC4143 endpoint, then `.well-known` `rtc_foci`), a Swift copy of what the SDK does not yet expose.

Also the two developer flags: `nativeCallEnabled` (default off) and `nativeCallPictureInPictureEnabled` (default on), with a "Native call" section in Developer Options. **Neither does anything yet**; the flag is wired in the audio call PR. The spike's Element Call compatibility picker is left out on purpose: only the state-event mode works on the released SDK.

Tests: error classification and the relay (`MatrixRtcTransportAdapterTests`), discovery parsing and fallback (`RTCTransportDiscoveryTests`).

### Pull Request Checklist

- [ ] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [ ] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
