### PR TITLE
NativeCall | Add the native call view model and tiles (audio)

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		08547E55DD3686A84550996D /* SeparatorMediaEventsTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13F354AD441E2FD83DED89AF /* SeparatorMediaEventsTimelineView.swift */; };
 		086D01E79C8E8D3F004FAF21 /* AudioPlayerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC9104846487244648D32C6D /* AudioPlayerProtocol.swift */; };
 		08CB4BD12CEEDE6AAE4A18DD /* WindowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035177BCD8E8308B098AC3C2 /* WindowManager.swift */; };
+		0902D78A62FA0442BECA4377 /* NativeCallTileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0610F3FDED4B26749AB9D5 /* NativeCallTileView.swift */; };
 		095C0ACFC234E0550A6404C5 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FC803282F9268D49F4ABF14 /* AppCoordinator.swift */; };
 		095D3906CF2F940C2D2D17CC /* RoomFlowCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FCB2126C091EEF2454B4D56 /* RoomFlowCoordinatorTests.swift */; };
 		09693596AA3CA4E598C0D2F1 /* ThreadTimelineScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73FEE625AB52042049DB9268 /* ThreadTimelineScreenCoordinator.swift */; };
@@ -440,6 +441,7 @@
 		4610C57A4785FFF5E67F0C6D /* SwiftOGG in Frameworks */ = {isa = PBXBuildFile; productRef = 391D11F92DFC91666AA1503F /* SwiftOGG */; };
 		46562110EE202E580A5FFD9C /* RoomScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CF7B19FFCF8EFBE0A8696A /* RoomScreenViewModelTests.swift */; };
 		4681820102DAC8BA586357D4 /* VoiceMessageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAB8D7926A5684E18196B538 /* VoiceMessageCache.swift */; };
+		4690D0810DDF514160ABA226 /* NativeCallControlsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0422F933274B4F3F83F7259 /* NativeCallControlsView.swift */; };
 		46A183C6125A669AEB005699 /* UserProfileScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = F134D2D91DFF732FB75B2CB7 /* UserProfileScreenViewModelProtocol.swift */; };
 		46A261AA898344A1F3C406B1 /* ReportContentScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCE3636E3D01477C8B2E9D0 /* ReportContentScreenModels.swift */; };
 		46A6DB0F78FB399BD59E2D41 /* EncryptionKeyProviderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E78FC546F28E045A560F2963 /* EncryptionKeyProviderProtocol.swift */; };
@@ -602,6 +604,7 @@
 		5F5488FBC9CFEB6F433D74A4 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 7109E709A7738E6BCC4553E6 /* Localizable.strings */; };
 		5FA1DCE55973862632961D7C /* PhotoLibraryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7495E1119753B06FF2C2279 /* PhotoLibraryManager.swift */; };
 		5FCD8AFA364206EE32B909A3 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = B050A6B233D95807A09289E7 /* Settings.bundle */; };
+		5FF7E19FAB4AF161ACC21001 /* NativeCallScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 852EEC661B81FD50070917C5 /* NativeCallScreenViewModelProtocol.swift */; };
 		601AB75BD52B0B4276CEB84A /* SessionVerificationScreenStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 161CD412E75F4086F422AE39 /* SessionVerificationScreenStateMachine.swift */; };
 		60ACDF0237CED82912786A33 /* test_apple_image.heic in Resources */ = {isa = PBXBuildFile; fileRef = 9C5639C7D679F094E7AB6B04 /* test_apple_image.heic */; };
 		60ED66E63A169E47489348A8 /* Collections in Frameworks */ = {isa = PBXBuildFile; productRef = A20EA00CCB9DBE0FFB17DD09 /* Collections */; };
