### PR TITLE
NativeCall | Add the MatrixRTC service and session

### DIFF
--- a/Components/MatrixRtcKit/Sources/Session/MatrixRtcService.swift
+++ b/Components/MatrixRtcKit/Sources/Session/MatrixRtcService.swift
@@ -1,0 +1,168 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Foundation
+import MatrixRtc
+import Synchronization
+
+/// One per Matrix session, created when the session exists rather than when a call starts: media
+/// keys arrive over to-device and cannot be caught up on, and the core is meant to notice calls.
+///
+/// Never rebuilt: it accumulates memberships and keys across calls.
+@MainActor
+public final class MatrixRtcService {
+    private let transport: MatrixRtcMatrixTransport
+    private var manager: RtcSessionManagerHandle?
+    private var keyFeeder: SessionKeyFeeder?
+    private var startTask: Task<RtcSessionManagerHandle, Never>?
+    private var sessions = [String: MatrixRtcSession]()
+    
+    public init(transport: MatrixRtcMatrixTransport) {
+        self.transport = transport
+    }
+    
+    /// Idempotent. Also called from `joinSession`, so a caller that forgets still gets a working call —
+    /// one that may have missed keys.
+    @discardableResult
+    func start() async -> RtcSessionManagerHandle {
+        if let manager {
+            return manager
+        }
+        if let startTask {
+            return await startTask.value
+        }
+        
+        let task = Task { [transport] in
+            // Logging must be installed by the host before this point; the core is silent otherwise.
+            let manager = RtcSessionManagerHandle()
+            do {
+                try await manager.setCommandSender(callback: MatrixRtcCommandSender(transport: transport))
+            } catch {
+                MatrixRtcLog.error("Failed setting the command sender: \(error)")
+            }
+            return manager
+        }
+        startTask = task
+        let manager = await task.value
+        self.manager = manager
+        
+        let keyFeeder = SessionKeyFeeder(manager: manager, transport: transport)
+        keyFeeder.start()
+        self.keyFeeder = keyFeeder
+        MatrixRtcLog.info("Core started for \(transport.userID)")
+        return manager
+    }
+    
+    public func stop() {
+        keyFeeder?.stop()
+        keyFeeder = nil
+    }
+    
+    /// Joins the slot: feeds room members and encryption first, joins, then subscribes and feeds memberships.
+    public func joinSession(roomID: String,
+                            slotID: String = MatrixRtcConstants.roomCallSlotID,
+                            application: String = MatrixRtcConstants.callApplication,
+                            transport liveKit: MatrixRtcTransport,
+                            compat: MatrixRtcElementCallCompat,
+                            notify: MatrixRtcNotify?) async throws -> MatrixRtcSession {
+        if let existing = sessions[roomID] {
+            throw MatrixRtcError.alreadyJoined(roomID: existing.roomID)
+        }
+        let manager = await start()
+        
+        // Nothing enforces this on the way in, and a malformed slot id looks healthy from our side
+        // while a conformant peer refuses the membership on sight.
+        if !slotID.hasPrefix("\(application)#") {
+            MatrixRtcLog.warning("Slot id '\(slotID)' does not start with '\(application)#'; conformant peers will refuse the membership")
+        }
+        
+        MatrixRtcLog.info("Joining \(roomID)/\(slotID) with Element Call compatibility \(compat)")
+        
+        do {
+            try await transport.willJoinRoom(roomID: roomID)
+        } catch {
+            MatrixRtcLog.error("The transport could not prepare \(roomID): \(error)")
+            throw MatrixRtcError.transport("\(error)")
+        }
+        
+        // Weak box so the feeder can report counts before the session object exists.
+        let countSink = MemberCountSink()
+        let feeder = RoomStateFeeder(manager: manager,
+                                     transport: transport,
+                                     roomID: roomID,
+                                     slotID: slotID,
+                                     compat: compat,
+                                     onMemberCount: { count in countSink.report(count) })
+        feeder.start()
+        await feeder.awaitRoomMembers()
+        
+        let memberID: String
+        do {
+            memberID = try await manager.join(params: FfiJoinSessionParams(userId: transport.userID,
+                                                                           deviceId: transport.deviceID,
+                                                                           roomId: roomID,
+                                                                           slotId: slotID,
+                                                                           application: application,
+                                                                           transport: liveKit.ffi,
+                                                                           canSubscribe: ["livekit"],
+                                                                           keepAliveTimeoutMs: 20000,
+                                                                           stickyDurationMs: nil, // The core owns the membership lifetime.
+                                                                           encryptionConfig: nil, // Follow whatever the slot prescribes.
+                                                                           elementCallCompat: compat.ffi,
+                                                                           notify: notify?.ffi))
+        } catch {
+            feeder.stop()
+            await transport.didLeaveRoom(roomID: roomID)
+            MatrixRtcLog.error("Join failed for \(roomID)/\(slotID): \(error)")
+            throw MatrixRtcError.ffi("\(error)")
+        }
+        MatrixRtcLog.info("Joined \(roomID)/\(slotID) as \(memberID)")
+        
+        let session = MatrixRtcSession(roomID: roomID,
+                                       slotID: slotID,
+                                       localMemberID: memberID,
+                                       manager: manager,
+                                       transport: transport,
+                                       feeder: feeder)
+        countSink.attach(session)
+        sessions[roomID] = session
+        await session.start()
+        return session
+    }
+    
+    /// Forgets a session once it has left; call after `MatrixRtcSession.leave()`.
+    public func release(roomID: String) async {
+        sessions[roomID] = nil
+        await transport.didLeaveRoom(roomID: roomID)
+    }
+    
+    public func debugSnapshot() async -> String {
+        guard let manager else { return "core not started" }
+        return await (try? manager.debugSnapshot()) ?? "unavailable"
+    }
+}
+
+/// Bridges the feeder's background count reports onto the main-actor session.
+private final nonisolated class MemberCountSink: Sendable {
+    private let session: Mutex<MatrixRtcSession?> = .init(nil)
+    private let pending: Mutex<Int?> = .init(nil)
+    
+    func attach(_ session: MatrixRtcSession) {
+        self.session.withLock { $0 = session }
+        if let count = pending.withLock({ $0 }) {
+            report(count)
+        }
+    }
+    
+    func report(_ count: Int) {
+        guard let session = session.withLock({ $0 }) else {
+            pending.withLock { $0 = count }
+            return
+        }
+        Task { @MainActor in session.setMemberCount(count) }
+    }
+}

