### PR TITLE
NativeCall | Capture the microphone and play remote audio

### DIFF
--- a/Components/MatrixRtcKit/Sources/Media/AudioPlaybackSink.swift
+++ b/Components/MatrixRtcKit/Sources/Media/AudioPlaybackSink.swift
@@ -1,0 +1,104 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import AVFoundation
+import MatrixRtc
+import Synchronization
+
+/// Plays one remote member: a source node on the engine pulls from a ring that a filler task keeps
+/// topped up from the decoded stream. Under-runs play silence and are counted; a full ring drops
+/// the oldest audio so latency stays bounded.
+final nonisolated class AudioPlaybackSink: @unchecked Sendable {
+    let memberID: String
+    private let engine: CallAudioEngine
+    private let ring = PCMRingBuffer(capacity: AudioFormat.samplesPerFrame * 20)
+    private let prefill = AudioFormat.samplesPerFrame * 3
+    private let flags = RenderFlags()
+    private let frameCount = Atomic<UInt64>(0)
+    
+    /// Shared with the render block, which must not capture the sink itself.
+    private final class RenderFlags: @unchecked Sendable {
+        let isPrimed = Atomic<Bool>(false)
+        let isDetached = Atomic<Bool>(false)
+        let underruns = Atomic<Int>(0)
+    }
+    
+    private let filler = Mutex<Task<Void, Never>?>(nil)
+    private let onLevel: @Sendable (String, MatrixRtcAudioLevel) -> Void
+    
+    init(memberID: String, engine: CallAudioEngine, onLevel: @escaping @Sendable (String, MatrixRtcAudioLevel) -> Void) {
+        self.memberID = memberID
+        self.engine = engine
+        self.onLevel = onLevel
+    }
+    
+    func start(stream: AudioFrameStream) {
+        let ring = ring
+        let flags = flags
+        let prefill = prefill
+        
+        // The render block captures only atomics and the ring, never self, so detaching while the
+        // engine runs is safe.
+        engine.addSourceNode(for: memberID) { _, _, frameCount, audioBufferList -> OSStatus in
+            let buffers = UnsafeMutableAudioBufferListPointer(audioBufferList)
+            guard let first = buffers.first, let data = first.mData else { return noErr }
+            let floats = data.assumingMemoryBound(to: Float.self)
+            let count = Int(frameCount)
+            
+            if flags.isDetached.load(ordering: .relaxed) || (!flags.isPrimed.load(ordering: .relaxed) && ring.availableToRead < prefill) {
+                for index in 0..<count {
+                    floats[index] = 0
+                }
+                return noErr
+            }
+            flags.isPrimed.store(true, ordering: .relaxed)
+            
+            var scratch = [Int16](repeating: 0, count: count)
+            let real = scratch.withUnsafeMutableBufferPointer { ring.read(into: $0) }
+            if real < count {
+                flags.underruns.wrappingAdd(1, ordering: .relaxed)
+                if real == 0 {
+                    flags.isPrimed.store(false, ordering: .relaxed)
+                }
+            }
+            for index in 0..<count {
+                floats[index] = Float(scratch[index]) / Float(Int16.max)
+            }
+            return noErr
+        }
+        
+        let task = Task.detached(priority: .userInitiated) { [weak self] in
+            while !Task.isCancelled, let frame = await stream.next() {
+                self?.push(frame)
+            }
+            MatrixRtcLog.debug("Audio stream ended for \(self?.memberID ?? "?")")
+        }
+        filler.withLock { $0 = task }
+    }
+    
+    func stop() {
+        filler.withLock { $0?.cancel(); $0 = nil }
+        flags.isDetached.store(true, ordering: .relaxed)
+        engine.removeSourceNode(for: memberID)
+    }
+    
+    private func push(_ frame: FfiAudioFrame) {
+        frame.data.withUnsafeBytes { bytes in
+            let samples = bytes.bindMemory(to: Int16.self)
+            if ring.availableToWrite < samples.count {
+                ring.dropOldest(samples.count - ring.availableToWrite)
+            }
+            ring.write(samples)
+            let count = frameCount.wrappingAdd(1, ordering: .relaxed).newValue
+            if count % 10 == 0 {
+                onLevel(memberID, .init(level: AudioLevelMeter.level(of: samples),
+                                        frameCount: count,
+                                        underrunCount: flags.underruns.load(ordering: .relaxed)))
+            }
+        }
+    }
+}