@@ -628,8 +631,10 @@
 		63CDC201A5980F304F6D0A1C /* WaveformInteractionModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFEE91FB8ABB5F5884B6D940 /* WaveformInteractionModifier.swift */; };
 		63DCEBC1DD555E0D645B9E98 /* MapTilerURLBuilderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1033290D99D5BBA1AF3560A /* MapTilerURLBuilderProtocol.swift */; };
 		63E46D18B91D08E15FC04125 /* ExpiringTaskRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B25F959A434BB9923A3223F /* ExpiringTaskRunner.swift */; };
+		63E81B3F525B077C33EC5F39 /* NativeCallScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C440CFD2ED8DA1C773031F5B /* NativeCallScreenModels.swift */; };
 		63FD7DBE7BBA149B4B8B99D7 /* TimelineControllerFactoryMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F5CC38803B8382D2C63222 /* TimelineControllerFactoryMock.swift */; };
 		6448F8D1D3CA4CD27BB4CADD /* RoomMemberProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F36C5D9B37E50915ECBD3EE /* RoomMemberProxy.swift */; };
+		645BD041B96D17BB0AF37CEF /* NativeCallScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DA7A8EA74AAA546DFED0EA /* NativeCallScreenViewModel.swift */; };
 		64AB99285DC4437C0DDE9585 /* MenuSheetLabelStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49ABAB186CF00B15C5521D04 /* MenuSheetLabelStyle.swift */; };
 		64D05250CEDE8B604119F6E6 /* Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 981663D961C94270FA035FD0 /* Alert.swift */; };
 		64E541F88F35BD126C4AFCA1 /* AppLockScreenPINKeypad.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38345442415E07A931197C55 /* AppLockScreenPINKeypad.swift */; };