--- a/Components/MatrixRtcKit/Sources/Session/MatrixRtcSession.swift
+++ b/Components/MatrixRtcKit/Sources/Session/MatrixRtcSession.swift
@@ -1,0 +1,168 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Foundation
+import MatrixRtc
+import Observation
+
+/// A joined MatrixRTC session: membership in, media attached separately.
+///
+/// Membership and media are separate steps. You are in the call as soon as `join` returned; media
+/// is attached with `connectMedia`. Teardown order matters: disconnect media → close the membership
+/// subscription → cancel feeds → leave.
+@MainActor
+@Observable
+public final class MatrixRtcSession {
+    public let roomID: String
+    public let slotID: String
+    /// Minted by the core at join time; what every event, roster entry and key report is keyed by.
+    public let localMemberID: String
+    
+    /// Identities from the core's membership projection (who is in the call).
+    public private(set) var members: [MatrixRtcMembership] = []
+    /// The core's own count, right whenever read; the projection above can lag in some compat modes.
+    public private(set) var memberCount = 0
+    public private(set) var call: MatrixRtcCall?
+    
+    private let manager: RtcSessionManagerHandle
+    private let transport: MatrixRtcMatrixTransport
+    private let feeder: RoomStateFeeder
+    private var hasLeft = false
+    
+    @ObservationIgnored private var membershipSubscription: MembershipSnapshotSubscription?
+    @ObservationIgnored private var membershipPoller: Task<Void, Never>?
+    
+    init(roomID: String,
+         slotID: String,
+         localMemberID: String,
+         manager: RtcSessionManagerHandle,
+         transport: MatrixRtcMatrixTransport,
+         feeder: RoomStateFeeder) {
+        self.roomID = roomID
+        self.slotID = slotID
+        self.localMemberID = localMemberID
+        self.manager = manager
+        self.transport = transport
+        self.feeder = feeder
+    }
+    
+    func setMemberCount(_ count: Int) {
+        memberCount = count
+    }
+    
+    /// Subscribes to membership snapshots, then starts the membership feed — in that order, because
+    /// `nextSnapshot()` only reports what changes *after* the subscription exists.
+    func start() async {
+        do {
+            membershipSubscription = try await manager.subscribeMembershipSnapshots(roomId: roomID, slotId: slotID)
+        } catch {
+            MatrixRtcLog.warning("Cannot subscribe to memberships for \(roomID)/\(slotID): \(error)")
+        }
+        
+        if let membershipSubscription {
+            // The Swift binding of `nextSnapshot()` is a non-blocking poll (Android gets a blocking reader):
+            // reading after each change would be ideal, a 1 s tick is close enough.
+            membershipPoller = Task { [weak self] in
+                while !Task.isCancelled {
+                    do {
+                        if let snapshot = try membershipSubscription.nextSnapshot() {
+                            let members = snapshot.map(MatrixRtcMembership.init)
+                            self?.updateMembers(members)
+                        }
+                    } catch {
+                        MatrixRtcLog.warning("Membership subscription for \(self?.roomID ?? "?") ended: \(error)")
+                        break
+                    }
+                    try? await Task.sleep(for: .seconds(1))
+                }
+            }
+        } else {
+            MatrixRtcLog.warning("No membership subscription for \(roomID)/\(slotID), the roster will not update")
+        }
+        
+        feeder.startMemberships()
+    }
+    
+    /// Attaches media. The core knows which membership this session joined as, so no member ID is passed.
+    public func connectMedia(transport liveKit: MatrixRtcTransport) async throws -> MatrixRtcCall {
+        if let call {
+            return call
+        }
+        guard case .liveKit(let serviceURL) = liveKit else { throw MatrixRtcError.noLiveKitTransport }
+        
+        let mediaSession: MediaSession
+        do {
+            mediaSession = try await connectMediaSession(manager: manager,
+                                                         config: MediaSessionConfig(roomId: roomID,
+                                                                                    slotId: slotID,
+                                                                                    userId: transport.userID,
+                                                                                    deviceId: transport.deviceID,
+                                                                                    livekitServiceUrl: serviceURL.absoluteString),
+                                                         tokenProvider: OpenIDTokenProviderAdapter(transport: transport))
+        } catch {
+            MatrixRtcLog.warning("Failed to connect media for \(roomID)/\(slotID): \(error)")
+            throw MatrixRtcError.media("\(error)")
+        }
+        
+        let call = MatrixRtcCall(localMemberID: localMemberID, mediaSession: mediaSession)
+        self.call = call
+        await call.start()
+        MatrixRtcLog.info("Media connected for \(roomID)/\(slotID) as \(localMemberID)")
+        return call
+    }
+    
+    /// Idempotent: hanging up and tearing the screen down both leave, and the core rejects a second attempt.
+    public func leave(reason: MatrixRtcLeaveReason? = nil) async {
+        guard !hasLeft else {
+            MatrixRtcLog.debug("Already left \(roomID)/\(slotID)")
+            return
+        }
+        hasLeft = true
+        
+        await call?.disconnect()
+        call = nil
+        // Before the leave: a snapshot arriving mid-leave makes the core create a fresh, unseeded session.
+        membershipPoller?.cancel()
+        membershipSubscription = nil
+        feeder.stop()
+        
+        do {
+            let leaveReason = reason.map { FfiLeaveReason(code: $0.code, reason: $0.reason) }
+            try await manager.leave(roomId: roomID, slotId: slotID, params: FfiLeaveSessionParams(leaveReason: leaveReason))
+            MatrixRtcLog.info("Left \(roomID)/\(slotID)")
+        } catch {
+            MatrixRtcLog.warning("Failed to leave \(roomID)/\(slotID): \(error)")
+        }
+    }
+    
+    private func updateMembers(_ members: [MatrixRtcMembership]) {
+        if members.map(\.memberID) != self.members.map(\.memberID) {
+            MatrixRtcLog.info("\(members.count) member(s) in \(roomID)/\(slotID): \(members.map(\.memberID))")
+        }
+        self.members = members
+    }
+}
+
+private final nonisolated class OpenIDTokenProviderAdapter: OpenIdTokenProvider, Sendable {
+    private let transport: MatrixRtcMatrixTransport
+    
+    init(transport: MatrixRtcMatrixTransport) {
+        self.transport = transport
+    }
+    
+    func getOpenIdToken() async throws -> FfiOpenIdToken {
+        do {
+            let token = try await transport.requestOpenIDToken()
+            return FfiOpenIdToken(accessToken: token.accessToken,
+                                  tokenType: token.tokenType,
+                                  matrixServerName: token.matrixServerName,
+                                  expiresInSecs: UInt64(max(0, token.expiresIn)))
+        } catch {
+            throw MediaFfiError.Token("OpenID token request failed: \(error)")
+        }
+    }
+}

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		0C797CD650DFD2876BEC5173 /* CollapsibleReactionLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7C6DDBB5D12F6EF6A3D6E1 /* CollapsibleReactionLayout.swift */; };
 		0C88044649BAEE6C49BFC43A /* SecureBackupControllerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C21A715237F2B6D6E80998C /* SecureBackupControllerProtocol.swift */; };
 		0C932A5158C1D0604DFC5750 /* ComposerToolbarViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA29952595B804DA221A0C1D /* ComposerToolbarViewModelTests.swift */; };