--- a/Components/MatrixRtcKit/Sources/Media/CallAudioSessionConfigurator.swift
+++ b/Components/MatrixRtcKit/Sources/Media/CallAudioSessionConfigurator.swift
@@ -1,0 +1,49 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import AVFoundation
+
+/// Configures the shared audio session for a call. Never activates it when CallKit is in charge —
+/// CallKit activates the session and reports it through `didActivate`, and activating it ourselves
+/// makes that callback fire twice or not at all.
+public nonisolated enum CallAudioSessionConfigurator {
+    /// No `.defaultToSpeaker` here on purpose: with it, clearing the output override still lands on
+    /// the speaker and the earpiece becomes unreachable. Video calls ask for the speaker explicitly
+    /// once the session is active (`setLoudspeaker`).
+    public static func configure() throws {
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.playAndRecord, mode: .voiceChat, options: [.allowBluetoothHFP])
+        try session.setPreferredSampleRate(Double(AudioFormat.sampleRate))
+        try session.setPreferredIOBufferDuration(0.01)
+    }
+    
+    /// For the simulator and any path where CallKit is not driving activation.
+    public static func activate() throws {
+        try AVAudioSession.sharedInstance().setActive(true, options: [])
+    }
+    
+    public static func deactivate() {
+        try? AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
+    }
+    
+    /// Speaker vs. whatever the system would pick (earpiece, headset, Bluetooth).
+    public static func setLoudspeaker(_ enabled: Bool) throws {
+        try AVAudioSession.sharedInstance().overrideOutputAudioPort(enabled ? .speaker : .none)
+    }
+    
+    public static var isLoudspeaker: Bool {
+        AVAudioSession.sharedInstance().currentRoute.outputs.contains { $0.portType == .builtInSpeaker }
+    }
+    
+    public static var isBuiltInReceiver: Bool {
+        AVAudioSession.sharedInstance().currentRoute.outputs.contains { $0.portType == .builtInReceiver }
+    }
+    
+    public static var currentOutputName: String? {
+        AVAudioSession.sharedInstance().currentRoute.outputs.first?.portName
+    }
+}

