### PR TITLE
NativeCall | Let ElementCallService run a CallKit session for a native call

### DIFF
--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -1948,6 +1948,99 @@ nonisolated class CXProviderMock: CXProviderProtocol, @unchecked Sendable {
         reportCallWithEndedAtReasonReceivedInvocationsLock.withLock { reportCallWithEndedAtReasonUnderlyingReceivedInvocations.append((uuid: uuid, endedAt: endedAt, reason: reason)) }
         reportCallWithEndedAtReasonClosure?(uuid, endedAt, reason)
     }
+    //MARK: - reportOutgoingCall
+
+    private let reportOutgoingCallWithStartedConnectingAtCallsCountLock = NSLock()
+    private nonisolated(unsafe) var reportOutgoingCallWithStartedConnectingAtUnderlyingCallsCount = 0
+    var reportOutgoingCallWithStartedConnectingAtCallsCount: Int {
+        get { reportOutgoingCallWithStartedConnectingAtCallsCountLock.withLock { reportOutgoingCallWithStartedConnectingAtUnderlyingCallsCount } }
+        set { reportOutgoingCallWithStartedConnectingAtCallsCountLock.withLock { reportOutgoingCallWithStartedConnectingAtUnderlyingCallsCount = newValue } }
+    }
+    var reportOutgoingCallWithStartedConnectingAtCalled: Bool {
+        return reportOutgoingCallWithStartedConnectingAtCallsCount > 0
+    }
+    private let reportOutgoingCallWithStartedConnectingAtReceivedArgumentsLock = NSLock()
+    private nonisolated(unsafe) var reportOutgoingCallWithStartedConnectingAtUnderlyingReceivedArguments: (uuid: UUID, startedConnectingAt: Date?)?
+    var reportOutgoingCallWithStartedConnectingAtReceivedArguments: (uuid: UUID, startedConnectingAt: Date?)? {
+        get { reportOutgoingCallWithStartedConnectingAtReceivedArgumentsLock.withLock { reportOutgoingCallWithStartedConnectingAtUnderlyingReceivedArguments } }
+        set { reportOutgoingCallWithStartedConnectingAtReceivedArgumentsLock.withLock { reportOutgoingCallWithStartedConnectingAtUnderlyingReceivedArguments = newValue } }
+    }
+    private let reportOutgoingCallWithStartedConnectingAtReceivedInvocationsLock = NSLock()
+    private nonisolated(unsafe) var reportOutgoingCallWithStartedConnectingAtUnderlyingReceivedInvocations: [(uuid: UUID, startedConnectingAt: Date?)] = []
+    var reportOutgoingCallWithStartedConnectingAtReceivedInvocations: [(uuid: UUID, startedConnectingAt: Date?)] {
+        get { reportOutgoingCallWithStartedConnectingAtReceivedInvocationsLock.withLock { reportOutgoingCallWithStartedConnectingAtUnderlyingReceivedInvocations } }
+        set { reportOutgoingCallWithStartedConnectingAtReceivedInvocationsLock.withLock { reportOutgoingCallWithStartedConnectingAtUnderlyingReceivedInvocations = newValue } }
+    }
+    nonisolated(unsafe) var reportOutgoingCallWithStartedConnectingAtClosure: ((UUID, Date?) -> Void)?
+
+    func reportOutgoingCall(with uuid: UUID, startedConnectingAt: Date?) {
+        reportOutgoingCallWithStartedConnectingAtCallsCountLock.withLock { reportOutgoingCallWithStartedConnectingAtUnderlyingCallsCount += 1 }
+        reportOutgoingCallWithStartedConnectingAtReceivedArguments = (uuid: uuid, startedConnectingAt: startedConnectingAt)
+        reportOutgoingCallWithStartedConnectingAtReceivedInvocationsLock.withLock { reportOutgoingCallWithStartedConnectingAtUnderlyingReceivedInvocations.append((uuid: uuid, startedConnectingAt: startedConnectingAt)) }
+        reportOutgoingCallWithStartedConnectingAtClosure?(uuid, startedConnectingAt)
+    }
+    //MARK: - reportOutgoingCall
+
+    private let reportOutgoingCallWithConnectedAtCallsCountLock = NSLock()
+    private nonisolated(unsafe) var reportOutgoingCallWithConnectedAtUnderlyingCallsCount = 0
+    var reportOutgoingCallWithConnectedAtCallsCount: Int {
+        get { reportOutgoingCallWithConnectedAtCallsCountLock.withLock { reportOutgoingCallWithConnectedAtUnderlyingCallsCount } }
+        set { reportOutgoingCallWithConnectedAtCallsCountLock.withLock { reportOutgoingCallWithConnectedAtUnderlyingCallsCount = newValue } }
+    }
+    var reportOutgoingCallWithConnectedAtCalled: Bool {
+        return reportOutgoingCallWithConnectedAtCallsCount > 0
+    }
+    private let reportOutgoingCallWithConnectedAtReceivedArgumentsLock = NSLock()
+    private nonisolated(unsafe) var reportOutgoingCallWithConnectedAtUnderlyingReceivedArguments: (uuid: UUID, connectedAt: Date?)?
+    var reportOutgoingCallWithConnectedAtReceivedArguments: (uuid: UUID, connectedAt: Date?)? {
+        get { reportOutgoingCallWithConnectedAtReceivedArgumentsLock.withLock { reportOutgoingCallWithConnectedAtUnderlyingReceivedArguments } }
+        set { reportOutgoingCallWithConnectedAtReceivedArgumentsLock.withLock { reportOutgoingCallWithConnectedAtUnderlyingReceivedArguments = newValue } }
+    }
+    private let reportOutgoingCallWithConnectedAtReceivedInvocationsLock = NSLock()
+    private nonisolated(unsafe) var reportOutgoingCallWithConnectedAtUnderlyingReceivedInvocations: [(uuid: UUID, connectedAt: Date?)] = []
+    var reportOutgoingCallWithConnectedAtReceivedInvocations: [(uuid: UUID, connectedAt: Date?)] {
+        get { reportOutgoingCallWithConnectedAtReceivedInvocationsLock.withLock { reportOutgoingCallWithConnectedAtUnderlyingReceivedInvocations } }
+        set { reportOutgoingCallWithConnectedAtReceivedInvocationsLock.withLock { reportOutgoingCallWithConnectedAtUnderlyingReceivedInvocations = newValue } }
+    }
+    nonisolated(unsafe) var reportOutgoingCallWithConnectedAtClosure: ((UUID, Date?) -> Void)?
+
+    func reportOutgoingCall(with uuid: UUID, connectedAt: Date?) {
+        reportOutgoingCallWithConnectedAtCallsCountLock.withLock { reportOutgoingCallWithConnectedAtUnderlyingCallsCount += 1 }
+        reportOutgoingCallWithConnectedAtReceivedArguments = (uuid: uuid, connectedAt: connectedAt)
+        reportOutgoingCallWithConnectedAtReceivedInvocationsLock.withLock { reportOutgoingCallWithConnectedAtUnderlyingReceivedInvocations.append((uuid: uuid, connectedAt: connectedAt)) }
+        reportOutgoingCallWithConnectedAtClosure?(uuid, connectedAt)
+    }
+    //MARK: - reportCall
+
+    private let reportCallWithUpdatedCallsCountLock = NSLock()
+    private nonisolated(unsafe) var reportCallWithUpdatedUnderlyingCallsCount = 0
+    var reportCallWithUpdatedCallsCount: Int {
+        get { reportCallWithUpdatedCallsCountLock.withLock { reportCallWithUpdatedUnderlyingCallsCount } }
+        set { reportCallWithUpdatedCallsCountLock.withLock { reportCallWithUpdatedUnderlyingCallsCount = newValue } }
+    }
+    var reportCallWithUpdatedCalled: Bool {
+        return reportCallWithUpdatedCallsCount > 0
+    }
+    private let reportCallWithUpdatedReceivedArgumentsLock = NSLock()
+    private nonisolated(unsafe) var reportCallWithUpdatedUnderlyingReceivedArguments: (uuid: UUID, update: CXCallUpdate)?
+    var reportCallWithUpdatedReceivedArguments: (uuid: UUID, update: CXCallUpdate)? {
+        get { reportCallWithUpdatedReceivedArgumentsLock.withLock { reportCallWithUpdatedUnderlyingReceivedArguments } }
+        set { reportCallWithUpdatedReceivedArgumentsLock.withLock { reportCallWithUpdatedUnderlyingReceivedArguments = newValue } }
+    }
+    private let reportCallWithUpdatedReceivedInvocationsLock = NSLock()
+    private nonisolated(unsafe) var reportCallWithUpdatedUnderlyingReceivedInvocations: [(uuid: UUID, update: CXCallUpdate)] = []
+    var reportCallWithUpdatedReceivedInvocations: [(uuid: UUID, update: CXCallUpdate)] {
+        get { reportCallWithUpdatedReceivedInvocationsLock.withLock { reportCallWithUpdatedUnderlyingReceivedInvocations } }
+        set { reportCallWithUpdatedReceivedInvocationsLock.withLock { reportCallWithUpdatedUnderlyingReceivedInvocations = newValue } }
+    }
+    nonisolated(unsafe) var reportCallWithUpdatedClosure: ((UUID, CXCallUpdate) -> Void)?
+
+    func reportCall(with uuid: UUID, updated update: CXCallUpdate) {
+        reportCallWithUpdatedCallsCountLock.withLock { reportCallWithUpdatedUnderlyingCallsCount += 1 }
+        reportCallWithUpdatedReceivedArguments = (uuid: uuid, update: update)
+        reportCallWithUpdatedReceivedInvocationsLock.withLock { reportCallWithUpdatedUnderlyingReceivedInvocations.append((uuid: uuid, update: update)) }
+        reportCallWithUpdatedClosure?(uuid, update)
+    }
 }
 nonisolated class ClassicAppManagerMock: ClassicAppManagerProtocol, @unchecked Sendable {
 
@@ -5017,6 +5110,130 @@ nonisolated class ElementCallServiceMock: ElementCallServiceProtocol, @unchecked
         setAudioEnabledRoomIDReceivedArguments = (enabled: enabled, roomID: roomID)
         setAudioEnabledRoomIDReceivedInvocationsLock.withLock { setAudioEnabledRoomIDUnderlyingReceivedInvocations.append((enabled: enabled, roomID: roomID)) }
         setAudioEnabledRoomIDClosure?(enabled, roomID)
+    }
+    //MARK: - setNativeCallModeEnabled
+
+    private let setNativeCallModeEnabledCallsCountLock = NSLock()
+    private nonisolated(unsafe) var setNativeCallModeEnabledUnderlyingCallsCount = 0
+    var setNativeCallModeEnabledCallsCount: Int {
+        get { setNativeCallModeEnabledCallsCountLock.withLock { setNativeCallModeEnabledUnderlyingCallsCount } }
+        set { setNativeCallModeEnabledCallsCountLock.withLock { setNativeCallModeEnabledUnderlyingCallsCount = newValue } }
+    }
+    var setNativeCallModeEnabledCalled: Bool {
+        return setNativeCallModeEnabledCallsCount > 0
+    }
+    private let setNativeCallModeEnabledReceivedEnabledLock = NSLock()
+    private nonisolated(unsafe) var setNativeCallModeEnabledUnderlyingReceivedEnabled: Bool?
+    var setNativeCallModeEnabledReceivedEnabled: Bool? {
+        get { setNativeCallModeEnabledReceivedEnabledLock.withLock { setNativeCallModeEnabledUnderlyingReceivedEnabled } }
+        set { setNativeCallModeEnabledReceivedEnabledLock.withLock { setNativeCallModeEnabledUnderlyingReceivedEnabled = newValue } }
+    }
+    private let setNativeCallModeEnabledReceivedInvocationsLock = NSLock()
+    private nonisolated(unsafe) var setNativeCallModeEnabledUnderlyingReceivedInvocations: [Bool] = []
+    var setNativeCallModeEnabledReceivedInvocations: [Bool] {
+        get { setNativeCallModeEnabledReceivedInvocationsLock.withLock { setNativeCallModeEnabledUnderlyingReceivedInvocations } }
+        set { setNativeCallModeEnabledReceivedInvocationsLock.withLock { setNativeCallModeEnabledUnderlyingReceivedInvocations = newValue } }
+    }
+    nonisolated(unsafe) var setNativeCallModeEnabledClosure: ((Bool) -> Void)?
+
+    func setNativeCallModeEnabled(_ enabled: Bool) {
+        setNativeCallModeEnabledCallsCountLock.withLock { setNativeCallModeEnabledUnderlyingCallsCount += 1 }
+        setNativeCallModeEnabledReceivedEnabled = enabled
+        setNativeCallModeEnabledReceivedInvocationsLock.withLock { setNativeCallModeEnabledUnderlyingReceivedInvocations.append(enabled) }
+        setNativeCallModeEnabledClosure?(enabled)
+    }
+    //MARK: - startNativeCallSession
+
+    private let startNativeCallSessionRoomIDRoomDisplayNameIsVideoCallsCountLock = NSLock()
+    private nonisolated(unsafe) var startNativeCallSessionRoomIDRoomDisplayNameIsVideoUnderlyingCallsCount = 0
+    var startNativeCallSessionRoomIDRoomDisplayNameIsVideoCallsCount: Int {
+        get { startNativeCallSessionRoomIDRoomDisplayNameIsVideoCallsCountLock.withLock { startNativeCallSessionRoomIDRoomDisplayNameIsVideoUnderlyingCallsCount } }
+        set { startNativeCallSessionRoomIDRoomDisplayNameIsVideoCallsCountLock.withLock { startNativeCallSessionRoomIDRoomDisplayNameIsVideoUnderlyingCallsCount = newValue } }
+    }
+    var startNativeCallSessionRoomIDRoomDisplayNameIsVideoCalled: Bool {
+        return startNativeCallSessionRoomIDRoomDisplayNameIsVideoCallsCount > 0
+    }
+    private let startNativeCallSessionRoomIDRoomDisplayNameIsVideoReceivedArgumentsLock = NSLock()
+    private nonisolated(unsafe) var startNativeCallSessionRoomIDRoomDisplayNameIsVideoUnderlyingReceivedArguments: (roomID: String, roomDisplayName: String, isVideo: Bool)?
+    var startNativeCallSessionRoomIDRoomDisplayNameIsVideoReceivedArguments: (roomID: String, roomDisplayName: String, isVideo: Bool)? {
+        get { startNativeCallSessionRoomIDRoomDisplayNameIsVideoReceivedArgumentsLock.withLock { startNativeCallSessionRoomIDRoomDisplayNameIsVideoUnderlyingReceivedArguments } }
+        set { startNativeCallSessionRoomIDRoomDisplayNameIsVideoReceivedArgumentsLock.withLock { startNativeCallSessionRoomIDRoomDisplayNameIsVideoUnderlyingReceivedArguments = newValue } }
+    }
+    private let startNativeCallSessionRoomIDRoomDisplayNameIsVideoReceivedInvocationsLock = NSLock()
+    private nonisolated(unsafe) var startNativeCallSessionRoomIDRoomDisplayNameIsVideoUnderlyingReceivedInvocations: [(roomID: String, roomDisplayName: String, isVideo: Bool)] = []
+    var startNativeCallSessionRoomIDRoomDisplayNameIsVideoReceivedInvocations: [(roomID: String, roomDisplayName: String, isVideo: Bool)] {
+        get { startNativeCallSessionRoomIDRoomDisplayNameIsVideoReceivedInvocationsLock.withLock { startNativeCallSessionRoomIDRoomDisplayNameIsVideoUnderlyingReceivedInvocations } }
+        set { startNativeCallSessionRoomIDRoomDisplayNameIsVideoReceivedInvocationsLock.withLock { startNativeCallSessionRoomIDRoomDisplayNameIsVideoUnderlyingReceivedInvocations = newValue } }
+    }
+    nonisolated(unsafe) var startNativeCallSessionRoomIDRoomDisplayNameIsVideoClosure: ((String, String, Bool) async -> Void)?
+
+    @concurrent func startNativeCallSession(roomID: String, roomDisplayName: String, isVideo: Bool) async {
+        startNativeCallSessionRoomIDRoomDisplayNameIsVideoCallsCountLock.withLock { startNativeCallSessionRoomIDRoomDisplayNameIsVideoUnderlyingCallsCount += 1 }
+        startNativeCallSessionRoomIDRoomDisplayNameIsVideoReceivedArguments = (roomID: roomID, roomDisplayName: roomDisplayName, isVideo: isVideo)
+        startNativeCallSessionRoomIDRoomDisplayNameIsVideoReceivedInvocationsLock.withLock { startNativeCallSessionRoomIDRoomDisplayNameIsVideoUnderlyingReceivedInvocations.append((roomID: roomID, roomDisplayName: roomDisplayName, isVideo: isVideo)) }
+        await startNativeCallSessionRoomIDRoomDisplayNameIsVideoClosure?(roomID, roomDisplayName, isVideo)
+    }
+    //MARK: - reportNativeCallConnected
+
+    private let reportNativeCallConnectedRoomIDCallsCountLock = NSLock()
+    private nonisolated(unsafe) var reportNativeCallConnectedRoomIDUnderlyingCallsCount = 0
+    var reportNativeCallConnectedRoomIDCallsCount: Int {
+        get { reportNativeCallConnectedRoomIDCallsCountLock.withLock { reportNativeCallConnectedRoomIDUnderlyingCallsCount } }
+        set { reportNativeCallConnectedRoomIDCallsCountLock.withLock { reportNativeCallConnectedRoomIDUnderlyingCallsCount = newValue } }
+    }
+    var reportNativeCallConnectedRoomIDCalled: Bool {
+        return reportNativeCallConnectedRoomIDCallsCount > 0
+    }
+    private let reportNativeCallConnectedRoomIDReceivedRoomIDLock = NSLock()
+    private nonisolated(unsafe) var reportNativeCallConnectedRoomIDUnderlyingReceivedRoomID: String?
+    var reportNativeCallConnectedRoomIDReceivedRoomID: String? {
+        get { reportNativeCallConnectedRoomIDReceivedRoomIDLock.withLock { reportNativeCallConnectedRoomIDUnderlyingReceivedRoomID } }
+        set { reportNativeCallConnectedRoomIDReceivedRoomIDLock.withLock { reportNativeCallConnectedRoomIDUnderlyingReceivedRoomID = newValue } }
+    }
+    private let reportNativeCallConnectedRoomIDReceivedInvocationsLock = NSLock()
+    private nonisolated(unsafe) var reportNativeCallConnectedRoomIDUnderlyingReceivedInvocations: [String] = []
+    var reportNativeCallConnectedRoomIDReceivedInvocations: [String] {
+        get { reportNativeCallConnectedRoomIDReceivedInvocationsLock.withLock { reportNativeCallConnectedRoomIDUnderlyingReceivedInvocations } }
+        set { reportNativeCallConnectedRoomIDReceivedInvocationsLock.withLock { reportNativeCallConnectedRoomIDUnderlyingReceivedInvocations = newValue } }
+    }
+    nonisolated(unsafe) var reportNativeCallConnectedRoomIDClosure: ((String) -> Void)?
+
+    func reportNativeCallConnected(roomID: String) {
+        reportNativeCallConnectedRoomIDCallsCountLock.withLock { reportNativeCallConnectedRoomIDUnderlyingCallsCount += 1 }
+        reportNativeCallConnectedRoomIDReceivedRoomID = roomID
+        reportNativeCallConnectedRoomIDReceivedInvocationsLock.withLock { reportNativeCallConnectedRoomIDUnderlyingReceivedInvocations.append(roomID) }
+        reportNativeCallConnectedRoomIDClosure?(roomID)
+    }
+    //MARK: - endNativeCallSession
+
+    private let endNativeCallSessionRoomIDCallsCountLock = NSLock()
+    private nonisolated(unsafe) var endNativeCallSessionRoomIDUnderlyingCallsCount = 0
+    var endNativeCallSessionRoomIDCallsCount: Int {
+        get { endNativeCallSessionRoomIDCallsCountLock.withLock { endNativeCallSessionRoomIDUnderlyingCallsCount } }
+        set { endNativeCallSessionRoomIDCallsCountLock.withLock { endNativeCallSessionRoomIDUnderlyingCallsCount = newValue } }
+    }
+    var endNativeCallSessionRoomIDCalled: Bool {
+        return endNativeCallSessionRoomIDCallsCount > 0
+    }
+    private let endNativeCallSessionRoomIDReceivedRoomIDLock = NSLock()
+    private nonisolated(unsafe) var endNativeCallSessionRoomIDUnderlyingReceivedRoomID: String?
+    var endNativeCallSessionRoomIDReceivedRoomID: String? {
+        get { endNativeCallSessionRoomIDReceivedRoomIDLock.withLock { endNativeCallSessionRoomIDUnderlyingReceivedRoomID } }
+        set { endNativeCallSessionRoomIDReceivedRoomIDLock.withLock { endNativeCallSessionRoomIDUnderlyingReceivedRoomID = newValue } }
+    }
+    private let endNativeCallSessionRoomIDReceivedInvocationsLock = NSLock()
+    private nonisolated(unsafe) var endNativeCallSessionRoomIDUnderlyingReceivedInvocations: [String] = []
+    var endNativeCallSessionRoomIDReceivedInvocations: [String] {
+        get { endNativeCallSessionRoomIDReceivedInvocationsLock.withLock { endNativeCallSessionRoomIDUnderlyingReceivedInvocations } }
+        set { endNativeCallSessionRoomIDReceivedInvocationsLock.withLock { endNativeCallSessionRoomIDUnderlyingReceivedInvocations = newValue } }
+    }
+    nonisolated(unsafe) var endNativeCallSessionRoomIDClosure: ((String) -> Void)?
+
+    func endNativeCallSession(roomID: String) {
+        endNativeCallSessionRoomIDCallsCountLock.withLock { endNativeCallSessionRoomIDUnderlyingCallsCount += 1 }
+        endNativeCallSessionRoomIDReceivedRoomID = roomID
+        endNativeCallSessionRoomIDReceivedInvocationsLock.withLock { endNativeCallSessionRoomIDUnderlyingReceivedInvocations.append(roomID) }
+        endNativeCallSessionRoomIDClosure?(roomID)
     }
 }
 nonisolated class ElementCallWidgetDriverMock: ElementCallWidgetDriverProtocol, @unchecked Sendable {

--- a/ElementX/Sources/Services/ElementCall/CXProviderProtocol.swift
+++ b/ElementX/Sources/Services/ElementCall/CXProviderProtocol.swift
@@ -12,6 +12,9 @@ protocol CXProviderProtocol {
     func setDelegate(_ delegate: CXProviderDelegate?, queue: DispatchQueue?)
     func reportNewIncomingCall(with uuid: UUID, update: CXCallUpdate, completion: @escaping @Sendable (Error?) -> Void)
     func reportCall(with uuid: UUID, endedAt: Date?, reason: CXCallEndedReason)
+    func reportOutgoingCall(with uuid: UUID, startedConnectingAt: Date?)
+    func reportOutgoingCall(with uuid: UUID, connectedAt: Date?)
+    func reportCall(with uuid: UUID, updated update: CXCallUpdate)
 }
 
 extension CXProvider: CXProviderProtocol { }

--- a/ElementX/Sources/Services/ElementCall/ElementCallService.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallService.swift
@@ -26,6 +26,14 @@ class ElementCallService: NSObject, ElementCallServiceProtocol, PKPushRegistryDe
         let roomID: String
         let rtcNotificationID: String?
         let isVoiceCall: Bool
+        /// A native call keeps its CallKit call alive; a web view call must not (see `CXAnswerCallAction`).
+        var isNative = false
+    }
+    
+    private var isNativeCallModeEnabled = false
+    
+    func setNativeCallModeEnabled(_ enabled: Bool) {
+        isNativeCallModeEnabled = enabled
     }
     
     private let pushRegistry: PKPushRegistry