+		0CDF28EF1AD76D952D6DA63E /* MatrixRtcService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 751A114F015E62F21DD18FF4 /* MatrixRtcService.swift */; };
 		0D4EB2ABAA5FE8CB10FDBCB8 /* TimelineItemFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA3AF94A06D319BB37E52DA /* TimelineItemFactoryTests.swift */; };
 		0D617A152D099D94271D3BA8 /* SecurityAndPrivacyScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D046ABB22E680F7C5054441B /* SecurityAndPrivacyScreenViewModelProtocol.swift */; };
 		0DAB08C117E0391F3ADB2031 /* SpaceRoomListProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2B564CA6570E1487A7C7CC /* SpaceRoomListProxy.swift */; };
@@ -1514,6 +1515,7 @@
 		EC236C92F6FA50062273AEE1 /* MatrixRtcRoomBridgeProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 936085D12BB0094F78E1FB67 /* MatrixRtcRoomBridgeProtocol.swift */; };
 		EC3320639828BED8B3E5F2C6 /* EncryptionResetScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5875F7C0A2398E9F134B1284 /* EncryptionResetScreenViewModel.swift */; };
 		EC5B6D717560B9E275A0EA2F /* landscape_test_image.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 028CAFDBB60E2DBB24C3F621 /* landscape_test_image.jpg */; };
