### PR TITLE
NativeCall | Add the native call controller (audio)

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -278,6 +278,7 @@
 		2AAB2A77F1762A2648078A30 /* InteractiveQuickLook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638A81B97D51591D0FCFA598 /* InteractiveQuickLook.swift */; };
 		2AED12987603157C32C2114D /* TimelineBubbleLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D8FEB1FED10E995CB002F7 /* TimelineBubbleLayout.swift */; };
 		2B52B2A5A6496C5C0F952776 /* BannedRoomProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30F45308428A4D9FFDB2FB8 /* BannedRoomProxy.swift */; };
+		2B87402F4AB61D864754457A /* NativeCallModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA11B9CC13DAE6E297BBEAE /* NativeCallModels.swift */; };
 		2B97BCE72D86645F1485C976 /* RoomDirectorySearchMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 894EE8F5B399A165BA2A6634 /* RoomDirectorySearchMock.swift */; };
 		2BA59D0AEFB4B82A2EC2A326 /* KZFileWatchers in Frameworks */ = {isa = PBXBuildFile; productRef = A2AE110B053B55E38F8D10C7 /* KZFileWatchers */; };
 		2BAA5B222856068158D0B3C6 /* MatrixRustSDK in Frameworks */ = {isa = PBXBuildFile; productRef = B1E8B697DF78FE7F61FC6CA4 /* MatrixRustSDK */; };
@@ -1362,6 +1363,7 @@
 		D2DBA32E3CBFBDB519359078 /* MapViewConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B6D13B1D213F8C27395D7A /* MapViewConfiguration.swift */; };
 		D304343515CE0464C5089537 /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD5523BDEDB247E29228476 /* AppSettings.swift */; };
 		D33AC79A50DFC26D2498DD28 /* FileRoomTimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5098DA7799946A61E34A2373 /* FileRoomTimelineItem.swift */; };
+		D38159E25477BA1BEB051E9B /* NativeCallController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18304AC6FE1E4B59C985EE8E /* NativeCallController.swift */; };
 		D38E59C48BE5499A48D12031 /* CreateRoomScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64AC8FCE224D4185F28636FF /* CreateRoomScreenCoordinator.swift */; };
 		D3ED5692672892F9F1E7375A /* LiveLocationSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2FEFA393FC7D2870263012 /* LiveLocationSession.swift */; };
 		D3FD96913D2B1AAA3149DAC7 /* CreateRoomViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69D42EE0102D2857933625DD /* CreateRoomViewModelTests.swift */; };
@@ -1945,6 +1947,7 @@
 		17A8AA0DFA06012A9DAB951E /* TimelineProxyMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineProxyMock.swift; sourceTree = "<group>"; };
 		17BAE25A0E9E9F2F1BBA8930 /* DeactivateAccountScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeactivateAccountScreenViewModel.swift; sourceTree = "<group>"; };
 		181CF280BC8E3F335AFCB4B8 /* RemotePreferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemotePreferenceTests.swift; sourceTree = "<group>"; };
+		18304AC6FE1E4B59C985EE8E /* NativeCallController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeCallController.swift; sourceTree = "<group>"; };
 		18486B87745B1811E7FBD3D2 /* AnalyticsPromptScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsPromptScreenModels.swift; sourceTree = "<group>"; };
 		184CF8C196BE143AE226628D /* DecorationTimelineItemProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecorationTimelineItemProtocol.swift; sourceTree = "<group>"; };
 		18678D0A4177D8F0A255BC36 /* NotificationToneManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationToneManagerMock.swift; sourceTree = "<group>"; };
@@ -2260,6 +2263,7 @@
 		49E6066092ED45E36BB306F7 /* zh-Hant-TW */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "zh-Hant-TW"; path = "zh-Hant-TW.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
 		4A2B5274C1D3D2999D643786 /* EncryptionResetPasswordScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptionResetPasswordScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		4A5B4CD611DE7E94F5BA87B2 /* AppLockTimerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockTimerTests.swift; sourceTree = "<group>"; };
+		4AA11B9CC13DAE6E297BBEAE /* NativeCallModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeCallModels.swift; sourceTree = "<group>"; };
 		4AB29A2D95D3469B5F016655 /* SecureBackupControllerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureBackupControllerMock.swift; sourceTree = "<group>"; };
 		4AC3F28DECDF8665E8EBC76E /* ClassicAppMediaLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClassicAppMediaLoaderTests.swift; sourceTree = "<group>"; };
 		4B1F71AC585827E6C416C15A /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = AppIcon.icon; sourceTree = "<group>"; };
@@ -4274,6 +4278,8 @@
 				364DFC4CB8071AB4DB1BDAB9 /* MatrixRtcLogBridge.swift */,
 				936085D12BB0094F78E1FB67 /* MatrixRtcRoomBridgeProtocol.swift */,
 				E110889C205CD3254AA10C98 /* MatrixRtcTransportAdapter.swift */,