@@ -2337,6 +2342,7 @@
 		578AF9CE60816069536C0953 /* RoomRole.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomRole.swift; sourceTree = "<group>"; };
 		57916A1578D8043BB0795441 /* GeneratedMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratedMocks.swift; sourceTree = "<group>"; };
 		57AD14D3ADADE8F6A10F9E88 /* EncryptionSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptionSettingsTests.swift; sourceTree = "<group>"; };
+		57DA7A8EA74AAA546DFED0EA /* NativeCallScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeCallScreenViewModel.swift; sourceTree = "<group>"; };
 		57EAAF82432B0B53881CF826 /* AudioRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRoomTimelineItem.swift; sourceTree = "<group>"; };
 		580BDCD23DD02481AB5FFB47 /* LeaveSpaceHandleSDKMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaveSpaceHandleSDKMock.swift; sourceTree = "<group>"; };
 		584A61D9C459FAFEF038A7C0 /* Section.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Section.swift; sourceTree = "<group>"; };
@@ -2606,6 +2612,7 @@
 		85149F56BA333619900E2410 /* UserDetailsEditScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDetailsEditScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		851B95BB98649B8E773D6790 /* AppLockService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockService.swift; sourceTree = "<group>"; };
 		8520AFD6680CBAD388F6D927 /* TimelineItemProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineItemProvider.swift; sourceTree = "<group>"; };
+		852EEC661B81FD50070917C5 /* NativeCallScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeCallScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		8536B40F578BA7FDB23D97B1 /* UserIdentityProxyMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserIdentityProxyMock.swift; sourceTree = "<group>"; };
 		8544F7058D31DBEB8DBFF0F5 /* NotificationSettingsEditScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsEditScreenViewModelTests.swift; sourceTree = "<group>"; };
 		854BCEAF2A832176FAACD2CB /* SplashScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashScreenCoordinator.swift; sourceTree = "<group>"; };
@@ -2729,6 +2736,7 @@
 		99EB08B2C8B01F3BFE4B0CEC /* RoomMemberDetailsScreenHook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomMemberDetailsScreenHook.swift; sourceTree = "<group>"; };
 		9A008E57D52B07B78DFAD1BB /* RoomFlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomFlowCoordinator.swift; sourceTree = "<group>"; };
 		9A028783CFFF861C5E44FFB1 /* BadgeLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeLabel.swift; sourceTree = "<group>"; };
+		9A0610F3FDED4B26749AB9D5 /* NativeCallTileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeCallTileView.swift; sourceTree = "<group>"; };
 		9A22A05E472533ED3C5A31B3 /* NavigationModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationModule.swift; sourceTree = "<group>"; };
 		9A34D9BCA1A7D9A56E1EAF1D /* ManageRoomMemberSheetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageRoomMemberSheetViewModel.swift; sourceTree = "<group>"; };
 		9A68BCE6438873D2661D93D0 /* BugReportServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugReportServiceProtocol.swift; sourceTree = "<group>"; };
@@ -2872,6 +2880,7 @@
 		AF848B41DAF1066F3054D4A1 /* SessionVerificationScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionVerificationScreenModels.swift; sourceTree = "<group>"; };
 		AF8548D48512127CCC17C520 /* PollRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollRoomTimelineView.swift; sourceTree = "<group>"; };
 		AFEF489B8E2450E2BA1A314E /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/SAS.strings; sourceTree = "<group>"; };
+		B0422F933274B4F3F83F7259 /* NativeCallControlsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeCallControlsView.swift; sourceTree = "<group>"; };
 		B050A6B233D95807A09289E7 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = wrapper.cfbundle; path = Settings.bundle; sourceTree = "<group>"; };
 		B0618820D26F9871A4BBB40E /* ComposerToolbarViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerToolbarViewModelProtocol.swift; sourceTree = "<group>"; };
 		B08CBE1E670690ECF11C2C6A /* eu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = eu; path = eu.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
@@ -2992,6 +3001,7 @@
 		C3285BD95B564CA2A948E511 /* OnboardingFlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFlowCoordinator.swift; sourceTree = "<group>"; };
 		C33B3F17996DFDF5F0181512 /* Data.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Data.swift; sourceTree = "<group>"; };
 		C352359663A0E52BA20761EE /* LoadableImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadableImage.swift; sourceTree = "<group>"; };
+		C440CFD2ED8DA1C773031F5B /* NativeCallScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeCallScreenModels.swift; sourceTree = "<group>"; };
 		C454F35D8884C0A952FF2F84 /* LiveLocationSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveLocationSheet.swift; sourceTree = "<group>"; };
 		C4756240773D26AB74C22668 /* OrientationManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrientationManagerProtocol.swift; sourceTree = "<group>"; };
 		C4C1C19A4BE46EDE1411ECCE /* ThreadTimelineScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadTimelineScreenViewModelProtocol.swift; sourceTree = "<group>"; };
@@ -5254,6 +5264,15 @@
 			path = SearchScreen;
 			sourceTree = "<group>";
 		};
+		69E6743659DF7792FCFCD461 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				B0422F933274B4F3F83F7259 /* NativeCallControlsView.swift */,
+				9A0610F3FDED4B26749AB9D5 /* NativeCallTileView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
 		6B0910BCE4F1B02F124E1A09 /* TimelineItemContent */ = {
 			isa = PBXGroup;
 			children = (
@@ -7158,6 +7177,17 @@
 			path = View;
 			sourceTree = "<group>";
 		};
+		DE07A244ACE83E40D894EDF3 /* NativeCallScreen */ = {
+			isa = PBXGroup;
+			children = (
+				C440CFD2ED8DA1C773031F5B /* NativeCallScreenModels.swift */,
+				57DA7A8EA74AAA546DFED0EA /* NativeCallScreenViewModel.swift */,
+				852EEC661B81FD50070917C5 /* NativeCallScreenViewModelProtocol.swift */,
+				69E6743659DF7792FCFCD461 /* View */,
+			);
+			path = NativeCallScreen;
+			sourceTree = "<group>";
+		};
 		DE77D5FC2A361306E4440687 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -7255,6 +7285,7 @@
 				87E2774157D9C4894BCFF3F8 /* MediaPickerScreen */,
 				23605DD08620BE6558242469 /* MediaUploadPreviewScreen */,
 				3348D14DBDB54E72FC67E2F3 /* MessageForwardingScreen */,
+				DE07A244ACE83E40D894EDF3 /* NativeCallScreen */,
 				8F074E22FD93E64211971845 /* Onboarding */,
 				A448A3A8F764174C60CD0CA1 /* Other */,
 				3E535010B850B53DDD3CFF2A /* PinnedEventsTimelineScreen */,
@@ -9316,7 +9347,12 @@
 				F9842667B68DC6FA1F9ECCBB /* NSItemProvider.swift in Sources */,
 				EA01A06EEDFEF4AE7652E5F3 /* NSRegularExpresion.swift in Sources */,
 				D38159E25477BA1BEB051E9B /* NativeCallController.swift in Sources */,
+				4690D0810DDF514160ABA226 /* NativeCallControlsView.swift in Sources */,
 				2B87402F4AB61D864754457A /* NativeCallModels.swift in Sources */,
+				63E81B3F525B077C33EC5F39 /* NativeCallScreenModels.swift in Sources */,
+				645BD041B96D17BB0AF37CEF /* NativeCallScreenViewModel.swift in Sources */,
+				5FF7E19FAB4AF161ACC21001 /* NativeCallScreenViewModelProtocol.swift in Sources */,
+				0902D78A62FA0442BECA4377 /* NativeCallTileView.swift in Sources */,
 				FA2BBAE9FC5E2E9F960C0980 /* NavigationCoordinators.swift in Sources */,
 				71C1347F23868324A4F43940 /* NavigationModule.swift in Sources */,
 				B5E455C9689EA600EDB3E9E0 /* NavigationRootCoordinator.swift in Sources */,

--- a/ElementX/Sources/Screens/NativeCallScreen/NativeCallScreenModels.swift
+++ b/ElementX/Sources/Screens/NativeCallScreen/NativeCallScreenModels.swift
@@ -1,0 +1,57 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Foundation
+
+enum NativeCallScreenViewModelAction {
+    case minimize
+    case dismiss
+}
+
+/// One tile of the call: a member as the layout sees it, video or avatar.
+struct NativeCallTile: Identifiable, Equatable {
+    let memberID: String
+    let userID: String
+    let displayName: String
+    let avatarURL: URL?
+    let isLocal: Bool
+    /// Cannot be heard: muted, or no microphone stream reached us at all. The badge collapses the
+    /// two on purpose; `hasMicrophone` keeps them apart for the stats overlay, where the question is why.
+    let isMicrophoneMuted: Bool
+    /// Whether a microphone stream reaches us at all, muted or not. Absent is a fault worth showing:
+    /// a member the SFU relays to everyone else would otherwise read here as having muted themselves.
+    let hasMicrophone: Bool
+    let isSpeaking: Bool
+    let audioLevel: Float
+    
+    var id: String {
+        memberID
+    }
+}
+
+struct NativeCallScreenViewState: BindableState {
+    var roomName: String
+    var connection: NativeCallConnection = .idle
+    var connectedAt: Date?
+    var memberCount = 0
+    var tiles: [NativeCallTile] = []
+    var isMicrophoneMuted = false
+    var isLoudspeaker = false
+    var isMediaDegraded = false
+    
+    var bindings = NativeCallScreenViewStateBindings()
+}
+
+struct NativeCallScreenViewStateBindings { }
+
+enum NativeCallScreenViewAction {
+    case toggleMicrophone
+    case toggleLoudspeaker
+    case minimize
+    case hangUp
+    case dismiss
+}

--- a/ElementX/Sources/Screens/NativeCallScreen/NativeCallScreenViewModel.swift
+++ b/ElementX/Sources/Screens/NativeCallScreen/NativeCallScreenViewModel.swift
@@ -1,0 +1,120 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Combine
+import MatrixRtcKit
+import SwiftUI
+
+typealias NativeCallScreenViewModelType = StateStoreViewModelV2<NativeCallScreenViewState, NativeCallScreenViewAction>
+
+/// Projects the app-scoped `NativeCallController` into a view state. The controller owns the call;
+/// this only renders it and forwards taps.
+class NativeCallScreenViewModel: NativeCallScreenViewModelType, NativeCallScreenViewModelProtocol {
+    private let actionsSubject: PassthroughSubject<NativeCallScreenViewModelAction, Never> = .init()
+    var actionsPublisher: AnyPublisher<NativeCallScreenViewModelAction, Never> {
+        actionsSubject.eraseToAnyPublisher()
+    }
+    
+    private let controller: NativeCallController
+    private let roomProxy: JoinedRoomProxyProtocol
+    private var observationTask: Task<Void, Never>?
+    private var members: [String: RoomMemberProxyProtocol] = [:]
+    private var hasRequestedDismissal = false
+    
+    init(controller: NativeCallController, roomProxy: JoinedRoomProxyProtocol, mediaProvider: MediaProviderProtocol?) {
+        self.controller = controller
+        self.roomProxy = roomProxy
+        super.init(initialViewState: .init(roomName: roomProxy.infoPublisher.value.displayName ?? roomProxy.id),
+                   mediaProvider: mediaProvider)
+        
+        roomProxy.infoPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] info in
+                guard let self else { return }
+                state.roomName = info.displayName ?? info.rawName ?? info.canonicalAlias ?? roomProxy.id
+            }
+            .store(in: &cancellables)
+        
+        roomProxy.membersPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] members in
+                self?.members = Dictionary(members.map { ($0.userID, $0) }) { first, _ in first }
+                self?.refresh()
+            }
+            .store(in: &cancellables)
+        
+        observe()
+    }
+    
+    override func process(viewAction: NativeCallScreenViewAction) {
+        switch viewAction {
+        case .toggleMicrophone:
+            controller.setMicrophoneMuted(!(controller.call?.isMicrophoneMuted ?? false))
+        case .toggleLoudspeaker:
+            controller.setLoudspeaker(!controller.isLoudspeaker)
+        case .minimize:
+            actionsSubject.send(.minimize)
+        case .hangUp:
+            controller.hangUp()
+        case .dismiss:
+            controller.reset()
+            actionsSubject.send(.dismiss)
+        }
+    }
+    
+    // MARK: - Private
+    
+    /// Re-reads the controller's snapshot whenever anything it (or the call) publishes changes.
+    private func observe() {
+        observationTask?.cancel()
+        observationTask = Task { [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                await withCheckedContinuation { continuation in
+                    withObservationTracking {
+                        self.refresh()
+                    } onChange: {
+                        continuation.resume()
+                    }
+                }
+            }
+        }
+    }
+    
+    private func refresh() {
+        state.connection = controller.connection
+        state.connectedAt = controller.connectedAt
+        state.isLoudspeaker = controller.isLoudspeaker
+        state.memberCount = controller.session?.memberCount ?? 0
+        
+        // The call object is gone once the call ended, so this must come before the early return.
+        if case .ended = controller.connection, !hasRequestedDismissal {
+            hasRequestedDismissal = true
+            actionsSubject.send(.dismiss)
+        }
+        
+        guard let call = controller.call else {
+            state.tiles = []
+            return
+        }
+        state.isMicrophoneMuted = call.isMicrophoneMuted
+        state.isMediaDegraded = call.isMediaDegraded
+        
+        state.tiles = call.participants.map { participant in
+            let member = members[participant.userID]
+            return NativeCallTile(memberID: participant.memberID,
+                                  userID: participant.userID,
+                                  displayName: participant.isLocal ? L10n.commonYou : (member?.displayName ?? participant.userID),
+                                  avatarURL: member?.avatarURL,
+                                  isLocal: participant.isLocal,
+                                  isMicrophoneMuted: participant.isLocal ? call.isMicrophoneMuted : !participant.isPublishing(.microphone),
+                                  hasMicrophone: participant.isLocal || participant.stream(.microphone) != nil,
+                                  isSpeaking: call.activeSpeakerIDs.contains(participant.memberID),
+                                  audioLevel: call.audioLevels[participant.memberID]?.level ?? 0)
+        }
+    }
+}