--- a/Components/MatrixRtcKit/Sources/Media/MicrophoneCapturer.swift
+++ b/Components/MatrixRtcKit/Sources/Media/MicrophoneCapturer.swift
@@ -1,0 +1,178 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import AVFoundation
+import MatrixRtc
+import Synchronization
+
+/// Pulls the microphone off the engine's real-time thread, converts it to 48 kHz mono Int16 and
+/// hands exactly 480-sample frames to the published track.
+///
+/// Muting stops handing frames over **and** tells the transport (done by the call); the engine and
+/// the capture stay up so unmuting is instant.
+final nonisolated class MicrophoneCapturer: @unchecked Sendable {
+    private let engine: CallAudioEngine
+    private let ring = PCMRingBuffer(capacity: AudioFormat.samplesPerFrame * 50)
+    private let isMuted = Atomic<Bool>(false)
+    private let isTestToneEnabled = Atomic<Bool>(false)
+    private let onLevel: @Sendable (MatrixRtcAudioLevel) -> Void
+    
+    private let state = Mutex<State>(.init())
+    
+    private struct State {
+        var track: FfiLocalTrack?
+        var drainer: Task<Void, Never>?
+        var converter: AVAudioConverter?
+        var inputFormat: AVAudioFormat?
+        var frameCount: UInt64 = 0
+        var tonePhase: Float = 0
+    }
+    
+    init(engine: CallAudioEngine, onLevel: @escaping @Sendable (MatrixRtcAudioLevel) -> Void) {
+        self.engine = engine
+        self.onLevel = onLevel
+    }
+    
+    func start(track: FfiLocalTrack) {
+        stop()
+        state.withLock { $0.track = track }
+        
+        // Converts to Int16 mono at the hardware rate on the render thread (cheap, no allocation
+        // beyond the small scratch buffer), then the drainer resamples to 48 kHz.
+        engine.installInputSink { [weak self] _, frameCount, audioBufferList -> OSStatus in
+            guard let self else { return noErr }
+            let buffers = UnsafeMutableAudioBufferListPointer(UnsafeMutablePointer(mutating: audioBufferList))
+            guard let first = buffers.first, let data = first.mData else { return noErr }
+            
+            let inputFormat = engine.inputFormat
+            let channels = Int(inputFormat.channelCount)
+            let count = Int(frameCount)
+            
+            // Hardware input is Float32; take channel 0 when it is stereo.
+            let floats = data.assumingMemoryBound(to: Float.self)
+            let interleaved = inputFormat.isInterleaved
+            var scratch = [Int16](repeating: 0, count: count)
+            for index in 0..<count {
+                let sample = interleaved ? floats[index * channels] : floats[index]
+                scratch[index] = Int16(max(-1, min(1, sample)) * Float(Int16.max))
+            }
+            scratch.withUnsafeBufferPointer { ring.write($0) }
+            return noErr
+        }
+        
+        let drainer = Task.detached(priority: .userInitiated) { [weak self] in
+            guard let self else { return }
+            await drain()
+        }
+        state.withLock { $0.drainer = drainer }
+    }
+    
+    func stop() {
+        let drainer = state.withLock { state -> Task<Void, Never>? in
+            defer { state.drainer = nil; state.track = nil; state.converter = nil }
+            return state.drainer
+        }
+        drainer?.cancel()
+        ring.clear()
+    }
+    
+    func setMuted(_ muted: Bool) {
+        isMuted.store(muted, ordering: .relaxed)
+    }
+    
+    /// A fixed 440 Hz sine at a known level takes the capture device out of the picture.
+    func setTestToneEnabled(_ enabled: Bool) {
+        isTestToneEnabled.store(enabled, ordering: .relaxed)
+    }
+    
+    // MARK: - Private
+    
+    /// Resamples whatever the hardware produced into 480-sample 48 kHz frames and pushes them.
+    private func drain() async {
+        var pending = [Int16]()
+        let output = [Int16](repeating: 0, count: AudioFormat.samplesPerFrame)
+        var frame = Data(count: AudioFormat.bytesPerFrame)
+        
+        while !Task.isCancelled {
+            let available = ring.availableToRead
+            if available < 64 {
+                try? await Task.sleep(for: .milliseconds(5))
+                continue
+            }
+            
+            var chunk = [Int16](repeating: 0, count: available)
+            chunk.withUnsafeMutableBufferPointer { ring.read(into: $0) }
+            pending += resampleToTarget(chunk)
+            
+            while pending.count >= AudioFormat.samplesPerFrame {
+                var samples = Array(pending.prefix(AudioFormat.samplesPerFrame))
+                pending.removeFirst(AudioFormat.samplesPerFrame)
+                
+                if isTestToneEnabled.load(ordering: .relaxed) {
+                    fillTestTone(&samples)
+                }
+                
+                // Meter before the mute check: knowing the microphone is alive while muted is exactly
+                // the question a silent call raises.
+                let level = samples.withUnsafeBufferPointer { AudioLevelMeter.level(of: $0) }
+                let count = state.withLock { state -> UInt64 in
+                    state.frameCount += 1
+                    return state.frameCount
+                }
+                if count % 10 == 0 {
+                    onLevel(.init(level: level, frameCount: count, underrunCount: nil))
+                }
+                
+                guard !isMuted.load(ordering: .relaxed), let track = state.withLock({ $0.track }) else { continue }
+                
+                frame.withUnsafeMutableBytes { bytes in
+                    bytes.copyBytes(from: samples.withUnsafeBufferPointer { UnsafeRawBufferPointer($0) })
+                }
+                do {
+                    try await track.captureAudio(frame: FfiAudioFrame(data: frame,
+                                                                      sampleRate: UInt32(AudioFormat.sampleRate),
+                                                                      numChannels: UInt32(AudioFormat.channelCount),
+                                                                      samplesPerChannel: UInt32(AudioFormat.samplesPerFrame)))
+                } catch {
+                    MatrixRtcLog.warning("captureAudio failed: \(error)")
+                }
+            }
+            _ = output
+        }
+    }
+    
+    /// Linear resampling from the hardware rate to 48 kHz; the hardware usually *is* 48 kHz, in
+    /// which case this is a copy.
+    private func resampleToTarget(_ samples: [Int16]) -> [Int16] {
+        let inputRate = engine.inputFormat.sampleRate
+        guard inputRate > 0, Int(inputRate) != AudioFormat.sampleRate else { return samples }
+        let ratio = inputRate / Double(AudioFormat.sampleRate)
+        let outputCount = Int(Double(samples.count) / ratio)
+        var output = [Int16](repeating: 0, count: outputCount)
+        for index in 0..<outputCount {
+            let position = Double(index) * ratio
+            let lower = Int(position)
+            let upper = min(lower + 1, samples.count - 1)
+            let fraction = Float(position - Double(lower))
+            output[index] = Int16(Float(samples[lower]) * (1 - fraction) + Float(samples[upper]) * fraction)
+        }
+        return output
+    }
+    
+    private func fillTestTone(_ samples: inout [Int16]) {
+        state.withLock { state in
+            let step = 2 * Float.pi * 440 / Float(AudioFormat.sampleRate)
+            for index in samples.indices {
+                samples[index] = Int16(sin(state.tonePhase) * 0.3 * Float(Int16.max))
+                state.tonePhase += step
+                if state.tonePhase > 2 * .pi {
+                    state.tonePhase -= 2 * .pi
+                }
+            }
+        }
+    }
+}

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -310,6 +310,7 @@
 		2F6207CB5C4715FE313B1E95 /* TimelineViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6509708F54FC883604DFDC95 /* TimelineViewModelTests.swift */; };
 		2F623DA1122140A987B34D08 /* NotificationSettingsEditScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA7BB497B2F539C17E88F6B7 /* NotificationSettingsEditScreenViewModelProtocol.swift */; };
 		2F94054F50E312AF30BE07F3 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B21E611DADDEF00307E7AC /* String.swift */; };