@@ -136,6 +144,55 @@ class ElementCallService: NSObject, ElementCallServiceProtocol, PKPushRegistryDe
         tearDownCallSession(sendEndCallAction: true)
     }
     
+    // MARK: - Native calls
+    
+    func startNativeCallSession(roomID: String, roomDisplayName: String, isVideo: Bool) async {
+        if ongoingCallID != nil {
+            tearDownCallSession()
+        }
+        
+        if let incomingCallID, incomingCallID.roomID == roomID {
+            // Answering the ringing call: it is already reported, keep it.
+            var callID = incomingCallID
+            callID.isNative = true
+            clearIncomingCallState()
+            ongoingCallID = callID
+            return
+        }
+        
+        let callID = CallID(callKitID: UUID(), roomID: roomID, rtcNotificationID: nil, isVoiceCall: !isVideo, isNative: true)
+        clearIncomingCallState()
+        ongoingCallID = callID
+        
+        let handle = CXHandle(type: .generic, value: roomID)
+        let startCallAction = CXStartCallAction(call: callID.callKitID, handle: handle)
+        startCallAction.contactIdentifier = roomDisplayName
+        startCallAction.isVideo = isVideo
+        
+        do {
+            try await callController.request(CXTransaction(action: startCallAction))
+        } catch {
+            MXLog.error("Failed requesting start call action with error: \(error)")
+        }
+        
+        // Without this the system call UI shows the handle, i.e. the room ID.
+        let update = CXCallUpdate()
+        update.localizedCallerName = roomDisplayName
+        update.remoteHandle = handle
+        update.hasVideo = isVideo
+        callProvider.reportCall(with: callID.callKitID, updated: update)
+    }
+    
+    func reportNativeCallConnected(roomID: String) {
+        guard let ongoingCallID, ongoingCallID.roomID == roomID, ongoingCallID.isNative else { return }
+        callProvider.reportOutgoingCall(with: ongoingCallID.callKitID, connectedAt: nil)
+    }
+    
+    func endNativeCallSession(roomID: String) {
+        guard ongoingCallID?.roomID == roomID else { return }
+        tearDownCallSession(sendEndCallAction: true)
+    }
+    
     func setAudioEnabled(_ enabled: Bool, roomID: String) {
         guard let ongoingCallID else {
             MXLog.error("Failed toggling call microphone, no calls running")
@@ -215,7 +272,9 @@ class ElementCallService: NSObject, ElementCallServiceProtocol, PKPushRegistryDe
         // If not for audio call the app will not be put to foreground and the webview won't be able to handle the call...
         // Consequence: The call will be presented to the user as a video call in CallKit UI,
         // but once Element Call is launched it will correctly route to a voice-only call.
-        update.hasVideo = true
+        // The native stack streams from the background like any VoIP app, so an audio call answered
+        // from the lock screen stays in the system UI and only a video call opens the app.
+        update.hasVideo = isNativeCallModeEnabled ? !isVoiceCall : true
         update.localizedCallerName = roomDisplayName
         // https://stackoverflow.com/a/41230020/730924
         update.remoteHandle = .init(type: .generic, value: roomID)
@@ -253,10 +312,19 @@ class ElementCallService: NSObject, ElementCallServiceProtocol, PKPushRegistryDe
     
     func provider(_ provider: CXProvider, didActivate audioSession: AVAudioSession) {
         MXLog.info("Call provider did activate audio session")
+        actionsSubject.send(.audioSessionActivated)
     }
     
     func provider(_ provider: CXProvider, didDeactivate audioSession: AVAudioSession) {
         MXLog.info("Call provider did deactivate audio session")
+        actionsSubject.send(.audioSessionDeactivated)
+    }
+    
+    func provider(_ provider: CXProvider, perform action: CXStartCallAction) {
+        // The native controller configured the audio session already; CallKit activates it and
+        // reports back through `didActivate`.
+        action.fulfill()
+        callProvider.reportOutgoingCall(with: action.callUUID, startedConnectingAt: nil)
     }
     
     func providerDidReset(_ provider: CXProvider) {
@@ -287,6 +355,14 @@ class ElementCallService: NSObject, ElementCallServiceProtocol, PKPushRegistryDe
         // First fullfill the action
         action.fulfill()
         
+        if isNativeCallModeEnabled {
+            // The native stack owns media in this process, so the CallKit call stays up: the
+            // controller attaches to it in `startNativeCallSession`.
+            endUnansweredCallTask?.cancel()
+            actionsSubject.send(.startCall(roomID: incomingCallID.roomID, isVoiceCall: incomingCallID.isVoiceCall))
+            return
+        }
+        
         // And delay ending the call so that the app has enough time
         // to get deeplinked into
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
@@ -302,7 +378,8 @@ class ElementCallService: NSObject, ElementCallServiceProtocol, PKPushRegistryDe
         if let ongoingCallID {
             actionsSubject.send(.setAudioEnabled(!action.isMuted, roomID: ongoingCallID.roomID))
         } else {
-            MXLog.error("Failed muting/unmuting call, missing ongoingCallID")
+            // CallKit un-mutes a call as it ends, so this is expected right after a hang-up.
+            MXLog.info("Ignoring a mute action without an ongoing call")
         }
         
         action.fulfill()

--- a/ElementX/Sources/Services/ElementCall/ElementCallServiceProtocol.swift
+++ b/ElementX/Sources/Services/ElementCall/ElementCallServiceProtocol.swift
@@ -13,6 +13,9 @@ enum ElementCallServiceAction {
     case startCall(roomID: String, isVoiceCall: Bool)
     case endCall(roomID: String)
     case setAudioEnabled(_ enabled: Bool, roomID: String)
+    /// CallKit activated the audio session: a native call may start its audio engine now.
+    case audioSessionActivated
+    case audioSessionDeactivated
 }
 
 // sourcery: AutoMockable
@@ -28,4 +31,14 @@ protocol ElementCallServiceProtocol {
     func tearDownCallSession()
     
     func setAudioEnabled(_ enabled: Bool, roomID: String)
+    
+    // MARK: Native calls
+    
+    /// Whether an answered incoming call is handed to the native stack (kept alive in CallKit)
+    /// rather than to the web view (ended right after answering).
+    func setNativeCallModeEnabled(_ enabled: Bool)
+    /// Reports an outgoing native call to CallKit, or attaches to the ringing call it answers.
+    func startNativeCallSession(roomID: String, roomDisplayName: String, isVideo: Bool) async
+    func reportNativeCallConnected(roomID: String)
+    func endNativeCallSession(roomID: String)
 }

--- a/UnitTests/Sources/ElementCallServiceTests.swift
+++ b/UnitTests/Sources/ElementCallServiceTests.swift
@@ -136,6 +136,88 @@ final class ElementCallServiceTests {
         #expect(reason == .unanswered, "Call should have ended as unanswered")
     }
     
+    // MARK: - Native calls
+    
+    @Test
+    func nativeCallSessionReportsTheRoomNameAndVideoToCallKit() async {
+        await service.startNativeCallSession(roomID: "!room:example.com", roomDisplayName: "welcome", isVideo: true)
+        
+        #expect(callProvider.reportCallWithUpdatedCalled)
+        if let args = callProvider.reportCallWithUpdatedReceivedArguments {
+            #expect(args.update.localizedCallerName == "welcome")
+            #expect(args.update.hasVideo == true)
+            #expect(args.update.remoteHandle?.value == "!room:example.com")
+        } else {
+            Issue.record("Expected reportCallWithUpdatedReceivedArguments to be captured")
+        }
+        
+        // Connected is only reported for the call that is actually ongoing.
+        service.reportNativeCallConnected(roomID: "!other:example.com")
+        #expect(!callProvider.reportOutgoingCallWithConnectedAtCalled)
+        service.reportNativeCallConnected(roomID: "!room:example.com")
+        #expect(callProvider.reportOutgoingCallWithConnectedAtCalled)
+        #expect(callProvider.reportOutgoingCallWithConnectedAtReceivedArguments?.uuid == callProvider.reportCallWithUpdatedReceivedArguments?.uuid)
+        
+        // Ending clears the session, so a later connected report has nothing to attach to.
+        service.endNativeCallSession(roomID: "!room:example.com")
+        service.reportNativeCallConnected(roomID: "!room:example.com")
+        #expect(callProvider.reportOutgoingCallWithConnectedAtReceivedInvocations.count == 1)
+    }
+    
+    @Test
+    func nativeModeReportsVoiceCallsWithoutVideo() async {
+        service.setNativeCallModeEnabled(true)
+        
+        await waitForConfirmation { confirmation in
+            let pkPushPayloadMock = PKPushPayloadMock().updatingExpiration(currentDate, lifetime: 30)
+                .updateIsVoice(true)
+            
+            service.pushRegistry(pushRegistry, didReceiveIncomingPushWith: pkPushPayloadMock, for: .voIP) {
+                confirmation()
+            }
+        }
+        
+        // The native stack streams from the background, so an audio call can stay in the system UI:
+        // no need for the web view's "always video" workaround.
+        #expect(callProvider.reportNewIncomingCallWithUpdateCompletionReceivedArguments?.update.hasVideo == false)
+    }
+    
+    @Test
+    func answeringAnIncomingNativeCallKeepsTheCallKitCall() async throws {
+        service.setNativeCallModeEnabled(true)
+        
+        await waitForConfirmation { confirmation in
+            let pkPushPayloadMock = PKPushPayloadMock().updatingExpiration(currentDate, lifetime: 30)
+            service.pushRegistry(pushRegistry, didReceiveIncomingPushWith: pkPushPayloadMock, for: .voIP) {
+                confirmation()
+            }
+        }
+        let incomingUUID = try #require(callProvider.reportNewIncomingCallWithUpdateCompletionReceivedArguments?.uuid)
+        
+        let deferredStart = deferFulfillment(service.actions) { action in
+            if case .startCall = action {
+                return true
+            }
+            return false
+        }
+        service.provider(CXProvider(configuration: .init()), perform: CXAnswerCallAction(call: incomingUUID))
+        let action = try await deferredStart.fulfill()
+        guard case .startCall(let roomID, let isVoiceCall) = action else {
+            Issue.record("Expected a start call action")
+            return
+        }
+        #expect(roomID == "!room:example.com")
+        #expect(!isVoiceCall)
+        // The web view path ends the CallKit call right after answering; the native path keeps it.
+        #expect(!callProvider.reportCallWithEndedAtReasonCalled)
+        
+        // The controller then attaches to the ringing call rather than starting a second one.
+        await service.startNativeCallSession(roomID: "!room:example.com", roomDisplayName: "welcome", isVideo: true)
+        #expect(!callProvider.reportCallWithUpdatedCalled)
+        service.reportNativeCallConnected(roomID: "!room:example.com")
+        #expect(callProvider.reportOutgoingCallWithConnectedAtReceivedArguments?.uuid == incomingUUID)
+    }
+    
     @Test
     func callIntentRawValues() {
         // Test to ensure that the implicit rawValue of the string enum matches the MSC values


### PR DESCRIPTION
Ninth step of the native MatrixRTC calls stack (spike: `valere/native_call`; previous: #6124).

A web view call reports its CallKit call as ended right after answering, so that the web view can acquire media. A native call owns media in this process, so its CallKit call stays up for the whole call. `ElementCallService` gains a native mode (`setNativeCallModeEnabled`, pushed in by the flow coordinator later): `startNativeCallSession` requests a `CXStartCallAction` and then a call update so the system UI shows the room name rather than the room ID as handle; `reportNativeCallConnected` and `endNativeCallSession` complete the lifecycle; answering a ringing call in native mode keeps the CallKit call and lets the controller attach to it. Audio-session activation and deactivation, which CallKit owns, are relayed as actions to whoever runs the media. Voice calls are reported without video in native mode, since the native stack streams from the background and an audio call can stay in the system UI.

`CXProviderProtocol` gains the three provider calls this needs. Tests cover the outgoing session, connected reporting scoped to the ongoing call, voice calls without video in native mode, and the answer path keeping the call. Native mode is off; no behaviour change.

### Pull Request Checklist

- [ ] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [ ] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