--- a/ElementX/Sources/Screens/NativeCallScreen/NativeCallScreenViewModelProtocol.swift
+++ b/ElementX/Sources/Screens/NativeCallScreen/NativeCallScreenViewModelProtocol.swift
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Combine
+
+@MainActor
+protocol NativeCallScreenViewModelProtocol {
+    var actionsPublisher: AnyPublisher<NativeCallScreenViewModelAction, Never> { get }
+    var context: NativeCallScreenViewModel.Context { get }
+}

--- a/ElementX/Sources/Screens/NativeCallScreen/View/NativeCallControlsView.swift
+++ b/ElementX/Sources/Screens/NativeCallScreen/View/NativeCallControlsView.swift
@@ -1,0 +1,85 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import AVKit
+import Compound
+import SwiftUI
+
+/// The floating bottom bar from the design: mic, audio route, hang up; camera and screen share come
+/// with their features.
+struct NativeCallControlsView: View {
+    @Bindable var context: NativeCallScreenViewModel.Context
+    
+    var body: some View {
+        HStack(spacing: 12) {
+            controlButton(icon: context.viewState.isMicrophoneMuted ? \.micOffSolid : \.micOnSolid,
+                          isActive: !context.viewState.isMicrophoneMuted,
+                          label: context.viewState.isMicrophoneMuted ? "Unmute" : "Mute") {
+                context.send(viewAction: .toggleMicrophone)
+            }
+            audioRouteButton
+            Button {
+                context.send(viewAction: .hangUp)
+            } label: {
+                CompoundIcon(\.endCall)
+                    .foregroundStyle(.white)
+                    .frame(width: 56, height: 56)
+                    .background(Color.compound.bgCriticalPrimary, in: Circle())
+            }
+            .accessibilityLabel("Hang up")
+        }
+        .padding(8)
+        .background(Color.compound.bgCanvasDefaultLevel1.opacity(0.9), in: Capsule())
+    }
+    
+    /// Speaker toggles the loudspeaker; a long press opens the system route picker for
+    /// Bluetooth and other outputs.
+    private var audioRouteButton: some View {
+        ZStack {
+            controlButton(icon: context.viewState.isLoudspeaker ? \.volumeOnSolid : \.volumeOffSolid,
+                          isActive: !context.viewState.isLoudspeaker,
+                          label: "Audio output") {
+                context.send(viewAction: .toggleLoudspeaker)
+            }
+            NativeAudioRoutePicker()
+                .frame(width: 56, height: 56)
+                .opacity(0.02)
+        }
+    }
+    
+    /// `isActive` is the resting state (dark circle); the inverse is the highlighted white circle
+    /// the design uses for mic off, camera off, sharing and loudspeaker.
+    private func controlButton(icon: KeyPath<CompoundIcons, Image>, isActive: Bool, label: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            CompoundIcon(icon)
+                .foregroundStyle(isActive ? .compound.iconPrimary : .compound.iconOnSolidPrimary)
+                .frame(width: 56, height: 56)
+                .background(isActive ? Color.compound.bgSubtleSecondary : Color.compound.bgActionPrimaryRest, in: Circle())
+        }
+        .accessibilityLabel(label)
+    }
+}
+
+struct NativeCallRoundButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .foregroundStyle(.compound.iconPrimary)
+            .frame(width: 44, height: 44)
+            .background(Color.compound.bgSubtleSecondary.opacity(configuration.isPressed ? 0.6 : 1), in: Circle())
+    }
+}
+
+/// The system output picker, drawn nearly transparent over the speaker button so a tap reaches it.
+struct NativeAudioRoutePicker: UIViewRepresentable {
+    func makeUIView(context: Context) -> AVRoutePickerView {
+        let view = AVRoutePickerView()
+        view.prioritizesVideoDevices = false
+        return view
+    }
+    
+    func updateUIView(_ uiView: AVRoutePickerView, context: Context) { }
+}