+		2FE4EC3C920218F221876614 /* AudioPlaybackSink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EBDFF25F71265C1E92CB68A /* AudioPlaybackSink.swift */; };
 		2FEC6652055984389CE1BBEC /* TimelineProxyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50F03079F6B5EF9CA005F14 /* TimelineProxyProtocol.swift */; };
 		3041EBA2660F28FFB7BDA339 /* EncryptionResetScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0FF9CB3EFA753277291F609 /* EncryptionResetScreenCoordinator.swift */; };
 		3042527CB344A9EF1157FC26 /* AudioRecorderStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C55CC239AE12339C565F6C9A /* AudioRecorderStateTests.swift */; };
@@ -663,6 +664,7 @@
 		6832733838C57A7D3FE8FEB5 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 50009897F60FAE7D63EF5E5B /* Kingfisher */; };
 		6851B077B4C913CC12DB6E77 /* AppLockFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCE93F0CBF0D96B77111C413 /* AppLockFlowCoordinator.swift */; };
 		6885C3D26FC1026E07408D3C /* RoomListActivityVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5DA892E8643240C7BC41900 /* RoomListActivityVisibility.swift */; };
+		68A3CC4BDA906C45230E7111 /* CallAudioSessionConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65640A70F416AC2E543AA1CA /* CallAudioSessionConfigurator.swift */; };
 		68B2DD307C57ECFABBB05323 /* DeclineAndBlockScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 127D1947BA9C6CA62E3D03EC /* DeclineAndBlockScreen.swift */; };
 		68B7308BA24EC3DC5FD87B61 /* OAuthPresenterHook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04CAC77224E949D8E758E2E3 /* OAuthPresenterHook.swift */; };
 		68C3AF257678F6E7BB238C3F /* AppAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FD22AEFFA20065494ED2333 /* AppAppearance.swift */; };