+		EC7C7F2AB5126997270C36B6 /* MatrixRtcSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65055EDE45A72BAD6671562 /* MatrixRtcSession.swift */; };
 		ECE4E03D17E309724013F825 /* TimelineInteractionHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C65A839BC897F6C236E8A5 /* TimelineInteractionHandlerTests.swift */; };
 		ED2BEDA7B074542A4D217ADF /* StaticLocationData.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECFB21A2FF41CF0E118790DD /* StaticLocationData.swift */; };
 		ED3E91E6166E4923791ACA84 /* ResolveVerifiedUserSendFailureScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56852036214ABA9D7D305768 /* ResolveVerifiedUserSendFailureScreenViewModelProtocol.swift */; };
@@ -2501,6 +2503,7 @@
 		74E08B8A66948E9690F38B94 /* SecureBackupLogoutConfirmationScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureBackupLogoutConfirmationScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		74FCAA90142DFBFA1E3E4216 /* SpaceAddRoomsScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceAddRoomsScreenCoordinator.swift; sourceTree = "<group>"; };
 		7509AB72755DCC4B4E721B36 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/SAS.strings; sourceTree = "<group>"; };
+		751A114F015E62F21DD18FF4 /* MatrixRtcService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatrixRtcService.swift; sourceTree = "<group>"; };
 		751C3DC87817362097287DCC /* HomeserverCapabilitiesProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeserverCapabilitiesProxy.swift; sourceTree = "<group>"; };
 		752A0EB49BF5BCEA37EDF7A3 /* Signposter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Signposter.swift; sourceTree = "<group>"; };
 		753B4C6C0EDDCBF0708DC384 /* TimelineItemSendInfoLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineItemSendInfoLabel.swift; sourceTree = "<group>"; };
@@ -3194,6 +3197,7 @@
 		E60757AFE04391B43EA568B8 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		E63072981793CCA84EE12798 /* ChatsSpaceFiltersScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatsSpaceFiltersScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		E6372DD10DED30E7AD7BCE21 /* RoomListFiltersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomListFiltersView.swift; sourceTree = "<group>"; };
+		E65055EDE45A72BAD6671562 /* MatrixRtcSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatrixRtcSession.swift; sourceTree = "<group>"; };
 		E66763BD54A3A1D9C6E6F2F1 /* PinnedItemsIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedItemsIndicatorView.swift; sourceTree = "<group>"; };
 		E6935A55AB3B0C94BC566DD6 /* EncryptionResetPasswordScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptionResetPasswordScreenCoordinator.swift; sourceTree = "<group>"; };
 		E6E6BDF9D26DB05C88901416 /* RedactedRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedactedRoomTimelineItem.swift; sourceTree = "<group>"; };
@@ -4946,6 +4950,8 @@
 				E3EBB4F8D3DA4CD7F772CF2A /* MatrixRtcCommandSender.swift */,
 				D57B7AE0E195E737317E87FD /* MatrixRtcLog.swift */,
 				649FCD89E514713DC785F91D /* MatrixRtcLogging.swift */,
