### PR TITLE
NativeCall | Add the audio-only MatrixRTC call

### DIFF
--- a/Components/MatrixRtcKit/Sources/Session/MatrixRtcCall.swift
+++ b/Components/MatrixRtcKit/Sources/Session/MatrixRtcCall.swift
@@ -1,0 +1,268 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Foundation
+import MatrixRtc
+import Observation
+import Synchronization
+import UIKit
+
+/// The media half of a session: publishes the microphone, camera and screen, plays every remote
+/// member and hands out video frames for tiles. Owned by `MatrixRtcSession`.
+@MainActor
+@Observable
+public final class MatrixRtcCall {
+    public let localMemberID: String
+    
+    /// The transport's roster (not the membership projection; the two can legitimately differ).
+    public private(set) var participants: [MatrixRtcParticipant] = []
+    public private(set) var audioLevels: [String: MatrixRtcAudioLevel] = [:]
+    public private(set) var receiveStats: [String: MatrixRtcReceiveStats] = [:]
+    public private(set) var activeSpeakerIDs: Set<String> = []
+    public private(set) var frameEncryption: [String: MatrixRtcFrameEncryptionState] = [:]
+    public private(set) var isMicrophoneMuted = false
+    public private(set) var isAudioTestToneEnabled = false
+    public private(set) var isMediaDegraded = false
+    public private(set) var hasEnded = false
+    
+    /// Every core event, after the call itself reacted to it.
+    public let events: AsyncStream<MatrixRtcCallEvent>
+    private let eventsContinuation: AsyncStream<MatrixRtcCallEvent>.Continuation
+    
+    private let mediaSession: MediaSession
+    private let audioEngine = CallAudioEngine()
+    @ObservationIgnored private lazy var microphone = MicrophoneCapturer(engine: audioEngine) { [weak self] level in
+        Task { @MainActor in self?.setAudioLevel(level, for: self?.localMemberID) }
+    }
+    
+    private var microphoneTrack: FfiLocalTrack?
+    private var playbackSinks = [String: AudioPlaybackSink]()
+    private var tasks = [Task<Void, Never>]()
+    
+    init(localMemberID: String, mediaSession: MediaSession) {
+        self.localMemberID = localMemberID
+        self.mediaSession = mediaSession
+        (events, eventsContinuation) = AsyncStream.makeStream(bufferingPolicy: .bufferingNewest(64))
+    }
+    
+    /// Starts the event pump **before** anything announces the call as connected (the stream has no
+    /// replay), then sweeps the roster for members already publishing.
+    func start() async {
+        tasks.append(Task { [weak self] in await self?.pumpEvents() })
+        tasks.append(Task { [weak self] in await self?.pollReceiveStats() })
+        refreshParticipants()
+        for participant in participants where !participant.isLocal && participant.stream(.microphone) != nil {
+            playAudio(of: participant.memberID)
+        }
+    }
+    
+    // MARK: - Audio device
+    
+    /// From CallKit's `didActivate audioSession` (or directly on the simulator).
+    public func startAudio() {
+        do {
+            try audioEngine.start()
+        } catch {
+            MatrixRtcLog.error("Failed starting the audio engine: \(error)")
+        }
+    }
+    
+    /// From CallKit's `didDeactivate audioSession`.
+    public func stopAudio() {
+        audioEngine.stop()
+    }
+    
+    // MARK: - Microphone
+    
+    public func publishMicrophone() async throws {
+        guard microphoneTrack == nil else { return }
+        let track: FfiLocalTrack
+        do {
+            track = try await mediaSession.publish(options: FfiPublishOptions(kind: .microphone,
+                                                                              audio: FfiAudioSourceConfig(sampleRate: UInt32(AudioFormat.sampleRate),
+                                                                                                          numChannels: UInt32(AudioFormat.channelCount)),
+                                                                              video: nil,
+                                                                              simulcast: false))
+        } catch {
+            throw MatrixRtcError.media("Failed to publish the microphone: \(error)")
+        }
+        microphoneTrack = track
+        microphone.setTestToneEnabled(isAudioTestToneEnabled)
+        microphone.start(track: track)
+        // The transport only learns about a mute once there is a track.
+        await setMicrophoneMuted(isMicrophoneMuted)
+        MatrixRtcLog.info("Publishing microphone as \(localMemberID)")
+    }
+    
+    /// Stops handing frames over **and** tells the transport, so peers see a deliberate mute rather
+    /// than a client that wedged.
+    public func setMicrophoneMuted(_ muted: Bool) async {
+        isMicrophoneMuted = muted
+        microphone.setMuted(muted)
+        await setTransportMuted(.microphone, muted: muted)
+    }
+    
+    public func setAudioTestToneEnabled(_ enabled: Bool) {
+        isAudioTestToneEnabled = enabled
+        microphone.setTestToneEnabled(enabled)
+    }
+    
+    public func disconnect() async {
+        tasks.forEach { $0.cancel() }
+        tasks.removeAll()
+        audioLevelFlush?.cancel()
+        audioLevelFlush = nil
+        microphone.stop()
+        playbackSinks.values.forEach { $0.stop() }
+        playbackSinks.removeAll()
+        audioEngine.stop()
+        do {
+            try await mediaSession.disconnect()
+        } catch {
+            MatrixRtcLog.warning("Failed to disconnect the media session: \(error)")
+        }
+        eventsContinuation.finish()
+    }
+    
+    // MARK: - Private
+    
+    private func pumpEvents() async {
+        while !Task.isCancelled, let ffiEvent = await mediaSession.nextEvent() {
+            let event = MatrixRtcCallEvent(ffiEvent)
+            handle(event)
+            eventsContinuation.yield(event)
+            refreshParticipants()
+        }
+        MatrixRtcLog.debug("Media event pump stopped")
+    }
+    
+    private func handle(_ event: MatrixRtcCallEvent) {
+        switch event {
+        case .streamStarted(let memberID, .microphone) where memberID != localMemberID:
+            playAudio(of: memberID)
+        case .streamStopped(let memberID, .microphone), .participantLeft(let memberID):
+            stopPlayback(of: memberID)
+        case .activeSpeakers(let speakers):
+            hasTransportSpeakerEvents = true
+            activeSpeakerIDs = Set(speakers.map(\.memberID))
+        case .frameEncryptionState(let memberID, let state):
+            if frameEncryption[memberID] != state {
+                MatrixRtcLog.warning("Frame encryption \(state) for \(memberID) (was \(frameEncryption[memberID].map { "\($0)" } ?? "unknown"))")
+            }
+            frameEncryption[memberID] = state
+        case .keyDiscarded(let memberID, let reason):
+            MatrixRtcLog.warning("Key for \(memberID) discarded: \(reason)")
+        case .keyImported(let memberID, let keyIndex):
+            MatrixRtcLog.info("Key index \(keyIndex) imported for \(memberID)")
+        case .mediaConnectionDegraded(let degraded):
+            isMediaDegraded = degraded
+        case .ended(let reason):
+            MatrixRtcLog.info("Media session ended: \(reason)")
+            hasEnded = true
+            playbackSinks.values.forEach { $0.stop() }
+            playbackSinks.removeAll()
+        default:
+            break
+        }
+    }
+    
+    /// `streamStarted` and the initial roster sweep both fire for a member already publishing; the
+    /// dictionary claim keeps a member from being played twice, slightly out of step.
+    private func playAudio(of memberID: String) {
+        guard memberID != localMemberID, playbackSinks[memberID] == nil else { return }
+        guard let stream = mediaSession.audioStream(memberId: memberID, kind: .microphone) else {
+            MatrixRtcLog.warning("Cannot open the audio stream for \(memberID)")
+            return
+        }
+        let sink = AudioPlaybackSink(memberID: memberID, engine: audioEngine) { [weak self] memberID, level in
+            Task { @MainActor in self?.setAudioLevel(level, for: memberID) }
+        }
+        playbackSinks[memberID] = sink
+        sink.start(stream: stream)
+        MatrixRtcLog.info("Playing audio of \(memberID)")
+    }
+    
+    private func stopPlayback(of memberID: String) {
+        playbackSinks.removeValue(forKey: memberID)?.stop()
+        audioLevels[memberID] = nil
+        pendingAudioLevels[memberID] = nil
+    }
+    
+    private func refreshParticipants() {
+        let refreshed = mediaSession.participants().map(MatrixRtcParticipant.init)
+        if Set(refreshed.map(\.memberID)) != Set(participants.map(\.memberID)) {
+            MatrixRtcLog.info("Media roster \(refreshed.count): \(refreshed.map { "\($0.memberID)\($0.isLocal ? " (self)" : "")" })")
+        }
+        participants = refreshed
+    }
+    
+    /// Above this RMS a member counts as speaking when the transport sends no speaker events.
+    private static let speakingThreshold: Float = 0.02
+    private var hasTransportSpeakerEvents = false
+    
+    /// Meters report ten times a second *per member*; published one by one, an eleven-person call
+    /// would rebuild every tile over a hundred times a second. Levels are collected here and
+    /// published in one batch per sample period, which is all a meter needs.
+    private static let audioLevelSamplePeriod: Duration = .milliseconds(100)
+    @ObservationIgnored private var pendingAudioLevels: [String: MatrixRtcAudioLevel] = [:]
+    @ObservationIgnored private var audioLevelFlush: Task<Void, Never>?
+    
+    private func setAudioLevel(_ level: MatrixRtcAudioLevel, for memberID: String?) {
+        guard let memberID else { return }
+        pendingAudioLevels[memberID] = level
+        guard audioLevelFlush == nil else { return }
+        audioLevelFlush = Task { [weak self] in
+            try? await Task.sleep(for: Self.audioLevelSamplePeriod)
+            guard !Task.isCancelled else { return }
+            self?.flushAudioLevels()
+        }
+    }
+    
+    private func flushAudioLevels() {
+        audioLevelFlush = nil
+        guard !pendingAudioLevels.isEmpty else { return }
+        var levels = audioLevels
+        for (memberID, level) in pendingAudioLevels {
+            levels[memberID] = level
+        }
+        pendingAudioLevels.removeAll(keepingCapacity: true)
+        audioLevels = levels
+        
+        // LiveKit's active-speaker updates have not been observed through the core (its event is
+        // logged at trace level only, so the log cannot say whether they fire); derive them from the
+        // decoded audio until they show up.
+        guard !hasTransportSpeakerEvents else { return }
+        let speaking = Set(audioLevels.filter { $0.value.level > Self.speakingThreshold }.keys)
+        if speaking != activeSpeakerIDs {
+            activeSpeakerIDs = speaking
+            let ranked = speaking.sorted { (audioLevels[$0]?.level ?? 0) > (audioLevels[$1]?.level ?? 0) }
+            eventsContinuation.yield(.activeSpeakers(ranked.map { .init(memberID: $0, level: audioLevels[$0]?.level ?? 0) }))
+        }
+    }
+    
+    /// RTCP reports arrive about once a second; polling faster only repeats values.
+    private func pollReceiveStats() async {
+        while !Task.isCancelled {
+            try? await Task.sleep(for: .seconds(1))
+            var stats = [String: MatrixRtcReceiveStats]()
+            for participant in participants where !participant.isLocal {
+                if let audio = await mediaSession.receiveStats(memberId: participant.memberID, kind: .microphone) {
+                    stats[participant.memberID] = .init(audio)
+                }
+            }
+            receiveStats = stats
+        }
+    }
+    
+    private func setTransportMuted(_ kind: MatrixRtcStreamKind, muted: Bool) async {
+        do {
+            try await mediaSession.setLocalMuted(kind: kind.ffi, muted: muted)
+        } catch {
+            MatrixRtcLog.warning("Could not tell the transport \(kind) is \(muted ? "muted" : "unmuted"): \(error)")
+        }
+    }
+}

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -1411,6 +1411,7 @@
 		DC08ADC41E792086A340A8B3 /* AccessibilityIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BB8DDE245ED86C489BA983 /* AccessibilityIdentifiers.swift */; };
 		DC68E866D6E664B0D2B06E74 /* MockImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC1DA29A5A041CC0BACA7CB0 /* MockImageCache.swift */; };
 		DC77E9DB2CFBE84A2BDF20C5 /* RoomRolesAndPermissionsFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0833F51229E166BCA141D004 /* RoomRolesAndPermissionsFlowCoordinator.swift */; };