@@ -1615,6 +1617,7 @@
 		FA71CD334F2D2289BEF0D749 /* SecureBackupRecoveryKeyScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2FCA3D0F239B9E911B966B /* SecureBackupRecoveryKeyScreen.swift */; };
 		FA9C427FFB11B1AA2DCC5602 /* RoomProxyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47111410B6E659A697D472B5 /* RoomProxyProtocol.swift */; };
 		FB595EC9C00AB32F39034055 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A37E2FACFD041CE466223CD /* SceneDelegate.swift */; };
+		FBC07D0E510235155CA227DB /* MicrophoneCapturer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D602B8318F6C15889AFFF2 /* MicrophoneCapturer.swift */; };
 		FBD402E3170EB1ED0D1AA672 /* EncryptionKeyProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2355398E4A55DA5A89128AD1 /* EncryptionKeyProvider.swift */; };
 		FBF09B6C900415800DDF2A21 /* EmojiProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C113E0CB7E15E9765B1817A /* EmojiProvider.swift */; };
 		FC10228E73323BDC09526F97 /* LRUCache in Frameworks */ = {isa = PBXBuildFile; productRef = 1081D3630AAD3ACEDDEC3A98 /* LRUCache */; };
@@ -2085,6 +2088,7 @@
 		2DA4F09CB613C54FDC73AE6A /* ThreadDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadDecorator.swift; sourceTree = "<group>"; };
 		2DB0E533508094156D8024C3 /* TimelineStyler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineStyler.swift; sourceTree = "<group>"; };
 		2E11E7C396ED06A154CF6DF3 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/SAS.strings; sourceTree = "<group>"; };
+		2EBDFF25F71265C1E92CB68A /* AudioPlaybackSink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlaybackSink.swift; sourceTree = "<group>"; };
 		2F06F70B9C433BAD4BC6B9F5 /* EncryptedRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptedRoomTimelineView.swift; sourceTree = "<group>"; };
 		2F36C5D9B37E50915ECBD3EE /* RoomMemberProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomMemberProxy.swift; sourceTree = "<group>"; };
 		2F65178687F725E8924B723C /* TimelineFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineFixtures.swift; sourceTree = "<group>"; };
@@ -2400,6 +2404,7 @@
 		64F49FB9EE2913234F06CE68 /* MediaPickerScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPickerScreenCoordinator.swift; sourceTree = "<group>"; };
 		6509708F54FC883604DFDC95 /* TimelineViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineViewModelTests.swift; sourceTree = "<group>"; };
 		653610CB5F9776EAAAB98155 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = fr; path = fr.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		65640A70F416AC2E543AA1CA /* CallAudioSessionConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallAudioSessionConfigurator.swift; sourceTree = "<group>"; };
 		6569593FA36B22259E806A67 /* AudioRecorderState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderState.swift; sourceTree = "<group>"; };
 		65AAD845E53B0C8B5E0812C2 /* UserDiscoveryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDiscoveryService.swift; sourceTree = "<group>"; };
 		6640DB5B9171D163E6742639 /* ServerSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSelectionTests.swift; sourceTree = "<group>"; };
@@ -2588,6 +2593,7 @@
 		84A00BB9CD12CF6AC98D5485 /* SecureBackupScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureBackupScreen.swift; sourceTree = "<group>"; };
 		84A87D0471D438A233C2CF4A /* RoomMemberDetailsScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomMemberDetailsScreenViewModel.swift; sourceTree = "<group>"; };
 		84B7A28A6606D58D1E38C55A /* ExpiringTaskRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpiringTaskRunnerTests.swift; sourceTree = "<group>"; };
+		84D602B8318F6C15889AFFF2 /* MicrophoneCapturer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrophoneCapturer.swift; sourceTree = "<group>"; };
 		8512B82404B1751D0BCC82D2 /* MediaEventsTimelineScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaEventsTimelineScreenCoordinator.swift; sourceTree = "<group>"; };
 		85149F56BA333619900E2410 /* UserDetailsEditScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDetailsEditScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		851B95BB98649B8E773D6790 /* AppLockService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockService.swift; sourceTree = "<group>"; };
@@ -4675,7 +4681,10 @@
 			isa = PBXGroup;
 			children = (
 				559EE7C08AA645C5D39AC80B /* AudioFormat.swift */,