--- a/ElementX/Sources/Screens/NativeCallScreen/View/NativeCallTileView.swift
+++ b/ElementX/Sources/Screens/NativeCallScreen/View/NativeCallTileView.swift
@@ -1,0 +1,75 @@
+//
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial.
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Compound
+import MatrixRtcKit
+import SwiftUI
+
+/// One participant: the avatar, name and mic badge, and an outline for the active speaker.
+struct NativeCallTileView: View {
+    let tile: NativeCallTile
+    var isSpotlight = false
+    var memberCount = 0
+    let mediaProvider: MediaProviderProtocol?
+    let onAction: (NativeCallScreenViewAction) -> Void
+    
+    var body: some View {
+        ZStack {
+            Color.compound.bgSubtleSecondary
+            
+            LoadableAvatarImage(url: tile.avatarURL,
+                                name: tile.displayName,
+                                contentID: tile.userID,
+                                avatarSize: .user(on: .memberDetails),
+                                mediaProvider: mediaProvider)
+            
+            cardChrome
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .overlay {
+            RoundedRectangle(cornerRadius: 16)
+                .strokeBorder(outlineColor, lineWidth: 3)
+        }
+    }
+    
+    private var cardChrome: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 4) {
+                if isSpotlight, memberCount > 0 {
+                    badge {
+                        CompoundIcon(\.userProfileSolid, size: .xSmall, relativeTo: .compound.bodySM)
+                        Text("\(memberCount)")
+                    }
+                }
+                Spacer()
+            }
+            Spacer()
+            HStack(alignment: .bottom, spacing: 4) {
+                badge {
+                    CompoundIcon(tile.isMicrophoneMuted ? \.micOffSolid : \.micOnSolid, size: .xSmall, relativeTo: .compound.bodySM)
+                    Text(tile.displayName)
+                        .lineLimit(1)
+                }
+                Spacer()
+            }
+        }
+        .padding(8)
+    }
+    
+    private var outlineColor: Color {
+        tile.isSpeaking ? .compound.borderSuccessSubtle : .clear
+    }
+    
+    private func badge(@ViewBuilder content: () -> some View) -> some View {
+        HStack(spacing: 4) { content() }
+            .font(.compound.bodySMSemibold)
+            .foregroundStyle(.compound.textPrimary)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(Color.black.opacity(0.5), in: Capsule())
+    }
+}