+		DCEB55DDD4D9E166C19BD762 /* MatrixRtcCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D36FFDFF7C73193741003D /* MatrixRtcCall.swift */; };
 		DCFE7CB3B9A104330BBB96AD /* AnalyticsPromptScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B67DF223EEB8DCAF178A1D4 /* AnalyticsPromptScreenCoordinator.swift */; };
 		DD21CE51DF9BD04FC8155972 /* LeaveSpaceHandleSDKMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 580BDCD23DD02481AB5FFB47 /* LeaveSpaceHandleSDKMock.swift */; };
 		DD4D8B5D668197D345A3ED42 /* TimelineControllerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F933BB25FC426D5C67E1D812 /* TimelineControllerMock.swift */; };
@@ -2977,6 +2978,7 @@
 		C258C9C815272911A5B132C3 /* FormattedBodyText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattedBodyText.swift; sourceTree = "<group>"; };
 		C2886615BEBAE33A0AA4D5F8 /* RoomScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomScreenModels.swift; sourceTree = "<group>"; };
 		C2B8AA3199BAAD066E36CB07 /* RoomListSDKMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomListSDKMock.swift; sourceTree = "<group>"; };
+		C2D36FFDFF7C73193741003D /* MatrixRtcCall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatrixRtcCall.swift; sourceTree = "<group>"; };
 		C2E9B841EE4878283ECDB554 /* InviteUsersScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteUsersScreen.swift; sourceTree = "<group>"; };
 		C30F45308428A4D9FFDB2FB8 /* BannedRoomProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannedRoomProxy.swift; sourceTree = "<group>"; };
 		C3141EE5B2CBEC45270E01EB /* CreateRoomSpaceSelectionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateRoomSpaceSelectionSheet.swift; sourceTree = "<group>"; };
@@ -4940,6 +4942,7 @@
 			children = (
 				09B9FCEB43FD29D422409981 /* EncryptionKeyMapper.swift */,
 				B0D181FBD3D73887CDF42718 /* Mappers.swift */,