+				2EBDFF25F71265C1E92CB68A /* AudioPlaybackSink.swift */,
 				8349CCB8DABCDD015B603D33 /* CallAudioEngine.swift */,
+				65640A70F416AC2E543AA1CA /* CallAudioSessionConfigurator.swift */,
+				84D602B8318F6C15889AFFF2 /* MicrophoneCapturer.swift */,
 				E5455967934AD958888D0C48 /* PCMRingBuffer.swift */,
 			);
 			path = Media;
@@ -8738,7 +8747,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				110B922A2DD7EEF8913C9F55 /* AudioFormat.swift in Sources */,
+				2FE4EC3C920218F221876614 /* AudioPlaybackSink.swift in Sources */,
 				BACFCA7E5EBA8BFFEE39A92F /* CallAudioEngine.swift in Sources */,
+				68A3CC4BDA906C45230E7111 /* CallAudioSessionConfigurator.swift in Sources */,
 				9F6EFBB1D710D34236F87430 /* EncryptionKeyMapper.swift in Sources */,
 				365D4AB2BD42729490C93146 /* Mappers.swift in Sources */,
 				5EFAB767D88D3D44E9AE89A4 /* MatrixRtcCommandSender.swift in Sources */,
@@ -8746,6 +8757,7 @@
 				C8B3100A1CC12F9FFDC64937 /* MatrixRtcLogging.swift in Sources */,
 				6F2925C185654654802C36C1 /* MatrixRtcMatrixTransport.swift in Sources */,
 				6D04ED80374F085C20AF8FC7 /* MatrixRtcModels.swift in Sources */,
+				FBC07D0E510235155CA227DB /* MicrophoneCapturer.swift in Sources */,
 				0E6ED509548F367AE52CEAF7 /* PCMRingBuffer.swift in Sources */,
 				6C408E7E641533FABC9C41CC /* RoomStateFeeder.swift in Sources */,
 				19F1848BE34E30486878517F /* SessionKeyFeeder.swift in Sources */,


### PR DESCRIPTION
Eighth step of the native MatrixRTC calls stack (spike: `valere/native_call`; previous: #6123).

`MicrophoneCapturer` takes the engine's input tap, converts to the core's PCM format, meters the level for the local speaking indicator and hands frames to the core's local audio track. `AudioPlaybackSink`, one per remote participant, pulls that participant's decoded frames from the core into a ring buffer that a source node on the engine's mixer drains, metering the level as well. `CallAudioSessionConfigurator` sets up the voice-chat audio session the way CallKit expects before it activates it.

No behaviour change: the call that owns these arrives in two PRs.

### Pull Request Checklist

- [ ] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [ ] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