+				18304AC6FE1E4B59C985EE8E /* NativeCallController.swift */,
+				4AA11B9CC13DAE6E297BBEAE /* NativeCallModels.swift */,
 				0A0069A4D4ECBF63B2974641 /* RTCTransportDiscovery.swift */,
 				9964009E0A18BE38FADB062B /* Widget */,
 			);
@@ -9309,6 +9315,8 @@
 				551E03A935A6B73158A1AB4A /* NSEUserSessionMock.swift in Sources */,
 				F9842667B68DC6FA1F9ECCBB /* NSItemProvider.swift in Sources */,
 				EA01A06EEDFEF4AE7652E5F3 /* NSRegularExpresion.swift in Sources */,
+				D38159E25477BA1BEB051E9B /* NativeCallController.swift in Sources */,
+				2B87402F4AB61D864754457A /* NativeCallModels.swift in Sources */,
 				FA2BBAE9FC5E2E9F960C0980 /* NavigationCoordinators.swift in Sources */,
 				71C1347F23868324A4F43940 /* NavigationModule.swift in Sources */,
 				B5E455C9689EA600EDB3E9E0 /* NavigationRootCoordinator.swift in Sources */,

--- a/ElementX/Sources/Services/NativeCall/NativeCallController.swift
+++ b/ElementX/Sources/Services/NativeCall/NativeCallController.swift
@@ -1,0 +1,324 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import AVFoundation
+import Combine
+import Foundation
+import MatrixRtcKit
+import Observation
+import SwiftUI
+
+/// Owns the native call above the UI, so the call is a fact about the app rather than about the
+/// screen showing it: the full-screen view and a minimized bar are two renderings of one thing.
+///
+/// One per user session, created with the `MatrixRtcService`. Mutations are funnelled through the
+/// main actor so the UI only ever sees whole snapshots.
+@Observable
+final class NativeCallController {
+    private(set) var callData: NativeCallData?
+    private(set) var connection: NativeCallConnection = .idle
+    private(set) var session: MatrixRtcSession?
+    private(set) var call: MatrixRtcCall?
+    private(set) var connectedAt: Date?
+    private(set) var isLoudspeaker = false
+    
+    private let rtcService: MatrixRtcService
+    private let clientProxy: ClientProxyProtocol
+    private let elementCallService: ElementCallServiceProtocol
+    private var eventsTask: Task<Void, Never>?
+    private var routeObserver: NSObjectProtocol?
+    
+    init(rtcService: MatrixRtcService,
+         clientProxy: ClientProxyProtocol,
+         elementCallService: ElementCallServiceProtocol) {
+        self.rtcService = rtcService
+        self.clientProxy = clientProxy
+        self.elementCallService = elementCallService
+        
+        routeObserver = NotificationCenter.default.addObserver(forName: AVAudioSession.routeChangeNotification, object: nil, queue: .main) { [weak self] _ in
+            MainActor.assumeIsolated { self?.isLoudspeaker = CallAudioSessionConfigurator.isLoudspeaker }
+        }
+    }
+    
+    var isInCall: Bool {
+        switch connection {
+        case .joining, .connectingMedia, .connected: true
+        default: false
+        }
+    }
+    
+    // MARK: - Lifecycle
+    
+    func startCall(_ callData: NativeCallData) {
+        guard !isInCall else {
+            MXLog.warning("NativeCall: already in a call, ignoring start for \(callData.roomID)")
+            return
+        }
+        self.callData = callData
+        connection = .joining
+        runTask = Task { await runCall(callData) }
+    }
+    
+    func hangUp() {
+        Task { await endCall(leave: true) }
+    }
+    
+    // MARK: - Media controls
+    
+    /// From the UI: mutes the call and tells CallKit, whose echo comes back through `applyCallKitMute`.
+    func setMicrophoneMuted(_ muted: Bool) {
+        guard let callData else { return }
+        Task { await call?.setMicrophoneMuted(muted) }
+        elementCallService.setAudioEnabled(!muted, roomID: callData.roomID)
+    }
+    
+    /// From CallKit (lock screen, the UI's own transaction echoing back): idempotent at the call level.
+    func applyCallKitMute(_ muted: Bool) {
+        guard let call, call.isMicrophoneMuted != muted else { return }
+        Task { await call.setMicrophoneMuted(muted) }
+    }
+    
+    func setLoudspeaker(_ enabled: Bool) {
+        do {
+            try CallAudioSessionConfigurator.setLoudspeaker(enabled)
+            isLoudspeaker = CallAudioSessionConfigurator.isLoudspeaker
+        } catch {
+            MXLog.warning("NativeCall: could not switch the audio output: \(error)")
+        }
+    }
+    
+    // MARK: - CallKit hooks
+    
+    private var isAudioSessionActive = false
+    
+    /// CallKit activated the audio session. It may happen before or after media connects, so the
+    /// engine starts from whichever comes second.
+    func audioSessionDidActivate() {
+        isAudioSessionActive = true
+        startAudioIfReady()
+    }
+    
+    func audioSessionDidDeactivate() {
+        isAudioSessionActive = false
+        call?.stopAudio()
+    }
+    
+    /// A video call is looked at, not held to an ear, so it starts on the loudspeaker; a headset
+    /// still wins over both built-in outputs when one is connected.
+    private func startAudioIfReady() {
+        guard isAudioSessionActive, let call else { return }
+        call.startAudio()
+        if let callData, !callData.isAudioCall, CallAudioSessionConfigurator.isBuiltInReceiver {
+            setLoudspeaker(true)
+        }
+    }
+    
+    // MARK: - Private
+    
+    /// The join in flight, cancelled by `endCall`. Joining takes seconds and a hang-up can land
+    /// anywhere inside it; without this the join carried on, published camera and microphone into a
+    /// session nobody owned any more, and the app kept both open with no screen left to stop them.
+    private var runTask: Task<Void, Never>?
+    
+    private func runCall(_ callData: NativeCallData) async {
+        MXLog.info("NativeCall: joining \(callData.roomID)")
+        guard let (session, transport) = await joinSession(for: callData) else { return }
+        
+        connection = .connectingMedia
+        let call: MatrixRtcCall
+        do {
+            call = try await session.connectMedia(transport: transport)
+        } catch {
+            await session.leave()
+            await rtcService.release(roomID: callData.roomID)
+            fail("Media failed: \(error)")
+            return
+        }
+        guard !Task.isCancelled else {
+            await abandon(session: session, call: call, roomID: callData.roomID)
+            return
+        }
+        self.call = call
+        
+        await publishMedia(on: call, session: session, callData: callData)
+    }
+    
+    /// Claims the CallKit call, finds a transport and joins the session (our membership goes out).
+    private func joinSession(for callData: NativeCallData) async -> (MatrixRtcSession, MatrixRtcTransport)? {
+        // Claim the CallKit call *before* our membership goes out: the incoming-call watcher reads
+        // our own membership as "answered elsewhere" and would end the ringing call under us.
+        // For an outgoing call this requests the start action; CallKit activates the audio session
+        // either way and reports it through `audioSessionDidActivate`.
+        do {
+            try CallAudioSessionConfigurator.configure()
+        } catch {
+            MXLog.warning("NativeCall: could not configure the audio session: \(error)")
+        }
+        await elementCallService.startNativeCallSession(roomID: callData.roomID,
+                                                        roomDisplayName: callData.roomDisplayName,
+                                                        isVideo: !callData.isAudioCall)
+        
+        let discovery = RTCTransportDiscovery(homeserverURL: clientProxy.homeserver,
+                                              serverName: clientProxy.userIDServerName) { [clientProxy] url in
+            switch await clientProxy.getURL(url) {
+            case .success(let data): return data
+            case .failure(let error): throw error
+            }
+        }
+        let transports = await discovery.discover()
+        guard !Task.isCancelled else { return nil }
+        guard let transport = transports.first(where: {
+            if case .liveKit = $0 {
+                return true
+            } else {
+                return false
+            }
+        }) else {
+            fail("Homeserver offers no LiveKit transport")
+            return nil
+        }
+        
+        // Pinned while the released SDK lacks sticky events; a developer setting for the other compat
+        // modes comes back once the bindings have them.
+        let compat = MatrixRtcElementCallCompat.stateEvents
+        MXLog.info("NativeCall: joining with Element Call compatibility \(compat)")
+        
+        let session: MatrixRtcSession
+        do {
+            session = try await rtcService.joinSession(roomID: callData.roomID,
+                                                       transport: transport,
+                                                       compat: compat,
+                                                       notify: notify(for: callData))
+        } catch {
+            fail("Join failed: \(error)")
+            return nil
+        }
+        guard !Task.isCancelled else {
+            await abandon(session: session, roomID: callData.roomID)
+            return nil
+        }
+        self.session = session
+        return (session, transport)
+    }
+    
+    /// Microphone, then camera for a video call; the call counts as connected once the microphone is up.
+    private func publishMedia(on call: MatrixRtcCall, session: MatrixRtcSession, callData: NativeCallData) async {
+        #if targetEnvironment(simulator)
+        // CallKit never activates the session on the simulator.
+        try? CallAudioSessionConfigurator.activate()
+        isAudioSessionActive = true
+        #endif
+        // CallKit usually activated the session while we were still joining.
+        startAudioIfReady()
+        
+        do {
+            try await call.publishMicrophone()
+        } catch {
+            fail("Microphone failed: \(error)")
+            return
+        }
+        guard !Task.isCancelled else {
+            await abandon(session: session, call: call, roomID: callData.roomID)
+            return
+        }
+        MXLog.info("NativeCall: connected as \(call.localMemberID)")
+        
+        eventsTask = Task { [weak self] in
+            for await event in call.events {
+                self?.handle(event)
+            }
+        }
+        
+        connection = .connected
+        connectedAt = .now
+        isLoudspeaker = CallAudioSessionConfigurator.isLoudspeaker
+        elementCallService.reportNativeCallConnected(roomID: callData.roomID)
+    }
+    
+    private func handle(_ event: MatrixRtcCallEvent) {
+        switch event {
+        case .ended:
+            // From a different task than the event collector: teardown cancels that task.
+            Task { await endCall(leave: false) }
+        default:
+            break
+        }
+    }
+    
+    /// Only when *starting* a call; joining one someone else started happens quietly. A DM rings,
+    /// a group call is an invitation rather than a summons.
+    private func notify(for callData: NativeCallData) -> MatrixRtcNotify? {
+        guard callData.isStartingCall else { return nil }
+        return MatrixRtcNotify(kind: callData.isDirect ? .ring : .notification,
+                               intent: callData.isAudioCall ? .audio : .video)
+    }
+    
+    private func fail(_ message: String) {
+        MXLog.error("NativeCall: \(message)")
+        connection = .failed(message)
+        Task { await endCall(leave: true) }
+    }
+    
+    /// Tears down what a join produced after the call was ended under it. `leave` is idempotent,
+    /// so a session `endCall` already left costs nothing to leave again.
+    private func abandon(session: MatrixRtcSession, call: MatrixRtcCall? = nil, roomID: String) async {
+        MXLog.info("NativeCall: join of \(roomID) was cancelled, releasing what it set up")
+        await call?.disconnect()
+        await session.leave()
+        await rtcService.release(roomID: roomID)
+        if self.call === call {
+            self.call = nil
+        }
+        if self.session === session {
+            self.session = nil
+        }
+    }
+    
+    private func endCall(leave: Bool) async {
+        guard let callData else { return }
+        MXLog.info("NativeCall: ending call in \(callData.roomID) (leave=\(leave))")
+        runTask?.cancel()
+        runTask = nil
+        eventsTask?.cancel()
+        eventsTask = nil
+        
+        if let session {
+            if leave {
+                await session.leave()
+            } else {
+                await session.call?.disconnect()
+            }
+            await rtcService.release(roomID: callData.roomID)
+        }
+        call = nil
+        session = nil
+        elementCallService.endNativeCallSession(roomID: callData.roomID)
+        #if targetEnvironment(simulator)
+        CallAudioSessionConfigurator.deactivate()
+        #endif
+        
+        if case .failed = connection {
+            // Keep the failure visible until the screen is dismissed.
+        } else {
+            connection = .ended
+        }
+        connectedAt = nil
+    }
+    
+    /// Previews only: shows a state without joining anything.
+    func setPreviewState(callData: NativeCallData, connection: NativeCallConnection) {
+        self.callData = callData
+        self.connection = connection
+    }
+    
+    /// Back to idle once the screen has gone; a new call can start.
+    func reset() {
+        guard !isInCall else { return }
+        callData = nil
+        connection = .idle
+    }
+}