### PR DESCRIPTION
Thirteenth step of the native MatrixRTC calls stack (spike: `valere/native_call`; previous: #6128).

`NativeCallScreenViewModel` (a `StateStoreViewModelV2`) projects the app-scoped `NativeCallController` into a view state. It re-reads the controller's snapshot through `withObservationTracking` whenever anything the controller or the call publishes changes, maps the call's participants onto `NativeCallTile`s with the room members' display names and avatars, mute state, microphone presence, speaking state and audio level, and forwards taps: mute, loudspeaker, hang up, minimize, dismiss. When the controller reports the call ended it asks for dismissal once.

`NativeCallTileView` draws the avatar, the name and mic badge, and the active-speaker outline; `NativeCallControlsView` is the floating bar with mic, audio route (tap toggles the loudspeaker, the system route picker sits over it for Bluetooth) and hang up. Camera, screen share, spotlight, Picture in Picture and the one-to-one layout extend these in their PRs.

No behaviour change: no screen presents this yet.

### Pull Request Checklist

- [ ] I read the [contributing guide](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md).
- [ ] I am aware of the [etiquette](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#etiquette).
- [ ] Pull request contains a [changelog label](https://github.com/element-hq/element-x-ios/blob/develop/CONTRIBUTING.md#changelog).
- [x] This PR has been made with the help of an LLM.

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
