### PR TITLE
Fix some SwiftLint warnings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,22 +18,9 @@ DerivedData/
 .swiftpm
 .netrc
 
-# fastlane
-#
-# It is recommended to not store the screenshots in the git repo.
-# Instead, use fastlane to re-generate the screenshots whenever they are needed.
-# For more information about the recommended setup visit:
-# https://docs.fastlane.tools/best-practices/source-control/#source-control
-
-fastlane/report.xml
-fastlane/Preview.html
-fastlane/screenshots/**/*.png
-fastlane/test_output
-towncrier.toml.tmp
-version_changes.md
-
 build
 /vendor/
+*/xcshareddata/xcodecloud
 
 ## macOS Files
 .DS_Store

--- a/ElementX/Sources/Other/MapLibre/MapLibreStaticMapView.swift
+++ b/ElementX/Sources/Other/MapLibre/MapLibreStaticMapView.swift
@@ -63,7 +63,7 @@ struct MapLibreStaticMapView<PinAnnotation: View>: View {
                         ZStack {
                             image
                                 .resizable()
-                                .aspectRatio(contentMode: .fill)
+                                .scaledToFill()
                             pinAnnotationView
                         }
                     case .failure(let error):

--- a/ElementX/Sources/Other/SwiftUI/Views/LoadableImage.swift
+++ b/ElementX/Sources/Other/SwiftUI/Views/LoadableImage.swift
@@ -423,7 +423,7 @@ struct LoadableImage_Previews: PreviewProvider, TestablePreview {
 
 private extension View {
     func layout(title: String, hideTimelineMedia: Bool = false) -> some View {
-        aspectRatio(contentMode: .fit)
+        scaledToFit()
             .clipShape(RoundedRectangle(cornerRadius: 20))
             .overlay(alignment: .bottom) {
                 Text(title)

--- a/ElementX/Sources/Other/SwiftUI/Views/OverridableAvatarImage.swift
+++ b/ElementX/Sources/Other/SwiftUI/Views/OverridableAvatarImage.swift
@@ -23,7 +23,7 @@ struct OverridableAvatarImage: View {
             AsyncImage(url: overrideURL) { image in
                 image
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
             } placeholder: {
                 ProgressView()
             }

--- a/ElementX/Sources/Screens/CreateRoomScreen/View/CreateRoomScreen.swift
+++ b/ElementX/Sources/Screens/CreateRoomScreen/View/CreateRoomScreen.swift
@@ -113,7 +113,7 @@ struct CreateRoomScreen: View {
             if let avatarImage = context.viewState.avatarImage {
                 Image(uiImage: avatarImage)
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
                     .scaledFrame(size: 70, relativeTo: .title)
                     .avatarShape(context.viewState.isSpace ? .roundedRect : .circle, size: 70)
                     .overlay(alignment: .bottomTrailing) {

--- a/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewRedactConfirmationView.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/View/TimelineMediaPreviewRedactConfirmationView.swift
@@ -74,7 +74,7 @@ struct TimelineMediaPreviewRedactConfirmationView: View {
                                       mediaProvider: context.mediaProvider) {
                             Color.compound.bgSubtleSecondary
                         }
-                        .aspectRatio(contentMode: .fill)
+                        .scaledToFill()
                     }
                     .clipShape(RoundedRectangle(cornerRadius: 8))
                     .accessibilityHidden(true)

--- a/ElementX/Sources/Screens/Onboarding/NotificationPermissionsScreen/View/NotificationPermissionsScreen.swift
+++ b/ElementX/Sources/Screens/Onboarding/NotificationPermissionsScreen/View/NotificationPermissionsScreen.swift
@@ -45,7 +45,7 @@ struct NotificationPermissionsScreen: View {
             Asset.Images.notificationsPromptGraphic
                 .swiftUIImage
                 .resizable()
-                .aspectRatio(contentMode: .fit)
+                .scaledToFit()
                 .accessibilityHidden(true)
         }
     }

--- a/ElementX/Sources/Screens/Timeline/TimelineInteractionHandler.swift
+++ b/ElementX/Sources/Screens/Timeline/TimelineInteractionHandler.swift
@@ -461,6 +461,7 @@ class TimelineInteractionHandler {
         audioPlayerState(for: itemID)?.setPlaybackSpeed(nextSpeed)
     }
     
+    // swiftlint:disable:next cyclomatic_complexity
     func playPauseAudio(for itemID: TimelineItemIdentifier) async {
         MXLog.info("Toggle play/pause audio for itemID \(itemID)")
         guard let timelineItem = timelineController.timelineItems.firstUsingStableID(itemID) else {

--- a/ElementX/Sources/Screens/Timeline/View/Replies/TimelineReplyView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/Replies/TimelineReplyView.swift
@@ -266,11 +266,11 @@ struct TimelineReplyView: View {
                         CompoundIcon(\.image)
                             .padding(4.0)
                     }
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
                 case .iconAsset(let asset):
                     Image(asset: asset)
                         .resizable()
-                        .aspectRatio(contentMode: .fit)
+                        .scaledToFit()
                         .padding(8.0)
                 case .icon(let keyPath):
                     CompoundIcon(keyPath, size: .medium, relativeTo: .body)

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/GalleryItemTileView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/GalleryItemTileView.swift
@@ -79,7 +79,7 @@ struct GalleryItemTileView: View {
                           size: item.size,
                           mediaProvider: mediaProvider) { imageView in
                 imageView
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
             } placeholder: {
                 placeholder
             }

--- a/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/GalleryListView.swift
+++ b/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/GalleryListView.swift
@@ -125,7 +125,7 @@ private struct GalleryListRow: View {
                           size: item.size,
                           mediaProvider: mediaProvider) { imageView in
                 imageView
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
             } placeholder: {
                 Color.compound.bgSubtleSecondary
             }

--- a/compound-ios/Sources/Compound/Components/BigIcon.swift
+++ b/compound-ios/Sources/Compound/Components/BigIcon.swift
@@ -66,7 +66,7 @@ public extension Image {
     func bigIcon(insets: CGFloat = 16, style: BigIcon.Style = .defaultSolid) -> some View {
         resizable()
             .renderingMode(.template)
-            .aspectRatio(contentMode: .fit)
+            .scaledToFit()
             .scaledPadding(insets, relativeTo: .compound.headingLG)
             .modifier(BigIconModifier(style: style))
     }


### PR DESCRIPTION
Looks like there's a new `legacy_swiftui_aspect_ratio` rule that whilst seemed odd to me (it isn't deprecated), is based on the Apple's docs:

https://developer.apple.com/documentation/swiftui/view/scaledtofit()

> This method is equivalent to calling [aspectRatio(_:contentMode:)](https://developer.apple.com/documentation/swiftui/view/aspectratio(_:contentmode:)) with a nil aspectRatio and a content mode of [ContentMode.fit](https://developer.apple.com/documentation/swiftui/contentmode/fit).

https://developer.apple.com/documentation/swiftui/view/scaledtofill()

> This method is equivalent to calling [aspectRatio(_:contentMode:)](https://developer.apple.com/documentation/swiftui/view/aspectratio(_:contentmode:)) with a nil aspectRatio and a content mode of [ContentMode.fill](https://developer.apple.com/documentation/swiftui/contentmode/fill).

So I ran `swiftlint lint --fix`