--- a/ElementX/Sources/Services/NativeCall/NativeCallModels.swift
+++ b/ElementX/Sources/Services/NativeCall/NativeCallModels.swift
@@ -1,0 +1,27 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Foundation
+
+/// What a call was started for; fixed at start time.
+struct NativeCallData: Equatable {
+    let roomID: String
+    let roomDisplayName: String
+    let isDirect: Bool
+    let isAudioCall: Bool
+    /// Whether this device is starting the call (rings the room) or joining one already running.
+    let isStartingCall: Bool
+}
+
+enum NativeCallConnection: Equatable {
+    case idle
+    case joining
+    case connectingMedia
+    case connected
+    case ended
+    case failed(String)
+}


### PR DESCRIPTION
Twelfth step of the native MatrixRTC calls stack (spike: `valere/native_call`; previous: #6127).

`NativeCallController` owns the native call above the UI, so the call is a fact about the app rather than about the screen showing it (the full-screen view and, later, a minimized bar are two renderings of one thing). One per user session, created with the `MatrixRtcService`. `startCall` claims the CallKit call *before* our membership goes out (the incoming-call watcher would otherwise read our own membership as "answered elsewhere"), discovers the LiveKit transport, joins the session in state-event compatibility mode, connects media, publishes the microphone and reports the call connected. It relays mute between the UI and CallKit in both directions, drives the loudspeaker, starts the audio engine once CallKit has activated the session (whichever of activation and media connection comes second), and tears down on hang-up, on the core ending the session, or on any failure. The join runs as one cancellable task, so a hang-up landing mid-join releases what the join had set up instead of leaking camera and microphone.

Audio only: camera, screen share, spotlight and Picture in Picture are added to this class by their PRs. `NativeCallData` and `NativeCallConnection` live in `NativeCallModels.swift` so the screen models can depend on them without the controller.

No behaviour change: nothing creates a controller yet.

### Pull Request Checklist

- [ ] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [ ] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