+				751A114F015E62F21DD18FF4 /* MatrixRtcService.swift */,
+				E65055EDE45A72BAD6671562 /* MatrixRtcSession.swift */,
 				1D742BDC7819B045C83A6588 /* RoomStateFeeder.swift */,
 				9F87A9DA8EABF5ADBFA67535 /* SessionKeyFeeder.swift */,
 			);
@@ -8761,6 +8767,8 @@
 				C8B3100A1CC12F9FFDC64937 /* MatrixRtcLogging.swift in Sources */,
 				6F2925C185654654802C36C1 /* MatrixRtcMatrixTransport.swift in Sources */,
 				6D04ED80374F085C20AF8FC7 /* MatrixRtcModels.swift in Sources */,
+				0CDF28EF1AD76D952D6DA63E /* MatrixRtcService.swift in Sources */,
+				EC7C7F2AB5126997270C36B6 /* MatrixRtcSession.swift in Sources */,
 				FBC07D0E510235155CA227DB /* MicrophoneCapturer.swift in Sources */,
 				0E6ED509548F367AE52CEAF7 /* PCMRingBuffer.swift in Sources */,
 				6C408E7E641533FABC9C41CC /* RoomStateFeeder.swift in Sources */,


### PR DESCRIPTION
Eleventh step of the native MatrixRTC calls stack (spike: `valere/native_call`; previous: #6126).

`MatrixRtcService` is the framework's entry point, one per Matrix session: it starts the Rust session manager with the command sender and the key feeder, and `joinSession` asks the transport to prepare the room (the widget bridge starts here), starts a room-state feeder, joins the call in Element Call state-event compatibility mode and returns a `MatrixRtcSession`. The session exposes the membership roster and member count as observed state, `connectMedia(transport:)` which exchanges an OpenID token for the LiveKit connection and returns the `MatrixRtcCall`, and `leave(reason:)`; `release(roomID:)` tears it down and lets the transport stop the room bridge.

One change from the spike: `MatrixRtcService.start()` no longer returns the FFI session-manager handle from a public method (the internal `startManager()` does; PR 14 finishes this split when the flow coordinator needs `start()`).

No behaviour change: nothing creates a service yet.

### Pull Request Checklist

- [ ] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [ ] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