+				C2D36FFDFF7C73193741003D /* MatrixRtcCall.swift */,
 				E3EBB4F8D3DA4CD7F772CF2A /* MatrixRtcCommandSender.swift */,
 				D57B7AE0E195E737317E87FD /* MatrixRtcLog.swift */,
 				649FCD89E514713DC785F91D /* MatrixRtcLogging.swift */,
@@ -8752,6 +8755,7 @@
 				68A3CC4BDA906C45230E7111 /* CallAudioSessionConfigurator.swift in Sources */,
 				9F6EFBB1D710D34236F87430 /* EncryptionKeyMapper.swift in Sources */,
 				365D4AB2BD42729490C93146 /* Mappers.swift in Sources */,
+				DCEB55DDD4D9E166C19BD762 /* MatrixRtcCall.swift in Sources */,
 				5EFAB767D88D3D44E9AE89A4 /* MatrixRtcCommandSender.swift in Sources */,
 				B63D2F54666E6BF9B7C35024 /* MatrixRtcLog.swift in Sources */,
 				C8B3100A1CC12F9FFDC64937 /* MatrixRtcLogging.swift in Sources */,


### PR DESCRIPTION
Tenth step of the native MatrixRTC calls stack (spike: `valere/native_call`; previous: #6125).

`MatrixRtcCall` is the media half of a session: it owns the audio engine, publishes the microphone to the core's local track, plays every remote member through a playback sink, pumps the core's media events (streams starting and stopping, participants, frame-encryption state, key imports, degraded connection, session end) into an observable roster and an event stream, batches the per-member audio levels into one publish per 100 ms, derives active speakers from those levels while the transport's own speaker events are not observed, and polls receive stats once a second. Audio only for now: the camera, screen share and remote video parts of this class arrive with the video PRs, as additions to this file.

Public surface: `startAudio`/`stopAudio` (driven by CallKit's audio-session activation), `publishMicrophone`, `setMicrophoneMuted` (also told to the transport so peers see a deliberate mute), `setAudioTestToneEnabled` (a developer aid), `disconnect`, plus the observed `participants`, `audioLevels`, `activeSpeakerIDs`, `frameEncryption`, `receiveStats`, `isMediaDegraded`, `hasEnded`.

No behaviour change: nothing creates a call yet.


### Pull Request Checklist

- [ ] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [ ] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
